### PR TITLE
3rd party libraries are now options

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -17,13 +17,6 @@
 
 	premake.api.deprecations "off"
 
---
--- Enable contrib support for 3rd party libraries
--- Curl includes support for http / https downloads
--- Compression will eventually include support for ZLib / Zip
-
-	local ENABLE_CURL = false
-	local ENABLE_COMPRESSION = true
 
 --
 -- Register supporting actions and options.
@@ -69,6 +62,18 @@
 	}
 
 
+	newoption {
+		trigger = "withcurl",
+		description = "Enable Curl 3rd party lib"
+	}
+
+
+	newoption {
+		trigger = "withzip",
+		description = "Enable Zlib/Zip 3rd party lib"
+	}
+
+
 
 --
 -- Define the project. Put the release configuration first so it will be the
@@ -88,12 +93,14 @@
 		kind        "ConsoleApp"
 		flags       { "No64BitChecks", "ExtraWarnings", "StaticRuntime" }
 		includedirs { "src/host/lua-5.1.4/src" }
-		if ENABLE_COMPRESSION then
+
+		-- optional 3rd party libraries
+		if _OPTIONS.withzip then
 			includedirs { "contrib/zlib", "contrib/libzip" }
 			defines { "PREMAKE_COMPRESSION" }
 			links { "zip-lib", "zlib-lib" }
 		end
-		if ENABLE_CURL then
+		if _OPTIONS.withcurl then
 			includedirs { "contrib/curl/include" }
 			defines { "CURL_STATICLIB", "PREMAKE_CURL" }
 			links { "curl-lib" }
@@ -161,15 +168,17 @@
 			defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }
 			links       { "m" }
 
-
+	-- optional 3rd party libraries
 	group 'contrib'
-		if ENABLE_COMPRESSION then
+		if _OPTIONS.withzip then
 			include 'contrib/zlib'
 			include 'contrib/libzip'
 		end
-		if ENABLE_CURL then
+		if _OPTIONS.withcurl then
 			include 'contrib/curl'
 		end
+
+
 --
 -- A more thorough cleanup.
 --

--- a/premake5.lua
+++ b/premake5.lua
@@ -63,14 +63,14 @@
 
 
 	newoption {
-		trigger = "withcurl",
-		description = "Enable Curl 3rd party lib"
+		trigger = "no-curl",
+		description = "Disable Curl 3rd party lib"
 	}
 
 
 	newoption {
-		trigger = "withzip",
-		description = "Enable Zlib/Zip 3rd party lib"
+		trigger = "no-zlib",
+		description = "Disable Zlib/Zip 3rd party lib"
 	}
 
 
@@ -95,12 +95,12 @@
 		includedirs { "src/host/lua-5.1.4/src" }
 
 		-- optional 3rd party libraries
-		if _OPTIONS.withzip then
+		if not _OPTIONS["no-zlib"] then
 			includedirs { "contrib/zlib", "contrib/libzip" }
 			defines { "PREMAKE_COMPRESSION" }
 			links { "zip-lib", "zlib-lib" }
 		end
-		if _OPTIONS.withcurl then
+		if not _OPTIONS["no-curl"] then
 			includedirs { "contrib/curl/include" }
 			defines { "CURL_STATICLIB", "PREMAKE_CURL" }
 			links { "curl-lib" }
@@ -169,13 +169,13 @@
 			links       { "m" }
 
 	-- optional 3rd party libraries
-	group 'contrib'
-		if _OPTIONS.withzip then
-			include 'contrib/zlib'
-			include 'contrib/libzip'
+	group "contrib"
+		if not _OPTIONS["no-zlib"] then
+			include "contrib/zlib"
+			include "contrib/libzip"
 		end
-		if _OPTIONS.withcurl then
-			include 'contrib/curl'
+		if not _OPTIONS["no-curl"] then
+			include "contrib/curl"
 		end
 
 


### PR DESCRIPTION
I removed the hardcoded ENABLE_CURL and ENABLE_COMPRESSION values and replaced them by options.
By default Premake will generate a project without any 3rd party library.