### PR TITLE
add new exceptionhandling and rtti API's, deprecate the corresponding flags.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -24,14 +24,14 @@
 		kind = "string",
 		allowed = {
 			"universal",
-			"x86",
-			"x86_64",
+			p.X86,
+			p.X86_64,
 		},
 		aliases = {
-			i386 = "x86",
-			amd64 = "x86_64",
-			x32 = "x86",	-- these should be DEPRECATED
-			x64 = "x86_64",
+			i386  = p.X86,
+			amd64 = p.X86_64,
+			x32   = p.X86,	-- these should be DEPRECATED
+			x64   = p.X86_64,
 		},
 	}
 
@@ -343,19 +343,34 @@
 	api.register {
 		name = "editandcontinue",
 		scope = "config",
-		kind = "boolean",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off",
+		},
 	}
 
 	api.register {
 		name = "exceptionhandling",
 		scope = "config",
-		kind = "boolean",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off",
+		},
 	}
 
 	api.register {
 		name = "rtti",
 		scope = "config",
-		kind = "boolean",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off",
+		},
 	}
 
 	api.register {
@@ -1264,9 +1279,6 @@
 -----------------------------------------------------------------------------
 
 	clr "Off"
-	editandcontinue "On"
-	exceptionhandling "On"
-	rtti "On"
 
 	-- Setting a default language makes some validation easier later
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -347,6 +347,18 @@
 	}
 
 	api.register {
+		name = "exceptionhandling",
+		scope = "config",
+		kind = "boolean",
+	}
+
+	api.register {
+		name = "rtti",
+		scope = "config",
+		kind = "boolean",
+	}
+
+	api.register {
 		name = "enablewarnings",
 		scope = "config",
 		kind = "list:string",
@@ -416,7 +428,7 @@
 			"No64BitChecks",
 			"NoCopyLocal",
 			"NoEditAndContinue",   -- DEPRECATED
-			"NoExceptions",
+			"NoExceptions",        -- DEPRECATED
 			"NoFramePointer",
 			"NoImplicitLink",
 			"NoImportLib",
@@ -426,7 +438,7 @@
 			"NoNativeWChar",       -- DEPRECATED
 			"NoPCH",
 			"NoRuntimeChecks",
-			"NoRTTI",
+			"NoRTTI",              -- DEPRECATED
 			"NoBufferSecurityCheck",
 			"NoWarnings",          -- DEPRECATED
 			"OmitDefaultLibrary",
@@ -1118,6 +1130,24 @@
 	end)
 
 
+	api.deprecateValue("flags", "NoExceptions", nil,
+	function(value)
+		exceptionhandling "Off"
+	end,
+	function(value)
+		exceptionhandling "On"
+	end)
+
+
+	api.deprecateValue("flags", "NoRTTI", nil,
+	function(value)
+		rtti "Off"
+	end,
+	function(value)
+		rtti "On"
+	end)
+
+
 	api.deprecateValue("flags", "Unsafe", nil,
 	function(value)
 		clr "Unsafe"
@@ -1235,6 +1265,8 @@
 
 	clr "Off"
 	editandcontinue "On"
+	exceptionhandling "On"
+	rtti "On"
 
 	-- Setting a default language makes some validation easier later
 

--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -753,10 +753,10 @@
 			return 1
 		else
 			-- Edit-and-continue doesn't work for some configurations
-			if not cfg.editandcontinue or
-				config.isOptimizedBuild(cfg) or
-			    cfg.clr ~= p.OFF or
-			    cfg.architecture == p.X86_64
+			if cfg.editandcontinue == p.OFF or
+			   config.isOptimizedBuild(cfg) or
+			   cfg.clr ~= p.OFF or
+			   cfg.architecture == p.X86_64
 			then
 				return 3
 			else
@@ -1122,7 +1122,7 @@
 
 
 	function m.exceptionHandling(cfg)
-		if cfg.exceptionhandling == false then
+		if cfg.exceptionhandling == p.OFF then
 			p.w('ExceptionHandling="%s"', iif(_ACTION < "vs2005", "FALSE", 0))
 		elseif cfg.flags.SEH and _ACTION > "vs2003" then
 			p.w('ExceptionHandling="2"')
@@ -1519,8 +1519,10 @@
 
 
 	function m.runtimeTypeInfo(cfg)
-		if cfg.rtti == false and cfg.clr == p.OFF then
+		if cfg.rtti == p.OFF and cfg.clr == p.OFF then
 			p.w('RuntimeTypeInfo="false"')
+		elseif cfg.rtti == p.ON then
+			p.w('RuntimeTypeInfo="true"')
 		end
 	end
 

--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -1122,7 +1122,7 @@
 
 
 	function m.exceptionHandling(cfg)
-		if cfg.flags.NoExceptions then
+		if cfg.exceptionhandling == false then
 			p.w('ExceptionHandling="%s"', iif(_ACTION < "vs2005", "FALSE", 0))
 		elseif cfg.flags.SEH and _ACTION > "vs2003" then
 			p.w('ExceptionHandling="2"')
@@ -1519,7 +1519,7 @@
 
 
 	function m.runtimeTypeInfo(cfg)
-		if cfg.flags.NoRTTI and cfg.clr == p.OFF then
+		if cfg.rtti == false and cfg.clr == p.OFF then
 			p.w('RuntimeTypeInfo="false"')
 		end
 	end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1097,10 +1097,14 @@
 
 
 	function m.exceptionHandling(cfg)
-		if cfg.flags.NoExceptions then
+		if cfg.exceptionhandling == false then
 			p.w('<ExceptionHandling>false</ExceptionHandling>')
-		elseif cfg.flags.SEH then
-			p.w('<ExceptionHandling>Async</ExceptionHandling>')
+		elseif cfg.exceptionhandling == true then
+			if cfg.flags.SEH then
+				p.w('<ExceptionHandling>Async</ExceptionHandling>')
+			else
+				p.w('<ExceptionHandling>Sync</ExceptionHandling>')
+			end
 		end
 	end
 
@@ -1608,8 +1612,10 @@
 	end
 
 	function m.runtimeTypeInfo(cfg)
-		if cfg.flags.NoRTTI and cfg.clr == p.OFF then
-			_p(3,'<RuntimeTypeInfo>false</RuntimeTypeInfo>')
+		if cfg.rtti == false and cfg.clr == p.OFF then
+			p.w('<RuntimeTypeInfo>false</RuntimeTypeInfo>')
+		elseif cfg.rtti == true then
+			p.w('<RuntimeTypeInfo>true</RuntimeTypeInfo>')
 		end
 	end
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -919,6 +919,7 @@
 		end
 	end
 
+
 	function m.additionalUsingDirectories(cfg)
 		if #cfg.usingdirs > 0 then
 			local dirs = table.concat(vstudio.path(cfg, cfg.usingdirs), ";")
@@ -1041,7 +1042,7 @@
 			elseif cfg.architecture == "x86_64" or
 				   cfg.clr ~= p.OFF or
 				   config.isOptimizedBuild(cfg) or
-				   not cfg.editandcontinue
+				   cfg.editandcontinue == p.OFF
 			then
 				value = "ProgramDatabase"
 			else
@@ -1097,9 +1098,9 @@
 
 
 	function m.exceptionHandling(cfg)
-		if cfg.exceptionhandling == false then
+		if cfg.exceptionhandling == p.OFF then
 			p.w('<ExceptionHandling>false</ExceptionHandling>')
-		elseif cfg.exceptionhandling == true then
+		elseif cfg.exceptionhandling == p.ON or cfg.flags.SEH then
 			if cfg.flags.SEH then
 				p.w('<ExceptionHandling>Async</ExceptionHandling>')
 			else
@@ -1612,9 +1613,9 @@
 	end
 
 	function m.runtimeTypeInfo(cfg)
-		if cfg.rtti == false and cfg.clr == p.OFF then
+		if cfg.rtti == p.OFF and cfg.clr == p.OFF then
 			p.w('<RuntimeTypeInfo>false</RuntimeTypeInfo>')
-		elseif cfg.rtti == true then
+		elseif cfg.rtti == p.ON then
 			p.w('<RuntimeTypeInfo>true</RuntimeTypeInfo>')
 		end
 	end

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -30,6 +30,8 @@
 	premake.MACOSX      = "macosx"
 	premake.MAKEFILE    = "Makefile"
 	premake.NONE        = "None"
+	premake.DEFAULT     = "Default"
+	premake.ON          = "On"
 	premake.OFF         = "Off"
 	premake.POSIX       = "posix"
 	premake.PS3         = "ps3"

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -320,7 +320,7 @@
 
 	function config.getruntime(cfg)
 		local linkage = iif(cfg.flags.StaticRuntime, "Static", "Shared")
-		if (cfg.runtime == nil) then
+		if not cfg.runtime then
 			return linkage .. iif(config.isDebugBuild(cfg), "Debug", "Release")
 		else
 			return linkage .. cfg.runtime

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -107,8 +107,6 @@
 
 	gcc.cxxflags = {
 		flags = {
-			NoExceptions = "-fno-exceptions",
-			NoRTTI = "-fno-rtti",
 			NoBufferSecurityCheck = "-fno-stack-protector",
 			["C++11"] = "-std=c++11",
 			["C++14"] = "-std=c++14",
@@ -117,6 +115,12 @@
 
 	function gcc.getcxxflags(cfg)
 		local flags = config.mapFlags(cfg, gcc.cxxflags)
+		if not cfg.exceptionhandling then
+			table.insert(flags, '-fno-exceptions')
+		end
+		if not cfg.rtti then
+			table.insert(flags, '-fno-rtti')
+		end
 		return flags
 	end
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -115,10 +115,10 @@
 
 	function gcc.getcxxflags(cfg)
 		local flags = config.mapFlags(cfg, gcc.cxxflags)
-		if not cfg.exceptionhandling then
+		if cfg.exceptionhandling == p.OFF then
 			table.insert(flags, '-fno-exceptions')
 		end
-		if not cfg.rtti then
+		if cfg.rtti == p.OFF then
 			table.insert(flags, '-fno-rtti')
 		end
 		return flags

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -103,16 +103,13 @@
 -- Returns list of C++ compiler flags for a configuration.
 --
 
-	msc.cxxflags = {
-		flags = {
-			NoRTTI = "/GR-",
-		}
-	}
-
 	function msc.getcxxflags(cfg)
-		local flags = config.mapFlags(cfg, msc.cxxflags)
+		local flags = {}
 
-		if not cfg.flags.SEH and not cfg.flags.NoExceptions then
+		if cfg.rtti == false then
+			table.insert(flags, "/GR-")
+		end
+		if not cfg.flags.SEH and cfg.exceptionhandling then
 			table.insert(flags, "/EHsc")
 		end
 

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -106,11 +106,16 @@
 	function msc.getcxxflags(cfg)
 		local flags = {}
 
-		if cfg.rtti == false then
+		if cfg.rtti == premake.OFF then
 			table.insert(flags, "/GR-")
 		end
-		if not cfg.flags.SEH and cfg.exceptionhandling then
-			table.insert(flags, "/EHsc")
+
+		if cfg.exceptionhandling == premake.ON or cfg.flags.SEH then
+			if cfg.flags.SEH then
+				table.insert(flags, "/EHa")
+			else
+				table.insert(flags, "/EHsc")
+			end
 		end
 
 		return flags

--- a/src/tools/snc.lua
+++ b/src/tools/snc.lua
@@ -41,20 +41,20 @@
 -- Retrieve the CXXFLAGS for a specific configuration.
 --
 
-	snc.cxxflags = {
-		NoExceptions   = "-Xc-=exceptions",
-		NoRTTI         = "-Xc-=rtti",
-	}
-
 	function snc.getcxxflags(cfg)
-		local flags = table.translate(cfg.flags, snc.cxxflags)
+		local flags = {}
 
 		-- turn on exceptions and RTTI by default, to match other toolsets
-		if not cfg.flags.NoExceptions then
+		if cfg.exceptionhandling then
 			table.insert(flags, "-Xc+=exceptions")
+		else 
+			table.insert(flags, "-Xc-=exceptions")
 		end
-		if not cfg.flags.NoRTTI then
+
+		if cfg.rtti then
 			table.insert(flags, "-Xc+=rtti")
+		else
+			table.insert(flags, "-Xc-=rtti")
 		end
 
 		return flags

--- a/src/tools/snc.lua
+++ b/src/tools/snc.lua
@@ -45,15 +45,15 @@
 		local flags = {}
 
 		-- turn on exceptions and RTTI by default, to match other toolsets
-		if cfg.exceptionhandling then
+		if cfg.exceptionhandling == p.ON then
 			table.insert(flags, "-Xc+=exceptions")
-		else 
+		elseif cfg.exceptionhandling == p.OFF then
 			table.insert(flags, "-Xc-=exceptions")
 		end
 
-		if cfg.rtti then
+		if cfg.rtti == p.ON then
 			table.insert(flags, "-Xc+=rtti")
-		else
+		elseif cfg.rtti == p.OFF then
 			table.insert(flags, "-Xc-=rtti")
 		end
 

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -36,6 +36,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -221,6 +223,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -233,6 +237,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -294,6 +300,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<AdditionalOptions>/xyz /abc %(AdditionalOptions)</AdditionalOptions>
 		]]
 	end
@@ -440,6 +448,8 @@
 	<WarningLevel>Level3</WarningLevel>
 	<DebugInformationFormat>EditAndContinue</DebugInformationFormat>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -475,6 +485,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
 		]]
 	end
@@ -487,6 +499,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
 		]]
 	end
@@ -528,11 +542,12 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
 	<RuntimeTypeInfo>false</RuntimeTypeInfo>
 		]]
 	end
 
-	function suite.runtimeTypeInfo_onNoRTTI()
+	function suite.runtimeTypeInfo_onNoBufferSecurityCheck()
 		flags "NoBufferSecurityCheck"
 		prepare()
 		test.capture [[
@@ -540,6 +555,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<BufferSecurityCheck>false</BufferSecurityCheck>
 		]]
 	end
@@ -686,6 +703,8 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<MinimalRebuild>false</MinimalRebuild>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<MultiProcessorCompilation>true</MultiProcessorCompilation>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -36,8 +36,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -223,8 +221,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -237,8 +233,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -300,8 +294,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<AdditionalOptions>/xyz /abc %(AdditionalOptions)</AdditionalOptions>
 		]]
 	end
@@ -448,8 +440,6 @@
 	<WarningLevel>Level3</WarningLevel>
 	<DebugInformationFormat>EditAndContinue</DebugInformationFormat>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -485,8 +475,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
 		]]
 	end
@@ -499,8 +487,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
 		]]
 	end
@@ -542,7 +528,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
 	<RuntimeTypeInfo>false</RuntimeTypeInfo>
 		]]
 	end
@@ -555,8 +540,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<BufferSecurityCheck>false</BufferSecurityCheck>
 		]]
 	end
@@ -703,8 +686,6 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<MinimalRebuild>false</MinimalRebuild>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<MultiProcessorCompilation>true</MultiProcessorCompilation>
 		]]
 	end

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -228,8 +228,15 @@
 --
 
 	function suite.cflags_onExceptions()
+		exceptionhandling "on"
 		prepare()
 		test.contains("/EHsc", msc.getcxxflags(cfg))
+	end
+
+	function suite.cflags_onSEH()
+		flags "SEH"
+		prepare()
+		test.contains("/EHa", msc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_onNoExceptions()


### PR DESCRIPTION
OK,

So with the "flags" system, you can set a flags, and later possibly remove it, which reverts the behavior to the "default" system behavior... which is not what I want... sometime I want to explicitly turn things ON or OFF, such as with these values..

I don't want to have an external project having to add a "removeflags { "NoExceptions" }", because it needs exception handling, just because someone might add the flag. But more importantly, removeflags is just not enough, it only allows me to get the default behavior, which may or may not be exceptionhandling enabled.

So internally, we're deprecating ALL flags that have to do with compiler settings, and make proper API out of it...

The question in this case is however, should we have "on", "off" and "default" as possible flags, or should it just be "on" and "off" like what I have in this commit... The downside is pretty obvious to just having "on" and "off", since it invalidated a bunch of tests which I fixed, but it basically now always outputs these flags into the visual studio project... with "default" we could get around that, where "default" would mean, don't output anything into the vcxproj. But, if we go that route, I would want the same for "editandcontinue"
