### PR TITLE
Forcing debugcommand for vs201x to be an absolute path

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj_user.lua
+++ b/src/actions/vstudio/vs2010_vcxproj_user.lua
@@ -87,7 +87,12 @@
 
 	function m.localDebuggerCommand(cfg)
 		if cfg.debugcommand then
-			local dir = p.project.getrelative(cfg.project, cfg.debugcommand)
+			if not path.isabsolute(cfg.debugcommand) then
+				print("Error: debugcommand must be an absolute path")
+				os.exit(1)
+			end
+			
+			local dir = cfg.debugcommand
 			p.w('<LocalDebuggerCommand>%s</LocalDebuggerCommand>', path.translate(dir))
 		end
 	end

--- a/src/actions/vstudio/vs2010_vcxproj_user.lua
+++ b/src/actions/vstudio/vs2010_vcxproj_user.lua
@@ -87,11 +87,6 @@
 
 	function m.localDebuggerCommand(cfg)
 		if cfg.debugcommand then
-			if not path.isabsolute(cfg.debugcommand) then
-				print("Error: debugcommand must be an absolute path")
-				os.exit(1)
-			end
-			
 			local dir = cfg.debugcommand
 			p.w('<LocalDebuggerCommand>%s</LocalDebuggerCommand>', path.translate(dir))
 		end

--- a/tests/actions/vstudio/vc2010/test_debug_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_debug_settings.lua
@@ -41,10 +41,11 @@
 	function suite.debugCommand_isProjectRelative()
 		debugcommand "bin/emulator.exe"
 		prepare()
-		test.capture [[
-<LocalDebuggerCommand>bin\emulator.exe</LocalDebuggerCommand>
-<DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-		]]
+
+		expectedPath = path.translate(path.getabsolute(os.getcwd())) .. "\\bin\\emulator.exe"
+		expected = "<LocalDebuggerCommand>" .. expectedPath .. "</LocalDebuggerCommand>"
+		expected = expected .. "\n<DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>"
+		test.capture (expected)
 	end
 
 


### PR DESCRIPTION
Visual Studio will not let you use a relative path for the debug command. cfg.debugcommand is already translating to an absolute path, so I just added a check.