### PR TITLE
Added aliases for explicit architectures

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -23,8 +23,14 @@
 		kind = "string",
 		allowed = {
 			"universal",
-			"x32",
-			"x64",
+			"x86",
+			"x86_64",
+		},
+		aliases = {
+			i386 = "x86",
+			amd64 = "x86_64",
+			x32 = "x86",	-- these should be DEPRECATED
+			x64 = "x86_64",
 		},
 	}
 

--- a/src/actions/vstudio/_vstudio.lua
+++ b/src/actions/vstudio/_vstudio.lua
@@ -21,8 +21,8 @@
 
 	vstudio.vs200x_architectures =
 	{
-		x32     = "x86",
-		x64     = "x64",
+		x86     = "x86",
+		x86_64  = "x64",
 		xbox360 = "Xbox 360",
 	}
 

--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -1094,7 +1094,7 @@
 	function m.enableEnhancedInstructionSet(cfg)
 		local map = { SSE = "1", SSE2 = "2" }
 		local value = map[cfg.vectorextensions]
-		if value and cfg.system ~= "Xbox360" and cfg.architecture ~= "x64" then
+		if value and cfg.system ~= "Xbox360" and cfg.architecture ~= "x86_64" then
 			p.w('EnableEnhancedInstructionSet="%d"', value)
 		end
 	end
@@ -1541,7 +1541,7 @@
 
 
 	function m.targetEnvironment(cfg)
-		if cfg.architecture == "x64" then
+		if cfg.architecture == "x86_64" then
 			p.w('TargetEnvironment="3"')
 		end
 	end
@@ -1564,7 +1564,7 @@
 
 	function m.targetMachine(cfg, toolset)
 		if not toolset then
-			p.w('TargetMachine="%d"', iif(cfg.architecture == "x64", 17, 1))
+			p.w('TargetMachine="%d"', iif(cfg.architecture == "x86_64", 17, 1))
 		end
 	end
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1019,7 +1019,7 @@
 		if cfg.flags.Symbols then
 			if cfg.debugformat == "c7" then
 				value = "OldStyle"
-			elseif cfg.architecture == "x64" or
+			elseif cfg.architecture == "x86_64" or
 				   cfg.clr ~= p.OFF or
 				   config.isOptimizedBuild(cfg) or
 				   not cfg.editAndContinue

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -40,8 +40,8 @@
 	premake.UTILITY     = "Utility"
 	premake.WINDOWEDAPP = "WindowedApp"
 	premake.WINDOWS     = "windows"
-	premake.X32         = "x32"
-	premake.X64         = "x64"
+	premake.X86         = "x86"
+	premake.X86_64      = "x86_64"
 	premake.XBOX360     = "xbox360"
 
 

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -152,8 +152,8 @@
 
 	clang.ldflags = {
 		architecture = {
-			x32 = "-m32",
-			x64 = "-m64",
+			x86 = "-m32",
+			x86_64 = "-m64",
 		},
 		kind = {
 			SharedLib = function(cfg)

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -34,8 +34,8 @@
 
 	gcc.cflags = {
 		architecture = {
-			x32 = "-m32",
-			x64 = "-m64",
+			x86 = "-m32",
+			x86_64 = "-m64",
 		},
 		flags = {
 			FatalCompileWarnings = "-Werror",
@@ -181,8 +181,8 @@
 
 	gcc.ldflags = {
 		architecture = {
-			x32 = "-m32",
-			x64 = "-m64",
+			x86 = "-m32",
+			x86_64 = "-m64",
 		},
 		flags = {
 			_Symbols = function(cfg)
@@ -220,8 +220,8 @@
 
 	gcc.libraryDirectories = {
 		architecture = {
-			x32 = "-L/usr/lib32",
-			x64 = "-L/usr/lib64",
+			x86 = "-L/usr/lib32",
+			x86_64 = "-L/usr/lib64",
 		},
 		system = {
 			wii = "-L$(LIBOGC_LIB)",

--- a/tests/actions/vstudio/cs2005/test_platform_groups.lua
+++ b/tests/actions/vstudio/cs2005/test_platform_groups.lua
@@ -72,7 +72,7 @@
 	end
 
 	function suite.onX32()
-		prepare("x32")
+		prepare("x86")
 		test.capture [[
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<PlatformTarget>x86</PlatformTarget>
@@ -81,7 +81,7 @@
 
 
 	function suite.onX64()
-		prepare("x64")
+		prepare("x86_64")
 		test.capture [[
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
 		<PlatformTarget>x64</PlatformTarget>

--- a/tests/actions/vstudio/sln2005/test_platforms.lua
+++ b/tests/actions/vstudio/sln2005/test_platforms.lua
@@ -192,7 +192,7 @@
 
 	function suite.onSingleCpp_noPlatforms_singleArch()
 		project "MyProject"
-		architecture "x64"
+		architecture "x86_64"
 		prepare()
 		test.capture [[
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -210,7 +210,7 @@
 
 	function suite.onSingleCs_noPlatforms_singleArch()
 		project "MyProject"
-		architecture "x64"
+		architecture "x86_64"
 		prepare()
 		test.capture [[
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -227,7 +227,7 @@
 	end
 
 	function suite.onMixedLanguage_noPlatforms_singleArch()
-		architecture "x64"
+		architecture "x86_64"
 
 		project "MyProject1"
 		language "C#"
@@ -264,7 +264,7 @@
 		uuid "52AD9329-0D74-4F66-A213-E649D8CCD737"
 
 		project "MyProject2"
-		architecture "x64"
+		architecture "x86_64"
 		prepare()
 		test.capture [[
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -290,7 +290,7 @@
 --
 
 	function suite.onSingleCpp_noPlatforms_x32()
-		architecture "x32"
+		architecture "x86"
 		project "MyProject"
 		prepare()
 		test.capture [[
@@ -308,7 +308,7 @@
 	end
 
 	function suite.onSingleCs_noPlatforms_x32()
-		architecture "x32"
+		architecture "x86"
 		project "MyProject"
 		language "C#"
 		prepare()
@@ -327,7 +327,7 @@
 	end
 
 	function suite.onMixedLanguage_noPlatforms_x32()
-		architecture "x32"
+		architecture "x86"
 
 		project "MyProject1"
 		language "C#"
@@ -361,9 +361,9 @@
 	function suite.onSingleCpp_withPlatforms_withArchs()
 		platforms { "DLL32", "DLL64" }
 		filter "platforms:DLL32"
-		architecture "x32"
+		architecture "x86"
 		filter "platforms:DLL64"
-		architecture "x64"
+		architecture "x86_64"
 
 		project "MyProject"
 		prepare()
@@ -390,9 +390,9 @@
 	function suite.onSingleCs_withPlatforms_withArchs()
 		platforms { "DLL32", "DLL64" }
 		filter "platforms:DLL32"
-		architecture "x32"
+		architecture "x86"
 		filter "platforms:DLL64"
-		architecture "x64"
+		architecture "x86_64"
 
 		project "MyProject"
 		language "C#"
@@ -420,9 +420,9 @@
 	function suite.onMixedLanguage_withPlatforms_withArchs()
 		platforms { "DLL32", "DLL64" }
 		filter "platforms:DLL32"
-		architecture "x32"
+		architecture "x86"
 		filter "platforms:DLL64"
-		architecture "x64"
+		architecture "x86_64"
 
 		project "MyProject1"
 		language "C#"

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -551,7 +551,7 @@
 
 	function suite.debugFormat_onWin32()
 		flags "Symbols"
-		architecture "x32"
+		architecture "x86"
 		prepare()
 		test.capture [[
 <ClCompile>
@@ -568,7 +568,7 @@
 
 	function suite.debugFormat_onWin64()
 		flags "Symbols"
-		architecture "x64"
+		architecture "x86_64"
 		prepare()
 		test.capture [[
 <ClCompile>

--- a/tests/actions/vstudio/vc2010/test_project_configs.lua
+++ b/tests/actions/vstudio/vc2010/test_project_configs.lua
@@ -55,9 +55,9 @@
 	function suite.allArchitecturesListed_onMultipleArchitectures()
 		platforms { "32b", "64b" }
 		filter "platforms:32b"
-			architecture "x32"
+			architecture "x86"
 		filter "platforms:64b"
-			architecture "x64"
+			architecture "x86_64"
 		prepare()
 		test.capture [[
 	<ItemGroup Label="ProjectConfigurations">

--- a/tests/project/test_getconfig.lua
+++ b/tests/project/test_getconfig.lua
@@ -92,10 +92,10 @@
 --
 
 	function suite.setsArchitecture_onMatchingPlatform()
-		platforms { "x32", "x64" }
+		platforms { "x86", "x64" }
 		project ("MyProject")
-		prepare("Debug", "x32")
-		test.isequal("x32", cfg.architecture)
+		prepare("Debug", "x86")
+		test.isequal("x86", cfg.architecture)
 	end
 
 
@@ -105,9 +105,9 @@
 --
 
 	function suite.doesNotOverride_onMatchingPlatform()
-		platforms { "x32", "x64" }
+		platforms { "x86", "x64" }
 		project ("MyProject")
-		architecture "x64"
-		prepare("Debug", "x32")
-		test.isequal("x64", cfg.architecture)
+		architecture "x86_64"
+		prepare("Debug", "x86")
+		test.isequal("x86_64", cfg.architecture)
 	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -276,25 +276,25 @@
 --
 
 	function suite.cflags_onX32()
-		architecture "x32"
+		architecture "x86"
 		prepare()
 		test.contains({ "-m32" }, gcc.getcflags(cfg))
 	end
 
 	function suite.ldflags_onX32()
-		architecture "x32"
+		architecture "x86"
 		prepare()
 		test.contains({ "-m32" }, gcc.getldflags(cfg))
 	end
 
 	function suite.cflags_onX64()
-		architecture "x64"
+		architecture "x86_64"
 		prepare()
 		test.contains({ "-m64" }, gcc.getcflags(cfg))
 	end
 
 	function suite.ldflags_onX64()
-		architecture "x64"
+		architecture "x86_64"
 		prepare()
 		test.contains({ "-m64" }, gcc.getldflags(cfg))
 	end


### PR DESCRIPTION
The 'architecture' api has always bothered me; none of the entries are actually architectures... and it's often necessary to select architectures explicitly.

@starkos I see you were going for something a little bit abstract, associating with the x86 toolchains '-m32'/'-m64' compile args. That's kind reasonable for x86, but doesn't make sense for anything else.

Obviously, we can't remove those entries, but I think we need to add explicit architectures alongside those abstract entries. Many of my modules introduce various explicit architectures, but I think explicit x86 variants should be defined in core.

I've always felt that x32 and x64 create confusion since they look like they may specify an explicit architecture ('x' implies x86 line of processors), but they're only meant to specify -m32/-m64. I think for premake5, we should rename those 2 entries to m32 and m64, which is what they are. I have created aliases for x32->m32 and x64->m64, which I think should be deprecated.

I then added x86 and x86_64; the proper names for those explicit architectures.

I'm not actually sure m32/m64 should exist, but they are certainly long-standing legacy, so I think it's better to keep them, and the rename makes their conceptual meaning more clear and avoid confusion with absolute architecture identifiers.

Then finally, I've painstakingly made everything work...

Please tell me this seems correct to you, I spent a lot of time on this ;)