### PR TITLE
add "system" to the filter for solutions, so we can do system specific solution configurations.

### DIFF
--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -64,6 +64,9 @@
 		context.addFilter(self, "_ACTION", _ACTION)
 		context.addFilter(self, "action", _ACTION)
 
+		self.system = self.system or p.action.current().os or os.get()
+		context.addFilter(self, "system", self.system)
+
 		-- Add command line options to the filtering options
 
 		local options = {}


### PR DESCRIPTION
this allows you to write:

```
solution "foo"
     filter { "system:win32" }
         platforms { "x86", "x86_64" }
     filter { "system:linux" }
         platforms { "x86_64" }
```
