### PR TITLE
Fix handling of "../../.." sequences in path.normalize()

### DIFF
--- a/src/host/path_normalize.c
+++ b/src/host/path_normalize.c
@@ -35,13 +35,11 @@ int path_normalize(lua_State* L)
 		if (ch == '.' && last == '.') {
 			ptr = dst - 3;
 			while (ptr >= buffer) {
-				if (*ptr != '/') {
-					--ptr;
-				}
-				else {
+				if (ptr[0] == '/' && ptr[1] != '.' && ptr[2] != '.') {
 					dst = ptr;
 					break;
 				}
+				--ptr;
 			}
 			if (ptr >= buffer) {
 				++src;

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -385,6 +385,21 @@
 		test.isequal("../../test", p)
 	end
 
+	function suite.normalize_Test4()
+		local p = path.normalize("../../../test/*.h")
+		test.isequal("../../../test/*.h", p)
+	end
+
+	function suite.normalize_trailingDots1()
+		local p = path.normalize("../game/test/..")
+		test.isequal("../game", p)
+	end
+
+	function suite.normalize_trailingDots2()
+		local p = path.normalize("../game/..")
+		test.isequal("..", p)
+	end
+
 	function suite.normalize()
 		test.isequal("d:/ProjectB/bin", path.normalize("d:/ProjectA/../ProjectB/bin"))
 		test.isequal("/ProjectB/bin", path.normalize("/ProjectA/../ProjectB/bin"))


### PR DESCRIPTION
The previous implementation of path.normalize() would begin stripping "../" after the second sequence: ../../../test would become ../../test. Fix and a unit test to cover.