### PR TITLE
Add file.directory token

### DIFF
--- a/src/base/fileconfig.lua
+++ b/src/base/fileconfig.lua
@@ -236,6 +236,11 @@
 	end
 
 
+	function fcfg_mt.directory(fcfg)
+		return path.getdirectory(fcfg.abspath)
+	end
+
+
 	function fcfg_mt.name(fcfg)
 		return path.getname(fcfg.abspath)
 	end


### PR DESCRIPTION
I could not find tests for sister token (abspath etc). Given one or guidance on how to implement one I'll add a test for this feature.

Useful for buildrules which require the directory of the file separate from its basename (protobuf 2.x).

Example:

``` lua

-- One or more commands to run (required)
protobuf_base = path.getabsolute(path.join(os.getcwd(), 'Third-Party/nanopb'))

buildcommands {
protobuf_base .. '/bin/protoc.exe -o%{cfg.objdir}/%{file.basename}.pb --proto_path=%{file.directory} %{file.abspath}',
'python ' .. protobuf_base .. '/generator/nanopb_generator.py --options-file=%{file.directory}/%{file.basename}.options %{cfg.objdir}/%{file.basename}.pb'
}

```