### PR TITLE
Add shell scripts to generate embedded lua scripts file and Makefile to build premake5

### DIFF
--- a/scripts/embed.lua
+++ b/scripts/embed.lua
@@ -23,13 +23,13 @@
 		s = s:gsub("[^\"']%-%-%[==%[.-%]==%]", "")
 
 		-- strip out inline comments
-		s = s:gsub("\n%-%-[^\n]*", "\n")
+		s = s:gsub("\n%s*%-%-[^\n]*", "\n")
 
 		-- escape backslashes
 		s = s:gsub("\\", "\\\\")
 
-		-- strip duplicate line feeds
-		s = s:gsub("\n+", "\n")
+		-- strip duplicate line feeds and blank lines
+		s = s:gsub("\n%s*\n+", "\n")
 
 		-- strip out leading comments
 		s = s:gsub("^%-%-[^\n]*\n", "")
@@ -89,6 +89,7 @@
 
 	local mask = path.join(_MAIN_SCRIPT_DIR, "**/_manifest.lua")
 	local manifests = os.matchfiles(mask)
+	table.sort(manifests)
 
 
 -- Generate an index of the script file names. Script names are stored

--- a/sh/embed.sh
+++ b/sh/embed.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+###################################################
+# Generate embedded lua scripts file 
+# like the premake 'embed' action
+
+usage()
+{
+	cat << EOF
+$(basename "${0}") [ -h] [-o <output directory>]
+	With
+		-o --output
+			Set embedded scripts file output directory
+			Default: ${defaultOutputDirectory}
+		-n --name
+			Set embedded scripts file name
+			Default: ${defaultPremakeEmbeddedScriptFile}
+		-h --help
+			This help
+EOF
+}
+
+# Create a temporary file
+ns_mktemp()
+{
+		local key=
+		if [ $# -gt 0 ]
+		then
+				key="${1}"
+				shift
+		else
+				key="$(date +%s)"
+		fi
+		if [ "$(uname -s)" == "Darwin" ]
+		then
+				#Use key as a prefix
+				mktemp -t "${key}"
+		else
+				#Use key as a suffix
+				mktemp --suffix "${key}"
+		fi
+}
+
+# Get real absolute path of a file or directory
+ns_realpath()
+{
+	local inputPath=
+	if [ $# -gt 0 ]
+	then
+		inputPath="${1}"
+		shift
+	fi
+	local cwd="$(pwd)"
+	[ -d "${inputPath}" ] && cd "${inputPath}" && inputPath="."
+	while [ -h "${inputPath}" ] ; do inputPath="$(readlink "${inputPath}")"; done
+	
+	if [ -d "${inputPath}" ]
+	then
+		inputPath="$(cd -P "$(dirname "${inputPath}")" && pwd)"
+	else
+		inputPath="$(cd -P "$(dirname "${inputPath}")" && pwd)/$(basename "${inputPath}")"
+	fi
+	
+	cd "${cwd}" 1>/dev/null 2>&1
+	echo "${inputPath}"
+}
+
+# Replace file content inplace using sed
+ns_sed_inplace()
+{
+	local inplaceOptionForm=
+	if [ -z "${__ns_sed_inplace_inplaceOptionForm}" ]
+	then
+		if [ "$(uname -s)" = 'Darwin' ]
+		then
+			if [ "$(which sed 2>/dev/null)" = '/usr/bin/sed' ]
+			then
+				inplaceOptionForm='arg'			
+			fi 
+		fi
+		
+		if [ -z "${inplaceOptionForm}" ]
+		then
+			# Attempt to guess it from help
+			if sed --helo 2>&1 | grep -q '\-i\[SUFFIX\]'
+			then
+				inplaceOptionForm='nested'
+			elif sed --helo 2>&1 | grep -q '\-i extension'
+			then
+				inplaceOptionForm='arg'
+			else
+				inplaceOptionForm='noarg'
+			fi
+		fi
+	else
+		inplaceOptionForm="${__ns_sed_inplace_inplaceOptionForm}"
+	fi
+	
+	# Store for later use
+	__ns_sed_inplace_inplaceOptionForm="${inplaceOptionForm}"
+	
+	if [ "${inplaceOptionForm}" = 'nested' ]
+	then
+		sed -i'' "${@}"
+	elif [ "${inplaceOptionForm}" = 'arg' ]
+	then
+		sed -i '' "${@}"
+	else
+		sed -i "${@}"
+	fi
+}
+
+# Output files listed in manifests
+# Use lua if available, otherwise, parse file manually
+manifest_filelist()
+{
+	local manifestPath="${1}"
+	if which lua 1>/dev/null 2>&1
+	then
+		lua -e 'for _, f in ipairs(dofile("'${manifestPath}'")) do print(f) end'
+	else
+		# We assume that all manifests respect the same formatting policy
+		# * A single "return {}" instruction
+		# * One file per line
+		# * Use double quotes 
+		sed -n 's,[[:space:]]"\(.*\.lua\)".*,\1,p' "${manifestPath}"
+	fi
+}
+
+# Append lua script content to embedded lua scripts file
+append_script()
+{
+	local file="${1}"
+	# * Remove tabs, CR, inline comments and blank lines
+	# * Escape backslashes and double quotes
+	# * Escape end of lines
+	
+	local tmp=$(ns_mktemp)
+	cp -pr "${file}" "${tmp}"
+	
+	# Strip block comments 
+	perl -0777 -i -pe 's,--\[\[.*?\]\],,sg' "${tmp}"
+	# Strip single line comments 		
+	perl -i -pe 's,^[ \t]*--.*,,g' "${tmp}"
+	# Strip tabs & CR
+	perl -i -pe 's,[\r\t],,g' "${tmp}"
+	# Strip whitespace lines
+	perl -i -pe 's,^[ \t]*$,,g' "${tmp}"
+	ns_sed_inplace "/^$/d" "${tmp}"
+	# Escape backslashes and double quotes
+	perl -i -pe 's,([\\"]),\\\1,g' "${tmp}"
+	# Escape LN
+	perl -i -pe 's,\n,\\n,g' "${tmp}"
+
+	local content="$(cat "${tmp}")"
+	
+	local read=0
+	local first=true
+	
+	if [ -z "${maxLineLength}" ] || [ ${maxLineLength} -le 0 ]
+	then
+		echo -ne '\t"'
+		echo -n "${content}"
+		echo  '",' 
+	else
+		# Split into ${maxLineLength} chunks
+		while true
+		do
+			local sub="${content:0:$(expr ${maxLineLength} + 1)}"
+			local len=${#sub}
+			
+			while [ "${sub:$(expr ${len} - 1)}" = '\' ]
+			do
+				len=$(expr ${len} - 1)
+				sub="${content:0:${len}}"
+			done
+			
+			[ ${len} -eq 0 ] && break
+			
+			${first} || echo ''
+			echo -ne '\t"'
+			echo -n "${sub}"
+			echo -n '"'
+			
+			first=false		
+			read=$(expr ${read} + ${len})
+			content="${content:${len}}"
+		done
+	fi
+	
+	echo ','
+	
+	rm -f "${tmp}"
+}
+
+scriptFilePath="$(ns_realpath "${0}")"
+scriptPath="$(dirname "${scriptFilePath}")"
+premakeRootPath="$(ns_realpath "${scriptPath}/..")"
+defaultOutputDirectory="${premakeRootPath}/src/host"
+outputDirectory="${defaultOutputDirectory}"
+maxLineLength=4096
+defaultPremakeEmbeddedScriptFile='scripts.c'
+premakeEmbeddedScriptFile="${defaultPremakeEmbeddedScriptFile}"
+
+####################
+# Parse command line
+while [ ${#} -gt 0 ]
+do
+	case "${1}" in
+		-o|--output)
+			outputDirectory="${2}"
+			shift
+			
+			if ! mkdir -p "${outputDirectory}"
+			then 
+				echo 'Invalid output directory' 1>&2
+				usage
+				exit 1
+			fi
+		;;
+		-n|--name)
+			premakeEmbeddedScriptFile="${2}"
+			shift
+			
+			if [ -z "${premakeEmbeddedScriptFile}" ]
+			then
+				echo 'Invalid output output script name' 1>&2
+				usage
+				exit 1
+			fi
+		;;
+		-h|--help)
+			usage
+			exit 0
+		;;
+		-*)
+			echo "Invalid option '${1}'" 1>&2
+			usage
+			exit 1
+		;;
+		*)
+			echo "Invalid argument '${1}'" 1>&2
+			usage
+			exit 1
+		;;
+	esac
+	
+	shift
+done
+
+####################
+# Check requirements
+for x in sed perl
+do
+	if ! which ${x} 1>/dev/null 2>&1
+	then
+		echo "${x} is required to create embedded script file" 1>&2
+		exit 1
+	fi
+done
+
+####################
+# Generate scripts.c
+premakeEmbeddedScriptFilePath="${outputDirectory}/${premakeEmbeddedScriptFile}"
+
+unset premakeManifestFilePaths
+while read f
+do
+	premakeManifestFilePaths=("${premakeManifestFilePaths[@]}" "${f#${premakeRootPath}/}")
+done << EOF
+$(find "${premakeRootPath}" -name '_manifest.lua' | sort)
+EOF
+
+cat > "${premakeEmbeddedScriptFilePath}" << EOF
+/* Premake's Lua scripts, as static data buffers for release mode builds */
+/* DO NOT EDIT - this file is autogenerated - see BUILD.txt */
+/* To regenerate this file, run: premake5 embed */
+
+#include "premake.h"
+
+const char* builtin_scripts_index[] = {
+EOF
+
+unset builtinScriptPaths
+for m in "${premakeManifestFilePaths[@]}"
+do
+	manifestPath="${premakeRootPath}/${m}"
+	manifestDirectory="$(dirname "${manifestPath}")"
+	manifestBaseDirectory="$(dirname "${manifestDirectory}")"
+	
+	while read f
+	do
+		builtinScriptPath="${manifestDirectory}/${f}"
+		builtinScriptPaths=("${builtinScriptPaths[@]}" "${builtinScriptPath}")
+		builtinScriptPath="${builtinScriptPath#${manifestBaseDirectory}/}"
+		echo -e "\t\"${builtinScriptPath}\"," >> "${premakeEmbeddedScriptFilePath}"
+	done << EOF 
+$(manifest_filelist "${manifestPath}")
+EOF
+done
+	
+# Manually added files
+for f in \
+	"src/_premake_main.lua" \
+	"src/_manifest.lua" \
+	"src/_modules.lua"
+do
+	builtinScriptPath="${premakeRootPath}/${f}"
+	builtinScriptPaths=("${builtinScriptPaths[@]}" "${builtinScriptPath}")
+	echo -e "\t\"${f}\"," >> "${premakeEmbeddedScriptFilePath}"
+done
+
+cat >> "${premakeEmbeddedScriptFilePath}" << EOF
+	NULL
+};
+
+const char* builtin_scripts[] = {
+EOF
+
+for f in "${builtinScriptPaths[@]}"
+do
+	append_script "${f}" >> "${premakeEmbeddedScriptFilePath}"
+done
+
+cat >> "${premakeEmbeddedScriptFilePath}" << EOF
+	NULL
+};
+EOF

--- a/sh/gmake.sh
+++ b/sh/gmake.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+###################################################
+# Generate a GNU makefile to build premake
+
+usage()
+{
+	cat << EOF
+$(basename "${0}") [ -h] [-e <embedded lua script file>] [-o <output directory>] [-t <target directory>]
+	With
+		-o --output
+			Set Makefile and binary output path
+			Default: ${defaultOutputDirectory}
+		-e --scripts
+			Embedded scripts file location
+			If not set, look in default location src/host/scripts.c
+			If scripts file does not exists, use embed.sh script to generate it
+		-t --target
+			Premake binary output directory
+			Default: ${defaultTargetDirectory}
+		-h --help
+			This help
+EOF
+}
+
+ns_mktemp()
+{
+		local key=
+		if [ $# -gt 0 ]
+		then
+				key="${1}"
+				shift
+		else
+				key="$(date +%s)"
+		fi
+		if [ "$(uname -s)" == "Darwin" ]
+		then
+				#Use key as a prefix
+				mktemp -t "${key}"
+		else
+				#Use key as a suffix
+				mktemp --suffix "${key}"
+		fi
+}
+
+ns_relativepath()
+{
+	local from=
+	if [ $# -gt 0 ]
+	then
+		from="${1}"
+		shift
+	fi
+	local base=
+	if [ $# -gt 0 ]
+	then
+		base="${1}"
+		shift
+	else
+		base="."
+	fi
+	[ -r "${from}" ] || return 1
+	[ -r "${base}" ] || return 2
+	[ ! -d "${base}" ] && base="$(dirname "${base}")"  
+	[ -d "${base}" ] || return 3
+	from="$(ns_realpath "${from}")"
+	base="$(ns_realpath "${base}")"
+	c=0
+	sub="${base}"
+	newsub=""
+	while [ "${from:0:${#sub}}" != "${sub}" ]
+	do
+		newsub="$(dirname "${sub}")"
+		[ "${newsub}" == "${sub}" ] && return 4
+		sub="${newsub}"
+		c="$(expr ${c} + 1)"
+	done
+	res="."
+	for ((i=0;${i}<${c};i++))
+	do
+		res="${res}/.."
+	done
+	res="${res}${from#${sub}}"
+	res="${res#./}"
+	echo "${res}"
+}
+
+ns_realpath()
+{
+	local inputPath=
+	if [ $# -gt 0 ]
+	then
+		inputPath="${1}"
+		shift
+	fi
+	local cwd="$(pwd)"
+	[ -d "${inputPath}" ] && cd "${inputPath}" && inputPath="."
+	while [ -h "${inputPath}" ] ; do inputPath="$(readlink "${inputPath}")"; done
+	
+	if [ -d "${inputPath}" ]
+	then
+		inputPath="$(cd -P "$(dirname "${inputPath}")" && pwd)"
+	else
+		inputPath="$(cd -P "$(dirname "${inputPath}")" && pwd)/$(basename "${inputPath}")"
+	fi
+	
+	cd "${cwd}" 1>/dev/null 2>&1
+	echo "${inputPath}"
+}
+
+scriptFilePath="$(ns_realpath "${0}")"
+scriptPath="$(dirname "${scriptFilePath}")"
+premakeRootPath="$(ns_realpath "${scriptPath}/..")"
+
+kernel="$(uname -s)"
+
+defaultEmbeddedScriptFilePath="${premakeRootPath}/src/host/scripts.c"
+embeddedScriptFilePath="${defaultEmbeddedScriptFilePath}"
+makefileName="Premake5.make"
+defaultOutputDirectory="${premakeRootPath}"
+outputDirectory="${defaultOutputDirectory}"
+defaultTargetDirectory="${premakeRootPath}/bin/release"
+targetDirectory="${defaultTargetDirectory}"
+
+luaSourceDirectoryName="$(find "${premakeRootPath}/src/host" -mindepth 1 -maxdepth 1 -type d -name 'lua*' -exec basename "{}" \;)"
+
+while [ ${#} -gt 0 ]
+do
+	case "${1}" in
+		-o|--output)
+			outputDirectory="${2}"
+			shift
+			
+			if ! mkdir -p "${outputDirectory}"
+			then 
+				echo 'Invalid output directory' 1>&2
+				usage
+				exit 1
+			fi
+		;;
+		-e|--scripts)
+			embeddedScriptFilePath="${2}"
+			if ! mkdir -p "$(dirname "${embeddedScriptFilePath}")"
+			then 
+				echo 'Invalid embedded scripts file directory' 1>&2
+				usage
+				exit 1
+			fi
+			shift
+			
+			embeddedScriptFilePath="$(ns_realpath "$(dirname "${embeddedScriptFilePath}")")/$(basename "${embeddedScriptFilePath}")"
+		;;
+		-t|--target)
+			targetDirectory="${2}"
+			shift
+			
+			if ! mkdir -p "${targetDirectory}"
+			then 
+				echo 'Invalid target directory' 1>&2
+				usage
+				exit 1
+			fi
+			
+			targetDirectory="$(ns_realpath "${targetDirectory}")"
+		;;
+		-h|--help)
+			usage
+			exit 0
+		;;
+		-*)
+			echo "Invalid option '${1}'" 1>&2
+			usage
+			exit 1
+		;;
+		*)
+			echo "Invalid argument '${1}'" 1>&2
+			usage
+			exit 1
+		;;
+	esac
+	
+	shift
+done
+
+####################
+# Check requirements
+
+####################
+# Generate makefile
+
+makefilePath="${outputDirectory}/${makefileName}"
+premakeSourceFiles=("${embeddedScriptFilePath}")
+unset premakeLinkFlags
+premakeBuildFlags=(-Wall -Wextra -Os)
+premakeDefines=(NDEBUG)
+
+# Exclude files, relative to preamke root
+premakeExcludeFiles=(\
+	"src/host/${luaSourceDirectoryName}/src/lauxlib.c" \
+	"src/host/${luaSourceDirectoryName}/src/lua.c" \
+	"src/host/${luaSourceDirectoryName}/src/luac.c" \
+	"src/host/${luaSourceDirectoryName}/src/print.c" \
+)
+
+if [ "${embeddedScriptFilePath}" != "${defaultEmbeddedScriptFilePath}" ]
+then
+	premakeExcludeFiles=("${premakeExcludeFiles[@]}" \
+		"${defaultEmbeddedScriptFilePath#${premakeRootPath}/}"\
+	)
+fi
+
+premakeIncludeDirectories=(\
+	"${premakeRootPath}/src/host" \
+	"${premakeRootPath}/src/host/${luaSourceDirectoryName}/src"\
+)
+
+if [ "${kernel}" = 'Darwin' ]
+then
+	premakeDefines=("${premakeDefines[@]}" LUA_USE_MACOSX)
+	premakeLinkFlags=("${premakeLinkFlags[@]}" -framework CoreServices)
+	premakeBuildFlags=("${premakeBuildFlags[@]}" -mmacosx-version-min=10.4)
+elif [ "${kernel}" = 'Linux' ]
+then
+	premakeDefines=("${premakeDefines[@]}" LUA_USE_POSIX LUA_USE_DLOPEN)
+	premakeLinkFlags=("${premakeLinkFlags[@]}" -rdynamic -ldl -lm)
+# TODO bsd, hurd etc.
+fi
+
+# Create source file list
+while read f
+do
+	r="${f#${premakeRootPath}/}"
+	add=true
+	
+	# Do not add files marked as excluded
+	for x in "${premakeExcludeFiles[@]}"
+	do
+		if [ "${r}" = "${x}" ]
+		then
+			add=false
+			break
+		fi
+	done
+	
+	# Do not add files in etc directory of lua sources
+	[ "${r}" = "${r#src/host/${luaSourceDirectoryName}/etc/}" ] || add=false
+		
+	${add} && 	premakeSourceFiles=("${premakeSourceFiles[@]}" "${f}")
+	
+done << EOF
+$(find "${premakeRootPath}/src" \( -name '*.c' \))
+EOF
+
+# Writing makefile
+cat > "${makefilePath}" << EOF
+# premake
+
+ifndef CC
+	CC = cc
+endif
+
+PREMAKE_SRC := $(for f in "${premakeSourceFiles[@]}"; do
+	echo -e "\t${f} \\"
+done)
+
+EMBEDDED_SCRIPTS_FILE := ${embeddedScriptFilePath}
+TARGETDIR := ${targetDirectory}
+TARGET := \$(TARGETDIR)/premake5
+
+INCLUDES := $(for d in "${premakeIncludeDirectories[@]}"; do
+	echo -e "\t-I'${d}' \\"
+done)
+
+DEFINES := $(for d in "${premakeDefines[@]}"; do
+	echo -e "\t-D${d} \\"
+done)
+
+CFLAGS += \$(INCLUDES) \$(DEFINES)
+CFLAGS += $(echo "${premakeBuildFlags[@]}")
+
+LDFLAGS += ${premakeLinkFlags[@]}
+
+.PHONY: all clean
+
+all: \$(EMBEDDED_SCRIPTS_FILE) \$(TARGET)
+
+\$(EMBEDDED_SCRIPTS_FILE): 
+	@echo Create embedded script file
+	@${scriptPath}/embed.sh -o "$(dirname "${embeddedScriptFilePath}")" -n "$(basename "${embeddedScriptFilePath}")"
+
+\$(TARGETDIR): 
+	@echo Create target directory
+	@mkdir -p "\$(TARGETDIR)" 
+
+\$(TARGET): \$(TARGETDIR) \$(PREMAKE_SRC)
+	@echo Building premake5
+	@\$(CC) \$(CFLAGS) -o "\$(TARGET)" \$(PREMAKE_SRC) \$(LDFLAGS)
+	
+clean:  
+	@echo Cleaning premake5
+	@rm -f "\$(TARGET)"	 
+EOF


### PR DESCRIPTION
Add shell scripts to generate embedded lua scripts file and Makefile to build premake5
* sh/embed.sh: Generate scripts.c like the embed action
* sh/gmake.sh: Generate GNU makefile to build premake5

Changed in "embed" action
* fix inline comments stripping when line starts with whitespace
* strip blank lines
* sort manifest files for better consistency accross platforms

Rationale
One issue I found while building premake is that premake itself is required to build premake. Precompiled binaries are available for Windows and Mac but Linux ones does not work most of the time, especially on ARM.
The two shell scripts of this pull request mimics the "embed" and "gmake" actions. Only bash, perl and sed are required.

Typical usage
```
#  Generate scripts.c in build directory
./sh/embed.sh -o build
#  Generate Premake5.make in build directory
./sh/gmake.sh -o build -e build/scripts.c -t install
# Build premake5 in install directory
make -f build/Premake5.make
```

Tested on Ubuntu 14.04, OS X 10.6 and a Linux BusyBox (ARM)

The changes made to "embed" action are mostly to get a consistent and very similar scripts.c on all platforms