### PR TITLE
Added MonoDevelop/Xamarin submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,9 @@
 [submodule "modules/xcode"]
 	path = modules/xcode
 	url = https://github.com/premake/premake-xcode.git
+[submodule "modules/monodevelop"]
+	path = modules/monodevelop
+	url = https://github.com/premake/premake-monodevelop.git
 [submodule "modules/codelite"]
 	path = modules/codelite
 	url = https://github.com/premake/premake-codelite.git


### PR DESCRIPTION
The MonoDevelop plugin is fairly mature. It'd be nice to make it available as part of the standard build.
Obviously I accept full responsibility servicing bug-reports for this submodule.