### PR TITLE
Finish renaming architectures away from x32/x64

### DIFF
--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -756,7 +756,7 @@
 			if not cfg.editAndContinue or
 				config.isOptimizedBuild(cfg) or
 			    cfg.clr ~= p.OFF or
-			    cfg.system == "x64"
+			    cfg.architecture == p.X86_64
 			then
 				return 3
 			else

--- a/src/base/project.lua
+++ b/src/base/project.lua
@@ -43,7 +43,7 @@
 --
 -- Returns an iterator function for the configuration objects contained by
 -- the project. Each configuration corresponds to a build configuration/
--- platform pair (i.e. "Debug|x32") as specified in the solution.
+-- platform pair (i.e. "Debug|x86") as specified in the solution.
 --
 -- @param prj
 --    The project object to query.

--- a/tests/actions/vstudio/cs2005/test_platform_groups.lua
+++ b/tests/actions/vstudio/cs2005/test_platform_groups.lua
@@ -71,7 +71,7 @@
 		]]
 	end
 
-	function suite.onX32()
+	function suite.onX86()
 		prepare("x86")
 		test.capture [[
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
@@ -80,7 +80,7 @@
 	end
 
 
-	function suite.onX64()
+	function suite.onX86_64()
 		prepare("x86_64")
 		test.capture [[
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/tests/actions/vstudio/sln2005/test_platforms.lua
+++ b/tests/actions/vstudio/sln2005/test_platforms.lua
@@ -289,7 +289,7 @@
 -- Use the right variant for 32-bit architectures.
 --
 
-	function suite.onSingleCpp_noPlatforms_x32()
+	function suite.onSingleCpp_noPlatforms_x86()
 		architecture "x86"
 		project "MyProject"
 		prepare()
@@ -307,7 +307,7 @@
 		]]
 	end
 
-	function suite.onSingleCs_noPlatforms_x32()
+	function suite.onSingleCs_noPlatforms_x86()
 		architecture "x86"
 		project "MyProject"
 		language "C#"
@@ -326,7 +326,7 @@
 		]]
 	end
 
-	function suite.onMixedLanguage_noPlatforms_x32()
+	function suite.onMixedLanguage_noPlatforms_x86()
 		architecture "x86"
 
 		project "MyProject1"
@@ -465,7 +465,7 @@
 --
 
 	function suite.onSingleCpp_withPlatformsMatchingArch_noArchs()
-		platforms { "x32", "Xbox360" }
+		platforms { "x86", "Xbox360" }
 		project "MyProject"
 		prepare()
 		test.capture [[
@@ -489,7 +489,7 @@
 	end
 
 	function suite.onSingleCs_withPlatformsMatchingArch_noArchs()
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		project "MyProject"
 		language "C#"
 		prepare()
@@ -514,7 +514,7 @@
 	end
 
 	function suite.onMixedLanguage_withPlatformsMatchingArch_noArchs()
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		project "MyProject1"
 		language "C#"
 		uuid "52AD9329-0D74-4F66-A213-E649D8CCD737"
@@ -795,8 +795,8 @@
 ---
 
 	function suite.onDefaultPlatforms()
-		platforms { "x32", "x64" }
-		defaultplatform "x64"
+		platforms { "x86", "x86_64" }
+		defaultplatform "x86_64"
 		project "MyProject"
 		prepare()
 		test.capture [[

--- a/tests/actions/vstudio/vc200x/test_configuration.lua
+++ b/tests/actions/vstudio/vc200x/test_configuration.lua
@@ -50,9 +50,9 @@
 -- If a platform is specified, it should be included in the platform name.
 --
 
-	function suite.usesWin32_onX32()
+	function suite.usesWin32_onX86()
 		solution "MySolution"
-		platforms { "x32" }
+		platforms { "x86" }
 		prepare()
 		test.capture [[
 <Configuration
@@ -65,8 +65,8 @@
 -- Check the x64 architecture handling.
 --
 
-	function suite.usesX64Architecture_onX64Platform()
-		platforms { "x64" }
+	function suite.usesX64Architecture_onX86_64Platform()
+		platforms { "x86_64" }
 		prepare()
 		test.capture [[
 <Configuration

--- a/tests/actions/vstudio/vc200x/test_platforms.lua
+++ b/tests/actions/vstudio/vc200x/test_platforms.lua
@@ -65,7 +65,7 @@
 --
 
 	function suite.allArchitecturesListed_onMultipleArchitectures()
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		prepare()
 		test.capture [[
 <Platforms>

--- a/tests/actions/vstudio/vc2010/test_project_configs.lua
+++ b/tests/actions/vstudio/vc2010/test_project_configs.lua
@@ -88,7 +88,7 @@
 --
 
 	function suite.allArchitecturesListed_onImplicitArchitectures()
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		prepare()
 		test.capture [[
 	<ItemGroup Label="ProjectConfigurations">

--- a/tests/base/test_criteria.lua
+++ b/tests/base/test_criteria.lua
@@ -31,7 +31,7 @@
 --
 
 	function suite.matches_fails_onMissingContext()
-		crit = criteria.new { "system:Windows", "architecture:x32" }
+		crit = criteria.new { "system:Windows", "architecture:x86" }
 		test.isfalse(criteria.matches(crit, { configurations="Debug", system="Windows" }))
 	end
 

--- a/tests/oven/test_objdirs.lua
+++ b/tests/oven/test_objdirs.lua
@@ -47,10 +47,10 @@
 	function suite.singleProject_withPlatforms()
 		sln = solution "MySolution"
 		configurations { "Debug", "Release" }
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		prj = project "MyProject"
 
-		test.isequal("obj/x32/Debug", result("Debug", "x32"))
+		test.isequal("obj/x86/Debug", result("Debug", "x86"))
 	end
 
 
@@ -67,20 +67,20 @@
 	function suite.singleProject_uniqueByTokens_withPlatforms()
 		sln = solution "MySolution"
 		configurations { "Debug", "Release" }
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		prj = project "MyProject"
 		objdir "obj/%{cfg.buildcfg}_%{cfg.platform}"
 
-		test.isequal("obj/Debug_x32", result("Debug", "x32"))
+		test.isequal("obj/Debug_x86", result("Debug", "x86"))
 	end
 
 
 	function suite.allowOverlap_onPrefixCode()
 		sln = solution "MySolution"
 		configurations { "Debug", "Release" }
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		prj = project "MyProject"
 		objdir "!obj/%{cfg.buildcfg}"
 
-		test.isequal("obj/Debug", result("Debug", "x32"))
+		test.isequal("obj/Debug", result("Debug", "x86"))
 	end

--- a/tests/project/test_config_maps.lua
+++ b/tests/project/test_config_maps.lua
@@ -133,16 +133,16 @@
 		removeconfigurations "*"
 		removeplatforms "*"
 		configurations { "Development", "Production" }
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 
 		configmap {
-			[{"Debug", "Win32"}] = { "Development", "x32" },
-			[{"Debug", "Linux"}] = { "Development", "x64" },
-			[{"Release", "Win32"}] = { "Production", "x32" },
-			[{"Release", "Linux"}] = { "Production", "x64" },
+			[{"Debug", "Win32"}] = { "Development", "x86" },
+			[{"Debug", "Linux"}] = { "Development", "x86_64" },
+			[{"Release", "Win32"}] = { "Production", "x86" },
+			[{"Release", "Linux"}] = { "Production", "x86_64" },
 		}
 		prepare("Debug", "Linux")
-		test.isequal({ "Development", "x64" }, { cfg.buildcfg, cfg.platform })
+		test.isequal({ "Development", "x86_64" }, { cfg.buildcfg, cfg.platform })
 	end
 
 

--- a/tests/project/test_eachconfig.lua
+++ b/tests/project/test_eachconfig.lua
@@ -47,7 +47,7 @@
 --
 
 	function suite.returnsNoValues_onNoConfigurationsButPlatforms()
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		prepare()
 		test.isemptycapture()
 	end
@@ -77,13 +77,13 @@
 
 	function suite.pairsConfigsAndPlatformsInOrder()
 		configurations { "Debug", "Release" }
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		prepare()
 		test.capture [[
-		Debug:x32
-		Debug:x64
-		Release:x32
-		Release:x64
+		Debug:x86
+		Debug:x86_64
+		Release:x86
+		Release:x86_64
 		]]
 	end
 
@@ -110,11 +110,11 @@
 	function suite.mapsPlatform_toPlatform()
 		configurations { "Debug", "Release" }
 		platforms { "Win32" }
-		configmap { ["Win32"] = "x64" }
+		configmap { ["Win32"] = "x86_64" }
 		prepare()
 		test.capture [[
-		Debug:x64
-		Release:x64
+		Debug:x86_64
+		Release:x86_64
 		]]
 	end
 
@@ -128,12 +128,12 @@
 	function suite.mapsBuildCfg_toBuildCfgAndPlatform()
 		configurations { "Debug", "Release" }
 		platforms { "Win32" }
-		configmap { ["Debug"] = { "ProjectDebug", "x64" } }
+		configmap { ["Debug"] = { "ProjectDebug", "x86_64" } }
 		prepare()
 		test.capture [[
-		ProjectDebug:x64
+		ProjectDebug:x86_64
 		ProjectDebug:Win32
-		Release:x64
+		Release:x86_64
 		Release:Win32
 		]]
 	end

--- a/tests/project/test_getconfig.lua
+++ b/tests/project/test_getconfig.lua
@@ -92,7 +92,7 @@
 --
 
 	function suite.setsArchitecture_onMatchingPlatform()
-		platforms { "x86", "x64" }
+		platforms { "x86", "x86_64" }
 		project ("MyProject")
 		prepare("Debug", "x86")
 		test.isequal("x86", cfg.architecture)

--- a/tests/solution/test_eachconfig.lua
+++ b/tests/solution/test_eachconfig.lua
@@ -14,7 +14,7 @@
 
 	local sln
 	function suite.setup()
-		sln = solution("MySolution") 
+		sln = solution("MySolution")
 	end
 
 	local function prepare()
@@ -49,15 +49,15 @@
 
 	function suite.listsInOrder_onBuildConfigsAndPlatforms()
 		configurations { "Debug", "Release" }
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		project("MyProject")
 		prepare()
 		test.capture [[
 		-
-		Debug:x32
-		Debug:x64
-		Release:x32
-		Release:x64
+		Debug:x86
+		Debug:x86_64
+		Release:x86
+		Release:x86_64
 		-
 		]]
 	end
@@ -72,7 +72,7 @@
 		configurations { "Debug", "Release" }
 		project ("MyProject")
 		configurations { "PrjDebug", "PrjRelease" }
-		platforms { "x32", "x64" }
+		platforms { "x86", "x86_64" }
 		prepare()
 		test.capture [[
 		-

--- a/tests/solution/test_objdirs.lua
+++ b/tests/solution/test_objdirs.lua
@@ -44,8 +44,8 @@
 
 	function suite.directoryIncludesPlatform_onPlatformConflict()
 		configurations { "Debug" }
-		platforms { "x32", "x64" }
-		test.isequal("obj/x32",  result())
+		platforms { "x86", "x86_64" }
+		test.isequal("obj/x86",  result())
 	end
 
 
@@ -67,8 +67,8 @@
 
 	function suite.directoryIncludesBuildCfg_onPlatformAndBuildCfgConflict()
 		configurations { "Debug", "Release" }
-		platforms { "x32", "x64" }
-		test.isequal("obj/x32/Debug",  result())
+		platforms { "x86", "x86_64" }
+		test.isequal("obj/x86/Debug",  result())
 	end
 
 

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -275,25 +275,25 @@
 -- Make sure system or architecture flags are added properly.
 --
 
-	function suite.cflags_onX32()
+	function suite.cflags_onX86()
 		architecture "x86"
 		prepare()
 		test.contains({ "-m32" }, gcc.getcflags(cfg))
 	end
 
-	function suite.ldflags_onX32()
+	function suite.ldflags_onX86()
 		architecture "x86"
 		prepare()
 		test.contains({ "-m32" }, gcc.getldflags(cfg))
 	end
 
-	function suite.cflags_onX64()
+	function suite.cflags_onX86_64()
 		architecture "x86_64"
 		prepare()
 		test.contains({ "-m64" }, gcc.getcflags(cfg))
 	end
 
-	function suite.ldflags_onX64()
+	function suite.ldflags_onX86_64()
 		architecture "x86_64"
 		prepare()
 		test.contains({ "-m64" }, gcc.getldflags(cfg))


### PR DESCRIPTION
A number of tests were relying on the fact that x32/x64 were being converted implicitly to x86/x86_64. If/when we retire those symbols, all of those tests would break. Renamed them now to avoid having to sort it out later. Also fixed up comments to keep everything consistent.