### PR TITLE
More debugging api's

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -241,6 +241,24 @@
 	}
 
 	api.register {
+		name = "debugger",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"GDB",
+			"LLDB",
+		}
+	}
+
+	api.register {
+		name = "debugpathmap",
+		scope = "config",
+		kind = "list:keyed:path",
+		tokens = true,
+	}
+
+	api.register {
 		name = "debugport",
 		scope = "config",
 		kind = "integer",
@@ -265,6 +283,22 @@
 		scope = "config",
 		kind = "list:string",
 		tokens = true,
+	}
+
+	api.register {
+		name = "debugtoolargs",
+		scope = "config",
+		kind = "list:string",
+		tokens = true,
+		pathVars = true,
+	}
+
+	api.register {
+		name = "debugtoolcommand",
+		scope = "config",
+		kind = "path",
+		tokens = true,
+		pathVars = true,
 	}
 
 	api.register {


### PR DESCRIPTION
Specify a debugger to use.
Specify the debugger binaries, args to run with.
Specify path remaps: It's typical to remap paths embedded in dwarf (as the exe was built) to the location of the source on your own pc.

I have another module which adds VisualGDB as a debugger for use with visual studio, and the D module supports an alternative debugger called Mago, which has D language expression parsing and better visualisations. There's another called WinGDB which can be used for Android.