### PR TITLE
Add capture support to UTF8 BOM output

### DIFF
--- a/src/actions/vstudio/vs2005_csproj.lua
+++ b/src/actions/vstudio/vs2005_csproj.lua
@@ -33,7 +33,7 @@
 	}
 
 	function cs2005.generate(prj)
-		io.utf8()
+		p.utf8()
 
 		premake.callarray(cs2005, cs2005.elements.project, prj)
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -48,7 +48,7 @@
 	end
 
 	function m.generate(prj)
-		io.utf8()
+		p.utf8()
 		p.callArray(m.elements.project, prj)
 		p.out('</Project>')
 	end

--- a/src/base/io.lua
+++ b/src/base/io.lua
@@ -20,12 +20,3 @@
 		end
 		return base(fname, mode)
 	end)
-
-
---
--- Output a UTF-8 signature.
---
-
-	function io.utf8()
-		io.write('\239\187\191')
-	end

--- a/src/base/premake.lua
+++ b/src/base/premake.lua
@@ -304,6 +304,18 @@ end
 
 
 
+--
+-- Output a UTF-8 BOM to the exported file.
+--
+
+	function premake.utf8()
+		if not _captured then
+			premake.out('\239\187\191')
+		end
+	end
+
+
+
 ---
 -- Write a formatted string to the exported file, at the current
 -- level of indentation, and appends an end of line sequence.


### PR DESCRIPTION
If `io.utf8()` is called while running unit tests, it would be output directly to the console since there is no active file output while testing. Replace call with premake.utf8() as a companion to premake.w() and ignore while capturing to prevent this spurious output.