### PR TITLE
Add bootstrap scripts to create premake initial executable

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -26,7 +26,15 @@ BUILDING FROM A SOURCE PACKAGE
 
 BUILDING FROM THE REPOSITORY
 
- If you have pulled sources from the Premake source repository, you will need
+ If you have pulled sources from the Premake source repository, you can run
+ the `bootstrap.sh` or `bootstrap.bat` script to generate your first premake
+ executable.
+
+    $ git submodule init
+    $ git submodule update
+    $ ./bootstrap.sh
+
+ If your toolset is not supported by the bootstrap script, you will need
  to embed the scripts into a C source file so they may be built into the
  executable, and also generate the project files for your chosen toolset. In
  order do either of these things, you will need a working Premake executable.

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,0 +1,58 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem Detect Visual Studio Version
+
+if not "%VS140COMNTOOLS%" == "" (
+  set _VSCOMMON="%VS140COMNTOOLS%"
+  set _VSVERSION=vs2015
+) else ( if not "%VS120COMNTOOLS%" == "" (
+  set _VSCOMMON="%VS120COMNTOOLS%"
+  set _VSVERSION=vs2013
+) else ( if not "%VS110COMNTOOLS%" == "" (
+  set _VSCOMMON="%VS110COMNTOOLS%"
+  set _VSVERSION=vs2012
+) else (
+  echo Visual Studio 2012, 2013 or 2014 not found!
+  exit /B 1
+) ) )
+
+echo Found %_VSVERSION%
+call %_VSCOMMON%vsvars32.bat
+
+rem Figure out which source files we want
+
+set LUA_SRC_DIR=%~dp0src\host\lua-5.1.4\src
+set SRC_DIR=%~dp0src\host
+set BOOTSTRAP_DIR=%~dp0build\bootstrap
+
+set SRC=
+for %%i in ("%SRC_DIR%\*.c") do (
+    if "%%i" == "%SRC_DIR%\scripts.c" ( rem
+    ) else ( set SRC=!SRC!"%%i" )
+)
+
+set LUA_SRC=
+for %%i in ("%LUA_SRC_DIR%\*.c") do (
+    if "%%i" == "%LUA_SRC_DIR%\lauxlib.c" ( rem
+	) else if "%%i" == "%LUA_SRC_DIR%\lua.c" ( rem
+	) else if "%%i" == "%LUA_SRC_DIR%\luac.c" ( rem
+	) else if "%%i" == "%LUA_SRC_DIR%\print.c" ( rem
+    ) else ( set LUA_SRC=!LUA_SRC!"%%i" )
+)
+
+rem Build a bootstrap executable
+
+IF NOT EXIST "%BOOTSTRAP_DIR%" ( mkdir "%BOOTSTRAP_DIR%" )
+cd "%BOOTSTRAP_DIR%"
+cl /Fepremake_bootstrap.exe /DPREMAKE_NO_BUILTIN_SCRIPTS /I"%LUA_SRC_DIR%" %LUA_SRC% %SRC% user32.lib ole32.lib
+cd %~dp0
+
+rem Embed scripts and build premake on the detected version of Visual Studio
+
+"%BOOTSTRAP_DIR%"\premake_bootstrap embed
+"%BOOTSTRAP_DIR%"\premake_bootstrap %_VSVERSION% --to="%BOOTSTRAP_DIR%"
+msbuild.exe "%BOOTSTRAP_DIR%"\Premake5.sln -nologo -consoleloggerparameters:NoSummary;Verbosity=minimal -m -p:Configuration=Release
+
+echo Bootstrap complete.
+echo %~dp0bin\release\premake5.exe

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -e
+TOP="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/. && pwd )"
+
+UNAME=`uname`
+case $UNAME in
+'Darwin')
+    EXTRA_PREMAKE_CFLAGS="-framework CoreServices"
+    CC=${CC-clang}
+    ;;
+'Linux')
+    EXTRA_PREMAKE_CFLAGS="-lm"
+    CC=${CC-gcc}
+    ;;
+MINGW32*)
+
+    # Use gcc on mingw if we have it,
+    # Otherwise chain to the Visual Studio bootstrap.
+
+    if [ "$CC" == "" ] ; then
+        if [ "$(which mingw32-gcc)" != "" ] ; then
+            CC="mingw32-gcc"
+        elif [ "$(which gcc)" != "" ] ; then
+            CC="gcc"
+        fi
+    fi
+
+    if [ "$MAKE" == "" ] ; then
+        if [ "$(which mingw32-make)" != "" ] ; then
+            MAKE="mingw32-make"
+        fi
+    fi
+
+    if [ "$CC" == "" ] || [ "$MAKE" == "" ] ; then
+        echo "MinGW bootstrap did not find GCC, using Visual Studio"
+        exec cmd //C "bootstrap.bat"
+    fi
+
+    EXTRA_PREMAKE_CFLAGS="-lole32"
+    export CC # So mingw32-make uses the CC we selected
+
+    echo "MinGW bootstrap found GCC, using $CC and $MAKE"
+    ;;
+*)
+    echo "$0: Don't know how to bootstrap on '$UNAME'"
+    exit 1
+    ;;
+esac
+
+MAKE=${MAKE-make}
+
+# Figure out which source files we want
+
+LUA_SRC_DIR="$TOP/src/host/lua-5.1.4/src"
+SRC_DIR="$TOP/src/host"
+BOOTSTRAP_DIR="$TOP/build/bootstrap"
+
+SRC=()
+for i in "$SRC_DIR"/*.c; do
+    case $i in
+		$SRC_DIR/scripts.c)   ;;
+        *)
+            SRC=("${SRC[@]}" "${i}")
+            ;;
+    esac
+done
+
+LUA_SRC=()
+for i in "$LUA_SRC_DIR"/*.c; do
+    case $i in
+		$LUA_SRC_DIR/lauxlib.c)   ;;
+		$LUA_SRC_DIR/lua.c)       ;;
+		$LUA_SRC_DIR/luac.c)      ;;
+		$LUA_SRC_DIR/print.c)     ;;
+        *)
+            LUA_SRC=("${LUA_SRC[@]}" "${i}")
+            ;;
+    esac
+done
+
+# Build a bootstrap executable
+
+mkdir -p "$BOOTSTRAP_DIR"
+cd "$BOOTSTRAP_DIR"
+
+$CC -o premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$LUA_SRC_DIR" "${LUA_SRC[@]}" "${SRC[@]}" $EXTRA_PREMAKE_CFLAGS
+
+cd "$TOP"
+
+# Embed scripts and build premake
+
+"$BOOTSTRAP_DIR/premake_bootstrap" embed
+"$BOOTSTRAP_DIR/premake_bootstrap" --to="$BOOTSTRAP_DIR" gmake
+"$MAKE" -C "$BOOTSTRAP_DIR"
+
+echo Bootstrap complete.
+echo $TOP/bin/release/premake5
+
+
+
+

--- a/scripts/package.lua
+++ b/scripts/package.lua
@@ -129,7 +129,7 @@
 		for _, name in ipairs { ".git" } do
 			os.rmdir(path.join(module, name))
 		end
-		for _, name in ipairs { ".DS_Store", ".git", ".gitignore", ".gitmodules", ".travis.yml", ".editorconfig" } do
+		for _, name in ipairs { ".DS_Store", ".git", ".gitignore", ".gitmodules", ".travis.yml", ".editorconfig", "bootstrap.sh", "bootstrap.bat" } do
 			os.remove(path.join(module, name))
 		end
 	end

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -293,6 +293,7 @@ int premake_test_file(lua_State* L, const char* filename, int searchMask)
 		if (path && do_locate(L, filename, path)) return OKAY;
 	}
 
+	#if !defined(PREMAKE_NO_BUILTIN_SCRIPTS)
 	if ((searchMask & TEST_EMBEDDED) != 0) {
 		/* Try to locate a record matching the filename */
 		for (i = 0; builtin_scripts_index[i] != NULL; ++i) {
@@ -304,6 +305,7 @@ int premake_test_file(lua_State* L, const char* filename, int searchMask)
 			}
 		}
 	}
+	#endif
 
 	return !OKAY;
 }
@@ -475,12 +477,14 @@ int premake_load_embedded_script(lua_State* L, const char* filename)
 #endif
 
 	/* Try to locate a record matching the filename */
+	#if !defined(PREMAKE_NO_BUILTIN_SCRIPTS)
 	for (i = 0; builtin_scripts_index[i] != NULL; ++i) {
 		if (strcmp(builtin_scripts_index[i], filename) == 0) {
 			chunk = builtin_scripts[i];
 			break;
 		}
 	}
+	#endif
 
 	if (chunk == NULL) {
 		return !OKAY;


### PR DESCRIPTION
On a fresh clone, `bootstrap.sh` or `bootstrap.bat` can be used to prepare the initial premake executable on Windows, OSX and Linux.
The bootstrap scripts are stripped from the source releases.