### PR TITLE
Embedded modules should now return "should load" test function from _preload.lua

### DIFF
--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -52,6 +52,6 @@
 		fname = fullPath or fname
 		if not io._includedFiles[fname] then
 			io._includedFiles[fname] = true
-			dofile(fname)
+			return dofile(fname)
 		end
 	end


### PR DESCRIPTION
Each _preload.lua script should now end by returning a function of the form `function (cfg) … end`, which should itself return true if the module is required by the provided configuration

````
-- for the Xcode module
return function ()
   return _ACTION == "xcode4"
end

-- for the D language module
return function (cfg) 
   return cfg.language == "D" 
end
```