### PR TITLE
Added D language submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "modules/codelite"]
 	path = modules/codelite
 	url = https://github.com/premake/premake-codelite.git
+[submodule "modules/d"]
+	path = modules/d
+	url = https://github.com/premake/premake-dlang.git


### PR DESCRIPTION
Add the dlang submodule.
This will ideally offer perspective while reworking the C/C++ tools... and it will lead to a nice press-release on the dlang forum that premake officially supports D ;)

`language "D"` is supported for gmake, vs20xx, and monodevelop.