### PR TITLE
Fix os.writefile_ifnotequal

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ for the complete list of changes from the Premake 4.x series.
 Since 5.0-alpha2:
 
 * New API: buildlog()
+* New API: os.writefile_ifnotequal()
 
 Since 5.0-alpha1:
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -26,7 +26,7 @@ Patch contributors:
     * add library search paths argument to os.findlib()
     * return command exit code from os.outputof()
   Tom van Dijck <tvandijck@blizzard.com>
-    * additional string and table functions
+    * additional os, string, and table functions
     * path.normalize() improvements
     * Visual Studio 2015 support
     * runtime()

--- a/src/host/os_writefile_ifnotequal.c
+++ b/src/host/os_writefile_ifnotequal.c
@@ -19,7 +19,7 @@
 static int compare_file(const char* content, size_t length, const char* dst)
 {
 	FILE* file = fopen(dst, "rb");
-	long size;
+	size_t size;
 	char buffer[4096];
 	int num;
 

--- a/src/host/os_writefile_ifnotequal.c
+++ b/src/host/os_writefile_ifnotequal.c
@@ -1,7 +1,7 @@
 /**
- * \file   os_copyfile.c
- * \brief  Copy a file from one location to another.
- * \author Copyright (c) 2002-2008 Jason Perkins and the Premake project
+ * \file   os_writefile_ifnotequal.c
+ * \brief  Writes a file only if it differs with its current contents.
+ * \author Copyright (c) 2015 Tom van Dijck and the Premake project
  */
 
 #include <stdio.h>


### PR DESCRIPTION
Fixes a Clang warning and the supporting documentation.