### PR TITLE
Performance improvement by handling edge .. directories during path join

### DIFF
--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -259,6 +259,26 @@
 		test.isequal("p2", path.join(".", "p2"))
 	end
 
+	function suite.join_OnBackToBasePath()
+		test.isequal("", path.join("p1/p2/", "../../"))
+	end
+
+	function suite.join_OnBackToBasePathWithoutFinalSlash()
+		test.isequal("", path.join("p1/p2/", "../.."))
+	end
+
+	function suite.join_OnUptwoFolders()
+		test.isequal("p1/foo", path.join("p1/p2/p3", "../../foo"))
+	end
+
+	function suite.join_OnUptoBase()
+		test.isequal("foo", path.join("p1/p2/p3", "../../../foo"))
+	end
+
+	function suite.join_OnUptoParentOfBase()
+		test.isequal("../../p1", path.join("p1/p2/p3/p4/p5/p6/p7/", "../../../../../../../../../p1"))
+	end
+
 	function suite.join_OnNilSecondPart()
 		test.isequal("p1", path.join("p1", nil))
 	end


### PR DESCRIPTION
On our repository this results in about a 30% performance improvements, because the path.normalize now doesn't have to do as much, and the join can achieve the same result with much less code and less copy-ing of strings.