### PR TITLE
Prevent environment variables from being trimmed out by path.join()

### DIFF
--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -307,6 +307,15 @@
 		test.isequal("/Users", path.join("/", "Users"))
 	end
 
+	function suite.join_keepsLeadingEnvVar()
+		test.isequal("$(ProjectDir)/../../Bin", path.join("$(ProjectDir)", "../../Bin"))
+	end
+
+	function suite.join_keepsInternalEnvVar()
+		test.isequal("$(ProjectDir)/$(TargetName)/../../Bin", path.join("$(ProjectDir)/$(TargetName)", "../../Bin"))
+	end
+
+
 
 --
 -- path.rebase() tests


### PR DESCRIPTION
Fix an edge case in the new path.join() logic.

This fix makes sure that this code returns "$(ProjectDir)/../../Bin" and not "../Bin".

```lua
path.join("$(ProjectDir)", "../../Bin")
```

