### PR TITLE
Narrow the Visual Studio /O2+/RTC1 compatibility test

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -943,7 +943,7 @@
 
 
 	function m.basicRuntimeChecks(cfg)
-		if cfg.flags.NoRuntimeChecks or config.isOptimizedBuild(cfg) then
+		if cfg.flags.NoRuntimeChecks or (config.isOptimizedBuild(cfg) and cfg.runtime == "Debug") then
 			p.w('<BasicRuntimeChecks>Default</BasicRuntimeChecks>')
 		end
 	end

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -160,7 +160,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
 	<Optimization>Full</Optimization>
 	<FunctionLevelLinking>true</FunctionLevelLinking>
 	<IntrinsicFunctions>true</IntrinsicFunctions>
@@ -176,7 +175,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
 	<Optimization>MinSpace</Optimization>
 	<FunctionLevelLinking>true</FunctionLevelLinking>
 	<IntrinsicFunctions>true</IntrinsicFunctions>
@@ -192,7 +190,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
 	<Optimization>MaxSpeed</Optimization>
 	<FunctionLevelLinking>true</FunctionLevelLinking>
 	<IntrinsicFunctions>true</IntrinsicFunctions>
@@ -208,7 +205,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
 	<Optimization>Full</Optimization>
 	<FunctionLevelLinking>true</FunctionLevelLinking>
 	<IntrinsicFunctions>true</IntrinsicFunctions>
@@ -612,7 +608,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
 	<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
 		]]
 	end
@@ -668,6 +663,18 @@
 
 	function suite.onNoRuntimeChecks()
 		flags { "NoRuntimeChecks" }
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
+		]]
+	end
+
+	function suite.onNoRuntimeChecks_onDebugRuntimeAndOptimize()
+		runtime "Debug"
+		optimize "On"
 		prepare()
 		test.capture [[
 <ClCompile>


### PR DESCRIPTION
As discussed in pull request #12, disable runtime checks only when optimizations AND the debug runtime are enabled.