### PR TITLE
stricter fix for /O2 not liking /RTC1, only when using the debug runtime.

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -944,7 +944,8 @@
 
 
 	function m.basicRuntimeChecks(cfg)
-		if cfg.flags.NoRuntimeChecks or config.isOptimizedBuild(cfg) then
+		local runtime = config.getruntime(cfg)
+		if cfg.flags.NoRuntimeChecks or (config.isOptimizedBuild(cfg) and runtime:endswith("Debug")) then
 			p.w('<BasicRuntimeChecks>Default</BasicRuntimeChecks>')
 		end
 	end
@@ -1591,7 +1592,7 @@
 
 	function m.runtimeLibrary(cfg)
 		local runtimes = {
-			StaticDebug = "MultiThreadedDebug",
+			StaticDebug   = "MultiThreadedDebug",
 			StaticRelease = "MultiThreaded",
 		}
 		local runtime = runtimes[config.getruntime(cfg)]

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -160,7 +160,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
 	<Optimization>Full</Optimization>
 	<FunctionLevelLinking>true</FunctionLevelLinking>
 	<IntrinsicFunctions>true</IntrinsicFunctions>
@@ -176,7 +175,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
 	<Optimization>MinSpace</Optimization>
 	<FunctionLevelLinking>true</FunctionLevelLinking>
 	<IntrinsicFunctions>true</IntrinsicFunctions>
@@ -192,7 +190,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
 	<Optimization>MaxSpeed</Optimization>
 	<FunctionLevelLinking>true</FunctionLevelLinking>
 	<IntrinsicFunctions>true</IntrinsicFunctions>
@@ -208,7 +205,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
 	<Optimization>Full</Optimization>
 	<FunctionLevelLinking>true</FunctionLevelLinking>
 	<IntrinsicFunctions>true</IntrinsicFunctions>
@@ -612,7 +608,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
 	<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
 		]]
 	end


### PR DESCRIPTION
outputs a lot less of these fields by default...