### PR TITLE
fixed a crash when a token contains non-escaped backslashes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,7 +23,7 @@ Since 5.0-alpha2:
 * Fix: Allow tokens in vpaths()
 * Fix: Silence xcopy output from {COPY} command token (StiX)
 * Fix: Remove ".." sequences in path.join()
-* Fix: Allow CC and CXX overrides from command line (Time Wharton)
+* Fix: Allow CC and CXX overrides from command line (Tim Wharton)
 * Fix: Enable solution level filtering on system values
 * Fix: Make configuration flag mapping order deterministic
 * Fix: Map "Win32" to x86 architecture for Visual Studio

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,8 +7,30 @@ for the complete list of changes from the Premake 4.x series.
 
 Since 5.0-alpha2:
 
+* New: CodeLite support
+* New: D language support
+* New: MonoDevelop support
 * New API: buildlog()
+* New API: callingconvention() (Tim Wharton)
 * New API: os.writefile_ifnotequal()
+* New API: sysincludedirs()
+* New API: syslibdirs()
+* New: toolset() can now specify a version number
+* New: Default values and categories for command line options
+* New: Add bootstrapping script for Git repository (Tim Wharton)
+* Fix: Modules are now loaded correctly in all situations (Damien Courtois)
+* Fix: Make Visual Studio debug commands absolute (amc522)
+* Fix: Allow tokens in vpaths()
+* Fix: Silence xcopy output from {COPY} command token (StiX)
+* Fix: Remove ".." sequences in path.join()
+* Fix: Allow CC and CXX overrides from command line (Time Wharton)
+* Fix: Enable solution level filtering on system values
+* Fix: Make configuration flag mapping order deterministic
+* Fix: Map "Win32" to x86 architecture for Visual Studio
+* Fix: Correct formatting for Visual Studio rule paths
+* Fix: Make project APIs consistently lowercase
+* Fix: Disable SSE/SSE2 flags for Visual Studio 64-bit builds
+* Fix: io.open() now creates directory append ("a") mode
 
 Since 5.0-alpha1:
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -19,9 +19,13 @@ Patch contributors:
   Blizzard Entertainment (contact tvandijck@blizzard.com)
     * additional os, string, and table functions
     * path.normalize() improvements
-    * Visual Studio 2015 support
+    * Visual Studio fixes and improvements
     * runtime()
     * verbosef()
+    * option default values and categories
+    * other fixes and improvements
+  Damien Courtois <https://github.com/dcourtois>
+    * module loading fixes
   Mark Chandler <https://bitbucket.org/mchandler_blizzard>
     * Prevent self-linking
   Mihai Sebea <http://twitter.com/mihai_sebea>
@@ -31,3 +35,7 @@ Patch contributors:
   Renaud Guillard <https://bitbucket.org/noresources>
     * add library search paths argument to os.findlib()
     * return command exit code from os.outputof()
+  Tim Wharton <https://github.com/moomalade>
+    * boostrapping scripts
+    * callingconvention()
+    * makefile environment overrides

--- a/scripts/RELEASE.txt
+++ b/scripts/RELEASE.txt
@@ -32,22 +32,13 @@ PACKAGE
 
 PUBLISH
 
- * Upload packages to SourceForge
+ * Create new release on GitHub from CHANGES.txt; upload files
 
- * On SourceForge, set package properties (platform, etc.)
-
- * Update the download page
-   http://industriousone.com/premake/download
+ * Update the download page on github.io
 
  * Post release announcement to the forums
 
- * Update the Latest News on the project home page
-
  * Post annoucement to @industrious on Twitter
-
- * Post announcement to email list
-
- * Post announcement to Industrious Facebook group
 
  * Add release to Freshmeat
    http://freshmeat.net/projects/premake

--- a/scripts/RELEASE.txt
+++ b/scripts/RELEASE.txt
@@ -7,6 +7,8 @@ PREP
 
  * Create working branch for release prep
 
+ * Update version in src/host/premake.c and commit
+
  * Make sure branch passes all tests on all platforms
 
  * Prep release announcement for forums
@@ -16,21 +18,9 @@ RELEASE
 
  * Merge working branch with release branch
 
- * Update the version number in src/host/premake.c and commit
-
- * Merge working branch to development branches
-
- * Close working branch
-
-
-PACKAGE
-
  * Run `premake5 package release source` (from Posix ideally)
 
  * On each platform, run `premake5 package release binary`
-
-
-PUBLISH
 
  * Create new release on GitHub from CHANGES.txt; upload files
 
@@ -42,3 +32,12 @@ PUBLISH
 
  * Add release to Freshmeat
    http://freshmeat.net/projects/premake
+
+
+CYCLE
+
+ * Update version in src/host/premake.c and commit
+
+ * Merge working branch to development branch
+
+ * Close working branch

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -347,6 +347,18 @@
 	}
 
 	api.register {
+		name = "exceptionhandling",
+		scope = "config",
+		kind = "boolean",
+	}
+
+	api.register {
+		name = "rtti",
+		scope = "config",
+		kind = "boolean",
+	}
+
+	api.register {
 		name = "enablewarnings",
 		scope = "config",
 		kind = "list:string",
@@ -416,7 +428,7 @@
 			"No64BitChecks",
 			"NoCopyLocal",
 			"NoEditAndContinue",   -- DEPRECATED
-			"NoExceptions",
+			"NoExceptions",        -- DEPRECATED
 			"NoFramePointer",
 			"NoImplicitLink",
 			"NoImportLib",
@@ -426,7 +438,7 @@
 			"NoNativeWChar",       -- DEPRECATED
 			"NoPCH",
 			"NoRuntimeChecks",
-			"NoRTTI",
+			"NoRTTI",              -- DEPRECATED
 			"NoBufferSecurityCheck",
 			"NoWarnings",          -- DEPRECATED
 			"OmitDefaultLibrary",
@@ -1130,6 +1142,24 @@
 	end)
 
 
+	api.deprecateValue("flags", "NoExceptions", nil,
+	function(value)
+		exceptionhandling "Off"
+	end,
+	function(value)
+		exceptionhandling "On"
+	end)
+
+
+	api.deprecateValue("flags", "NoRTTI", nil,
+	function(value)
+		rtti "Off"
+	end,
+	function(value)
+		rtti "On"
+	end)
+
+
 	api.deprecateValue("flags", "Unsafe", nil,
 	function(value)
 		clr "Unsafe"
@@ -1247,6 +1277,8 @@
 
 	clr "Off"
 	editandcontinue "On"
+	exceptionhandling "On"
+	rtti "On"
 
 	-- Setting a default language makes some validation easier later
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -501,7 +501,7 @@
 			"Default",
 			"Disabled",
 			"Explicit",
-			"Implicit"
+			"Auto"
 		}
 	}
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -359,17 +359,7 @@
 			"Default",
 			"On",
 			"Off",
-		},
-	}
-
-	api.register {
-		name = "rtti",
-		scope = "config",
-		kind = "string",
-		allowed = {
-			"Default",
-			"On",
-			"Off",
+			"SEH"
 		},
 	}
 
@@ -462,7 +452,7 @@
 			"OptimizeSpeed",       -- DEPRECATED
 			"RelativeLinks",
 			"ReleaseRuntime",      -- DEPRECATED
-			"SEH",
+			"SEH",                 -- DEPRECATED
 			"ShadowedVariables",
 			"StaticRuntime",
 			"Symbols",
@@ -855,6 +845,17 @@
 	}
 
 	api.register {
+		name = "rtti",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off",
+		},
+	}
+
+	api.register {
 		name = "rules",
 		scope = "project",
 		kind = "list:string",
@@ -1174,6 +1175,13 @@
 		rtti "On"
 	end)
 
+	api.deprecateValue("flags", "SEH", 'Use `exceptionhandling "SEH"` instead',
+	function(value)
+		exceptionhandling "SEH"
+	end,
+	function(value)
+		exceptionhandling "Default"
+	end)
 
 	api.deprecateValue("flags", "Unsafe", nil,
 	function(value)
@@ -1291,6 +1299,8 @@
 -----------------------------------------------------------------------------
 
 	clr "Off"
+	exceptionhandling "Default"
+	rtti "Default"
 
 	-- Setting a default language makes some validation easier later
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1158,7 +1158,7 @@
 	end)
 
 
-	api.deprecateValue("flags", "NoExceptions", nil,
+	api.deprecateValue("flags", "NoExceptions", 'Use `exceptionhandling "Off"` instead',
 	function(value)
 		exceptionhandling "Off"
 	end,
@@ -1167,7 +1167,7 @@
 	end)
 
 
-	api.deprecateValue("flags", "NoRTTI", nil,
+	api.deprecateValue("flags", "NoRTTI", 'Use `rtti "Off"` instead',
 	function(value)
 		rtti "Off"
 	end,

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -24,14 +24,14 @@
 		kind = "string",
 		allowed = {
 			"universal",
-			"x86",
-			"x86_64",
+			p.X86,
+			p.X86_64,
 		},
 		aliases = {
-			i386 = "x86",
-			amd64 = "x86_64",
-			x32 = "x86",	-- these should be DEPRECATED
-			x64 = "x86_64",
+			i386  = p.X86,
+			amd64 = p.X86_64,
+			x32   = p.X86,	-- these should be DEPRECATED
+			x64   = p.X86_64,
 		},
 	}
 
@@ -343,19 +343,34 @@
 	api.register {
 		name = "editandcontinue",
 		scope = "config",
-		kind = "boolean",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off",
+		},
 	}
 
 	api.register {
 		name = "exceptionhandling",
 		scope = "config",
-		kind = "boolean",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off",
+		},
 	}
 
 	api.register {
 		name = "rtti",
 		scope = "config",
-		kind = "boolean",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off",
+		},
 	}
 
 	api.register {
@@ -1276,9 +1291,6 @@
 -----------------------------------------------------------------------------
 
 	clr "Off"
-	editandcontinue "On"
-	exceptionhandling "On"
-	rtti "On"
 
 	-- Setting a default language makes some validation easier later
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -467,6 +467,18 @@
 	}
 
 	api.register {
+		name = "inlining",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"Disabled",
+			"Explicit",
+			"Implicit"
+		}
+	}
+
+	api.register {
 		name = "callingconvention",
 		scope = "config",
 		kind = "string",

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -959,6 +959,12 @@
 		end,
 	}
 
+  api.register {
+    name = "customtoolnamespace",
+    scope = "config",
+    kind = "string",
+  }
+
 	api.register {
 		name = "undefines",
 		scope = "config",

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -426,9 +426,9 @@
 	function make.linkCmd(cfg, toolset)
 		if cfg.kind == premake.STATICLIB then
 			if cfg.architecture == premake.UNIVERSAL then
-				_p('  LINKCMD = libtool -o $(TARGET) $(OBJECTS)')
+				_p('  LINKCMD = libtool -o "$@" $(OBJECTS)')
 			else
-				_p('  LINKCMD = $(AR) -rcs $(TARGET) $(OBJECTS)')
+				_p('  LINKCMD = $(AR) -rcs "$@" $(OBJECTS)')
 			end
 		else
 			-- this was $(TARGET) $(LDFLAGS) $(OBJECTS)
@@ -437,7 +437,7 @@
 			-- $(LIBS) moved to end (http://sourceforge.net/p/premake/bugs/279/)
 
 			local cc = iif(cfg.language == "C", "CC", "CXX")
-			_p('  LINKCMD = $(%s) -o $(TARGET) $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)', cc)
+			_p('  LINKCMD = $(%s) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)', cc)
 		end
 	end
 

--- a/src/actions/vstudio/_vstudio.lua
+++ b/src/actions/vstudio/_vstudio.lua
@@ -399,7 +399,13 @@
 
 	function vstudio.path(cfg, value)
 		cfg = cfg.project or cfg
-		return path.translate(project.getrelative(cfg, value))
+		local dirs = path.translate(project.getrelative(cfg, value))
+
+		if type(dirs) == 'table' then
+			dirs = table.filterempty(dirs)
+		end
+
+		return dirs
 	end
 
 

--- a/src/actions/vstudio/vs2005_csproj.lua
+++ b/src/actions/vstudio/vs2005_csproj.lua
@@ -182,6 +182,9 @@
 					if #contents > 0 then
 						_p("%s", contents)
 					end
+					if info.action == "EmbeddedResource" and cfg.customtoolnamespace then
+						_p(3,"<CustomToolNamespace>%s</CustomToolNamespace>", cfg.customtoolnamespace)
+					end
 					_p(2,'</%s>', info.action)
 				else
 					_p(2,'<%s Include="%s" />', info.action, fname)

--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -1124,7 +1124,7 @@
 	function m.exceptionHandling(cfg)
 		if cfg.exceptionhandling == p.OFF then
 			p.w('ExceptionHandling="%s"', iif(_ACTION < "vs2005", "FALSE", 0))
-		elseif cfg.flags.SEH and _ACTION > "vs2003" then
+		elseif cfg.exceptionhandling == "SEH" and _ACTION > "vs2003" then
 			p.w('ExceptionHandling="2"')
 		end
 	end

--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -753,10 +753,10 @@
 			return 1
 		else
 			-- Edit-and-continue doesn't work for some configurations
-			if not cfg.editandcontinue or
-				config.isOptimizedBuild(cfg) or
-			    cfg.clr ~= p.OFF or
-			    cfg.architecture == p.X86_64
+			if cfg.editandcontinue == p.OFF or
+			   config.isOptimizedBuild(cfg) or
+			   cfg.clr ~= p.OFF or
+			   cfg.architecture == p.X86_64
 			then
 				return 3
 			else
@@ -1122,7 +1122,7 @@
 
 
 	function m.exceptionHandling(cfg)
-		if cfg.exceptionhandling == false then
+		if cfg.exceptionhandling == p.OFF then
 			p.w('ExceptionHandling="%s"', iif(_ACTION < "vs2005", "FALSE", 0))
 		elseif cfg.flags.SEH and _ACTION > "vs2003" then
 			p.w('ExceptionHandling="2"')
@@ -1519,8 +1519,10 @@
 
 
 	function m.runtimeTypeInfo(cfg)
-		if cfg.rtti == false and cfg.clr == p.OFF then
+		if cfg.rtti == p.OFF and cfg.clr == p.OFF then
 			p.w('RuntimeTypeInfo="false"')
+		elseif cfg.rtti == p.ON then
+			p.w('RuntimeTypeInfo="true"')
 		end
 	end
 

--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -1122,7 +1122,7 @@
 
 
 	function m.exceptionHandling(cfg)
-		if cfg.flags.NoExceptions then
+		if cfg.exceptionhandling == false then
 			p.w('ExceptionHandling="%s"', iif(_ACTION < "vs2005", "FALSE", 0))
 		elseif cfg.flags.SEH and _ACTION > "vs2003" then
 			p.w('ExceptionHandling="2"')
@@ -1519,7 +1519,7 @@
 
 
 	function m.runtimeTypeInfo(cfg)
-		if cfg.flags.NoRTTI and cfg.clr == p.OFF then
+		if cfg.rtti == false and cfg.clr == p.OFF then
 			p.w('RuntimeTypeInfo="false"')
 		end
 	end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1097,10 +1097,14 @@
 
 
 	function m.exceptionHandling(cfg)
-		if cfg.flags.NoExceptions then
+		if cfg.exceptionhandling == false then
 			p.w('<ExceptionHandling>false</ExceptionHandling>')
-		elseif cfg.flags.SEH then
-			p.w('<ExceptionHandling>Async</ExceptionHandling>')
+		elseif cfg.exceptionhandling == true then
+			if cfg.flags.SEH then
+				p.w('<ExceptionHandling>Async</ExceptionHandling>')
+			else
+				p.w('<ExceptionHandling>Sync</ExceptionHandling>')
+			end
 		end
 	end
 
@@ -1621,8 +1625,10 @@
 	end
 
 	function m.runtimeTypeInfo(cfg)
-		if cfg.flags.NoRTTI and cfg.clr == p.OFF then
-			_p(3,'<RuntimeTypeInfo>false</RuntimeTypeInfo>')
+		if cfg.rtti == false and cfg.clr == p.OFF then
+			p.w('<RuntimeTypeInfo>false</RuntimeTypeInfo>')
+		elseif cfg.rtti == true then
+			p.w('<RuntimeTypeInfo>true</RuntimeTypeInfo>')
 		end
 	end
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -318,6 +318,7 @@
 			m.bufferSecurityCheck,
 			m.treatWChar_tAsBuiltInType,
 			m.floatingPointModel,
+			m.inlineFunctionExpansion,
 			m.enableEnhancedInstructionSet,
 			m.multiProcessorCompilation,
 			m.additionalCompileOptions,
@@ -1126,6 +1127,17 @@
 		end
 	end
 
+	function m.inlineFunctionExpansion(cfg)
+		if cfg.inlining then
+			local types = {
+				Default = "Default",
+				Disabled = "Disabled",
+				Explicit = "OnlyExplicitInline",
+				Implicit = "AnySuitable",
+			}
+			p.w('<InlineFunctionExpansion>%s</InlineFunctionExpansion>', types[cfg.inlining])
+		end
+	end
 
 	function m.forceIncludes(cfg, condition)
 		if #cfg.forceincludes > 0 then

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1098,14 +1098,11 @@
 
 
 	function m.exceptionHandling(cfg)
+		local value
 		if cfg.exceptionhandling == p.OFF then
 			p.w('<ExceptionHandling>false</ExceptionHandling>')
-		elseif cfg.exceptionhandling == p.ON or cfg.flags.SEH then
-			if cfg.flags.SEH then
-				p.w('<ExceptionHandling>Async</ExceptionHandling>')
-			else
-				p.w('<ExceptionHandling>Sync</ExceptionHandling>')
-			end
+		elseif cfg.exceptionhandling == "SEH" then
+			p.w('<ExceptionHandling>Async</ExceptionHandling>')
 		end
 	end
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -904,8 +904,7 @@
 
 	function m.additionalIncludeDirectories(cfg, includedirs)
 		if #includedirs > 0 then
-			local dirs = vstudio.path(cfg.project, includedirs)
-			dirs = table.filterempty(dirs)
+			local dirs = vstudio.path(cfg, includedirs)
 			if #dirs > 0 then
 				p.x('<AdditionalIncludeDirectories>%s;%%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>', table.concat(dirs, ";"))
 			end
@@ -1142,11 +1141,15 @@
 	function m.forceIncludes(cfg, condition)
 		if #cfg.forceincludes > 0 then
 			local includes = vstudio.path(cfg, cfg.forceincludes)
-			m.element("ForcedIncludeFiles", condition, table.concat(includes, ';'))
+			if #includes > 0 then
+				m.element("ForcedIncludeFiles", condition, table.concat(includes, ';'))
+			end
 		end
 		if #cfg.forceusings > 0 then
 			local usings = vstudio.path(cfg, cfg.forceusings)
-			m.element("ForcedUsingFiles", condition, table.concat(usings, ';'))
+			if #usings > 0 then
+				m.element("ForcedUsingFiles", condition, table.concat(usings, ';'))
+			end
 		end
 	end
 
@@ -1445,9 +1448,7 @@
 
 
 	function m.executablePath(cfg)
-		local dirs = project.getrelative(cfg.project, cfg.bindirs)
-		dirs = table.filterempty(dirs)
-
+		local dirs = vstudio.path(cfg, cfg.bindirs)
 		if #dirs > 0 then
 			_x(2,'<ExecutablePath>%s;$(ExecutablePath)</ExecutablePath>', path.translate(table.concat(dirs, ";")))
 		end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -584,7 +584,8 @@
 		"none",
 		"resourceCompile",
 		"customBuild",
-		"customRule"
+		"customRule",
+		"midlCompile"
 	}
 
 	m.elements.files = function(prj, groups)
@@ -780,6 +781,35 @@
 		end
 	end
 
+	function m.midlCompileFiles(prj, groups)
+		local files = groups.MidlCompile or {}
+		if #files > 0  then
+			p.push('<ItemGroup>')
+			for i, file in ipairs(files) do
+				local contents = p.capture(function ()
+					p.push()
+					for cfg in project.eachconfig(prj) do
+						local condition = m.condition(cfg)
+						local filecfg = fileconfig.getconfig(file, cfg)
+						if cfg.system == premake.WINDOWS then
+							m.excludedFromBuild(cfg, filecfg)
+						end
+					end
+					p.pop()
+				end)
+
+				if #contents > 0 then
+					p.push('<Midl Include=\"%s\">', path.translate(file.relpath))
+					p.outln(contents)
+					p.pop('</Midl>')
+				else
+					p.x('<Midl Include=\"%s\" />', path.translate(file.relpath))
+				end
+			end
+			p.pop('</ItemGroup>')
+		end
+	end
+
 
 	function m.categorize(prj, file)
 		-- If any configuration for this file uses a custom build step,
@@ -804,6 +834,8 @@
 			return "ClInclude"
 		elseif path.isresourcefile(file.name) then
 			return "ResourceCompile"
+		elseif path.isidlfile(file.name) then
+			return "MidlCompile"
 		else
 			return "None"
 		end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1137,7 +1137,7 @@
 				Default = "Default",
 				Disabled = "Disabled",
 				Explicit = "OnlyExplicitInline",
-				Implicit = "AnySuitable",
+				Auto = "AnySuitable",
 			}
 			p.w('<InlineFunctionExpansion>%s</InlineFunctionExpansion>', types[cfg.inlining])
 		end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -919,6 +919,7 @@
 		end
 	end
 
+
 	function m.additionalUsingDirectories(cfg)
 		if #cfg.usingdirs > 0 then
 			local dirs = table.concat(vstudio.path(cfg, cfg.usingdirs), ";")
@@ -1041,7 +1042,7 @@
 			elseif cfg.architecture == "x86_64" or
 				   cfg.clr ~= p.OFF or
 				   config.isOptimizedBuild(cfg) or
-				   not cfg.editandcontinue
+				   cfg.editandcontinue == p.OFF
 			then
 				value = "ProgramDatabase"
 			else
@@ -1097,9 +1098,9 @@
 
 
 	function m.exceptionHandling(cfg)
-		if cfg.exceptionhandling == false then
+		if cfg.exceptionhandling == p.OFF then
 			p.w('<ExceptionHandling>false</ExceptionHandling>')
-		elseif cfg.exceptionhandling == true then
+		elseif cfg.exceptionhandling == p.ON or cfg.flags.SEH then
 			if cfg.flags.SEH then
 				p.w('<ExceptionHandling>Async</ExceptionHandling>')
 			else
@@ -1625,9 +1626,9 @@
 	end
 
 	function m.runtimeTypeInfo(cfg)
-		if cfg.rtti == false and cfg.clr == p.OFF then
+		if cfg.rtti == p.OFF and cfg.clr == p.OFF then
 			p.w('<RuntimeTypeInfo>false</RuntimeTypeInfo>')
-		elseif cfg.rtti == true then
+		elseif cfg.rtti == p.ON then
 			p.w('<RuntimeTypeInfo>true</RuntimeTypeInfo>')
 		end
 	end

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -30,6 +30,8 @@
 	premake.MACOSX      = "macosx"
 	premake.MAKEFILE    = "Makefile"
 	premake.NONE        = "None"
+	premake.DEFAULT     = "Default"
+	premake.ON          = "On"
 	premake.OFF         = "Off"
 	premake.POSIX       = "posix"
 	premake.PS3         = "ps3"

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -4,6 +4,9 @@
 ---
 
 	premake = premake or {}
+	premake._VERSION = _PREMAKE_VERSION
+	package.loaded["premake"] = premake
+
 	premake.modules = {}
 	premake.extensions = premake.modules
 
@@ -101,6 +104,10 @@
 ---
 
 	function p.checkVersion(version, checks)
+		if not version then
+			return false
+		end
+
 		local function parse(str)
 			local major, minor, patch, dev = str:match("^(%d+)%.?(%d*)%.?(%d*)(.-)$")
 			major = tonumber(major) or 0
@@ -141,6 +148,9 @@
 				check = check:sub(3)
 			elseif check:startswith("<") then
 				func = lt
+				check = check:sub(2)
+			elseif check:startswith("=") then
+				func = eq
 				check = check:sub(2)
 			else
 				func = ge

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -5,8 +5,9 @@
 
 	premake = premake or {}
 	premake.modules = {}
-
 	premake.extensions = premake.modules
+
+	local p = premake
 
 
 -- Keep track of warnings that have been shown, so they don't get shown twice
@@ -86,9 +87,75 @@
 
 
 ---
--- Clears the list of already fired warning messages, allowing them
--- to be fired again.
+-- Compare a version string of the form "major.minor.patch.dev" against a
+-- version comparision string. Comparisions take the form of ">=5.0" (5.0 or
+-- later), "5.0" (5.0 or later), ">=5.0 <6.0" (5.0 or later but not 6.0 or
+-- later).
+--
+-- @param version
+--    The version to be tested.
+-- @param checks
+--    The comparision string to be evaluated.
+-- @return
+--    True if the comparisions pass, false if any fail.
 ---
+
+	function p.checkVersion(version, checks)
+		local function parse(str)
+			local major, minor, patch, dev = str:match("^(%d+)%.?(%d*)%.?(%d*)(.-)$")
+			major = tonumber(major) or 0
+			minor = tonumber(minor) or 0
+			patch = tonumber(patch) or 0
+			dev = dev or ""
+			return { major, minor, patch, dev }
+		end
+
+		local function compare(a, b)
+			for i=1,4 do
+				if a[i] > b[i] then return 1 end
+				if a[i] < b[i] then return -1 end
+			end
+			return 0
+		end
+
+		local function eq(r) return r == 0 end
+		local function le(r) return r <= 0 end
+		local function lt(r) return r < 0  end
+		local function ge(r) return r >= 0 end
+		local function gt(r) return r > 0  end
+
+		version = parse(version)
+
+		checks = string.explode(checks, " ", true)
+		for i = 1, #checks do
+			local check = checks[i]
+			local func
+			if check:startswith(">=") then
+				func = ge
+				check = check:sub(3)
+			elseif check:startswith(">") then
+				func = gt
+				check = check:sub(2)
+			elseif check:startswith("<=") then
+				func = le
+				check = check:sub(3)
+			elseif check:startswith("<") then
+				func = lt
+				check = check:sub(2)
+			else
+				func = ge
+			end
+
+			check = parse(check)
+			if not func(compare(version, check)) then
+				return false
+			end
+		end
+
+		return true
+	end
+
+
 
 	function premake.clearWarnings()
 		_warnings = {}

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -31,7 +31,14 @@
 	function config.buildtargetinfo(cfg, kind, field)
 		local basedir = cfg.project.location
 
-		local directory = cfg[field.."dir"] or cfg.targetdir or basedir
+		local targetdir
+		if cfg.platform then
+			targetdir = path.join(basedir, 'bin', cfg.platform, cfg.buildcfg)
+		else
+			targetdir = path.join(basedir, 'bin', cfg.buildcfg)
+		end
+
+		local directory = cfg[field.."dir"] or cfg.targetdir or targetdir
 		local basename = cfg[field.."name"] or cfg.targetname or cfg.project.name
 
 		local prefix = cfg[field.."prefix"] or cfg.targetprefix or ""

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -320,7 +320,7 @@
 
 	function config.getruntime(cfg)
 		local linkage = iif(cfg.flags.StaticRuntime, "Static", "Shared")
-		if (cfg.runtime == nil) then
+		if not cfg.runtime then
 			return linkage .. iif(config.isDebugBuild(cfg), "Debug", "Release")
 		else
 			return linkage .. cfg.runtime

--- a/src/base/detoken.lua
+++ b/src/base/detoken.lua
@@ -110,7 +110,7 @@
 			local count
 			repeat
 				value, count = value:gsub("%%{(.-)}", function(token)
-					local result, err = expandtoken(token, environ)
+					local result, err = expandtoken(token:gsub("\\", "\\\\"), environ)
 					if not result then
 						error(err, 0)
 					end
@@ -139,8 +139,7 @@
 				end
 				return value
 			else
-				-- escape backslashes: they will break loadstring
-				return expandvalue(value:gsub("\\", "\\\\"))
+				return expandvalue(value)
 			end
 		end
 

--- a/src/base/detoken.lua
+++ b/src/base/detoken.lua
@@ -139,7 +139,8 @@
 				end
 				return value
 			else
-				return expandvalue(value)
+				-- escape backslashes: they will break loadstring
+				return expandvalue(value:gsub("\\", "\\\\"))
 			end
 		end
 

--- a/src/base/fileconfig.lua
+++ b/src/base/fileconfig.lua
@@ -236,6 +236,11 @@
 	end
 
 
+	function fcfg_mt.directory(fcfg)
+		return path.getdirectory(fcfg.abspath)
+	end
+
+
 	function fcfg_mt.name(fcfg)
 		return path.getname(fcfg.abspath)
 	end

--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -52,6 +52,6 @@
 		fname = fullPath or fname
 		if not io._includedFiles[fname] then
 			io._includedFiles[fname] = true
-			dofile(fname)
+			return dofile(fname)
 		end
 	end

--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -55,3 +55,29 @@
 			return dofile(fname)
 		end
 	end
+
+
+
+---
+-- Extend require() with a second argument to specify the expected
+-- version of the loaded module. Raises an error if the version criteria
+-- are not met.
+--
+-- @param modname
+--    The name of the module to load.
+-- @param versions
+--    An optional version criteria string; see premake.checkVersion()
+--    for more information on the format.
+-- @return
+--    If successful, the loaded module, which is also stored into the
+--    global package.loaded table.
+---
+
+	premake.override(_G, "require", function(base, modname, versions)
+		local mod = base(modname)
+		if mod and versions and not premake.checkVersion(mod._VERSION, versions) then
+			error(string.format("module %s %s does not meet version criteria %s",
+				modname, mod._VERSION or "(none)", versions), 3)
+		end
+		return mod
+	end)

--- a/src/base/path.lua
+++ b/src/base/path.lua
@@ -197,6 +197,14 @@
 		return path.hasextension(fname, ".rc")
 	end
 
+--
+-- Returns true if the filename represents a Windows idl file.
+--
+
+	function path.isidlfile(fname)
+		return path.hasextension(fname, ".idl")
+	end
+
 
 --
 -- Takes a path which is relative to one location and makes it relative

--- a/src/host/path_join.c
+++ b/src/host/path_join.c
@@ -28,6 +28,12 @@ int path_join(lua_State* L)
 		part = luaL_checkstring(L, i);
 		len = strlen(part);
 
+		/* remove leading "./" */
+		while (strncmp(part, "./", 2) == 0) {
+			part += 2;
+			len -= 2;
+		}
+
 		/* remove trailing slashes */
 		while (len > 1 && part[len - 1] == '/') {
 			--len;

--- a/src/host/path_normalize.c
+++ b/src/host/path_normalize.c
@@ -47,6 +47,15 @@ int path_normalize(lua_State* L)
 			}
 		}
 
+		/* filter out /./ */
+		if (ch == '/' && last == '.') {
+			ptr = dst - 2;
+			if (ptr >= buffer && ptr[0] == '/') {
+				dst = ptr;
+				continue;
+			}
+		}
+
 		/* add to the result, filtering out duplicate slashes */
 		if (ch != '/' || last != '/') {
 			*(dst++) = ch;

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -462,6 +462,26 @@ static int run_premake_main(lua_State* L, const char* script)
 
 
 /**
+ * Locate a file in the embedded script index. If found, returns the
+ * contents of the file's script.
+ */
+
+ const char* premake_find_embedded_script(const char* filename)
+ {
+#if !defined(PREMAKE_NO_BUILTIN_SCRIPTS)
+ 	int i;
+	for (i = 0; builtin_scripts_index[i] != NULL; ++i) {
+		if (strcmp(builtin_scripts_index[i], filename) == 0) {
+			return builtin_scripts[i];
+		}
+	}
+#endif
+	return NULL;
+ }
+
+
+
+/**
  * Load a script that was previously embedded into the executable. If
  * successful, a function containing the new script chunk is pushed to
  * the stack, just like luaL_loadfile would do had the chunk been loaded
@@ -470,22 +490,11 @@ static int run_premake_main(lua_State* L, const char* script)
 
 int premake_load_embedded_script(lua_State* L, const char* filename)
 {
-	int i;
-	const char* chunk = NULL;
 #if !defined(NDEBUG)
 	static int warned = 0;
 #endif
 
-	/* Try to locate a record matching the filename */
-	#if !defined(PREMAKE_NO_BUILTIN_SCRIPTS)
-	for (i = 0; builtin_scripts_index[i] != NULL; ++i) {
-		if (strcmp(builtin_scripts_index[i], filename) == 0) {
-			chunk = builtin_scripts[i];
-			break;
-		}
-	}
-	#endif
-
+	const char* chunk = premake_find_embedded_script(filename);
 	if (chunk == NULL) {
 		return !OKAY;
 	}

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -14,7 +14,7 @@
 #endif
 
 
-#define VERSION        "HEAD"
+#define VERSION        "5.0.0-dev"
 #define COPYRIGHT      "Copyright (C) 2002-2015 Jason Perkins and the Premake Project"
 #define PROJECT_URL    "https://github.com/premake/premake-core/wiki"
 #define ERROR_MESSAGE  "Error: %s\n"

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -125,6 +125,7 @@ int string_startswith(lua_State* L);
 /* Engine interface */
 int premake_init(lua_State* L);
 int premake_execute(lua_State* L, int argc, const char** argv, const char* script);
+const char* premake_find_embedded_script(const char* filename);
 int premake_load_embedded_script(lua_State* L, const char* filename);
 int premake_locate_executable(lua_State* L, const char* argv0);
 int premake_test_file(lua_State* L, const char* filename, int searchMask);

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -155,6 +155,9 @@
 			x86 = "-m32",
 			x86_64 = "-m64",
 		},
+		flags = {
+			LinkTimeOptimization = "-flto",
+		},
 		kind = {
 			SharedLib = function(cfg)
 				local r = { iif(cfg.system == premake.MACOSX, "-dynamiclib", "-shared") }

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -42,6 +42,7 @@
 		},
 		flags = {
 			FatalCompileWarnings = "-Werror",
+			LinkTimeOptimization = "-flto",
 			NoFramePointer = "-fomit-frame-pointer",
 			ShadowedVariables = "-Wshadow",
 			Symbols = "-g",
@@ -196,6 +197,7 @@
 			x86_64 = "-m64",
 		},
 		flags = {
+			LinkTimeOptimization = "-flto",
 			_Symbols = function(cfg)
 				-- OS X has a bug, see http://lists.apple.com/archives/Darwin-dev/2006/Sep/msg00084.html
 				return iif(cfg.system == premake.MACOSX, "-Wl,-x", "-s")

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -107,8 +107,6 @@
 
 	gcc.cxxflags = {
 		flags = {
-			NoExceptions = "-fno-exceptions",
-			NoRTTI = "-fno-rtti",
 			NoBufferSecurityCheck = "-fno-stack-protector",
 			["C++11"] = "-std=c++11",
 			["C++14"] = "-std=c++14",
@@ -117,6 +115,12 @@
 
 	function gcc.getcxxflags(cfg)
 		local flags = config.mapFlags(cfg, gcc.cxxflags)
+		if not cfg.exceptionhandling then
+			table.insert(flags, '-fno-exceptions')
+		end
+		if not cfg.rtti then
+			table.insert(flags, '-fno-rtti')
+		end
 		return flags
 	end
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -106,21 +106,21 @@
 --
 
 	gcc.cxxflags = {
+		exceptionhandling = {
+			Off = "-fno-exceptions"
+		},
 		flags = {
 			NoBufferSecurityCheck = "-fno-stack-protector",
 			["C++11"] = "-std=c++11",
 			["C++14"] = "-std=c++14",
+		},
+		rtti = {
+			Off = "-fno-rtti"
 		}
 	}
 
 	function gcc.getcxxflags(cfg)
 		local flags = config.mapFlags(cfg, gcc.cxxflags)
-		if cfg.exceptionhandling == p.OFF then
-			table.insert(flags, '-fno-exceptions')
-		end
-		if cfg.rtti == p.OFF then
-			table.insert(flags, '-fno-rtti')
-		end
 		return flags
 	end
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -115,10 +115,10 @@
 
 	function gcc.getcxxflags(cfg)
 		local flags = config.mapFlags(cfg, gcc.cxxflags)
-		if not cfg.exceptionhandling then
+		if cfg.exceptionhandling == p.OFF then
 			table.insert(flags, '-fno-exceptions')
 		end
-		if not cfg.rtti then
+		if cfg.rtti == p.OFF then
 			table.insert(flags, '-fno-rtti')
 		end
 		return flags

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -103,16 +103,13 @@
 -- Returns list of C++ compiler flags for a configuration.
 --
 
-	msc.cxxflags = {
-		flags = {
-			NoRTTI = "/GR-",
-		}
-	}
-
 	function msc.getcxxflags(cfg)
-		local flags = config.mapFlags(cfg, msc.cxxflags)
+		local flags = {}
 
-		if not cfg.flags.SEH and not cfg.flags.NoExceptions then
+		if cfg.rtti == false then
+			table.insert(flags, "/GR-")
+		end
+		if not cfg.flags.SEH and cfg.exceptionhandling then
 			table.insert(flags, "/EHsc")
 		end
 

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -40,7 +40,6 @@
 			MultiProcessorCompile = "/MP",
 			NoFramePointer = "/Oy",
 			NoMinimalRebuild = "/Gm-",
-			SEH = "/EHa",
 			Symbols = "/Z7",
 			OmitDefaultLibrary = "/Zl",
 		},
@@ -106,6 +105,11 @@
 --
 
 	msc.cxxflags = {
+		exceptionhandling = {
+			Default = "/EHsc",
+			On = "/EHsc",
+			SEH = "/EHa",
+		},
 		rtti = {
 			Off = "/GR-"
 		}
@@ -113,11 +117,6 @@
 
 	function msc.getcxxflags(cfg)
 		local flags = config.mapFlags(cfg, msc.cxxflags)
-
-        if not cfg.flags.SEH and cfg.exceptionhandling ~= p.OFF then
-			table.insert(flags, "/EHsc")
-		end
-
 		return flags
 	end
 

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -106,11 +106,16 @@
 	function msc.getcxxflags(cfg)
 		local flags = {}
 
-		if cfg.rtti == false then
+		if cfg.rtti == premake.OFF then
 			table.insert(flags, "/GR-")
 		end
-		if not cfg.flags.SEH and cfg.exceptionhandling then
-			table.insert(flags, "/EHsc")
+
+		if cfg.exceptionhandling == premake.ON or cfg.flags.SEH then
+			if cfg.flags.SEH then
+				table.insert(flags, "/EHa")
+			else
+				table.insert(flags, "/EHsc")
+			end
 		end
 
 		return flags

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -7,10 +7,12 @@
 ---
 
 
-	premake.tools.msc = {}
-	local msc = premake.tools.msc
-	local project = premake.project
-	local config = premake.config
+	local p = premake
+
+	p.tools.msc = {}
+	local msc = p.tools.msc
+	local project = p.project
+	local config = p.config
 
 
 --
@@ -103,19 +105,17 @@
 -- Returns list of C++ compiler flags for a configuration.
 --
 
+	msc.cxxflags = {
+		rtti = {
+			Off = "/GR-"
+		}
+	}
+
 	function msc.getcxxflags(cfg)
-		local flags = {}
+		local flags = config.mapFlags(cfg, msc.cxxflags)
 
-		if cfg.rtti == premake.OFF then
-			table.insert(flags, "/GR-")
-		end
-
-		if cfg.exceptionhandling == premake.ON or cfg.flags.SEH then
-			if cfg.flags.SEH then
-				table.insert(flags, "/EHa")
-			else
-				table.insert(flags, "/EHsc")
-			end
+        if not cfg.flags.SEH and cfg.exceptionhandling ~= p.OFF then
+			table.insert(flags, "/EHsc")
 		end
 
 		return flags

--- a/src/tools/snc.lua
+++ b/src/tools/snc.lua
@@ -41,20 +41,20 @@
 -- Retrieve the CXXFLAGS for a specific configuration.
 --
 
-	snc.cxxflags = {
-		NoExceptions   = "-Xc-=exceptions",
-		NoRTTI         = "-Xc-=rtti",
-	}
-
 	function snc.getcxxflags(cfg)
-		local flags = table.translate(cfg.flags, snc.cxxflags)
+		local flags = {}
 
 		-- turn on exceptions and RTTI by default, to match other toolsets
-		if not cfg.flags.NoExceptions then
+		if cfg.exceptionhandling then
 			table.insert(flags, "-Xc+=exceptions")
+		else 
+			table.insert(flags, "-Xc-=exceptions")
 		end
-		if not cfg.flags.NoRTTI then
+
+		if cfg.rtti then
 			table.insert(flags, "-Xc+=rtti")
+		else
+			table.insert(flags, "-Xc-=rtti")
 		end
 
 		return flags

--- a/src/tools/snc.lua
+++ b/src/tools/snc.lua
@@ -45,15 +45,15 @@
 		local flags = {}
 
 		-- turn on exceptions and RTTI by default, to match other toolsets
-		if cfg.exceptionhandling then
+		if cfg.exceptionhandling == p.ON then
 			table.insert(flags, "-Xc+=exceptions")
-		else 
+		elseif cfg.exceptionhandling == p.OFF then
 			table.insert(flags, "-Xc-=exceptions")
 		end
 
-		if cfg.rtti then
+		if cfg.rtti == p.ON then
 			table.insert(flags, "-Xc+=rtti")
-		else
+		elseif cfg.rtti == p.OFF then
 			table.insert(flags, "-Xc-=rtti")
 		end
 

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -15,6 +15,7 @@ return {
 	"base/test_table.lua",
 	"base/test_tree.lua",
 	"base/test_uuid.lua",
+	"base/test_versions.lua",
 
 	-- Solution object tests
 	"solution/test_eachconfig.lua",

--- a/tests/actions/make/cpp/test_make_linking.lua
+++ b/tests/actions/make/cpp/test_make_linking.lua
@@ -36,7 +36,7 @@
 		prepare { "ldFlags", "linkCmd" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s -shared
-  LINKCMD = $(CXX) -o $(TARGET) $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)
+  LINKCMD = $(CXX) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)
 		]]
 	end
 
@@ -51,7 +51,7 @@
 		prepare { "ldFlags", "linkCmd" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s -shared
-  LINKCMD = $(CC) -o $(TARGET) $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)
+  LINKCMD = $(CC) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)
 		]]
 	end
 
@@ -65,7 +65,7 @@
 		prepare { "ldFlags", "linkCmd" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s
-  LINKCMD = $(AR) -rcs $(TARGET) $(OBJECTS)
+  LINKCMD = $(AR) -rcs "$@" $(OBJECTS)
 		]]
 	end
 
@@ -80,7 +80,7 @@
 		prepare { "ldFlags", "linkCmd" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s
-  LINKCMD = libtool -o $(TARGET) $(OBJECTS)
+  LINKCMD = libtool -o "$@" $(OBJECTS)
 		]]
 	end
 

--- a/tests/actions/make/cpp/test_make_linking.lua
+++ b/tests/actions/make/cpp/test_make_linking.lua
@@ -99,8 +99,8 @@
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s
-  LIBS += build/libMyProject2.a
-  LDDEPS += build/libMyProject2.a
+  LIBS += build/bin/Debug/libMyProject2.a
+  LDDEPS += build/bin/Debug/libMyProject2.a
 		]]
 	end
 
@@ -119,8 +119,8 @@
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s
-  LIBS += build/libMyProject2.so
-  LDDEPS += build/libMyProject2.so
+  LIBS += build/bin/Debug/libMyProject2.so
+  LDDEPS += build/bin/Debug/libMyProject2.so
 		]]
 	end
 
@@ -138,9 +138,9 @@
 
         prepare { "ldFlags", "libs", "ldDeps" }
         test.capture [[
-  ALL_LDFLAGS += $(LDFLAGS) -Lbuild -s
+  ALL_LDFLAGS += $(LDFLAGS) -Lbuild/bin/Debug -s
   LIBS += -lMyProject2
-  LDDEPS += build/libMyProject2.so
+  LDDEPS += build/bin/Debug/libMyProject2.so
         ]]
     end
 

--- a/tests/actions/make/cs/test_links.lua
+++ b/tests/actions/make/cs/test_links.lua
@@ -54,6 +54,6 @@
 
         prepare ()
         test.capture [[
-  DEPENDS = MyProject2.dll MyProject3.dll
+  DEPENDS = bin/Debug/MyProject2.dll bin/Debug/MyProject3.dll
         ]]
     end

--- a/tests/actions/vstudio/cs2005/test_output_props.lua
+++ b/tests/actions/vstudio/cs2005/test_output_props.lua
@@ -48,7 +48,7 @@
 		_ACTION = "vs2008"
 		prepare()
 		test.capture [[
-		<OutputPath>.\</OutputPath>
+		<OutputPath>bin\Debug\</OutputPath>
 		<IntermediateOutputPath>obj\Debug\</IntermediateOutputPath>
 		]]
 	end
@@ -57,7 +57,7 @@
 		_ACTION = "vs2010"
 		prepare()
 		test.capture [[
-		<OutputPath>.\</OutputPath>
+		<OutputPath>bin\Debug\</OutputPath>
 		<BaseIntermediateOutputPath>obj\Debug\</BaseIntermediateOutputPath>
 		<IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
 		]]

--- a/tests/actions/vstudio/vc200x/test_configuration.lua
+++ b/tests/actions/vstudio/vc200x/test_configuration.lua
@@ -37,7 +37,7 @@
 		test.capture [[
 <Configuration
 	Name="Debug|Win32"
-	OutputDirectory="."
+	OutputDirectory="bin\Debug"
 	IntermediateDirectory="obj\Debug"
 	ConfigurationType="1"
 	CharacterSet="2"
@@ -101,7 +101,7 @@
 		test.capture [[
 <Configuration
 	Name="Debug|Win32"
-	OutputDirectory="."
+	OutputDirectory="bin\Debug"
 	IntermediateDirectory="obj\Debug"
 	ConfigurationType="0"
 	>
@@ -114,7 +114,7 @@
 		test.capture [[
 <Configuration
 	Name="Debug|Win32"
-	OutputDirectory="."
+	OutputDirectory="bin\Debug"
 	IntermediateDirectory="obj\Debug"
 	ConfigurationType="0"
 	>

--- a/tests/actions/vstudio/vc200x/test_excluded_configs.lua
+++ b/tests/actions/vstudio/vc200x/test_excluded_configs.lua
@@ -68,6 +68,6 @@
 <Tool
 	Name="VCLinkerTool"
 	LinkLibraryDependencies="false"
-	AdditionalDependencies="MyProject2.lib"
+	AdditionalDependencies="bin\Ares\Debug\MyProject2.lib"
 		]]
 	end

--- a/tests/actions/vstudio/vc200x/test_linker_block.lua
+++ b/tests/actions/vstudio/vc200x/test_linker_block.lua
@@ -82,7 +82,7 @@
 	LinkIncremental="2"
 	GenerateDebugInformation="false"
 	SubSystem="2"
-	ImportLibrary="MyProject.lib"
+	ImportLibrary="bin\Debug\MyProject.lib"
 	TargetMachine="1"
 />
 		]]
@@ -245,7 +245,7 @@
 <Tool
 	Name="VCLinkerTool"
 	LinkLibraryDependencies="false"
-	AdditionalDependencies="MyProject2.lib"
+	AdditionalDependencies="bin\Debug\MyProject2.lib"
 		]]
 	end
 

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -36,6 +36,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -221,6 +223,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -233,6 +237,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -294,6 +300,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<AdditionalOptions>/xyz /abc %(AdditionalOptions)</AdditionalOptions>
 		]]
 	end
@@ -440,6 +448,8 @@
 	<WarningLevel>Level3</WarningLevel>
 	<DebugInformationFormat>EditAndContinue</DebugInformationFormat>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -475,6 +485,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
 		]]
 	end
@@ -487,6 +499,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
 		]]
 	end
@@ -528,11 +542,12 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
 	<RuntimeTypeInfo>false</RuntimeTypeInfo>
 		]]
 	end
 
-	function suite.runtimeTypeInfo_onNoRTTI()
+	function suite.runtimeTypeInfo_onNoBufferSecurityCheck()
 		flags "NoBufferSecurityCheck"
 		prepare()
 		test.capture [[
@@ -540,6 +555,8 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<BufferSecurityCheck>false</BufferSecurityCheck>
 		]]
 	end
@@ -686,6 +703,8 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<MinimalRebuild>false</MinimalRebuild>
+	<ExceptionHandling>Sync</ExceptionHandling>
+	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<MultiProcessorCompilation>true</MultiProcessorCompilation>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -497,7 +497,7 @@
 --
 
 	function suite.exceptions_onNoExceptions()
-		flags "NoExceptions"
+		exceptionhandling "Off"
 		prepare()
 		test.capture [[
 <ClCompile>
@@ -521,7 +521,7 @@
 	end
 
 	function suite.runtimeTypeInfo_onNoRTTI()
-		flags "NoRTTI"
+		rtti "Off"
 		prepare()
 		test.capture [[
 <ClCompile>

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -36,8 +36,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -223,8 +221,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -237,8 +233,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -300,8 +294,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<AdditionalOptions>/xyz /abc %(AdditionalOptions)</AdditionalOptions>
 		]]
 	end
@@ -448,8 +440,6 @@
 	<WarningLevel>Level3</WarningLevel>
 	<DebugInformationFormat>EditAndContinue</DebugInformationFormat>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 </ClCompile>
 		]]
 	end
@@ -485,8 +475,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
 		]]
 	end
@@ -499,8 +487,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
 		]]
 	end
@@ -542,7 +528,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
 	<RuntimeTypeInfo>false</RuntimeTypeInfo>
 		]]
 	end
@@ -555,8 +540,6 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<BufferSecurityCheck>false</BufferSecurityCheck>
 		]]
 	end
@@ -703,8 +686,6 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<MinimalRebuild>false</MinimalRebuild>
-	<ExceptionHandling>Sync</ExceptionHandling>
-	<RuntimeTypeInfo>true</RuntimeTypeInfo>
 	<MultiProcessorCompilation>true</MultiProcessorCompilation>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -509,7 +509,7 @@
 	end
 
 	function suite.exceptions_onSEH()
-		flags "SEH"
+		exceptionhandling "SEH"
 		prepare()
 		test.capture [[
 <ClCompile>

--- a/tests/actions/vstudio/vc2010/test_config_props.lua
+++ b/tests/actions/vstudio/vc2010/test_config_props.lua
@@ -254,7 +254,7 @@
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
 		<ConfigurationType>Makefile</ConfigurationType>
 		<UseDebugLibraries>false</UseDebugLibraries>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<IntDir>obj\Debug\</IntDir>
 	</PropertyGroup>
 		]]
@@ -267,7 +267,7 @@
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
 		<ConfigurationType>Makefile</ConfigurationType>
 		<UseDebugLibraries>false</UseDebugLibraries>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<IntDir>obj\Debug\</IntDir>
 	</PropertyGroup>
 		]]

--- a/tests/actions/vstudio/vc2010/test_excluded_configs.lua
+++ b/tests/actions/vstudio/vc2010/test_excluded_configs.lua
@@ -71,7 +71,7 @@
 		<Link>
 			<SubSystem>Console</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<AdditionalDependencies>MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalDependencies>bin/Ares/Debug/MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
 			<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 		</Link>
 		<ProjectReference>

--- a/tests/actions/vstudio/vc2010/test_excluded_configs.lua
+++ b/tests/actions/vstudio/vc2010/test_excluded_configs.lua
@@ -71,7 +71,7 @@
 		<Link>
 			<SubSystem>Console</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<AdditionalDependencies>bin/Ares/Debug/MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalDependencies>bin\Ares\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
 			<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 		</Link>
 		<ProjectReference>

--- a/tests/actions/vstudio/vc2010/test_files.lua
+++ b/tests/actions/vstudio/vc2010/test_files.lua
@@ -68,6 +68,16 @@
 		]]
 	end
 
+	function suite.midlCompile_onIDLFile()
+		files { "idl/interfaces.idl" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<Midl Include="idl\interfaces.idl" />
+</ItemGroup>
+		]]
+	end
+
 	function suite.none_onTxtFile()
 		files { "docs/hello.txt" }
 		prepare()

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -214,7 +214,7 @@
 		<Link>
 			<SubSystem>Windows</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<AdditionalDependencies>bin/Debug/MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalDependencies>bin\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
 			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 		</Link>
 		<ProjectReference>

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -38,7 +38,7 @@
 		<Link>
 			<SubSystem>Windows</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>MyProject.lib</ImportLibrary>
+			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 		</Link>
 		]]
 	end
@@ -57,7 +57,7 @@
 			<GenerateDebugInformation>false</GenerateDebugInformation>
 			<EnableCOMDATFolding>true</EnableCOMDATFolding>
 			<OptimizeReferences>true</OptimizeReferences>
-			<ImportLibrary>MyProject.lib</ImportLibrary>
+			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 		</Link>
 		]]
 	end
@@ -96,7 +96,7 @@
 		<Link>
 			<SubSystem>Windows</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>MyProject.lib</ImportLibrary>
+			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 		</Link>
 		]]
 	end
@@ -124,7 +124,7 @@
 		<Link>
 			<SubSystem>Windows</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>MyProject.lib</ImportLibrary>
+			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 		</Link>
 		<ProjectReference>
 			<LinkLibraryDependencies>false</LinkLibraryDependencies>
@@ -194,7 +194,7 @@
 		<Link>
 			<SubSystem>Windows</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>MyProject.lib</ImportLibrary>
+			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 		</Link>
 		]]
 	end
@@ -214,8 +214,8 @@
 		<Link>
 			<SubSystem>Windows</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<AdditionalDependencies>MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<ImportLibrary>MyProject.lib</ImportLibrary>
+			<AdditionalDependencies>bin/Debug/MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 		</Link>
 		<ProjectReference>
 			<LinkLibraryDependencies>false</LinkLibraryDependencies>
@@ -273,7 +273,7 @@
 		<Link>
 			<SubSystem>Windows</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>MyProject.lib</ImportLibrary>
+			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 			<AdditionalOptions>/kupo %(AdditionalOptions)</AdditionalOptions>
 		]]
 	end
@@ -322,7 +322,7 @@
 		<Link>
 			<SubSystem>Windows</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>MyProject.lib</ImportLibrary>
+			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 			<ModuleDefinitionFile>hello.def</ModuleDefinitionFile>
 		</Link>
 		]]
@@ -421,7 +421,7 @@
 		<Link>
 			<SubSystem>Windows</SubSystem>
 			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>MyProject.lib</ImportLibrary>
+			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 			<GenerateMapFile>true</GenerateMapFile>
 		</Link>
 		]]

--- a/tests/actions/vstudio/vc2010/test_output_props.lua
+++ b/tests/actions/vstudio/vc2010/test_output_props.lua
@@ -34,7 +34,7 @@
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 		<LinkIncremental>true</LinkIncremental>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<IntDir>obj\Debug\</IntDir>
 		<TargetName>MyProject</TargetName>
 		<TargetExt>.exe</TargetExt>
@@ -70,7 +70,7 @@
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Xbox 360'">
 		<LinkIncremental>true</LinkIncremental>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<OutputFile>$(OutDir)MyProject.exe</OutputFile>
 		<IntDir>obj\Debug\</IntDir>
 		<TargetName>MyProject</TargetName>
@@ -86,7 +86,7 @@
 		prepare()
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Xbox 360'">
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<OutputFile>$(OutDir)MyProject.lib</OutputFile>
 		<IntDir>obj\Debug\</IntDir>
 		<TargetName>MyProject</TargetName>
@@ -106,7 +106,7 @@
 		prepare()
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		]]
 	end
 
@@ -147,7 +147,7 @@
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 		<LinkIncremental>true</LinkIncremental>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<IntDir>..\tmp\Debug\</IntDir>
 		]]
 	end
@@ -162,7 +162,7 @@
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 		<LinkIncremental>true</LinkIncremental>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<IntDir>obj\Debug\</IntDir>
 		<TargetName>MyTarget</TargetName>
 		]]
@@ -190,7 +190,7 @@
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 		<LinkIncremental>true</LinkIncremental>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		]]
 	end
 
@@ -205,7 +205,7 @@
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 		<LinkIncremental>true</LinkIncremental>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<IntDir>obj\Debug\</IntDir>
 		<TargetName>MyProject</TargetName>
 		<TargetExt>.exe</TargetExt>
@@ -224,7 +224,7 @@
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 		<LinkIncremental>true</LinkIncremental>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<IntDir>obj\Debug\</IntDir>
 		<TargetName>MyProject</TargetName>
 		<TargetExt>
@@ -245,7 +245,7 @@
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 		<LinkIncremental>true</LinkIncremental>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<IntDir>obj\Debug\</IntDir>
 		<TargetName>MyProject</TargetName>
 		<TargetExt>.exe</TargetExt>
@@ -265,7 +265,7 @@
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 		<LinkIncremental>true</LinkIncremental>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<IntDir>obj\Debug\</IntDir>
 		<TargetName>MyProject</TargetName>
 		<TargetExt>.exe</TargetExt>
@@ -280,7 +280,7 @@
 		test.capture [[
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 		<LinkIncremental>true</LinkIncremental>
-		<OutDir>.\</OutDir>
+		<OutDir>bin\Debug\</OutDir>
 		<IntDir>obj\Debug\</IntDir>
 		<TargetName>MyProject</TargetName>
 		<TargetExt>.exe</TargetExt>

--- a/tests/base/test_configset.lua
+++ b/tests/base/test_configset.lua
@@ -175,15 +175,15 @@
 
 	function suite.remove_onExactValueMatch()
 		local f = field.get("flags")
-		configset.store(cset, f, { "Symbols", "WinMain", "NoRTTI" })
+		configset.store(cset, f, { "Symbols", "WinMain", "MFC" })
 		configset.remove(cset, f, { "WinMain" })
-		test.isequal({ "Symbols", "NoRTTI" }, configset.fetch(cset, f, {}))
+		test.isequal({ "Symbols", "MFC" }, configset.fetch(cset, f, {}))
 	end
 
 	function suite.remove_onMultipleValues()
 		local f = field.get("flags")
-		configset.store(cset, f, { "Symbols", "NoExceptions", "WinMain", "NoRTTI" })
-		configset.remove(cset, f, { "NoExceptions", "NoRTTI" })
+		configset.store(cset, f, { "Symbols", "Maps", "WinMain", "MFC" })
+		configset.remove(cset, f, { "Maps", "MFC" })
 		test.isequal({ "Symbols", "WinMain" }, configset.fetch(cset, f, {}))
 	end
 

--- a/tests/base/test_detoken.lua
+++ b/tests/base/test_detoken.lua
@@ -129,3 +129,13 @@
 		x = detoken.expand("%{foo:gsub('/', '\\')}", environ)
 		test.isequal("some\\path", x)
 	end
+
+--
+-- Escapes backslashes correctly, but not outside tokens.
+--
+
+	function suite.escapesBackslashes2()
+		environ.foo = "some/path"
+		x = detoken.expand("%{foo:gsub('/', '\\')}\\already\\escaped", environ)
+		test.isequal("some\\path\\already\\escaped", x)
+	end

--- a/tests/base/test_detoken.lua
+++ b/tests/base/test_detoken.lua
@@ -119,3 +119,13 @@
 		x = detoken.expand(os.getcwd() .. "/%{cfg.objdir}/file", environ, {paths=true,pathVars=true})
 		test.isequal("$(IntDir)/file", x)
 	end
+
+--
+-- Escapes backslashes correctly.
+--
+
+	function suite.escapesBackslashes()
+		environ.foo = "some/path"
+		x = detoken.expand("%{foo:gsub('/', '\\')}", environ)
+		test.isequal("some\\path", x)
+	end

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -277,7 +277,7 @@
 
 	function suite.join_ignoreLeadingDots()
 		test.isequal("p1/p2/foo", path.join("p1/p2", "././foo"))
-	end	
+	end
 
 	function suite.join_OnUptoParentOfBase()
 		test.isequal("../../p1", path.join("p1/p2/p3/p4/p5/p6/p7/", "../../../../../../../../../p1"))
@@ -434,8 +434,8 @@
 	end
 
 	function suite.normalize_singleDot()
-		local p = path.normalize("../../generated/Protocol/External/BattlePay/./asterion.pb.cc")
-		test.isequal("../../generated/Protocol/External/BattlePay/asterion.pb.cc", p)
+		local p = path.normalize("../../p1/p2/p3/p4/./a.pb.cc")
+		test.isequal("../../p1/p2/p3/p4/a.pb.cc", p)
 	end
 
 	function suite.normalize()

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -275,6 +275,10 @@
 		test.isequal("foo", path.join("p1/p2/p3", "../../../foo"))
 	end
 
+	function suite.join_ignoreLeadingDots()
+		test.isequal("p1/p2/foo", path.join("p1/p2", "././foo"))
+	end	
+
 	function suite.join_OnUptoParentOfBase()
 		test.isequal("../../p1", path.join("p1/p2/p3/p4/p5/p6/p7/", "../../../../../../../../../p1"))
 	end
@@ -427,6 +431,11 @@
 	function suite.normalize_trailingDots2()
 		local p = path.normalize("../game/..")
 		test.isequal("..", p)
+	end
+
+	function suite.normalize_singleDot()
+		local p = path.normalize("../../generated/Protocol/External/BattlePay/./asterion.pb.cc")
+		test.isequal("../../generated/Protocol/External/BattlePay/asterion.pb.cc", p)
 	end
 
 	function suite.normalize()

--- a/tests/base/test_versions.lua
+++ b/tests/base/test_versions.lua
@@ -1,0 +1,171 @@
+--
+-- tests/base/test_versions.lua
+-- Verify the version comparisons.
+-- Copyright (c) 2015 Jason Perkins and the Premake project
+--
+
+	local suite = test.declare("premake_versions")
+
+	local p = premake
+
+
+--
+-- If only major version is specified, anything after should pass.
+--
+
+	function suite.pass_majorOnly_sameMajor()
+		test.istrue(p.checkVersion("1.0.0", "1"))
+	end
+
+	function suite.pass_majorOnly_laterMajor()
+		test.istrue(p.checkVersion("2.0.0", "1"))
+	end
+
+	function suite.pass_majorOnly_laterMinor()
+		test.istrue(p.checkVersion("1.1.0", "1"))
+	end
+
+	function suite.pass_majorOnly_laterPatch()
+		test.istrue(p.checkVersion("1.0.1", "1"))
+	end
+
+	function suite.pass_majorOnly_alpha()
+		test.istrue(p.checkVersion("1.0.0.alpha1", "1"))
+	end
+
+	function suite.pass_majorOnly_dev()
+		test.istrue(p.checkVersion("1.0.0.dev", "1"))
+	end
+
+	function suite.fail_earlierMajor()
+		test.isfalse(p.checkVersion("0.9.0", "1"))
+	end
+
+--
+-- If major and minor are specified, anything after should pass
+--
+
+	function suite.pass_majorMinor_sameMajorMinor()
+		test.istrue(p.checkVersion("1.1.0", "1.1"))
+	end
+
+	function suite.pass_majorMinor_sameMajorLaterMinor()
+		test.istrue(p.checkVersion("1.2.0", "1.1"))
+	end
+
+	function suite.pass_majorMinor_sameMajorLaterPath()
+		test.istrue(p.checkVersion("1.1.1", "1.1"))
+	end
+
+	function suite.pass_majorMinor_laterMajorSameMinor()
+		test.istrue(p.checkVersion("2.0.0", "1.1"))
+	end
+
+	function suite.pass_majorMinor_laterMajorEarlierMinor()
+		test.istrue(p.checkVersion("2.0.0", "1.1"))
+	end
+
+	function suite.pass_majorMinor_laterMajorLaterMinor()
+		test.istrue(p.checkVersion("2.2.0", "1.1"))
+	end
+
+	function suite.fail_majorMinor_sameMajorEarlierMinor()
+		test.isfalse(p.checkVersion("1.0.0", "1.1"))
+	end
+
+	function suite.fail_majorMinor_earlierMajor()
+		test.isfalse(p.checkVersion("0.9.0", "1.1"))
+	end
+
+
+--
+-- Alpha comes before beta comes before dev
+--
+
+	function suite.pass_alphaBeforeBeta()
+		test.istrue(p.checkVersion("1.0.0.beta1", "1.0.0.alpha1"))
+	end
+
+	function suite.fail_alphaBeforeBeta()
+		test.isfalse(p.checkVersion("1.0.0.alpha1", "1.0.0.beta1"))
+	end
+
+	function suite.pass_betaBeforeDev()
+		test.istrue(p.checkVersion("1.0.0.dev", "1.0.0.beta1"))
+	end
+
+	function suite.fail_betaBeforeDev()
+		test.isfalse(p.checkVersion("1.0.0.beta1", "1.0.0.dev"))
+	end
+
+
+--
+-- Check ">=" operator
+--
+
+	function suite.pass_ge_sameMajorMinorPatch()
+		test.istrue(p.checkVersion("1.1.0", ">=1.1"))
+	end
+
+	function suite.pass_ge_sameMajorMinorLaterPatch()
+		test.istrue(p.checkVersion("1.1.1", ">=1.1"))
+	end
+
+	function suite.pass_ge_laterMajorEarlierMinor()
+		test.istrue(p.checkVersion("2.0.1", ">=1.1"))
+	end
+
+	function suite.pass_ge_sameMajorLaterMinor()
+		test.istrue(p.checkVersion("1.2.1", ">=1.1"))
+	end
+
+	function suite.fail_ge_earlierMajor()
+		test.isfalse(p.checkVersion("0.1.1", ">=1.1"))
+	end
+
+	function suite.fail_ge_earlierMinor()
+		test.isfalse(p.checkVersion("1.0.1", ">=1.1"))
+	end
+
+
+--
+-- Check ">" operator
+--
+
+	function suite.pass_gt_sameMajorMinorLaterPatch()
+		test.istrue(p.checkVersion("1.1.1", ">1.1"))
+	end
+
+	function suite.pass_gt_laterMajor()
+		test.istrue(p.checkVersion("2.0.1", ">1.1"))
+	end
+
+	function suite.pass_gt_laterMinor()
+		test.istrue(p.checkVersion("1.2.1", ">1.1"))
+	end
+
+	function suite.fail_gt_sameMajorMinorPatch()
+		test.isfalse(p.checkVersion("1.1.0", ">1.1"))
+	end
+
+	function suite.fail_gt_earlierMajor()
+		test.isfalse(p.checkVersion("0.1.1", ">1.1"))
+	end
+
+	function suite.fail_gt_earlierMinor()
+		test.isfalse(p.checkVersion("1.0.1", ">1.1"))
+	end
+
+
+--
+-- Check multiple conditions
+--
+
+	function suite.pass_onMultipleConditions()
+		test.istrue(p.checkVersion("1.2.0.0", ">=1.0 <2.0"))
+	end
+
+	function suite.fail_onMultipleConditions()
+		test.isfalse(p.checkVersion("2.2.0.0", ">=1.0 <2.0"))
+	end
+

--- a/tests/base/test_versions.lua
+++ b/tests/base/test_versions.lua
@@ -169,3 +169,11 @@
 		test.isfalse(p.checkVersion("2.2.0.0", ">=1.0 <2.0"))
 	end
 
+
+--
+-- If there is no version information, fails.
+--
+
+	function suite.fail_onNoVersion()
+		test.isfalse(p.checkVersion(nil, "1.0"))
+	end

--- a/tests/config/test_linkinfo.lua
+++ b/tests/config/test_linkinfo.lua
@@ -28,16 +28,6 @@
 
 
 --
--- Directory should be current (".") by default.
---
-
-	function suite.directoryIsDot_onNoTargetDir()
-		i = prepare()
-		test.isequal(".", path.getrelative(os.getcwd(), i.directory))
-	end
-
-
---
 -- Directory should use targetdir() value if present.
 --
 

--- a/tests/config/test_links.lua
+++ b/tests/config/test_links.lua
@@ -135,7 +135,7 @@
 		language "C++"
 
 		local r = prepare("all", "fullpath")
-		test.isequal({ "MyProject2.lib" }, r)
+		test.isequal({ "bin/Debug/MyProject2.lib" }, r)
 	end
 
 	function suite.canLink_CsAndCs()
@@ -147,7 +147,7 @@
 		language "C#"
 
 		local r = prepare("all", "fullpath")
-		test.isequal({ "MyProject2.dll" }, r)
+		test.isequal({ "bin/Debug/MyProject2.dll" }, r)
 	end
 
 	function suite.canLink_ManagedCppAndManagedCpp()
@@ -160,7 +160,7 @@
 		clr "On"
 
 		local r = prepare("all", "fullpath")
-		test.isequal({ "MyProject2.lib" }, r)
+		test.isequal({ "bin/Debug/MyProject2.lib" }, r)
 	end
 
 	function suite.canLink_ManagedCppAndCs()
@@ -172,7 +172,7 @@
 		language "C#"
 
 		local r = prepare("all", "fullpath")
-		test.isequal({ "MyProject2.dll" }, r)
+		test.isequal({ "bin/Debug/MyProject2.dll" }, r)
 	end
 
 

--- a/tests/config/test_targetinfo.lua
+++ b/tests/config/test_targetinfo.lua
@@ -27,16 +27,6 @@
 
 
 --
--- Directory should be current (".") by default.
---
-
-	function suite.directoryIsDot_onNoTargetDir()
-		i = prepare()
-		test.isequal(".", path.getrelative(os.getcwd(), i.directory))
-	end
-
-
---
 -- Directory uses targetdir() value if present.
 --
 
@@ -242,7 +232,7 @@
 		kind "WindowedApp"
 		system "MacOSX"
 		i = prepare()
-		test.isequal("MyProject.app/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
+		test.isequal("bin/Debug/MyProject.app/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
 	end
 
 

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -493,3 +493,20 @@
 		prepare()
 		test.contains("-L/usr/local/lib", gcc.getLibraryDirectories(cfg))
 	end
+
+
+--
+-- Check handling of link time optimization flag.
+--
+
+	function suite.cflags_onLinkTimeOptimization()
+		flags "LinkTimeOptimization"
+		prepare()
+		test.contains("-flto", gcc.getcflags(cfg))
+	end
+
+	function suite.ldflags_onLinkTimeOptimization()
+		flags "LinkTimeOptimization"
+		prepare()
+		test.contains("-flto", gcc.getldflags(cfg))
+	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -259,7 +259,7 @@
 		system "Windows"
 		kind "SharedLib"
 		prepare()
-		test.contains({ "-shared", '-Wl,--out-implib="MyProject.lib"' }, gcc.getldflags(cfg))
+		test.contains({ "-shared", '-Wl,--out-implib="bin/Debug/MyProject.lib"' }, gcc.getldflags(cfg))
 	end
 
 	function suite.ldflags_onWindowsApp()

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -199,7 +199,7 @@
 --
 
 	function suite.cflags_onNoExceptions()
-		flags { "NoExceptions" }
+		exceptionhandling "Off"
 		prepare()
 		test.contains({ "-fno-exceptions" }, gcc.getcxxflags(cfg))
 	end

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -240,13 +240,13 @@
 	end
 
 	function suite.cflags_onNoExceptions()
-		flags "NoExceptions"
+		exceptionhandling "Off"
 		prepare()
 		test.missing("/EHsc", msc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_onNoRTTI()
-		flags "NoRTTI"
+		rtti "Off"
 		prepare()
 		test.contains("/GR-", msc.getcxxflags(cfg))
 	end

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -228,8 +228,15 @@
 --
 
 	function suite.cflags_onExceptions()
+		exceptionhandling "on"
 		prepare()
 		test.contains("/EHsc", msc.getcxxflags(cfg))
+	end
+
+	function suite.cflags_onSEH()
+		flags "SEH"
+		prepare()
+		test.contains("/EHa", msc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_onNoExceptions()

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -227,25 +227,25 @@
 -- Check handling of C++ language features.
 --
 
-	function suite.cflags_onExceptions()
+	function suite.cxxflags_onExceptions()
 		exceptionhandling "on"
 		prepare()
 		test.contains("/EHsc", msc.getcxxflags(cfg))
 	end
 
-	function suite.cflags_onSEH()
-		flags "SEH"
+	function suite.cxxflags_onSEH()
+		exceptionhandling "SEH"
 		prepare()
 		test.contains("/EHa", msc.getcxxflags(cfg))
 	end
 
-	function suite.cflags_onNoExceptions()
+	function suite.cxxflags_onNoExceptions()
 		exceptionhandling "Off"
 		prepare()
 		test.missing("/EHsc", msc.getcxxflags(cfg))
 	end
 
-	function suite.cflags_onNoRTTI()
+	function suite.cxxflags_onNoRTTI()
 		rtti "Off"
 		prepare()
 		test.contains("/GR-", msc.getcxxflags(cfg))


### PR DESCRIPTION
If you use a token containing a non-escaped backslash (e.g. "%{cfg.linktarget.directory:gsub('/', '\\\\')}" then the detoken function will crash with the following error "unfinished string near '<eof>'". This is due to the fact that even though the backslash is escaped, once sent to the loadstring function, there is only one backslash left, thus the crash.

This pull request simply adds a unit test for this case (which I use in almost all my scripts, and which worked fine until recently, oddly enough ..) and the fix simply consists on escaping again any backslashes.