### PR TITLE
Bootstrap Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
+os:
+  - linux
 
-before_install:
- - sudo add-apt-repository -y ppa:codegear/release
- - sudo apt-get -qq update
- - sudo apt-get install premake4
- 
 script:
- - premake4 embed
- - premake4 gmake
- - make -j8
+ - make -f Bootstrap.mak $TRAVIS_OS_NAME
  - bin/release/premake5 test
 

--- a/BUILD.txt
+++ b/BUILD.txt
@@ -33,9 +33,14 @@ BUILDING FROM THE REPOSITORY
     $ git submodule update
     $ make -f Bootstrap.mak PLATFORM
 
- Where PLATFORM can be osx or linux. On Windows use nmake:
+ Where PLATFORM can be osx or linux.
+ On Windows with Visual Studio use nmake:
 
     $ nmake -f Bootstrap.mak windows
+
+ Or on Windows with MinGW use mingw32-make:
+
+    $ CC=mingw32-gcc mingw32-make -f Bootstrap.mak mingw
 
  If your toolset is not supported by the bootstrap Makefile, you will need
  to embed the scripts into a C source file so they may be built into the

--- a/BUILD.txt
+++ b/BUILD.txt
@@ -26,7 +26,18 @@ BUILDING FROM A SOURCE PACKAGE
 
 BUILDING FROM THE REPOSITORY
 
- If you have pulled sources from the Premake source repository, you will need
+ If you have pulled sources from the Premake source repository, you can
+ use `Bootstrap.mak` to generate your first premake executable:
+
+    $ git submodule init
+    $ git submodule update
+    $ make -f Bootstrap.mak PLATFORM
+
+ Where PLATFORM can be osx or linux. On Windows use nmake:
+
+    $ nmake -f Bootstrap.mak windows
+
+ If your toolset is not supported by the bootstrap Makefile, you will need
  to embed the scripts into a C source file so they may be built into the
  executable, and also generate the project files for your chosen toolset. In
  order do either of these things, you will need a working Premake executable.

--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -37,9 +37,18 @@ none:
 	@echo "Please do"
 	@echo "   nmake -f Bootstrap.mak windows"
 	@echo "or"
-	@echo "   make -f Bootstrap.mak PLATFORM"
-	@echo "where PLATFORM is one of these:"
+	@echo "   CC=mingw32-gcc mingw32-make -f Bootstrap.mak mingw"
+	@echo "or"
+	@echo "   make -f Bootstrap.mak HOST_PLATFORM"
+	@echo "where HOST_PLATFORM is one of these:"
 	@echo "   osx linux"
+
+mingw: $(SRC)
+	mkdir -p build/bootstrap
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$(LUA_DIR)" $? -lole32
+	./build/bootstrap/premake_bootstrap embed
+	./build/bootstrap/premake_bootstrap --os=windows --to=build/bootstrap gmake
+	$(MAKE) -C build/bootstrap
 
 osx: $(SRC)
 	mkdir -p build/bootstrap

--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -1,0 +1,64 @@
+LUA_DIR=src/host/lua-5.1.4/src
+
+SRC= src/host/*.c \
+$(LUA_DIR)/lapi.c 		\
+$(LUA_DIR)/lcode.c		\
+$(LUA_DIR)/ldebug.c 	\
+$(LUA_DIR)/ldump.c		\
+$(LUA_DIR)/lgc.c			\
+$(LUA_DIR)/liolib.c 	\
+$(LUA_DIR)/lmathlib.c \
+$(LUA_DIR)/loadlib.c	\
+$(LUA_DIR)/lopcodes.c \
+$(LUA_DIR)/lparser.c	\
+$(LUA_DIR)/lstring.c	\
+$(LUA_DIR)/ltable.c 	\
+$(LUA_DIR)/ltm.c			\
+$(LUA_DIR)/lvm.c			\
+$(LUA_DIR)/lbaselib.c \
+$(LUA_DIR)/ldblib.c 	\
+$(LUA_DIR)/ldo.c			\
+$(LUA_DIR)/lfunc.c		\
+$(LUA_DIR)/linit.c		\
+$(LUA_DIR)/llex.c 		\
+$(LUA_DIR)/lmem.c 		\
+$(LUA_DIR)/lobject.c	\
+$(LUA_DIR)/loslib.c 	\
+$(LUA_DIR)/lstate.c 	\
+$(LUA_DIR)/lstrlib.c	\
+$(LUA_DIR)/ltablib.c	\
+$(LUA_DIR)/lundump.c	\
+$(LUA_DIR)/lzio.c
+
+PLATFORM= none
+default: $(PLATFORM)
+
+none:
+	@echo "Please do"
+	@echo "   nmake -f Bootstrap.mak windows"
+	@echo "or"
+	@echo "   make -f Bootstrap.mak PLATFORM"
+	@echo "where PLATFORM is one of these:"
+	@echo "   osx linux"
+
+osx: $(SRC)
+	mkdir -p build/bootstrap
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$(LUA_DIR)" -framework CoreServices $?
+	./build/bootstrap/premake_bootstrap embed
+	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake
+	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN`
+
+linux: $(SRC)
+	mkdir -p build/bootstrap
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$(LUA_DIR)" $? -lm
+	./build/bootstrap/premake_bootstrap embed
+	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake
+	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN`
+
+windows: $(SRC)
+	if not exist build\bootstrap (mkdir build\bootstrap)
+	cl /Fo.\build\bootstrap\ /Fe.\build\bootstrap\premake_bootstrap.exe /DPREMAKE_NO_BUILTIN_SCRIPTS /I"$(LUA_DIR)" user32.lib ole32.lib $**
+	.\build\bootstrap\premake_bootstrap.exe embed
+	.\build\bootstrap\premake_bootstrap --to=build/bootstrap vs2012
+	devenv .\build\bootstrap\Premake5.sln /Upgrade
+	devenv .\build\bootstrap\Premake5.sln /Build Release

--- a/scripts/package.lua
+++ b/scripts/package.lua
@@ -129,7 +129,7 @@
 		for _, name in ipairs { ".git" } do
 			os.rmdir(path.join(module, name))
 		end
-		for _, name in ipairs { ".DS_Store", ".git", ".gitignore", ".gitmodules", ".travis.yml", ".editorconfig" } do
+		for _, name in ipairs { ".DS_Store", ".git", ".gitignore", ".gitmodules", ".travis.yml", ".editorconfig", "Bootstrap.mak" } do
 			os.remove(path.join(module, name))
 		end
 	end

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -293,6 +293,7 @@ int premake_test_file(lua_State* L, const char* filename, int searchMask)
 		if (path && do_locate(L, filename, path)) return OKAY;
 	}
 
+	#if !defined(PREMAKE_NO_BUILTIN_SCRIPTS)
 	if ((searchMask & TEST_EMBEDDED) != 0) {
 		/* Try to locate a record matching the filename */
 		for (i = 0; builtin_scripts_index[i] != NULL; ++i) {
@@ -304,6 +305,7 @@ int premake_test_file(lua_State* L, const char* filename, int searchMask)
 			}
 		}
 	}
+	#endif
 
 	return !OKAY;
 }
@@ -475,12 +477,14 @@ int premake_load_embedded_script(lua_State* L, const char* filename)
 #endif
 
 	/* Try to locate a record matching the filename */
+	#if !defined(PREMAKE_NO_BUILTIN_SCRIPTS)
 	for (i = 0; builtin_scripts_index[i] != NULL; ++i) {
 		if (strcmp(builtin_scripts_index[i], filename) == 0) {
 			chunk = builtin_scripts[i];
 			break;
 		}
 	}
+	#endif
 
 	if (chunk == NULL) {
 		return !OKAY;


### PR DESCRIPTION
Following on from discussion in PR #96 .

mingw gcc distros on windows don't install a 'cc', so you need to say: `CC=mingw32-gcc mingw32-make -f Bootstrap.mak mingw`, which makes the instructions a little less neat. But that's also true of the gmake.windows build files. I can take or leave mingw32 bootstrap host platform support.

Travis changes to build for osx would need osx builds enabled on premake travis, which appears to be 'by request'. Right now I see it only building linux on my account, regardless of what you ask for. Maybe this should be teased out into a separate PR for testing.
