### PR TITLE
Fix handling of external rules

### DIFF
--- a/src/actions/vstudio/vs2012.lua
+++ b/src/actions/vstudio/vs2012.lua
@@ -43,6 +43,9 @@
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
 		end,
+		onRule = function(rule)
+			vstudio.vs2010.generateRule(rule)
+		end,
 
 		onCleanSolution = function(sln)
 			vstudio.cleanSolution(sln)

--- a/src/actions/vstudio/vs2013.lua
+++ b/src/actions/vstudio/vs2013.lua
@@ -45,6 +45,9 @@
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
 		end,
+		onRule = function(rule)
+			vstudio.vs2010.generateRule(rule)
+		end,
 
 		onCleanSolution = function(sln)
 			vstudio.cleanSolution(sln)

--- a/src/actions/vstudio/vs2015.lua
+++ b/src/actions/vstudio/vs2015.lua
@@ -45,6 +45,9 @@
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
 		end,
+		onRule = function(rule)
+			vstudio.vs2010.generateRule(rule)
+		end,
 
 		onCleanSolution = function(sln)
 			vstudio.cleanSolution(sln)

--- a/src/base/action.lua
+++ b/src/base/action.lua
@@ -81,7 +81,7 @@
 
 		for sln in p.global.eachSolution() do
 			local onSolution = act.onSolution or act.onsolution
-			if onSolution then
+			if onSolution and not sln.external then
 				onSolution(sln)
 			end
 
@@ -95,7 +95,7 @@
 
 		for rule in p.global.eachRule() do
 			local onRule = act.onRule or act.onrule
-			if onRule then
+			if onRule and not rule.external then
 				onRule(rule)
 			end
 		end
@@ -232,11 +232,11 @@
 	end
 
 
--- 
+--
 -- Determines if an action supports a particular configuration.
 -- @return
 -- True if the configuration is supported, false otherwise.
--- 
+--
 	function premake.action.supportsconfig(action, cfg)
 		if not action then
 			return false


### PR DESCRIPTION
As reported in issue #126. Added check to prevent generation of external rules and solutions the same way we skip external projects. Also noticed that rules were not turned on for Visual Studio versions later than 2010; fixed that too.