### PR TITLE
Add system include and library search paths

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -829,6 +829,13 @@
 	}
 
 	api.register {
+		name = "syslibdirs",
+		scope = "config",
+		kind = "list:directory",
+		tokens = true,
+	}
+
+	api.register {
 		name = "system",
 		scope = "config",
 		kind = "string",

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -822,6 +822,13 @@
 	}
 
 	api.register {
+		name = "sysincludedirs",
+		scope = "config",
+		kind = "list:directory",
+		tokens = true,
+	}
+
+	api.register {
 		name = "system",
 		scope = "config",
 		kind = "string",

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -394,7 +394,7 @@
 
 
 	function make.includes(cfg, toolset)
-		local includes = premake.esc(toolset.getincludedirs(cfg, cfg.includedirs))
+		local includes = premake.esc(toolset.getincludedirs(cfg, cfg.includedirs, cfg.sysincludedirs))
 		_p('  INCLUDES +=%s', make.list(includes))
 	end
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -194,6 +194,7 @@
 				m.intDir,
 				m.targetName,
 				m.targetExt,
+				m.includePath,
 				m.imageXexOutput,
 				m.generateManifest,
 				m.extensionsToDeleteOnClean,
@@ -1238,6 +1239,14 @@
 	function m.importLibrary(cfg)
 		if cfg.kind == premake.SHAREDLIB then
 			_x(3,'<ImportLibrary>%s</ImportLibrary>', path.translate(cfg.linktarget.relpath))
+		end
+	end
+
+
+	function m.includePath(cfg)
+		local dirs = vstudio.path(cfg, cfg.sysincludedirs)
+		if #dirs > 0 then
+			p.x('<IncludePath>%s;$(IncludePath)</IncludePath>', table.concat(dirs, ";"))
 		end
 	end
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -195,6 +195,7 @@
 				m.targetName,
 				m.targetExt,
 				m.includePath,
+				m.libraryPath,
 				m.imageXexOutput,
 				m.generateManifest,
 				m.extensionsToDeleteOnClean,
@@ -1292,6 +1293,14 @@
 				end
 				_p(2,'<RootNamespace>%s</RootNamespace>', prj.name)
 			end
+		end
+	end
+
+
+	function m.libraryPath(cfg)
+		local dirs = vstudio.path(cfg, cfg.syslibdirs)
+		if #dirs > 0 then
+			p.x('<LibraryPath>%s;$(LibraryPath)</LibraryPath>', table.concat(dirs, ";"))
 		end
 	end
 

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -131,10 +131,10 @@
 --    An array of symbols with the appropriate flag decorations.
 --
 
-	function clang.getincludedirs(cfg, dirs)
+	function clang.getincludedirs(cfg, dirs, sysdirs)
 
 		-- Just pass through to GCC for now
-		local flags = gcc.getincludedirs(cfg, dirs)
+		local flags = gcc.getincludedirs(cfg, dirs, sysdirs)
 		return flags
 
 	end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -1,13 +1,16 @@
---
+---
 -- gcc.lua
 -- Provides GCC-specific configuration strings.
--- Copyright (c) 2002-2014 Jason Perkins and the Premake project
---
+-- Copyright (c) 2002-2015 Jason Perkins and the Premake project
+---
 
-	premake.tools.gcc = {}
-	local gcc = premake.tools.gcc
-	local project = premake.project
-	local config = premake.config
+	local p = premake
+
+	p.tools.gcc = {}
+	local gcc = p.tools.gcc
+
+	local project = p.project
+	local config = p.config
 
 
 --
@@ -165,7 +168,7 @@
 -- Decorate include file search paths for the GCC command line.
 --
 
-	function gcc.getincludedirs(cfg, dirs)
+	function gcc.getincludedirs(cfg, dirs, sysdirs)
 		local result = {}
 		for _, dir in ipairs(dirs) do
 			dir = project.getrelative(cfg.project, dir)
@@ -238,7 +241,7 @@
 		end
 
 		if cfg.flags.RelativeLinks then
-			for _, dir in ipairs(premake.config.getlinks(cfg, "siblings", "directory")) do
+			for _, dir in ipairs(config.getlinks(cfg, "siblings", "directory")) do
 				local libFlag = "-L" .. premake.project.getrelative(cfg.project, dir)
 				if not table.contains(flags, libFlag) then
 					table.insert(flags, libFlag)
@@ -260,7 +263,7 @@
 
 		if not systemonly then
 			if cfg.flags.RelativeLinks then
-				local libFiles = premake.config.getlinks(cfg, "siblings", "basename")
+				local libFiles = config.getlinks(cfg, "siblings", "basename")
 				for _, link in ipairs(libFiles) do
 					if string.find(link, "lib") == 1 then
 						link = link:sub(4)

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -174,6 +174,10 @@
 			dir = project.getrelative(cfg.project, dir)
 			table.insert(result, '-I' .. premake.quoted(dir))
 		end
+		for _, dir in ipairs(sysdirs or {}) do
+			dir = project.getrelative(cfg.project, dir)
+			table.insert(result, '-isystem ' .. premake.quoted(dir))
+		end
 		return result
 	end
 
@@ -235,7 +239,8 @@
 		local flags = config.mapFlags(cfg, gcc.libraryDirectories)
 
 		-- Scan the list of linked libraries. If any are referenced with
-		-- paths, add those to the list of library search paths
+		-- paths, add those to the list of library search paths. The call
+		-- config.getlinks() all includes cfg.libdirs.
 		for _, dir in ipairs(config.getlinks(cfg, "system", "directory")) do
 			table.insert(flags, '-L' .. premake.quoted(dir))
 		end
@@ -247,6 +252,10 @@
 					table.insert(flags, libFlag)
 				end
 			end
+		end
+
+		for _, dir in ipairs(cfg.syslibdirs) do
+			table.insert(flags, '-L' .. premake.quoted(dir))
 		end
 
 		return flags

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -1,8 +1,10 @@
---
+---
 -- msc.lua
 -- Interface for the MS C/C++ compiler.
--- Copyright (c) 2009-2014 Jason Perkins and the Premake project
---
+-- Author Jason Perkins
+-- Modified by Manu Evans
+-- Copyright (c) 2009-2015 Jason Perkins and the Premake project
+---
 
 
 	premake.tools.msc = {}
@@ -160,8 +162,9 @@
 -- Decorate include file search paths for the MSVC command line.
 --
 
-	function msc.getincludedirs(cfg, dirs)
+	function msc.getincludedirs(cfg, dirs, sysdirs)
 		local result = {}
+		dirs = table.join(dirs, sysdirs)
 		for _, dir in ipairs(dirs) do
 			dir = project.getrelative(cfg.project, dir)
 			table.insert(result, '-I' ..  premake.quoted(dir))
@@ -214,7 +217,8 @@
 
 	function msc.getLibraryDirectories(cfg)
 		local flags = {}
-		for i, dir in ipairs(cfg.libdirs) do
+		local dirs = table.join(cfg.libdirs, cfg.syslibdirs)
+		for i, dir in ipairs(dirs) do
 			dir = project.getrelative(cfg.project, dir)
 			table.insert(flags, '/LIBPATH:"' .. dir .. '"')
 		end

--- a/tests/actions/vstudio/vc2010/test_output_props.lua
+++ b/tests/actions/vstudio/vc2010/test_output_props.lua
@@ -273,3 +273,18 @@
 	</PropertyGroup>
 		]]
 	end
+
+	function suite.onSystemLibraryDirs()
+		syslibdirs { "$(DXSDK_DIR)/lib/x86" }
+		prepare()
+		test.capture [[
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+		<LinkIncremental>true</LinkIncremental>
+		<OutDir>.\</OutDir>
+		<IntDir>obj\Debug\</IntDir>
+		<TargetName>MyProject</TargetName>
+		<TargetExt>.exe</TargetExt>
+		<LibraryPath>$(DXSDK_DIR)\lib\x86;$(LibraryPath)</LibraryPath>
+	</PropertyGroup>
+		]]
+	end

--- a/tests/actions/vstudio/vc2010/test_output_props.lua
+++ b/tests/actions/vstudio/vc2010/test_output_props.lua
@@ -253,3 +253,23 @@
 	</PropertyGroup>
 		]]
 	end
+
+
+--
+-- Check the handling of the VC++ Directories.
+--
+
+	function suite.onSystemIncludeDirs()
+		sysincludedirs { "$(DXSDK_DIR)/Include" }
+		prepare()
+		test.capture [[
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+		<LinkIncremental>true</LinkIncremental>
+		<OutDir>.\</OutDir>
+		<IntDir>obj\Debug\</IntDir>
+		<TargetName>MyProject</TargetName>
+		<TargetExt>.exe</TargetExt>
+		<IncludePath>$(DXSDK_DIR)\Include;$(IncludePath)</IncludePath>
+	</PropertyGroup>
+		]]
+	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -476,3 +476,20 @@
 		prepare()
 		test.contains({ "-fstrict-aliasing", "-Wstrict-aliasing=3" }, gcc.getcflags(cfg))
 	end
+
+
+--
+-- Check handling of system search paths.
+--
+
+	function suite.includeDirs_onSysIncludeDirs()
+		sysincludedirs { "/usr/local/include" }
+		prepare()
+		test.contains("-isystem /usr/local/include", gcc.getincludedirs(cfg, cfg.includedirs, cfg.sysincludedirs))
+	end
+
+	function suite.libDirs_onSysLibDirs()
+		syslibdirs { "/usr/local/lib" }
+		prepare()
+		test.contains("-L/usr/local/lib", gcc.getLibraryDirectories(cfg))
+	end

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -302,3 +302,20 @@
 		prepare()
 		test.contains("/clr:pure", msc.getcflags(cfg))
 	end
+
+
+--
+-- Check handling of system search paths.
+--
+
+	function suite.includeDirs_onSysIncludeDirs()
+		sysincludedirs { "/usr/local/include" }
+		prepare()
+		test.contains("-I/usr/local/include", msc.getincludedirs(cfg, cfg.includedirs, cfg.sysincludedirs))
+	end
+
+	function suite.libDirs_onSysLibDirs()
+		syslibdirs { "/usr/local/lib" }
+		prepare()
+		test.contains('/LIBPATH:"/usr/local/lib"', msc.getLibraryDirectories(cfg))
+	end


### PR DESCRIPTION
Adds sysincludedir() and syslibdir() APIs, which are added to the "VC++ Directories" in Visual Studio, and decorated with -isystem and -L for GCC and Clang.