### PR TITLE
VC 2010 exporter cleanup

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -60,7 +60,7 @@
 --
 
 	function m.project(prj)
-		local action = premake.action.current()
+		local action = p.action.current()
 		p.push('<Project DefaultTargets="Build" ToolsVersion="%s" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">',
 			action.vstudio.toolsVersion)
 	end
@@ -105,7 +105,7 @@
 --
 
 	function m.targetFramework(prj)
-		local action = premake.action.current()
+		local action = p.action.current()
 		local tools = string.format(' ToolsVersion="%s"', action.vstudio.toolsVersion)
 
 		local framework = prj.framework or action.vstudio.targetFramework or "4.0"
@@ -347,7 +347,7 @@
 	end
 
 	function m.resourceCompile(cfg)
-		if cfg.system ~= premake.XBOX360 and config.hasResourceFiles(cfg) then
+		if cfg.system ~= p.XBOX360 and config.hasResourceFiles(cfg) then
 			local contents = p.capture(function ()
 				p.push()
 				p.callArray(m.elements.resourceCompile, cfg)
@@ -1092,7 +1092,7 @@
 
 
 	function m.deploy(cfg)
-		if cfg.system == premake.XBOX360 then
+		if cfg.system == p.XBOX360 then
 			p.push('<Deploy>')
 			p.w('<DeploymentType>CopyToHardDrive</DeploymentType>')
 			p.w('<DvdEmulationType>ZeroSeekTimes</DvdEmulationType>')
@@ -1123,10 +1123,10 @@
 
 
 	function m.entryPointSymbol(cfg)
-		if (cfg.kind == premake.CONSOLEAPP or cfg.kind == premake.WINDOWEDAPP) and
+		if (cfg.kind == p.CONSOLEAPP or cfg.kind == p.WINDOWEDAPP) and
 		   not cfg.flags.WinMain and
 		   cfg.clr == p.OFF and
-		   cfg.system ~= premake.XBOX360
+		   cfg.system ~= p.XBOX360
 		then
 			p.w('<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>')
 		end
@@ -1236,14 +1236,14 @@
 
 
 	function m.ignoreImportLibrary(cfg)
-		if cfg.kind == premake.SHAREDLIB and cfg.flags.NoImportLib then
+		if cfg.kind == p.SHAREDLIB and cfg.flags.NoImportLib then
 			p.w('<IgnoreImportLibrary>true</IgnoreImportLibrary>');
 		end
 	end
 
 
 	function m.imageXex(cfg)
-		if cfg.system == premake.XBOX360 then
+		if cfg.system == p.XBOX360 then
 			p.push('<ImageXex>')
 			if cfg.configfile then
 				p.w('<ConfigurationFile>%s</ConfigurationFile>', cfg.configfile)
@@ -1259,7 +1259,7 @@
 
 
 	function m.imageXexOutput(cfg)
-		if cfg.system == premake.XBOX360 then
+		if cfg.system == p.XBOX360 then
 			p.x('<ImageXexOutput>$(OutDir)$(TargetName).xex</ImageXexOutput>')
 		end
 	end
@@ -1302,7 +1302,7 @@
 
 
 	function m.importLibrary(cfg)
-		if cfg.kind == premake.SHAREDLIB then
+		if cfg.kind == p.SHAREDLIB then
 			p.x('<ImportLibrary>%s</ImportLibrary>', path.translate(cfg.linktarget.relpath))
 		end
 	end
@@ -1334,7 +1334,7 @@
 		-- try to determine what kind of targets we're building here
 		local isWin, isManaged, isMakefile
 		for cfg in project.eachconfig(prj) do
-			if cfg.system == premake.WINDOWS then
+			if cfg.system == p.WINDOWS then
 				isWin = true
 			end
 			if cfg.clr ~= p.OFF then
@@ -1371,7 +1371,7 @@
 
 
 	function m.linkIncremental(cfg)
-		if cfg.kind ~= premake.STATICLIB then
+		if cfg.kind ~= p.STATICLIB then
 			p.w('<LinkIncremental>%s</LinkIncremental>', tostring(config.canLinkIncremental(cfg)))
 		end
 	end
@@ -1393,7 +1393,7 @@
 		if config.isOptimizedBuild(cfg) or
 		   cfg.flags.NoMinimalRebuild or
 		   cfg.flags.MultiProcessorCompile or
-		   cfg.debugformat == premake.C7
+		   cfg.debugformat == p.C7
 		then
 			p.w('<MinimalRebuild>false</MinimalRebuild>')
 		end
@@ -1418,7 +1418,7 @@
 	function m.nmakeCommandLine(cfg, commands, phase)
 		if #commands > 0 then
 			commands = os.translateCommands(commands, p.WINDOWS)
-			commands = table.concat(premake.esc(commands), p.eol())
+			commands = table.concat(p.esc(commands), p.eol())
 			p.w('<NMake%sCommandLine>%s</NMake%sCommandLine>', phase, commands, phase)
 		end
 	end
@@ -1484,7 +1484,7 @@
 
 
 	function m.outputFile(cfg)
-		if cfg.system == premake.XBOX360 then
+		if cfg.system == p.XBOX360 then
 			p.w('<OutputFile>$(OutDir)%s</OutputFile>', cfg.buildtarget.name)
 		end
 	end
@@ -1503,7 +1503,7 @@
 		if version then
 			version = "v" .. version
 		else
-			local action = premake.action.current()
+			local action = p.action.current()
 			version = action.vstudio.platformToolset
 		end
 		if version then
@@ -1543,7 +1543,7 @@
 			if escapeQuotes then
 				defines = defines:gsub('"', '\\"')
 			end
-			defines = premake.esc(defines) .. ";%%(PreprocessorDefinitions)"
+			defines = p.esc(defines) .. ";%%(PreprocessorDefinitions)"
 			m.element('PreprocessorDefinitions', condition, defines)
 		end
 	end
@@ -1555,7 +1555,7 @@
 			if escapeQuotes then
 				undefines = undefines:gsub('"', '\\"')
 			end
-			undefines = premake.esc(undefines) .. ";%%(UndefinePreprocessorDefinitions)"
+			undefines = p.esc(undefines) .. ";%%(UndefinePreprocessorDefinitions)"
 			m.element('UndefinePreprocessorDefinitions', condition, undefines)
 		end
 	end
@@ -1686,8 +1686,8 @@
 
 
 	function m.subSystem(cfg)
-		if cfg.system ~= premake.XBOX360 then
-			local subsystem = iif(cfg.kind == premake.CONSOLEAPP, "Console", "Windows")
+		if cfg.system ~= p.XBOX360 then
+			local subsystem = iif(cfg.kind == p.CONSOLEAPP, "Console", "Windows")
 			p.w('<SubSystem>%s</SubSystem>', subsystem)
 		end
 	end
@@ -1711,7 +1711,7 @@
 
 	function m.treatLinkerWarningAsErrors(cfg)
 		if cfg.flags.FatalLinkWarnings then
-			local el = iif(cfg.kind == premake.STATICLIB, "Lib", "Linker")
+			local el = iif(cfg.kind == p.STATICLIB, "Lib", "Linker")
 			p.w('<Treat%sWarningAsErrors>true</Treat%sWarningAsErrors>', el, el)
 		end
 	end
@@ -1736,7 +1736,7 @@
 	function m.disableSpecificWarnings(cfg, condition)
 		if #cfg.disablewarnings > 0 then
 			local warnings = table.concat(cfg.disablewarnings, ";")
-			warnings = premake.esc(warnings) .. ";%%(DisableSpecificWarnings)"
+			warnings = p.esc(warnings) .. ";%%(DisableSpecificWarnings)"
 			m.element('DisableSpecificWarnings', condition, warnings)
 		end
 	end
@@ -1745,7 +1745,7 @@
 	function m.treatSpecificWarningsAsErrors(cfg, condition)
 		if #cfg.fatalwarnings > 0 then
 			local fatal = table.concat(cfg.fatalwarnings, ";")
-			fatal = premake.esc(fatal) .. ";%%(TreatSpecificWarningsAsErrors)"
+			fatal = p.esc(fatal) .. ";%%(TreatSpecificWarningsAsErrors)"
 			m.element('TreatSpecificWarningsAsErrors', condition, fatal)
 		end
 	end
@@ -1801,7 +1801,7 @@
 --
 
 	function m.condition(cfg)
-		return string.format('Condition="\'$(Configuration)|$(Platform)\'==\'%s\'"', premake.esc(vstudio.projectConfig(cfg)))
+		return string.format('Condition="\'$(Configuration)|$(Platform)\'==\'%s\'"', p.esc(vstudio.projectConfig(cfg)))
 	end
 
 
@@ -1823,7 +1823,7 @@
 
 	function m.element(name, condition, value, ...)
 		if select('#',...) == 0 then
-			value = premake.esc(value)
+			value = p.esc(value)
 		end
 
 		local format

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1,7 +1,7 @@
 --
 -- vs2010_vcxproj.lua
 -- Generate a Visual Studio 201x C/C++ project.
--- Copyright (c) 2009-2014 Jason Perkins and the Premake project
+-- Copyright (c) 2009-2015 Jason Perkins and the Premake project
 --
 
 	premake.vstudio.vc2010 = {}
@@ -904,7 +904,7 @@
 
 		if #links > 0 then
 			links = path.translate(table.concat(links, ";"))
-			p.x('<AdditionalDependencies>%s;%%(AdditionalDependencies)</AdditionalDependencies>', links)
+			m.element("AdditionalDependencies", nil, "%s;%%(AdditionalDependencies)", links)
 		end
 	end
 
@@ -913,7 +913,7 @@
 		if #includedirs > 0 then
 			local dirs = vstudio.path(cfg, includedirs)
 			if #dirs > 0 then
-				p.x('<AdditionalIncludeDirectories>%s;%%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>', table.concat(dirs, ";"))
+				m.element("AdditionalIncludeDirectories", nil, "%s;%%(AdditionalIncludeDirectories)", table.concat(dirs, ";"))
 			end
 		end
 	end
@@ -922,7 +922,7 @@
 	function m.additionalLibraryDirectories(cfg)
 		if #cfg.libdirs > 0 then
 			local dirs = table.concat(vstudio.path(cfg, cfg.libdirs), ";")
-			p.x('<AdditionalLibraryDirectories>%s;%%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>', dirs)
+			m.element("AdditionalLibraryDirectories", nil, "%s;%%(AdditionalLibraryDirectories)", dirs)
 		end
 	end
 
@@ -930,7 +930,7 @@
 	function m.additionalUsingDirectories(cfg)
 		if #cfg.usingdirs > 0 then
 			local dirs = table.concat(vstudio.path(cfg, cfg.usingdirs), ";")
-			p.x('<AdditionalUsingDirectories>%s;%%(AdditionalUsingDirectories)</AdditionalUsingDirectories>', dirs)
+			m.element("AdditionalUsingDirectories", nil, "%s;%%(AdditionalUsingDirectories)", dirs)
 		end
 	end
 
@@ -946,7 +946,7 @@
 	function m.additionalLinkOptions(cfg)
 		if #cfg.linkoptions > 0 then
 			local opts = table.concat(cfg.linkoptions, " ")
-			p.x('<AdditionalOptions>%s %%(AdditionalOptions)</AdditionalOptions>', opts)
+			m.element("AdditionalOptions", nil, "%s %%(AdditionalOptions)", opts)
 		end
 	end
 
@@ -954,7 +954,7 @@
 	function m.basicRuntimeChecks(cfg)
 		local runtime = config.getruntime(cfg)
 		if cfg.flags.NoRuntimeChecks or (config.isOptimizedBuild(cfg) and runtime:endswith("Debug")) then
-			p.w('<BasicRuntimeChecks>Default</BasicRuntimeChecks>')
+			m.element("BasicRuntimeChecks", nil, "Default")
 		end
 	end
 
@@ -977,7 +977,7 @@
 	function m.buildLog(cfg)
 		if cfg.buildlog and #cfg.buildlog > 0 then
 			p.push('<BuildLog>')
-			p.x('<Path>%s</Path>', vstudio.path(cfg, cfg.buildlog))
+			m.element("Path", nil, "%s", vstudio.path(cfg, cfg.buildlog))
 			p.pop('</BuildLog>')
 		end
 	end
@@ -998,14 +998,14 @@
 
 	function m.characterSet(cfg)
 		if not vstudio.isMakefile(cfg) then
-			p.w('<CharacterSet>%s</CharacterSet>', iif(cfg.flags.Unicode, "Unicode", "MultiByte"))
+			m.element("CharacterSet", nil, iif(cfg.flags.Unicode, "Unicode", "MultiByte"))
 		end
 	end
 
 
 	function m.wholeProgramOptimization(cfg)
 		if cfg.flags.LinkTimeOptimization then
-			p.w('<WholeProgramOptimization>true</WholeProgramOptimization>')
+			m.element("WholeProgramOptimization", nil, "true")
 		end
 	end
 
@@ -1036,14 +1036,14 @@
 			value = cfg.clr
 		end
 		if value then
-			p.w('<CLRSupport>%s</CLRSupport>', value)
+			m.element("CLRSupport", nil, value)
 		end
 	end
 
 
 	function m.compileAs(cfg)
 		if cfg.project.language == "C" then
-			p.w('<CompileAs>CompileAsC</CompileAs>')
+			m.element("CompileAs", nil, "CompileAsC")
 		end
 	end
 
@@ -1058,14 +1058,14 @@
 			None = "Makefile",
 			Utility = "Utility",
 		}
-		p.w('<ConfigurationType>%s</ConfigurationType>', types[cfg.kind])
+		m.element("ConfigurationType", nil, types[cfg.kind])
 	end
 
 
 	function m.culture(cfg)
 		local value = vstudio.cultureForLocale(cfg.locale)
 		if value then
-			p.w('<Culture>0x%04x</Culture>', value)
+			m.element("Culture", nil, "0x%04x", tostring(value))
 		end
 	end
 
@@ -1086,7 +1086,7 @@
 			end
 		end
 		if value then
-			p.w('<DebugInformationFormat>%s</DebugInformationFormat>', value)
+			m.element("DebugInformationFormat", nil, value)
 		end
 	end
 
@@ -1094,9 +1094,9 @@
 	function m.deploy(cfg)
 		if cfg.system == p.XBOX360 then
 			p.push('<Deploy>')
-			p.w('<DeploymentType>CopyToHardDrive</DeploymentType>')
-			p.w('<DvdEmulationType>ZeroSeekTimes</DvdEmulationType>')
-			p.w('<DeploymentFiles>$(RemoteRoot)=$(ImagePath);</DeploymentFiles>')
+			m.element("DeploymentType", nil, "CopyToHardDrive")
+			m.element("DvdEmulationType", nil, "ZeroSeekTimes")
+			m.element("DeploymentFiles", nil, "$(RemoteRoot)=$(ImagePath);")
 			p.pop('</Deploy>')
 		end
 	end
@@ -1128,7 +1128,7 @@
 		   cfg.clr == p.OFF and
 		   cfg.system ~= p.XBOX360
 		then
-			p.w('<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>')
+			m.element("EntryPointSymbol", nil, "mainCRTStartup")
 		end
 	end
 
@@ -1136,9 +1136,9 @@
 	function m.exceptionHandling(cfg)
 		local value
 		if cfg.exceptionhandling == p.OFF then
-			p.w('<ExceptionHandling>false</ExceptionHandling>')
+			m.element("ExceptionHandling", nil, "false")
 		elseif cfg.exceptionhandling == "SEH" then
-			p.w('<ExceptionHandling>Async</ExceptionHandling>')
+			m.element("ExceptionHandling", nil, "Async")
 		end
 	end
 
@@ -1159,13 +1159,13 @@
 
 
 	function m.fileType(cfg, file)
-		p.w('<FileType>Document</FileType>')
+		m.element("FileType", nil, "Document")
 	end
 
 
 	function m.floatingPointModel(cfg)
 		if cfg.floatingpoint then
-			p.w('<FloatingPointModel>%s</FloatingPointModel>', cfg.floatingpoint)
+			m.element("FloatingPointModel", nil, cfg.floatingpoint)
 		end
 	end
 
@@ -1177,7 +1177,7 @@
 				Explicit = "OnlyExplicitInline",
 				Auto = "AnySuitable",
 			}
-			p.w('<InlineFunctionExpansion>%s</InlineFunctionExpansion>', types[cfg.inlining])
+			m.element("InlineFunctionExpansion", nil, types[cfg.inlining])
 		end
 	end
 
@@ -1199,26 +1199,26 @@
 
 	function m.functionLevelLinking(cfg)
 		if config.isOptimizedBuild(cfg) then
-			p.w('<FunctionLevelLinking>true</FunctionLevelLinking>')
+			m.element("FunctionLevelLinking", nil, "true")
 		end
 	end
 
 
 	function m.generateDebugInformation(cfg)
-		p.w('<GenerateDebugInformation>%s</GenerateDebugInformation>', tostring(cfg.flags.Symbols ~= nil))
+		m.element("GenerateDebugInformation", nil, tostring(cfg.flags.Symbols ~= nil))
 	end
 
 
 	function m.generateManifest(cfg)
 		if cfg.flags.NoManifest then
-			p.w('<GenerateManifest>false</GenerateManifest>')
+			m.element("GenerateManifest", nil, "false")
 		end
 	end
 
 
 	function m.generateMapFile(cfg)
 		if cfg.flags.Maps then
-			p.w('<GenerateMapFile>true</GenerateMapFile>')
+			m.element("GenerateMapFile", nil, "true")
 		end
 	end
 
@@ -1230,14 +1230,14 @@
 		-- Premake already adds unique object names to conflicting file names, so
 		-- just go ahead and disable that warning.
 		if _ACTION > "vs2012" then
-			p.w('<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>')
+			m.element("IgnoreWarnCompileDuplicatedFilename", nil, "true")
 		end
 	end
 
 
 	function m.ignoreImportLibrary(cfg)
 		if cfg.kind == p.SHAREDLIB and cfg.flags.NoImportLib then
-			p.w('<IgnoreImportLibrary>true</IgnoreImportLibrary>');
+			m.element("IgnoreImportLibrary", nil, "true")
 		end
 	end
 
@@ -1246,7 +1246,7 @@
 		if cfg.system == p.XBOX360 then
 			p.push('<ImageXex>')
 			if cfg.configfile then
-				p.w('<ConfigurationFile>%s</ConfigurationFile>', cfg.configfile)
+				m.element("ConfigurationFile", nil, "%s", cfg.configfile)
 			else
 				p.w('<ConfigurationFile>')
 				p.w('</ConfigurationFile>')
@@ -1260,7 +1260,7 @@
 
 	function m.imageXexOutput(cfg)
 		if cfg.system == p.XBOX360 then
-			p.x('<ImageXexOutput>$(OutDir)$(TargetName).xex</ImageXexOutput>')
+			m.element("ImageXexOutput", nil, "%s", "$(OutDir)$(TargetName).xex")
 		end
 	end
 
@@ -1303,7 +1303,7 @@
 
 	function m.importLibrary(cfg)
 		if cfg.kind == p.SHAREDLIB then
-			p.x('<ImportLibrary>%s</ImportLibrary>', path.translate(cfg.linktarget.relpath))
+			m.element("ImportLibrary", nil, "%s", path.translate(cfg.linktarget.relpath))
 		end
 	end
 
@@ -1311,20 +1311,20 @@
 	function m.includePath(cfg)
 		local dirs = vstudio.path(cfg, cfg.sysincludedirs)
 		if #dirs > 0 then
-			p.x('<IncludePath>%s;$(IncludePath)</IncludePath>', table.concat(dirs, ";"))
+			m.element("IncludePath", nil, "%s;$(IncludePath)", table.concat(dirs, ";"))
 		end
 	end
 
 
 	function m.intDir(cfg)
 		local objdir = vstudio.path(cfg, cfg.objdir)
-		p.x('<IntDir>%s\\</IntDir>', objdir)
+		m.element("IntDir", nil, "%s\\", objdir)
 	end
 
 
 	function m.intrinsicFunctions(cfg)
 		if config.isOptimizedBuild(cfg) then
-			p.w('<IntrinsicFunctions>true</IntrinsicFunctions>')
+			m.element("IntrinsicFunctions", nil, "true")
 		end
 	end
 
@@ -1347,15 +1347,15 @@
 
 		if isWin then
 			if isMakefile then
-				p.w('<Keyword>MakeFileProj</Keyword>')
+				m.element("Keyword", nil, "MakeFileProj")
 			else
 				if isManaged then
 					m.targetFramework(prj)
-					p.w('<Keyword>ManagedCProj</Keyword>')
+					m.element("Keyword", nil, "ManagedCProj")
 				else
-					p.w('<Keyword>Win32Proj</Keyword>')
+					m.element("Keyword", nil, "Win32Proj")
 				end
-				p.w('<RootNamespace>%s</RootNamespace>', prj.name)
+				m.element("RootNamespace", nil, "%s", prj.name)
 			end
 		end
 	end
@@ -1364,7 +1364,7 @@
 	function m.libraryPath(cfg)
 		local dirs = vstudio.path(cfg, cfg.syslibdirs)
 		if #dirs > 0 then
-			p.x('<LibraryPath>%s;$(LibraryPath)</LibraryPath>', table.concat(dirs, ";"))
+			m.element("LibraryPath", nil, "%s;$(LibraryPath)", table.concat(dirs, ";"))
 		end
 	end
 
@@ -1372,7 +1372,7 @@
 
 	function m.linkIncremental(cfg)
 		if cfg.kind ~= p.STATICLIB then
-			p.w('<LinkIncremental>%s</LinkIncremental>', tostring(config.canLinkIncremental(cfg)))
+			m.element("LinkIncremental", nil, "%s", tostring(config.canLinkIncremental(cfg)))
 		end
 	end
 
@@ -1383,7 +1383,7 @@
 		-- linking and list all siblings explicitly
 		if explicit then
 			p.push('<ProjectReference>')
-			p.w('<LinkLibraryDependencies>false</LinkLibraryDependencies>')
+			m.element("LinkLibraryDependencies", nil, "false")
 			p.pop('</ProjectReference>')
 		end
 	end
@@ -1395,7 +1395,7 @@
 		   cfg.flags.MultiProcessorCompile or
 		   cfg.debugformat == p.C7
 		then
-			p.w('<MinimalRebuild>false</MinimalRebuild>')
+			m.element("MinimalRebuild", nil, "false")
 		end
 	end
 
@@ -1403,14 +1403,14 @@
 	function m.moduleDefinitionFile(cfg)
 		local df = config.findfile(cfg, ".def")
 		if df then
-			p.w('<ModuleDefinitionFile>%s</ModuleDefinitionFile>', df)
+			m.element("ModuleDefinitionFile", nil, "%s", df)
 		end
 	end
 
 
 	function m.multiProcessorCompilation(cfg)
 		if cfg.flags.MultiProcessorCompile then
-			p.w('<MultiProcessorCompilation>true</MultiProcessorCompilation>')
+			m.element("MultiProcessorCompilation", nil, "true")
 		end
 	end
 
@@ -1432,14 +1432,14 @@
 	end
 
 	function m.nmakeOutput(cfg)
-		p.w('<NMakeOutput>$(OutDir)%s</NMakeOutput>', cfg.buildtarget.name)
+		m.element("NMakeOutput", nil, "$(OutDir)%s", cfg.buildtarget.name)
 	end
 
 
 
 	function m.objectFileName(fcfg)
 		if fcfg.objname ~= fcfg.basename then
-			p.w('<ObjectFileName %s>$(IntDir)\\%s.obj</ObjectFileName>', m.condition(fcfg.config), fcfg.objname)
+			m.element("ObjectFileName", m.condition(fcfg.config), "$(IntDir)\\%s.obj", fcfg.objname)
 		end
 	end
 
@@ -1447,7 +1447,7 @@
 
 	function m.omitDefaultLib(cfg)
 		if cfg.flags.OmitDefaultLibrary then
-			p.w('<OmitDefaultLibName>true</OmitDefaultLibName>')
+			m.element("OmitDefaultLibName", nil, "true")
 		end
 	end
 
@@ -1455,15 +1455,15 @@
 
 	function m.omitFramePointers(cfg)
 		if cfg.flags.NoFramePointer then
-			p.w('<OmitFramePointers>true</OmitFramePointers>')
+			m.element("OmitFramePointers", nil, "true")
 		end
 	end
 
 
 	function m.optimizeReferences(cfg)
 		if config.isOptimizedBuild(cfg) then
-			p.w('<EnableCOMDATFolding>true</EnableCOMDATFolding>')
-			p.w('<OptimizeReferences>true</OptimizeReferences>')
+			m.element("EnableCOMDATFolding", nil, "true")
+			m.element("OptimizeReferences", nil, "true")
 		end
 	end
 
@@ -1479,13 +1479,13 @@
 
 	function m.outDir(cfg)
 		local outdir = vstudio.path(cfg, cfg.buildtarget.directory)
-		p.x('<OutDir>%s\\</OutDir>', outdir)
+		m.element("OutDir", nil, "%s\\", outdir)
 	end
 
 
 	function m.outputFile(cfg)
 		if cfg.system == p.XBOX360 then
-			p.w('<OutputFile>$(OutDir)%s</OutputFile>', cfg.buildtarget.name)
+			m.element("OutputFile", nil, "$(OutDir)%s", cfg.buildtarget.name)
 		end
 	end
 
@@ -1493,7 +1493,7 @@
 	function m.executablePath(cfg)
 		local dirs = vstudio.path(cfg, cfg.bindirs)
 		if #dirs > 0 then
-			p.x('<ExecutablePath>%s;$(ExecutablePath)</ExecutablePath>', path.translate(table.concat(dirs, ";")))
+			m.element("ExecutablePath", nil, "%s;$(ExecutablePath)", table.concat(dirs, ";"))
 		end
 	end
 
@@ -1510,7 +1510,7 @@
 			-- should only be written if there is a C/C++ file in the config
 			for i = 1, #cfg.files do
 				if path.iscppfile(cfg.files[i]) then
-					p.w('<PlatformToolset>%s</PlatformToolset>', version)
+					m.element("PlatformToolset", nil, version)
 					break
 				end
 			end
@@ -1528,10 +1528,10 @@
 			end
 		else
 			if not prjcfg.flags.NoPCH and prjcfg.pchheader then
-				p.w('<PrecompiledHeader>Use</PrecompiledHeader>')
-				p.x('<PrecompiledHeaderFile>%s</PrecompiledHeaderFile>', prjcfg.pchheader)
+				m.element("PrecompiledHeader", nil, "Use")
+				m.element("PrecompiledHeaderFile", nil, "%s", prjcfg.pchheader)
 			else
-				p.w('<PrecompiledHeader>NotUsing</PrecompiledHeader>')
+				m.element("PrecompiledHeader", nil, "NotUsing")
 			end
 		end
 	end
@@ -1567,13 +1567,13 @@
 
 
 	function m.projectGuid(prj)
-		p.w('<ProjectGuid>{%s}</ProjectGuid>', prj.uuid)
+		m.element("ProjectGuid", nil, "{%s}", prj.uuid)
 	end
 
 
 	function m.projectName(prj)
 		if prj.name ~= prj.filename then
-			p.x('<ProjectName>%s</ProjectName>', prj.name)
+			m.element("ProjectName", nil, "%s", prj.name)
 		end
 	end
 
@@ -1608,32 +1608,32 @@
 
 
 	function m.referenceCopyLocalSatelliteAssemblies(prj, ref)
-		p.w('<CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>')
+		m.element("CopyLocalSatelliteAssemblies", nil, "false")
 	end
 
 
 	function m.referenceLinkLibraryDependencies(prj, ref)
-		p.w('<LinkLibraryDependencies>true</LinkLibraryDependencies>')
+		m.element("LinkLibraryDependencies", nil, "true")
 	end
 
 
 	function m.referenceOutputAssembly(prj, ref)
-		p.w('<ReferenceOutputAssembly>true</ReferenceOutputAssembly>')
+		m.element("ReferenceOutputAssembly", nil, "true")
 	end
 
 
 	function m.referencePrivate(prj, ref)
-		p.w('<Private>true</Private>')
+		m.element("Private", nil, "true")
 	end
 
 
 	function m.referenceProject(prj, ref)
-		p.w('<Project>{%s}</Project>', ref.uuid)
+		m.element("Project", nil, "{%s}", ref.uuid)
 	end
 
 
 	function m.referenceUseLibraryDependences(prj, ref)
-		p.w('<UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>')
+		m.element("UseLibraryDependencyInputs", nil, "false")
 	end
 
 
@@ -1654,33 +1654,33 @@
 		}
 		local runtime = runtimes[config.getruntime(cfg)]
 		if runtime then
-			p.w('<RuntimeLibrary>%s</RuntimeLibrary>', runtime)
+			m.element("RuntimeLibrary", nil, runtime)
 		end
 	end
 
 	function m.callingConvention(cfg)
 		if cfg.callingconvention then
-			p.w('<CallingConvention>%s</CallingConvention>', cfg.callingconvention)
+			m.element("CallingConvention", nil, cfg.callingconvention)
 		end
 	end
 
 	function m.runtimeTypeInfo(cfg)
 		if cfg.rtti == p.OFF and cfg.clr == p.OFF then
-			p.w('<RuntimeTypeInfo>false</RuntimeTypeInfo>')
+			m.element("RuntimeTypeInfo", nil, "false")
 		elseif cfg.rtti == p.ON then
-			p.w('<RuntimeTypeInfo>true</RuntimeTypeInfo>')
+			m.element("RuntimeTypeInfo", nil, "true")
 		end
 	end
 
 	function m.bufferSecurityCheck(cfg)
 		if cfg.flags.NoBufferSecurityCheck then
-			p.w('<BufferSecurityCheck>false</BufferSecurityCheck>')
+			m.element("BufferSecurityCheck", nil, "false")
 		end
 	end
 
 	function m.stringPooling(cfg)
 		if config.isOptimizedBuild(cfg) then
-			p.w('<StringPooling>true</StringPooling>')
+			m.element("StringPooling", nil, "true")
 		end
 	end
 
@@ -1688,7 +1688,7 @@
 	function m.subSystem(cfg)
 		if cfg.system ~= p.XBOX360 then
 			local subsystem = iif(cfg.kind == p.CONSOLEAPP, "Console", "Windows")
-			p.w('<SubSystem>%s</SubSystem>', subsystem)
+			m.element("SubSystem", nil, subsystem)
 		end
 	end
 
@@ -1696,7 +1696,7 @@
 	function m.targetExt(cfg)
 		local ext = cfg.buildtarget.extension
 		if ext ~= "" then
-			p.x('<TargetExt>%s</TargetExt>', ext)
+			m.element("TargetExt", nil, "%s", ext)
 		else
 			p.w('<TargetExt>')
 			p.w('</TargetExt>')
@@ -1705,14 +1705,14 @@
 
 
 	function m.targetName(cfg)
-		p.x('<TargetName>%s%s</TargetName>', cfg.buildtarget.prefix, cfg.buildtarget.basename)
+		m.element("TargetName", nil, "%s%s", cfg.buildtarget.prefix, cfg.buildtarget.basename)
 	end
 
 
 	function m.treatLinkerWarningAsErrors(cfg)
 		if cfg.flags.FatalLinkWarnings then
 			local el = iif(cfg.kind == p.STATICLIB, "Lib", "Linker")
-			p.w('<Treat%sWarningAsErrors>true</Treat%sWarningAsErrors>', el, el)
+			m.element("Treat" .. el .. "WarningAsErrors", nil, "true")
 		end
 	end
 
@@ -1721,14 +1721,14 @@
 		local map = { On = "true", Off = "false" }
 		local value = map[cfg.nativewchar]
 		if value then
-			p.w('<TreatWChar_tAsBuiltInType>%s</TreatWChar_tAsBuiltInType>', value)
+			m.element("TreatWChar_tAsBuiltInType", nil, value)
 		end
 	end
 
 
 	function m.treatWarningAsError(cfg)
 		if cfg.flags.FatalCompileWarnings and cfg.warnings ~= p.OFF then
-			p.w('<TreatWarningAsError>true</TreatWarningAsError>')
+			m.element("TreatWarningAsError", nil, "true")
 		end
 	end
 
@@ -1753,19 +1753,19 @@
 
 	function m.useDebugLibraries(cfg)
 		local runtime = config.getruntime(cfg)
-		p.w('<UseDebugLibraries>%s</UseDebugLibraries>', tostring(runtime:endswith("Debug")))
+		m.element("UseDebugLibraries", nil, tostring(runtime:endswith("Debug")))
 	end
 
 
 	function m.useOfMfc(cfg)
 		if cfg.flags.MFC then
-			p.w('<UseOfMfc>%s</UseOfMfc>', iif(cfg.flags.StaticRuntime, "Static", "Dynamic"))
+			m.element("UseOfMfc", nil, iif(cfg.flags.StaticRuntime, "Static", "Dynamic"))
 		end
 	end
 
 	function m.useOfAtl(cfg)
 		if cfg.atl then
-			p.w('<UseOfATL>%s</UseOfATL>', cfg.atl)
+			m.element("UseOfATL", nil, cfg.atl)
 		end
 	end
 

--- a/tests/actions/vstudio/vc2010/test_assembly_refs.lua
+++ b/tests/actions/vstudio/vc2010/test_assembly_refs.lua
@@ -44,10 +44,10 @@
 		links { "System.dll", "System.Data.dll" }
 		prepare()
 		test.capture [[
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Data" />
-	</ItemGroup>
+<ItemGroup>
+	<Reference Include="System" />
+	<Reference Include="System.Data" />
+</ItemGroup>
 		]]
 	end
 
@@ -60,9 +60,9 @@
 		links { "m", "System.dll" }
 		prepare()
 		test.capture [[
-	<ItemGroup>
-		<Reference Include="System" />
-	</ItemGroup>
+<ItemGroup>
+	<Reference Include="System" />
+</ItemGroup>
 		]]
 	end
 
@@ -75,10 +75,10 @@
 		links { "../nunit.framework.dll" }
 		prepare()
 		test.capture [[
-	<ItemGroup>
-		<Reference Include="nunit.framework">
-			<HintPath>..\nunit.framework.dll</HintPath>
-		</Reference>
-	</ItemGroup>
+<ItemGroup>
+	<Reference Include="nunit.framework">
+		<HintPath>..\nunit.framework.dll</HintPath>
+	</Reference>
+</ItemGroup>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_build_events.lua
+++ b/tests/actions/vstudio/vc2010/test_build_events.lua
@@ -43,9 +43,9 @@
 		prebuildcommands { "command1" }
 		prepare()
 		test.capture [[
-		<PreBuildEvent>
-			<Command>command1</Command>
-		</PreBuildEvent>
+<PreBuildEvent>
+	<Command>command1</Command>
+</PreBuildEvent>
 		]]
 	end
 
@@ -53,9 +53,9 @@
 		postbuildcommands { "command1" }
 		prepare()
 		test.capture [[
-		<PostBuildEvent>
-			<Command>command1</Command>
-		</PostBuildEvent>
+<PostBuildEvent>
+	<Command>command1</Command>
+</PostBuildEvent>
 		]]
 	end
 
@@ -64,12 +64,12 @@
 		postbuildcommands { "command2" }
 		prepare()
 		test.capture [[
-		<PreBuildEvent>
-			<Command>command1</Command>
-		</PreBuildEvent>
-		<PostBuildEvent>
-			<Command>command2</Command>
-		</PostBuildEvent>
+<PreBuildEvent>
+	<Command>command1</Command>
+</PreBuildEvent>
+<PostBuildEvent>
+	<Command>command2</Command>
+</PostBuildEvent>
 		]]
 	end
 
@@ -81,7 +81,7 @@
 	function suite.splits_onMultipleCommands()
 		postbuildcommands { "command1", "command2" }
 		prepare()
-		test.capture ("\t\t<PostBuildEvent>\n\t\t\t<Command>command1\r\ncommand2</Command>\n\t\t</PostBuildEvent>\n")
+		test.capture ("<PostBuildEvent>\n\t<Command>command1\r\ncommand2</Command>\n</PostBuildEvent>\n")
 	end
 
 
@@ -94,9 +94,9 @@
 		postbuildcommands { '\' " < > &' }
 		prepare()
 		test.capture [[
-		<PostBuildEvent>
-			<Command>' " &lt; &gt; &amp;</Command>
-		</PostBuildEvent>
+<PostBuildEvent>
+	<Command>' " &lt; &gt; &amp;</Command>
+</PostBuildEvent>
 		]]
 	end
 
@@ -110,9 +110,9 @@
 		postbuildmessage "Post-building..."
 		prepare()
 		test.capture [[
-		<PostBuildEvent>
-			<Command>command1</Command>
-			<Message>Post-building...</Message>
-		</PostBuildEvent>
+<PostBuildEvent>
+	<Command>command1</Command>
+	<Message>Post-building...</Message>
+</PostBuildEvent>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_config_props.lua
+++ b/tests/actions/vstudio/vc2010/test_config_props.lua
@@ -33,11 +33,11 @@
 	function suite.structureIsCorrect_onDefaultValues()
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<CharacterSet>MultiByte</CharacterSet>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>MultiByte</CharacterSet>
+</PropertyGroup>
 		]]
 	end
 
@@ -50,8 +50,8 @@
 		kind "ConsoleApp"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
 		]]
 	end
 
@@ -59,8 +59,8 @@
 		kind "WindowedApp"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
 		]]
 	end
 
@@ -68,8 +68,8 @@
 		kind "SharedLib"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>DynamicLibrary</ConfigurationType>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>DynamicLibrary</ConfigurationType>
 		]]
 	end
 
@@ -77,8 +77,8 @@
 		kind "StaticLib"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>StaticLibrary</ConfigurationType>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>StaticLibrary</ConfigurationType>
 		]]
 	end
 
@@ -90,9 +90,9 @@
 		flags "Symbols"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>true</UseDebugLibraries>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>true</UseDebugLibraries>
 		]]
 	end
 
@@ -104,10 +104,10 @@
 		flags "Unicode"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<CharacterSet>Unicode</CharacterSet>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
 		]]
 	end
 
@@ -120,10 +120,10 @@
 		clr "On"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<CLRSupport>true</CLRSupport>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CLRSupport>true</CLRSupport>
 		]]
 	end
 
@@ -131,9 +131,9 @@
 		clr "Off"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
 		]]
 	end
 
@@ -141,10 +141,10 @@
 		clr "Unsafe"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<CLRSupport>true</CLRSupport>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CLRSupport>true</CLRSupport>
 		]]
 	end
 
@@ -152,10 +152,10 @@
 		clr "Safe"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<CLRSupport>Safe</CLRSupport>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CLRSupport>Safe</CLRSupport>
 		]]
 	end
 
@@ -163,10 +163,10 @@
 		clr "Pure"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<CLRSupport>Pure</CLRSupport>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CLRSupport>Pure</CLRSupport>
 		]]
 	end
 
@@ -179,10 +179,10 @@
 		flags "MFC"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<UseOfMfc>Dynamic</UseOfMfc>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<UseOfMfc>Dynamic</UseOfMfc>
 		]]
 	end
 
@@ -190,10 +190,10 @@
 		flags { "MFC", "StaticRuntime" }
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<UseOfMfc>Static</UseOfMfc>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<UseOfMfc>Static</UseOfMfc>
 		]]
 	end
 
@@ -205,10 +205,10 @@
 		atl "Dynamic"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<UseOfATL>Dynamic</UseOfATL>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<UseOfATL>Dynamic</UseOfATL>
 		]]
 	end
 
@@ -216,10 +216,10 @@
 		atl "Static"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<UseOfATL>Static</UseOfATL>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<UseOfATL>Static</UseOfATL>
 		]]
 	end
 
@@ -233,9 +233,9 @@
 		flags { "Symbols", "ReleaseRuntime" }
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
 		]]
 	end
 
@@ -251,12 +251,12 @@
 		kind "Makefile"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Makefile</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<OutDir>bin\Debug\</OutDir>
-		<IntDir>obj\Debug\</IntDir>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Makefile</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+</PropertyGroup>
 		]]
 	end
 
@@ -264,12 +264,12 @@
 		kind "None"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Makefile</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<OutDir>bin\Debug\</OutDir>
-		<IntDir>obj\Debug\</IntDir>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Makefile</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+</PropertyGroup>
 		]]
 	end
 
@@ -281,9 +281,9 @@
 		kind "Utility"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Utility</ConfigurationType>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Utility</ConfigurationType>
+</PropertyGroup>
 		]]
 	end
 
@@ -295,10 +295,10 @@
 		flags { "LinkTimeOptimization" }
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<CharacterSet>MultiByte</CharacterSet>
-		<WholeProgramOptimization>true</WholeProgramOptimization>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>MultiByte</CharacterSet>
+	<WholeProgramOptimization>true</WholeProgramOptimization>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_excluded_configs.lua
+++ b/tests/actions/vstudio/vc2010/test_excluded_configs.lua
@@ -49,11 +49,11 @@
 	function suite.normalLink_onIncludedConfig()
 		prepare("Zeus")
 		test.capture [[
-		<Link>
-			<SubSystem>Console</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
-		</Link>
+<Link>
+	<SubSystem>Console</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
+</Link>
 		]]
 	end
 
@@ -68,14 +68,14 @@
 	function suite.explicitLink_onExcludedConfig()
 		prepare("Ares")
 		test.capture [[
-		<Link>
-			<SubSystem>Console</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<AdditionalDependencies>bin\Ares\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
-		</Link>
-		<ProjectReference>
-			<LinkLibraryDependencies>false</LinkLibraryDependencies>
-		</ProjectReference>
+<Link>
+	<SubSystem>Console</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<AdditionalDependencies>bin\Ares\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
+</Link>
+<ProjectReference>
+	<LinkLibraryDependencies>false</LinkLibraryDependencies>
+</ProjectReference>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_globals.lua
+++ b/tests/actions/vstudio/vc2010/test_globals.lua
@@ -32,11 +32,11 @@
 	function suite.structureIsCorrect_onDefaultValues()
 		prepare()
 		test.capture [[
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-		<Keyword>Win32Proj</Keyword>
-		<RootNamespace>MyProject</RootNamespace>
-	</PropertyGroup>
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<Keyword>Win32Proj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
 		]]
 	end
 
@@ -49,12 +49,12 @@
 		clr "On"
 		prepare()
 		test.capture [[
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-		<TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-		<Keyword>ManagedCProj</Keyword>
-		<RootNamespace>MyProject</RootNamespace>
-	</PropertyGroup>
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+	<Keyword>ManagedCProj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
 		]]
 	end
 
@@ -68,12 +68,12 @@
 		framework "4.5"
 		prepare()
 		test.capture [[
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-		<Keyword>ManagedCProj</Keyword>
-		<RootNamespace>MyProject</RootNamespace>
-	</PropertyGroup>
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	<Keyword>ManagedCProj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
 		]]
 	end
 
@@ -82,13 +82,13 @@
 		clr "On"
 		prepare()
 		test.capture [[
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-		<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
-		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-		<Keyword>ManagedCProj</Keyword>
-		<RootNamespace>MyProject</RootNamespace>
-	</PropertyGroup>
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
+	<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	<Keyword>ManagedCProj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
 		]]
 	end
 
@@ -100,9 +100,9 @@
 		system "Linux"
 		prepare()
 		test.capture [[
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-	</PropertyGroup>
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+</PropertyGroup>
 		]]
 	end
 
@@ -118,11 +118,11 @@
 			system "Linux"
 		prepare()
 		test.capture [[
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-		<Keyword>Win32Proj</Keyword>
-		<RootNamespace>MyProject</RootNamespace>
-	</PropertyGroup>
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<Keyword>Win32Proj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
 		]]
 	end
 
@@ -135,10 +135,10 @@
 		kind "Makefile"
 		prepare()
 		test.capture [[
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-		<Keyword>MakeFileProj</Keyword>
-	</PropertyGroup>
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<Keyword>MakeFileProj</Keyword>
+</PropertyGroup>
 		]]
 	end
 
@@ -146,10 +146,10 @@
 		kind "None"
 		prepare()
 		test.capture [[
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-		<Keyword>MakeFileProj</Keyword>
-	</PropertyGroup>
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<Keyword>MakeFileProj</Keyword>
+</PropertyGroup>
 		]]
 	end
 
@@ -163,12 +163,12 @@
 		filename "MyProject_2012"
 		prepare()
 		test.capture [[
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-		<Keyword>Win32Proj</Keyword>
-		<RootNamespace>MyProject</RootNamespace>
-		<ProjectName>MyProject</ProjectName>
-	</PropertyGroup>
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<Keyword>Win32Proj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+	<ProjectName>MyProject</ProjectName>
+</PropertyGroup>
 		]]
 	end
 
@@ -183,11 +183,11 @@
 		_ACTION = "vs2013"
 		prepare()
 		test.capture [[
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-		<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
-		<Keyword>Win32Proj</Keyword>
-		<RootNamespace>MyProject</RootNamespace>
-	</PropertyGroup>
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
+	<Keyword>Win32Proj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_imagexex_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_imagexex_settings.lua
@@ -31,12 +31,12 @@
 	function suite.defaultSettings()
 		prepare()
 		test.capture [[
-		<ImageXex>
-			<ConfigurationFile>
-			</ConfigurationFile>
-			<AdditionalSections>
-			</AdditionalSections>
-		</ImageXex>
+<ImageXex>
+	<ConfigurationFile>
+	</ConfigurationFile>
+	<AdditionalSections>
+	</AdditionalSections>
+</ImageXex>
 		]]
 	end
 
@@ -47,10 +47,10 @@
 		configfile "testconfig.xml"
 		prepare()
 		test.capture [[
-		<ImageXex>
-			<ConfigurationFile>testconfig.xml</ConfigurationFile>
-			<AdditionalSections>
-			</AdditionalSections>
-		</ImageXex>
+<ImageXex>
+	<ConfigurationFile>testconfig.xml</ConfigurationFile>
+	<AdditionalSections>
+	</AdditionalSections>
+</ImageXex>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -35,11 +35,11 @@
 		kind "SharedLib"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
-		</Link>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+</Link>
 		]]
 	end
 
@@ -52,13 +52,13 @@
 		optimize "On"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<EnableCOMDATFolding>true</EnableCOMDATFolding>
-			<OptimizeReferences>true</OptimizeReferences>
-			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
-		</Link>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<EnableCOMDATFolding>true</EnableCOMDATFolding>
+	<OptimizeReferences>true</OptimizeReferences>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+</Link>
 		]]
 	end
 
@@ -71,10 +71,10 @@
 		kind "ConsoleApp"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Console</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
+<Link>
+	<SubSystem>Console</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 		]]
 	end
 
@@ -82,10 +82,10 @@
 		kind "WindowedApp"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 		]]
 	end
 
@@ -93,11 +93,11 @@
 		kind "SharedLib"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
-		</Link>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+</Link>
 		]]
 	end
 
@@ -105,10 +105,10 @@
 		kind "StaticLib"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-		</Link>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+</Link>
 		]]
 	end
 
@@ -121,14 +121,14 @@
 		flags "NoImplicitLink"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
-		</Link>
-		<ProjectReference>
-			<LinkLibraryDependencies>false</LinkLibraryDependencies>
-		</ProjectReference>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+</Link>
+<ProjectReference>
+	<LinkLibraryDependencies>false</LinkLibraryDependencies>
+</ProjectReference>
 		]]
 	end
 
@@ -140,9 +140,9 @@
 		flags "Symbols"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
 		]]
 	end
 
@@ -156,10 +156,10 @@
 		links { "lua", "zlib" }
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<AdditionalDependencies>lua.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<AdditionalDependencies>lua.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
 		]]
 	end
 
@@ -172,10 +172,10 @@
 		libdirs { "../lib", "../lib64" }
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<AdditionalLibraryDirectories>..\lib;..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<AdditionalLibraryDirectories>..\lib;..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
 		]]
 	end
 
@@ -191,11 +191,11 @@
 		kind "SharedLib"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
-		</Link>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+</Link>
 		]]
 	end
 
@@ -211,15 +211,15 @@
 		kind "SharedLib"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<AdditionalDependencies>bin\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
-		</Link>
-		<ProjectReference>
-			<LinkLibraryDependencies>false</LinkLibraryDependencies>
-		</ProjectReference>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<AdditionalDependencies>bin\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+</Link>
+<ProjectReference>
+	<LinkLibraryDependencies>false</LinkLibraryDependencies>
+</ProjectReference>
 		]]
 	end
 
@@ -235,10 +235,10 @@
 		libdirs { "../lib", "../lib64" }
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-		</Link>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+</Link>
 		]]
 	end
 
@@ -251,11 +251,11 @@
 		implibdir "../lib"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>..\lib\MyProject.lib</ImportLibrary>
-		</Link>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<ImportLibrary>..\lib\MyProject.lib</ImportLibrary>
+</Link>
 		]]
 	end
 
@@ -270,11 +270,11 @@
 		linkoptions { "/kupo" }
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
-			<AdditionalOptions>/kupo %(AdditionalOptions)</AdditionalOptions>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<AdditionalOptions>/kupo %(AdditionalOptions)</AdditionalOptions>
 		]]
 	end
 
@@ -283,13 +283,13 @@
 		linkoptions { "/kupo" }
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-		</Link>
-		<Lib>
-			<AdditionalOptions>/kupo %(AdditionalOptions)</AdditionalOptions>
-		</Lib>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+</Link>
+<Lib>
+	<AdditionalOptions>/kupo %(AdditionalOptions)</AdditionalOptions>
+</Lib>
 		]]
 	end
 
@@ -302,11 +302,11 @@
 		optimize "On"
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<EnableCOMDATFolding>true</EnableCOMDATFolding>
-			<OptimizeReferences>true</OptimizeReferences>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<EnableCOMDATFolding>true</EnableCOMDATFolding>
+	<OptimizeReferences>true</OptimizeReferences>
 		]]
 	end
 
@@ -319,12 +319,12 @@
 		files { "hello.cpp", "hello.def" }
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
-			<ModuleDefinitionFile>hello.def</ModuleDefinitionFile>
-		</Link>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ModuleDefinitionFile>hello.def</ModuleDefinitionFile>
+</Link>
 		]]
 	end
 
@@ -337,10 +337,10 @@
 		links { "kernel32", "System.dll", "System.Data.dll" }
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<AdditionalDependencies>kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<AdditionalDependencies>kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
 		]]
 	end
 
@@ -354,9 +354,9 @@
 		system "Xbox360"
 		prepare()
 		test.capture [[
-		<Link>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-		</Link>
+<Link>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+</Link>
 		]]
 	end
 
@@ -369,10 +369,10 @@
 		links { "user32" }
 		prepare()
 		test.capture [[
-		<Link>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<AdditionalDependencies>user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-		</Link>
+<Link>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<AdditionalDependencies>user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+</Link>
 		]]
 	end
 
@@ -386,11 +386,11 @@
 		flags { "FatalLinkWarnings" }
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Console</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
-			<TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
+<Link>
+	<SubSystem>Console</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
+	<TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
 		]]
 	end
 
@@ -399,13 +399,13 @@
 		flags { "FatalLinkWarnings" }
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-		</Link>
-		<Lib>
-			<TreatLibWarningAsErrors>true</TreatLibWarningAsErrors>
-		</Lib>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+</Link>
+<Lib>
+	<TreatLibWarningAsErrors>true</TreatLibWarningAsErrors>
+</Lib>
 		]]
 	end
 
@@ -418,11 +418,11 @@
 		flags { "Maps" }
 		prepare()
 		test.capture [[
-		<Link>
-			<SubSystem>Windows</SubSystem>
-			<GenerateDebugInformation>false</GenerateDebugInformation>
-			<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
-			<GenerateMapFile>true</GenerateMapFile>
-		</Link>
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<GenerateMapFile>true</GenerateMapFile>
+</Link>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_nmake_props.lua
+++ b/tests/actions/vstudio/vc2010/test_nmake_props.lua
@@ -33,9 +33,9 @@
 	function suite.structureIsCorrect_onDefaultValues()
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
+</PropertyGroup>
 		]]
 	end
 
@@ -59,9 +59,9 @@
 		targetextension ".exe"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<NMakeOutput>$(OutDir)MyProject.exe</NMakeOutput>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject.exe</NMakeOutput>
+</PropertyGroup>
 		]]
 	end
 
@@ -74,10 +74,10 @@
 		buildcommands { "command 1" }
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
-		<NMakeBuildCommandLine>command 1</NMakeBuildCommandLine>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
+	<NMakeBuildCommandLine>command 1</NMakeBuildCommandLine>
+</PropertyGroup>
 		]]
 	end
 
@@ -85,11 +85,11 @@
 		buildcommands { "command 1", "command 2" }
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
-		<NMakeBuildCommandLine>command 1
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
+	<NMakeBuildCommandLine>command 1
 command 2</NMakeBuildCommandLine>
-	</PropertyGroup>
+</PropertyGroup>
 		]]
 	end
 
@@ -97,10 +97,10 @@ command 2</NMakeBuildCommandLine>
 		rebuildcommands { "command 1" }
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
-		<NMakeReBuildCommandLine>command 1</NMakeReBuildCommandLine>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
+	<NMakeReBuildCommandLine>command 1</NMakeReBuildCommandLine>
+</PropertyGroup>
 		]]
 	end
 
@@ -108,9 +108,9 @@ command 2</NMakeBuildCommandLine>
 		cleancommands { "command 1" }
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
-		<NMakeCleanCommandLine>command 1</NMakeCleanCommandLine>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
+	<NMakeCleanCommandLine>command 1</NMakeCleanCommandLine>
+</PropertyGroup>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_output_props.lua
+++ b/tests/actions/vstudio/vc2010/test_output_props.lua
@@ -32,13 +32,13 @@
 	function suite.structureIsCorrect_onDefaultValues()
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>bin\Debug\</OutDir>
-		<IntDir>obj\Debug\</IntDir>
-		<TargetName>MyProject</TargetName>
-		<TargetExt>.exe</TargetExt>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+</PropertyGroup>
 		]]
 	end
 
@@ -68,15 +68,15 @@
 		system "Xbox360"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Xbox 360'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>bin\Debug\</OutDir>
-		<OutputFile>$(OutDir)MyProject.exe</OutputFile>
-		<IntDir>obj\Debug\</IntDir>
-		<TargetName>MyProject</TargetName>
-		<TargetExt>.exe</TargetExt>
-		<ImageXexOutput>$(OutDir)$(TargetName).xex</ImageXexOutput>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Xbox 360'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<OutputFile>$(OutDir)MyProject.exe</OutputFile>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+	<ImageXexOutput>$(OutDir)$(TargetName).xex</ImageXexOutput>
+</PropertyGroup>
 		]]
 	end
 
@@ -85,14 +85,14 @@
 		kind "StaticLib"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Xbox 360'">
-		<OutDir>bin\Debug\</OutDir>
-		<OutputFile>$(OutDir)MyProject.lib</OutputFile>
-		<IntDir>obj\Debug\</IntDir>
-		<TargetName>MyProject</TargetName>
-		<TargetExt>.lib</TargetExt>
-		<ImageXexOutput>$(OutDir)$(TargetName).xex</ImageXexOutput>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Xbox 360'">
+	<OutDir>bin\Debug\</OutDir>
+	<OutputFile>$(OutDir)MyProject.lib</OutputFile>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.lib</TargetExt>
+	<ImageXexOutput>$(OutDir)$(TargetName).xex</ImageXexOutput>
+</PropertyGroup>
 		]]
 	end
 
@@ -105,8 +105,8 @@
 		kind "StaticLib"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<OutDir>bin\Debug\</OutDir>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<OutDir>bin\Debug\</OutDir>
 		]]
 	end
 
@@ -118,8 +118,8 @@
 		optimize "On"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>false</LinkIncremental>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>false</LinkIncremental>
 		]]
 	end
 
@@ -131,9 +131,9 @@
 		targetdir "../bin"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>..\bin\</OutDir>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>..\bin\</OutDir>
 		]]
 	end
 
@@ -145,10 +145,10 @@
 		objdir "../tmp"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>bin\Debug\</OutDir>
-		<IntDir>..\tmp\Debug\</IntDir>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>..\tmp\Debug\</IntDir>
 		]]
 	end
 
@@ -160,11 +160,11 @@
 		targetname "MyTarget"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>bin\Debug\</OutDir>
-		<IntDir>obj\Debug\</IntDir>
-		<TargetName>MyTarget</TargetName>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyTarget</TargetName>
 		]]
 	end
 
@@ -177,9 +177,9 @@
 		flags "NoImportLib"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<IgnoreImportLibrary>true</IgnoreImportLibrary>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<IgnoreImportLibrary>true</IgnoreImportLibrary>
 		]]
 	end
 
@@ -188,9 +188,9 @@
 		flags "NoImportLib"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>bin\Debug\</OutDir>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
 		]]
 	end
 
@@ -203,13 +203,13 @@
 		flags "NoManifest"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>bin\Debug\</OutDir>
-		<IntDir>obj\Debug\</IntDir>
-		<TargetName>MyProject</TargetName>
-		<TargetExt>.exe</TargetExt>
-		<GenerateManifest>false</GenerateManifest>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+	<GenerateManifest>false</GenerateManifest>
 		]]
 	end
 
@@ -222,14 +222,14 @@
 		targetextension ""
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>bin\Debug\</OutDir>
-		<IntDir>obj\Debug\</IntDir>
-		<TargetName>MyProject</TargetName>
-		<TargetExt>
-		</TargetExt>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>
+	</TargetExt>
+</PropertyGroup>
 		]]
 	end
 
@@ -243,14 +243,14 @@
 		cleanextensions { ".temp1", ".temp2" }
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>bin\Debug\</OutDir>
-		<IntDir>obj\Debug\</IntDir>
-		<TargetName>MyProject</TargetName>
-		<TargetExt>.exe</TargetExt>
-		<ExtensionsToDeleteOnClean>*.temp1;*.temp2;$(ExtensionsToDeleteOnClean)</ExtensionsToDeleteOnClean>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+	<ExtensionsToDeleteOnClean>*.temp1;*.temp2;$(ExtensionsToDeleteOnClean)</ExtensionsToDeleteOnClean>
+</PropertyGroup>
 		]]
 	end
 
@@ -263,14 +263,14 @@
 		sysincludedirs { "$(DXSDK_DIR)/Include" }
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>bin\Debug\</OutDir>
-		<IntDir>obj\Debug\</IntDir>
-		<TargetName>MyProject</TargetName>
-		<TargetExt>.exe</TargetExt>
-		<IncludePath>$(DXSDK_DIR)\Include;$(IncludePath)</IncludePath>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+	<IncludePath>$(DXSDK_DIR)\Include;$(IncludePath)</IncludePath>
+</PropertyGroup>
 		]]
 	end
 
@@ -278,13 +278,13 @@
 		syslibdirs { "$(DXSDK_DIR)/lib/x86" }
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>bin\Debug\</OutDir>
-		<IntDir>obj\Debug\</IntDir>
-		<TargetName>MyProject</TargetName>
-		<TargetExt>.exe</TargetExt>
-		<LibraryPath>$(DXSDK_DIR)\lib\x86;$(LibraryPath)</LibraryPath>
-	</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+	<LibraryPath>$(DXSDK_DIR)\lib\x86;$(LibraryPath)</LibraryPath>
+</PropertyGroup>
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_project_configs.lua
+++ b/tests/actions/vstudio/vc2010/test_project_configs.lua
@@ -32,16 +32,16 @@
 	function suite.win32Listed_onNoPlatforms()
 		prepare()
 		test.capture [[
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="Debug|Win32">
-			<Configuration>Debug</Configuration>
-			<Platform>Win32</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Release|Win32">
-			<Configuration>Release</Configuration>
-			<Platform>Win32</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
+<ItemGroup Label="ProjectConfigurations">
+	<ProjectConfiguration Include="Debug|Win32">
+		<Configuration>Debug</Configuration>
+		<Platform>Win32</Platform>
+	</ProjectConfiguration>
+	<ProjectConfiguration Include="Release|Win32">
+		<Configuration>Release</Configuration>
+		<Platform>Win32</Platform>
+	</ProjectConfiguration>
+</ItemGroup>
 		]]
 	end
 
@@ -60,24 +60,24 @@
 			architecture "x86_64"
 		prepare()
 		test.capture [[
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="Debug 32b|Win32">
-			<Configuration>Debug 32b</Configuration>
-			<Platform>Win32</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Debug 32b|x64">
-			<Configuration>Debug 32b</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Debug 64b|Win32">
-			<Configuration>Debug 64b</Configuration>
-			<Platform>Win32</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Debug 64b|x64">
-			<Configuration>Debug 64b</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Release 32b|Win32">
+<ItemGroup Label="ProjectConfigurations">
+	<ProjectConfiguration Include="Debug 32b|Win32">
+		<Configuration>Debug 32b</Configuration>
+		<Platform>Win32</Platform>
+	</ProjectConfiguration>
+	<ProjectConfiguration Include="Debug 32b|x64">
+		<Configuration>Debug 32b</Configuration>
+		<Platform>x64</Platform>
+	</ProjectConfiguration>
+	<ProjectConfiguration Include="Debug 64b|Win32">
+		<Configuration>Debug 64b</Configuration>
+		<Platform>Win32</Platform>
+	</ProjectConfiguration>
+	<ProjectConfiguration Include="Debug 64b|x64">
+		<Configuration>Debug 64b</Configuration>
+		<Platform>x64</Platform>
+	</ProjectConfiguration>
+	<ProjectConfiguration Include="Release 32b|Win32">
 		]]
 	end
 
@@ -91,15 +91,15 @@
 		platforms { "x86", "x86_64" }
 		prepare()
 		test.capture [[
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="Debug|Win32">
-			<Configuration>Debug</Configuration>
-			<Platform>Win32</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Debug|x64">
-			<Configuration>Debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Release|Win32">
+<ItemGroup Label="ProjectConfigurations">
+	<ProjectConfiguration Include="Debug|Win32">
+		<Configuration>Debug</Configuration>
+		<Platform>Win32</Platform>
+	</ProjectConfiguration>
+	<ProjectConfiguration Include="Debug|x64">
+		<Configuration>Debug</Configuration>
+		<Platform>x64</Platform>
+	</ProjectConfiguration>
+	<ProjectConfiguration Include="Release|Win32">
 		]]
 	end

--- a/tests/actions/vstudio/vc2010/test_prop_sheet.lua
+++ b/tests/actions/vstudio/vc2010/test_prop_sheet.lua
@@ -32,8 +32,8 @@
 	function suite.structureIsCorrect_onDefaultValues()
 		prepare()
 		test.capture [[
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
+<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+</ImportGroup>
 		]]
 	end


### PR DESCRIPTION
Finish cleaning up the VC 2010 exporter code so I can reference it in the "hacking on Premake" part of the documentation.

* Converted all major sections to use call arrays
* Converted all _p() and _x() calls to the new indentation-aware APIs
* Use the p.* namespace alias consistently
* Use the m.element() call consistently (enables adding more per-file configurations too)