### PR TITLE
Restore ordering of include file search paths

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -902,12 +902,10 @@
 
 	function m.additionalIncludeDirectories(cfg, includedirs)
 		if #includedirs > 0 then
-			local dirs = project.getrelative(cfg.project, includedirs)
+			local dirs = vstudio.path(cfg.project, includedirs)
 			dirs = table.filterempty(dirs)
-
 			if #dirs > 0 then
-				table.sort(dirs)
-				p.x('<AdditionalIncludeDirectories>%s;%%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>', path.translate(table.concat(dirs, ";")))
+				p.x('<AdditionalIncludeDirectories>%s;%%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>', table.concat(dirs, ";"))
 			end
 		end
 	end


### PR DESCRIPTION
Sorry I didn't catch this sooner, but we need to maintain control over the ordering of the include file search paths. I removed the table.sort() call, and since I was in there swapped out the path.getrelative() and path.translate() with the new vstudio.path() call.