### PR TITLE
Enable Makefile environment overrides for CC,CXX and AR.

### DIFF
--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -359,17 +359,23 @@
 	function make.cppTools(cfg, toolset)
 		local tool = toolset.gettoolname(cfg, "cc")
 		if tool then
-			_p('  CC = %s', tool)
+			_p('  ifeq ($(origin CC), default)')
+			_p('    CC = %s', tool)
+			_p('  endif' )
 		end
 
 		tool = toolset.gettoolname(cfg, "cxx")
 		if tool then
-			_p('  CXX = %s', tool)
+			_p('  ifeq ($(origin CXX), default)')
+			_p('    CXX = %s', tool)
+			_p('  endif' )
 		end
 
 		tool = toolset.gettoolname(cfg, "ar")
 		if tool then
-			_p('  AR = %s', tool)
+			_p('  ifeq ($(origin AR), default)')
+			_p('    AR = %s', tool)
+			_p('  endif' )
 		end
 
 		tool = toolset.gettoolname(cfg, "rc")

--- a/tests/actions/make/cpp/test_clang.lua
+++ b/tests/actions/make/cpp/test_clang.lua
@@ -31,9 +31,15 @@
 		make.cppConfigs(prj)
 		test.capture [[
 ifeq ($(config),debug)
-  CC = clang
-  CXX = clang++
-  AR = ar
+  ifeq ($(origin CC), default)
+    CC = clang
+  endif
+  ifeq ($(origin CXX), default)
+    CXX = clang++
+  endif
+  ifeq ($(origin AR), default)
+    AR = ar
+  endif
   		]]
 	end
 


### PR DESCRIPTION
Overriding toolchains from the command line is useful when swapping between compilers.
For example: `CC=gcc-4.8.1 make -C build`

CC can be set by make itself so we can use following idiom to allow overrides:

     CC ?= cc
       ifeq ($(origin CC), default)
       CC = cc
     endif

If the value is not set, or if it's set to the default make value, then use the premake defined value, otherwise leave it alone.