### PR TITLE
Make application of flag mappings deterministic (and potentially prioritized)

### DIFF
--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -469,46 +469,52 @@
 			table.insertflat(flags, replacement)
 		end
 
-		-- For each configuration field provided in the mapping, pull the
-		-- corresponding list of values from the configuration
+		-- To ensure we get deterministic results that don't change as more keys
+		-- are added to the map, and to open the possibility to controlling the
+		-- application order of flags, use a prioritized list of fields to order
+		-- the mapping, even though it takes a little longer.
 
-		for field, map in pairs(mappings) do
-			local values = cfg[field]
-			if type(values) ~= "table" then
-				values = { values }
-			end
+		for field in p.field.eachOrdered() do
+			local map = mappings[field.name]
+			if map then
 
-			-- Pass each value in the list through the map and append the
-			-- replacement, if any, to the result
+				-- Pass each cfg value in the list through the map and append the
+				-- replacement, if any, to the result
 
-			local foundValue = false
-			table.foreachi(values, function(value)
-				local replacement = map[value]
-				if replacement ~= nil then
-					foundValue = true
-					add(replacement)
+				local values = cfg[field.name]
+				if type(values) ~= "table" then
+					values = { values }
 				end
-			end)
 
-			-- If no value was mapped, check to see if the map specifies a
-			-- default value and, if so, push that into the result
-
-			if not foundValue then
-				add(map._)
-			end
-
-			-- Finally, check for "not values", which should be added to the
-			-- result if the corresponding value is not present
-
-			for key, replacement in pairs(map) do
-				if #key > 1 and key:startswith("_") then
-					key = key:sub(2)
-					if values[key] == nil then
+				local foundValue = false
+				table.foreachi(values, function(value)
+					local replacement = map[value]
+					if replacement ~= nil then
+						foundValue = true
 						add(replacement)
 					end
-				end
-			end
+				end)
 
+				-- If no value was mapped, check to see if the map specifies a
+				-- default value and, if so, push that into the result
+
+				if not foundValue then
+					add(map._)
+				end
+
+				-- Finally, check for "not values", which should be added to the
+				-- result if the corresponding value is not present
+
+				for key, replacement in pairs(map) do
+					if #key > 1 and key:startswith("_") then
+						key = key:sub(2)
+						if values[key] == nil then
+							add(replacement)
+						end
+					end
+				end
+
+			end
 		end
 
 		return flags

--- a/src/base/field.lua
+++ b/src/base/field.lua
@@ -20,6 +20,7 @@
 
 	field._list = {}
 	field._loweredList = {}
+	field._sortedList = nil
 	field._kinds = {}
 
 	-- For historical reasons
@@ -96,6 +97,7 @@
 
 		field._list[f.name] = f
 		field._loweredList[f.name:lower()] = f
+		field._sortedList = nil
 
 		return f
 	end
@@ -109,12 +111,14 @@
 	function field.unregister(f)
 		field._list[f.name] = nil
 		field._loweredList[f.name:lower()] = nil
+		field._sortedList = nil
 	end
 
 
 
 ---
--- Returns an iterator for the list of register fields.
+-- Returns an iterator for the list of registered fields; the
+-- ordering of returned results is arbitrary.
 ---
 
 	function field.each()
@@ -125,6 +129,31 @@
 		end
 	end
 
+
+
+---
+-- Returns an iterator for the list of registered fields; the
+-- results are in a prioritized order, then alphabetized.
+---
+
+	function field.eachOrdered()
+		if not field._sortedList then
+			-- no priorities yet, just alpha sort
+			local keys = table.keys(field._list)
+			table.sort(keys)
+
+			field._sortedList = {}
+			for i = 1, #keys do
+				field._sortedList[i] = field._list[keys[i]]
+			end
+		end
+
+		local i = 0
+		return function ()
+			i = i + 1
+			return field._sortedList[i]
+		end
+	end
 
 
 ---


### PR DESCRIPTION
Currently, the ways flags are ordered in config.mapFlags() is arbitrary, and changes each time a new entry is added to the mapping table. Make the application deterministic by enumerating a sorted list of fields, and using the field names to look up the values in the map, instead of enumerating the map keys directly.

This also opens up the possibility of controlling the order in which Premake's fields are applied, if that becomes necessary (we may have a need for that, but aren't using it currently).

Trade-off is that the mapping runs a little slower, since it has to enumerate all of the fields instead of just the map keys.