### PR TITLE
Llvm toolset - alt

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -970,11 +970,11 @@
 		end,
 	}
 
-  api.register {
-    name = "customtoolnamespace",
-    scope = "config",
-    kind = "string",
-  }
+	api.register {
+		name = "customtoolnamespace",
+		scope = "config",
+		kind = "string",
+	}
 
 	api.register {
 		name = "undefines",

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1072,13 +1072,15 @@
 
 	function m.debugInformationFormat(cfg)
 		local value
+		local tool, toolVersion = p.config.toolset(cfg)
 		if cfg.flags.Symbols then
 			if cfg.debugformat == "c7" then
 				value = "OldStyle"
 			elseif cfg.architecture == "x86_64" or
 				   cfg.clr ~= p.OFF or
 				   config.isOptimizedBuild(cfg) or
-				   cfg.editandcontinue == p.OFF
+				   cfg.editandcontinue == p.OFF or
+				   (toolVersion and toolVersion:startswith("LLVM-vs"))
 			then
 				value = "ProgramDatabase"
 			else
@@ -1501,7 +1503,7 @@
 	function m.platformToolset(cfg)
 		local tool, version = p.config.toolset(cfg)
 		if version then
-			if tonumber(version) ~= nil then
+			if tonumber(version:sub(1,3)) ~= nil then
 				version = "v" .. version
 			end
 		else
@@ -1675,7 +1677,8 @@
 	end
 
 	function m.bufferSecurityCheck(cfg)
-		if cfg.flags.NoBufferSecurityCheck then
+		local tool, toolVersion = p.config.toolset(cfg)
+		if cfg.flags.NoBufferSecurityCheck or (toolVersion and toolVersion:startswith("LLVM-vs")) then
 			m.element("BufferSecurityCheck", nil, "false")
 		end
 	end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1502,11 +1502,7 @@
 
 	function m.platformToolset(cfg)
 		local tool, version = p.config.toolset(cfg)
-		if version then
-			if tonumber(version:sub(1,3)) ~= nil then
-				version = "v" .. version
-			end
-		else
+		if not version then
 			local action = p.action.current()
 			version = action.vstudio.platformToolset
 		end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1501,7 +1501,9 @@
 	function m.platformToolset(cfg)
 		local tool, version = p.config.toolset(cfg)
 		if version then
-			version = "v" .. version
+			if tonumber(version) ~= nil then
+				version = "v" .. version
+			end
 		else
 			local action = p.action.current()
 			version = action.vstudio.platformToolset

--- a/src/base/tools.lua
+++ b/src/base/tools.lua
@@ -33,8 +33,15 @@
 		local parts
 		if identifier:startswith("v") then
 			parts = { "msc", identifier:sub(2) }
+		elseif identifier:startswith("llvm-vs") then -- support LLVM toolset in VS
+			parts = { "msc", "LLVM-vs" .. identifier:sub(8) }
 		else
 			parts = identifier:explode("-")
+
+			-- hack to check for LLVM toolsets, which would be corrupted by the previous line
+			if parts[1] == "msc" and parts[2] == "llvm" and parts[3]:startswith("vs") then
+				parts = { parts[1], "LLVM-" .. parts[3] }
+			end
 		end
 		return p.tools[parts[1]], parts[2]
 	end

--- a/src/base/tools.lua
+++ b/src/base/tools.lua
@@ -32,7 +32,7 @@
 	function p.tools.canonical(identifier)
 		local parts
 		if identifier:startswith("v") then
-			parts = { "msc", identifier:sub(2) }
+			parts = { "msc", identifier }
 		elseif identifier:startswith("llvm-vs") then -- support LLVM toolset in VS
 			parts = { "msc", "LLVM-vs" .. identifier:sub(8) }
 		else

--- a/tests/actions/vstudio/vc2010/test_platform_toolset.lua
+++ b/tests/actions/vstudio/vc2010/test_platform_toolset.lua
@@ -80,7 +80,7 @@
 	end
 
 	function suite.canOverrideFromScript_withMsc()
-		toolset "msc-100"
+		toolset "msc-v100"
 		prepare()
 		test.capture [[
 <PlatformToolset>v100</PlatformToolset>

--- a/tests/actions/vstudio/vc2010/test_platform_toolset.lua
+++ b/tests/actions/vstudio/vc2010/test_platform_toolset.lua
@@ -86,3 +86,27 @@
 <PlatformToolset>v100</PlatformToolset>
 		]]
 	end
+
+	function suite.canOverrideFromScript_withV()
+		toolset "v120_xp"
+		prepare()
+		test.capture [[
+<PlatformToolset>v120_xp</PlatformToolset>
+		]]
+	end
+
+	function suite.canOverrideFromScript_withV()
+		toolset "LLVM-vs2010"
+		prepare()
+		test.capture [[
+<PlatformToolset>LLVM-vs2010</PlatformToolset>
+		]]
+	end
+
+	function suite.canOverrideFromScript_withMsc()
+		toolset "msc-llvm-vs2014_xp"
+		prepare()
+		test.capture [[
+<PlatformToolset>LLVM-vs2014_xp</PlatformToolset>
+		]]
+	end

--- a/tests/actions/vstudio/vc2010/test_platform_toolset.lua
+++ b/tests/actions/vstudio/vc2010/test_platform_toolset.lua
@@ -87,7 +87,7 @@
 		]]
 	end
 
-	function suite.canOverrideFromScript_withV()
+	function suite.canOverrideFromScript_withXP()
 		toolset "v120_xp"
 		prepare()
 		test.capture [[
@@ -95,7 +95,7 @@
 		]]
 	end
 
-	function suite.canOverrideFromScript_withV()
+	function suite.canOverrideFromScript_withLLVM()
 		toolset "LLVM-vs2010"
 		prepare()
 		test.capture [[
@@ -103,7 +103,7 @@
 		]]
 	end
 
-	function suite.canOverrideFromScript_withMsc()
+	function suite.canOverrideFromScript_withMscAndLLVM()
 		toolset "msc-llvm-vs2014_xp"
 		prepare()
 		test.capture [[


### PR DESCRIPTION
This is an alternative approach to the VS version issue.
This one has simpler logic, but removes support for vs versions without 'v';
ie, `msc-100` must be `msc-v100`.

I'm just offering options. Feel free to suggest other solutions.
Personally, I felt a combination approach just bloated the logic too much. If you want to keep `msc-100` support, I'd stick with the other PR.