### PR TITLE
Support LLVM platform toolset for MSC; Clang in Visual Studio.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -976,11 +976,11 @@
 		end,
 	}
 
-  api.register {
-    name = "customtoolnamespace",
-    scope = "config",
-    kind = "string",
-  }
+	api.register {
+		name = "customtoolnamespace",
+		scope = "config",
+		kind = "string",
+	}
 
 	api.register {
 		name = "undefines",

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1509,7 +1509,9 @@
 	function m.platformToolset(cfg)
 		local tool, version = p.config.toolset(cfg)
 		if version then
-			version = "v" .. version
+			if tonumber(version) ~= nil then
+				version = "v" .. version
+			end
 		else
 			local action = p.action.current()
 			version = action.vstudio.platformToolset

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1510,11 +1510,7 @@
 
 	function m.platformToolset(cfg)
 		local tool, version = p.config.toolset(cfg)
-		if version then
-			if tonumber(version:sub(1,3)) ~= nil then
-				version = "v" .. version
-			end
-		else
+		if not version then
 			local action = p.action.current()
 			version = action.vstudio.platformToolset
 		end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1076,13 +1076,15 @@
 
 	function m.debugInformationFormat(cfg)
 		local value
+		local tool, toolVersion = p.config.toolset(cfg)
 		if cfg.flags.Symbols then
 			if cfg.debugformat == "c7" then
 				value = "OldStyle"
 			elseif cfg.architecture == "x86_64" or
 				   cfg.clr ~= p.OFF or
 				   config.isOptimizedBuild(cfg) or
-				   cfg.editandcontinue == p.OFF
+				   cfg.editandcontinue == p.OFF or
+				   (toolVersion and toolVersion:startswith("LLVM-vs"))
 			then
 				value = "ProgramDatabase"
 			else
@@ -1509,7 +1511,7 @@
 	function m.platformToolset(cfg)
 		local tool, version = p.config.toolset(cfg)
 		if version then
-			if tonumber(version) ~= nil then
+			if tonumber(version:sub(1,3)) ~= nil then
 				version = "v" .. version
 			end
 		else
@@ -1683,7 +1685,8 @@
 	end
 
 	function m.bufferSecurityCheck(cfg)
-		if cfg.flags.NoBufferSecurityCheck then
+		local tool, toolVersion = p.config.toolset(cfg)
+		if cfg.flags.NoBufferSecurityCheck or (toolVersion and toolVersion:startswith("LLVM-vs")) then
 			m.element("BufferSecurityCheck", nil, "false")
 		end
 	end

--- a/src/base/string.lua
+++ b/src/base/string.lua
@@ -29,13 +29,19 @@
 -- formed by splitting on boundaries formed by `pattern`.
 --
 
-	function string.explode(s, pattern, plain)
+	function string.explode(s, pattern, plain, maxTokens)
 		if (pattern == '') then return false end
 		local pos = 0
 		local arr = { }
 		for st,sp in function() return s:find(pattern, pos, plain) end do
 			table.insert(arr, s:sub(pos, st-1))
 			pos = sp + 1
+			if maxTokens ~= nil and maxTokens > 0 then
+				maxTokens = maxTokens - 1
+				if maxTokens == 0 then
+					break
+				end
+			end
 		end
 		table.insert(arr, s:sub(pos))
 		return arr

--- a/src/base/tools.lua
+++ b/src/base/tools.lua
@@ -33,8 +33,15 @@
 		local parts
 		if identifier:startswith("v") then
 			parts = { "msc", identifier:sub(2) }
+		elseif identifier:startswith("llvm-vs") then -- support LLVM toolset in VS
+			parts = { "msc", "LLVM-vs" .. identifier:sub(8) }
 		else
 			parts = identifier:explode("-")
+
+			-- hack to check for LLVM toolsets, which would be corrupted by the previous line
+			if parts[1] == "msc" and parts[2] == "llvm" and parts[3]:startswith("vs") then
+				parts = { parts[1], "LLVM-" .. parts[3] }
+			end
 		end
 		return p.tools[parts[1]], parts[2]
 	end

--- a/src/base/tools.lua
+++ b/src/base/tools.lua
@@ -31,16 +31,22 @@
 
 	function p.tools.canonical(identifier)
 		local parts
-		if identifier:startswith("v") then
-			parts = { "msc", identifier:sub(2) }
-		elseif identifier:startswith("llvm-vs") then -- support LLVM toolset in VS
-			parts = { "msc", "LLVM-vs" .. identifier:sub(8) }
+		if identifier:startswith("v") then -- TODO: this should be deprecated?
+			parts = { "msc", identifier }
 		else
-			parts = identifier:explode("-")
+			parts = identifier:explode("-", true, 1)
 
-			-- hack to check for LLVM toolsets, which would be corrupted by the previous line
-			if parts[1] == "msc" and parts[2] == "llvm" and parts[3]:startswith("vs") then
-				parts = { parts[1], "LLVM-" .. parts[3] }
+			-- couple of little hacks here to fix up version names
+			if parts[2] ~= nil then
+				-- 'msc-100' is accepted, but the code expects 'v100'
+				if parts[1] == "msc" and tonumber(parts[2]:sub(1,3)) ~= nil then
+					parts[2] = "v" .. parts[2]
+				end
+
+				-- perform case-correction of the LLVM toolset
+				if parts[2]:startswith("llvm-vs") then
+					parts[2] = "LLVM-" .. parts[2]:sub(6)
+				end
 			end
 		end
 		return p.tools[parts[1]], parts[2]

--- a/tests/actions/vstudio/vc2010/test_platform_toolset.lua
+++ b/tests/actions/vstudio/vc2010/test_platform_toolset.lua
@@ -86,3 +86,27 @@
 <PlatformToolset>v100</PlatformToolset>
 		]]
 	end
+
+	function suite.canOverrideFromScript_withV()
+		toolset "v120_xp"
+		prepare()
+		test.capture [[
+<PlatformToolset>v120_xp</PlatformToolset>
+		]]
+	end
+
+	function suite.canOverrideFromScript_withV()
+		toolset "LLVM-vs2010"
+		prepare()
+		test.capture [[
+<PlatformToolset>LLVM-vs2010</PlatformToolset>
+		]]
+	end
+
+	function suite.canOverrideFromScript_withMsc()
+		toolset "msc-llvm-vs2014_xp"
+		prepare()
+		test.capture [[
+<PlatformToolset>LLVM-vs2014_xp</PlatformToolset>
+		]]
+	end

--- a/tests/actions/vstudio/vc2010/test_platform_toolset.lua
+++ b/tests/actions/vstudio/vc2010/test_platform_toolset.lua
@@ -87,7 +87,7 @@
 		]]
 	end
 
-	function suite.canOverrideFromScript_withV()
+	function suite.canOverrideFromScript_withXP()
 		toolset "v120_xp"
 		prepare()
 		test.capture [[
@@ -95,7 +95,7 @@
 		]]
 	end
 
-	function suite.canOverrideFromScript_withV()
+	function suite.canOverrideFromScript_withLLVM()
 		toolset "LLVM-vs2010"
 		prepare()
 		test.capture [[
@@ -103,7 +103,7 @@
 		]]
 	end
 
-	function suite.canOverrideFromScript_withMsc()
+	function suite.canOverrideFromScript_withMscAndLLVM()
 		toolset "msc-llvm-vs2014_xp"
 		prepare()
 		test.capture [[

--- a/tests/actions/vstudio/vc2010/test_platform_toolset.lua
+++ b/tests/actions/vstudio/vc2010/test_platform_toolset.lua
@@ -96,14 +96,6 @@
 	end
 
 	function suite.canOverrideFromScript_withLLVM()
-		toolset "LLVM-vs2010"
-		prepare()
-		test.capture [[
-<PlatformToolset>LLVM-vs2010</PlatformToolset>
-		]]
-	end
-
-	function suite.canOverrideFromScript_withMscAndLLVM()
 		toolset "msc-llvm-vs2014_xp"
 		prepare()
 		test.capture [[


### PR DESCRIPTION
Installing the LLVM bundle these days integrates Clang with VS.

The method is different than the popular vs-tool plugin which populates the project with Clang compiler settings, instead LLVM installs a shim for MSC.
I feel the best way to express this in premake is to retain `toolset='msc'`, and support it like the other VS platform toolset options.

I have added support the same way we can use `toolset="v100"`; use `toolset="LLVM_vs2010"` instead.

`toolset="msc-LLVM-vs2010"` is also supported. I'm not sure this is the best expression, but I can't think of a more appropriate one.