### PR TITLE
Fix #39, working tokens and wildcards in the same path

### DIFF
--- a/src/base/context.lua
+++ b/src/base/context.lua
@@ -172,13 +172,8 @@
 		-- If there is a matching field, then go fetch the aggregated value
 		-- from my configuration set, and then cache it future lookups.
 
-		local value = configset.fetch(ctx._cfgset, field, ctx.terms)
+		local value = configset.fetch(ctx._cfgset, field, ctx.terms, ctx)
 		if value then
-			-- do I need to expand tokens?
-			if field and field.tokens then
-				value = p.detoken.expand(value, ctx.environ, field, ctx._basedir)
-			end
-
 			-- store the result for later lookups
 			ctx[key] = value
 		end

--- a/src/base/detoken.lua
+++ b/src/base/detoken.lua
@@ -104,7 +104,7 @@
 
 		function expandvalue(value)
 			if type(value) ~= "string" then
-				return
+				return value
 			end
 
 			local count

--- a/src/base/field.lua
+++ b/src/base/field.lua
@@ -371,3 +371,20 @@
 			return value
 		end
 	end
+
+
+
+	function field.translate(f, value)
+		local processor = field.accessor(f, "translate")
+		if processor then
+			return processor(f, value, nil)[1]
+		else
+			return value
+		end
+	end
+
+
+	function field.translates(f)
+		return (field.accessor(f, "translate") ~= nil)
+	end
+

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -364,13 +364,8 @@
 			if not field then
 				ctx[key] = rawget(ctx, key)
 			else
-				local value = p.configset.fetch(cset, field, terms)
+				local value = p.configset.fetch(cset, field, terms, ctx)
 				if value then
-					-- do I need to expand tokens?
-					if field and field.tokens then
-						value = p.detoken.expand(value, ctx.environ, field, ctx._basedir)
-					end
-
 					ctx[key] = value
 				end
 			end

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -27,6 +27,7 @@ return {
 	"project/test_eachconfig.lua",
 	"project/test_getconfig.lua",
 	"project/test_location.lua",
+	"project/test_sources.lua",
 	"project/test_vpaths.lua",
 
 	-- Configuration object tests

--- a/tests/project/test_sources.lua
+++ b/tests/project/test_sources.lua
@@ -1,0 +1,93 @@
+--
+-- tests/project/test_sources.lua
+-- Automated test suite for the source tree, including tokens and wildcards.
+-- Copyright (c) 2011-2013 Jason Perkins and the Premake project
+--
+
+	local suite = test.declare("project_sources")
+	local project = premake.project
+
+
+--
+-- Setup and teardown
+--
+
+	local sln, prj
+
+	local cwd = os.getcwd()
+	local oldcwd
+
+	function suite.setup()
+		sln, prj = test.createsolution()
+
+		-- We change the directory to get nice relative paths
+		oldcwd = os.getcwd()
+		os.chdir(cwd)
+
+		-- Create a token to be used in search paths
+		premake.api.register { name = "mytoken", kind = "string", scope = "config" }
+		mytoken "test"
+	end
+
+	function suite.teardown()
+		mytoken = nil
+		os.chdir(oldcwd)
+	end
+
+	local function run()
+		local cfg = test.getconfig(prj, "Debug")
+
+		local files = {}
+		for _, file in ipairs(cfg.files) do
+			table.insert(files, path.getrelative(cwd, file))
+		end
+
+		return files
+	end
+
+
+--
+-- Test single file
+--
+
+	function suite.SingleFile()
+		files { "test_sources.lua" }
+		test.isequal({"test_sources.lua"}, run())
+	end
+
+--
+-- Test tokens
+--
+
+	function suite.SingleFileWithToken()
+		files { "%{cfg.mytoken}_sources.lua" }
+		test.isequal({"test_sources.lua"}, run())
+	end
+
+--
+-- Test wildcards
+--
+
+	function suite.FilesWithWildcard()
+		files { "test_*.lua" }
+		test.contains("test_sources.lua", run())
+	end
+
+	function suite.FilesWithRecursiveWildcard()
+		files { "../**_sources.lua" }
+		test.contains("test_sources.lua", run())
+	end
+
+--
+-- Test wildcards and tokens combined
+--
+
+	function suite.FilesWithWildcardAndToken()
+		files { "%{cfg.mytoken}_*.lua" }
+		test.contains("test_sources.lua", run())
+	end
+
+	function suite.FilesWithRecursiveWildcardAndToken()
+		files { "../**/%{cfg.mytoken}_sources.lua" }
+		test.contains("test_sources.lua", run())
+	end


### PR DESCRIPTION
```
Add a "translate" accessor to field kinds, allowing to perform a custom
processing (after detoken has happened)
Detoken is now applied to the "remove" elements
Detoken and translate are now performed in configset.fetch
```
This commit adds the new
`translate = function(field, current, _, processor)`
to field kinds. This function is called after detoken has been performed, and must return a table containing the result of the translation. For file and paths, it performs a wildcard lookup if required.

This code create a new regression error on vstudio_vs2010_rule_vars.onBooleanVar, but I really have no idea how this can happen...

It would be great if some people could test this patch on their solutions (if possible with many wildcards and tokens).