### PR TITLE
Add Visual Studio calling convention support

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -467,6 +467,18 @@
 	}
 
 	api.register {
+		name = "callingconvention",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Cdecl",
+			"FastCall",
+			"StdCall",
+			"VectorCall",
+		}
+	}
+
+	api.register {
 		name = "forceincludes",
 		scope = "config",
 		kind = "list:mixed",

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -322,6 +322,7 @@
 			m.multiProcessorCompilation,
 			m.additionalCompileOptions,
 			m.compileAs,
+			m.callingConvention,
 		}
 	end
 
@@ -1599,7 +1600,11 @@
 		end
 	end
 
-
+	function m.callingConvention(cfg)
+		if cfg.callingconvention then
+			p.w('<CallingConvention>%s</CallingConvention>', cfg.callingconvention)
+		end
+	end
 
 	function m.runtimeTypeInfo(cfg)
 		if cfg.flags.NoRTTI and cfg.clr == p.OFF then

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -46,6 +46,12 @@
 			Fast = "/fp:fast",
 			Strict = "/fp:strict",
 		},
+		callingconvention = {
+			Cdecl = "/Gd",
+			FastCall = "/Gr",
+			StdCall = "/Gz",
+			VectorCall = "/Gv",
+		},
 		optimize = {
 			Off = "/Od",
 			On = "/Ot",


### PR DESCRIPTION
Add callingconvention directive, possible values are: Cdecl, FastCall, StdCall or VectorCall.