### PR TITLE
Add modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ syntax: glob
 
 build
 bin
+modules
 obj
 release
 ipch


### PR DESCRIPTION
Prevents private or in-progress modules from appearing in pending changes, makes it a little easier to work against core.