### PR TITLE
Add midl compiler tags to Visual Studio vxproj files

### DIFF
--- a/src/base/path.lua
+++ b/src/base/path.lua
@@ -197,6 +197,14 @@
 		return path.hasextension(fname, ".rc")
 	end
 
+--
+-- Returns true if the filename represents a Windows idl file.
+--
+
+	function path.isidlfile(fname)
+		return path.hasextension(fname, ".idl")
+	end
+
 
 --
 -- Takes a path which is relative to one location and makes it relative

--- a/tests/actions/vstudio/vc2010/test_files.lua
+++ b/tests/actions/vstudio/vc2010/test_files.lua
@@ -68,6 +68,16 @@
 		]]
 	end
 
+	function suite.midlCompile_onIDLFile()
+		files { "idl/interfaces.idl" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<Midl Include="idl\interfaces.idl" />
+</ItemGroup>
+		]]
+	end
+
 	function suite.none_onTxtFile()
 		files { "docs/hello.txt" }
 		prepare()


### PR DESCRIPTION
Prior to this premake would not generate the right tags to compile idl files. This would make projects who depend on the midl output fail.