### PR TITLE
Fix external casing

### DIFF
--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -1,7 +1,8 @@
 --
 -- api.lua
 -- Implementation of the solution, project, and configuration APIs.
--- Copyright (c) 2002-2014 Jason Perkins and the Premake project
+-- Author Jason Perkins
+-- Copyright (c) 2002-2015 Jason Perkins and the Premake project
 --
 
 	local p = premake
@@ -58,11 +59,14 @@
 			return c
 		end
 
-		_G["external" .. containerName:capitalized()] = function(name)
+		_G["external" .. containerName] = function(name)
 			local c = _G[containerName](name)
 			c.external = true
 			return c
 		end
+
+		-- for backward compatibility
+		_G["external" .. containerName:capitalized()] = _G["external" .. containerName]
 
 		return class
 	end
@@ -75,11 +79,13 @@
 -- scripts as external.
 ---
 
-	function includeExternal(fname)
+	function includeexternal(fname)
 		api._isIncludingExternal = true
 		include(fname)
 		api._isIncludingExternal = nil
 	end
+
+	includeExternal = includeexternal
 
 
 

--- a/src/base/project.lua
+++ b/src/base/project.lua
@@ -1,7 +1,8 @@
 ---
 -- project.lua
 -- Premake project object API
--- Copyright (c) 2011-2014 Jason Perkins and the Premake project
+-- Author Jason Perkins
+-- Copyright (c) 2011-2015 Jason Perkins and the Premake project
 ---
 
 	local p = premake
@@ -13,11 +14,11 @@
 
 
 ---
--- Alias the old external() call to the new externalProject(), to distinguish
--- between it and externalRule().
+-- Alias the old external() call to the new externalproject(), to distinguish
+-- between it and externalrule().
 ---
 
-	external = externalProject
+	external = externalproject
 
 
 

--- a/tests/actions/vstudio/sln2005/test_projects.lua
+++ b/tests/actions/vstudio/sln2005/test_projects.lua
@@ -184,7 +184,7 @@ EndProject
 --
 
 	function suite.translatesEnvironmentVars()
-		externalProject "MyProject"
+		externalproject "MyProject"
 		location "$(SDK_LOCATION)/MyProject"
 		uuid "30A1B994-C2C6-485F-911B-FB4674366DA8"
 		kind "SharedLib"


### PR DESCRIPTION
Standardized the names of the generated external…() functions (externalproject, externalrule) to be all lowercase, matching the rest of the project API.