### PR TITLE
Move project language and kind checks to validation.lua

### DIFF
--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -117,18 +117,6 @@
 	function p.project.bake(self)
 		local sln = self.solution
 
-		-- check if the language for this project is supported by the action.
-
-		if not p.action.supports(self.language) then
-			p.warn("    Unsupported language '%s' used for '%s'.", self.language, self.name)
-		end
-
-		-- check if the kind for this project is supported by the action.
-
-		if not p.action.supports(self.kind) then
-			p.warn("    Unsupported kind '%s' used for '%s'.", self.kind, self.name)
-		end
-
 		-- Add filtering terms to the context to make it as specific as I can.
 		-- Start with the same filtering that was applied at the solution level.
 

--- a/src/base/validation.lua
+++ b/src/base/validation.lua
@@ -55,6 +55,14 @@
 			p.error("project '%s' does not have a language", self.name)
 		end
 
+		if not p.action.supports(self.language) then
+			p.warn("unsupported language '%s' used for project '%s'", self.language, self.name)
+		end
+
+		if not p.action.supports(self.kind) then
+			p.warn("unsupported kind '%s' used for project '%s'", self.kind, self.name)
+		end
+
 		-- all rules must exist
 		for i = 1, #self.rules do
 			local rule = self.rules[i]


### PR DESCRIPTION
These validation checks were added to oven.lua by a previous commit. Move them over to validation.lua with the rest of the validation logic.