### PR TITLE
Begin renaming solution to workspace

### DIFF
--- a/src/_manifest.lua
+++ b/src/_manifest.lua
@@ -37,7 +37,7 @@
 
 		-- project objects
 		"base/global.lua",
-		"base/solution.lua",
+		"base/workspace.lua",
 		"base/group.lua",
 		"base/project.lua",
 		"base/config.lua",

--- a/src/actions/make/_make.lua
+++ b/src/actions/make/_make.lua
@@ -28,9 +28,9 @@
 			dotnet = { "mono", "msnet", "pnet" }
 		},
 
-		onWorkspace = function(wrk)
+		onWorkspace = function(wks)
 			premake.escaper(make.esc)
-			premake.generate(wrk, make.getmakefilename(wrk, false), make.generate_solution)
+			premake.generate(wks, make.getmakefilename(wks, false), make.generate_solution)
 		end,
 
 		onProject = function(prj)
@@ -43,8 +43,8 @@
 			end
 		end,
 
-		onCleanWorkspace = function(wrk)
-			premake.clean.file(wrk, make.getmakefilename(wrk, false))
+		onCleanWorkspace = function(wks)
+			premake.clean.file(wks, make.getmakefilename(wks, false))
 		end,
 
 		onCleanProject = function(prj)

--- a/src/actions/make/_make.lua
+++ b/src/actions/make/_make.lua
@@ -1,7 +1,7 @@
 --
 -- _make.lua
 -- Define the makefile action(s).
--- Copyright (c) 2002-2013 Jason Perkins and the Premake project
+-- Copyright (c) 2002-2015 Jason Perkins and the Premake project
 --
 
 	premake.make = {}
@@ -28,9 +28,9 @@
 			dotnet = { "mono", "msnet", "pnet" }
 		},
 
-		onSolution = function(sln)
+		onWorkspace = function(wrk)
 			premake.escaper(make.esc)
-			premake.generate(sln, make.getmakefilename(sln, false), make.generate_solution)
+			premake.generate(wrk, make.getmakefilename(wrk, false), make.generate_solution)
 		end,
 
 		onProject = function(prj)
@@ -43,8 +43,8 @@
 			end
 		end,
 
-		onCleanSolution = function(sln)
-			premake.clean.file(sln, make.getmakefilename(sln, false))
+		onCleanWorkspace = function(wrk)
+			premake.clean.file(wrk, make.getmakefilename(wrk, false))
 		end,
 
 		onCleanProject = function(prj)

--- a/src/actions/vstudio/vs2005.lua
+++ b/src/actions/vstudio/vs2005.lua
@@ -96,12 +96,12 @@
 
 		-- Solution and project generation logic
 
-		onSolution = vstudio.vs2005.generateSolution,
-		onProject  = vstudio.vs2005.generateProject,
+		onWorkspace = vstudio.vs2005.generateSolution,
+		onProject   = vstudio.vs2005.generateProject,
 
-		onCleanSolution = vstudio.cleanSolution,
-		onCleanProject  = vstudio.cleanProject,
-		onCleanTarget   = vstudio.cleanTarget,
+		onCleanWorkspace = vstudio.cleanSolution,
+		onCleanProject   = vstudio.cleanProject,
+		onCleanTarget    = vstudio.cleanTarget,
 
 		-- This stuff is specific to the Visual Studio exporters
 

--- a/src/actions/vstudio/vs2008.lua
+++ b/src/actions/vstudio/vs2008.lua
@@ -35,12 +35,12 @@
 
 		-- Solution and project generation logic
 
-		onSolution = vstudio.vs2005.generateSolution,
-		onProject  = vstudio.vs2005.generateProject,
+		onWorkspace = vstudio.vs2005.generateSolution,
+		onProject   = vstudio.vs2005.generateProject,
 
-		onCleanSolution = vstudio.cleanSolution,
-		onCleanProject  = vstudio.cleanProject,
-		onCleanTarget   = vstudio.cleanTarget,
+		onCleanWorkspace = vstudio.cleanSolution,
+		onCleanProject   = vstudio.cleanProject,
+		onCleanTarget    = vstudio.cleanTarget,
 
 		-- This stuff is specific to the Visual Studio exporters
 

--- a/src/actions/vstudio/vs2010.lua
+++ b/src/actions/vstudio/vs2010.lua
@@ -121,8 +121,8 @@
 
 		-- Solution and project generation logic
 
-		onSolution = function(sln)
-			vstudio.vs2005.generateSolution(sln)
+		onWorkspace = function(wrk)
+			vstudio.vs2005.generateSolution(wrk)
 		end,
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
@@ -131,8 +131,8 @@
 			vstudio.vs2010.generateRule(rule)
 		end,
 
-		onCleanSolution = function(sln)
-			vstudio.cleanSolution(sln)
+		onCleanWorkspace = function(wrk)
+			vstudio.cleanSolution(wrk)
 		end,
 		onCleanProject = function(prj)
 			vstudio.cleanProject(prj)

--- a/src/actions/vstudio/vs2010.lua
+++ b/src/actions/vstudio/vs2010.lua
@@ -121,8 +121,8 @@
 
 		-- Solution and project generation logic
 
-		onWorkspace = function(wrk)
-			vstudio.vs2005.generateSolution(wrk)
+		onWorkspace = function(wks)
+			vstudio.vs2005.generateSolution(wks)
 		end,
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
@@ -131,8 +131,8 @@
 			vstudio.vs2010.generateRule(rule)
 		end,
 
-		onCleanWorkspace = function(wrk)
-			vstudio.cleanSolution(wrk)
+		onCleanWorkspace = function(wks)
+			vstudio.cleanSolution(wks)
 		end,
 		onCleanProject = function(prj)
 			vstudio.cleanProject(prj)

--- a/src/actions/vstudio/vs2012.lua
+++ b/src/actions/vstudio/vs2012.lua
@@ -37,8 +37,8 @@
 
 		-- Solution and project generation logic
 
-		onWorkspace = function(wrk)
-			vstudio.vs2005.generateSolution(wrk)
+		onWorkspace = function(wks)
+			vstudio.vs2005.generateSolution(wks)
 		end,
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
@@ -47,8 +47,8 @@
 			vstudio.vs2010.generateRule(rule)
 		end,
 
-		onCleanWorkspace = function(wrk)
-			vstudio.cleanSolution(wrk)
+		onCleanWorkspace = function(wks)
+			vstudio.cleanSolution(wks)
 		end,
 		onCleanProject = function(prj)
 			vstudio.cleanProject(prj)

--- a/src/actions/vstudio/vs2012.lua
+++ b/src/actions/vstudio/vs2012.lua
@@ -37,8 +37,8 @@
 
 		-- Solution and project generation logic
 
-		onSolution = function(sln)
-			vstudio.vs2005.generateSolution(sln)
+		onWorkspace = function(wrk)
+			vstudio.vs2005.generateSolution(wrk)
 		end,
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
@@ -47,8 +47,8 @@
 			vstudio.vs2010.generateRule(rule)
 		end,
 
-		onCleanSolution = function(sln)
-			vstudio.cleanSolution(sln)
+		onCleanWorkspace = function(wrk)
+			vstudio.cleanSolution(wrk)
 		end,
 		onCleanProject = function(prj)
 			vstudio.cleanProject(prj)

--- a/src/actions/vstudio/vs2013.lua
+++ b/src/actions/vstudio/vs2013.lua
@@ -39,8 +39,8 @@
 
 		-- Solution and project generation logic
 
-		onWorkspace = function(wrk)
-			vstudio.vs2005.generateSolution(wrk)
+		onWorkspace = function(wks)
+			vstudio.vs2005.generateSolution(wks)
 		end,
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
@@ -49,8 +49,8 @@
 			vstudio.vs2010.generateRule(rule)
 		end,
 
-		onCleanWorkspace = function(wrk)
-			vstudio.cleanSolution(wrk)
+		onCleanWorkspace = function(wks)
+			vstudio.cleanSolution(wks)
 		end,
 		onCleanProject = function(prj)
 			vstudio.cleanProject(prj)

--- a/src/actions/vstudio/vs2013.lua
+++ b/src/actions/vstudio/vs2013.lua
@@ -39,8 +39,8 @@
 
 		-- Solution and project generation logic
 
-		onSolution = function(sln)
-			vstudio.vs2005.generateSolution(sln)
+		onWorkspace = function(wrk)
+			vstudio.vs2005.generateSolution(wrk)
 		end,
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
@@ -49,8 +49,8 @@
 			vstudio.vs2010.generateRule(rule)
 		end,
 
-		onCleanSolution = function(sln)
-			vstudio.cleanSolution(sln)
+		onCleanWorkspace = function(wrk)
+			vstudio.cleanSolution(wrk)
 		end,
 		onCleanProject = function(prj)
 			vstudio.cleanProject(prj)

--- a/src/actions/vstudio/vs2015.lua
+++ b/src/actions/vstudio/vs2015.lua
@@ -39,8 +39,8 @@
 
 		-- Solution and project generation logic
 
-		onWorkspace = function(wrk)
-			vstudio.vs2005.generateSolution(wrk)
+		onWorkspace = function(wks)
+			vstudio.vs2005.generateSolution(wks)
 		end,
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
@@ -49,8 +49,8 @@
 			vstudio.vs2010.generateRule(rule)
 		end,
 
-		onCleanWorkspace = function(wrk)
-			vstudio.cleanSolution(wrk)
+		onCleanWorkspace = function(wks)
+			vstudio.cleanSolution(wks)
 		end,
 		onCleanProject = function(prj)
 			vstudio.cleanProject(prj)

--- a/src/actions/vstudio/vs2015.lua
+++ b/src/actions/vstudio/vs2015.lua
@@ -39,8 +39,8 @@
 
 		-- Solution and project generation logic
 
-		onSolution = function(sln)
-			vstudio.vs2005.generateSolution(sln)
+		onWorkspace = function(wrk)
+			vstudio.vs2005.generateSolution(wrk)
 		end,
 		onProject = function(prj)
 			vstudio.vs2010.generateProject(prj)
@@ -49,8 +49,8 @@
 			vstudio.vs2010.generateRule(rule)
 		end,
 
-		onCleanSolution = function(sln)
-			vstudio.cleanSolution(sln)
+		onCleanWorkspace = function(wrk)
+			vstudio.cleanSolution(wrk)
 		end,
 		onCleanProject = function(prj)
 			vstudio.cleanProject(prj)

--- a/src/base/action.lua
+++ b/src/base/action.lua
@@ -73,20 +73,20 @@
 ---
 
 	function action.call(name)
-		local act = action._list[name]
+		local a = action._list[name]
 
-		if act.onStart then
-			act.onStart()
+		if a.onStart then
+			a.onStart()
 		end
 
 		for sln in p.global.eachSolution() do
-			local onSolution = act.onSolution or act.onsolution
+			local onSolution = a.onWorkspace or a.onSolution or a.onsolution
 			if onSolution and not sln.external then
 				onSolution(sln)
 			end
 
 			for prj in p.solution.eachproject(sln) do
-				local onProject = act.onProject or act.onproject
+				local onProject = a.onProject or a.onproject
 				if onProject and not prj.external then
 					onProject(prj)
 				end
@@ -94,18 +94,18 @@
 		end
 
 		for rule in p.global.eachRule() do
-			local onRule = act.onRule or act.onrule
+			local onRule = a.onRule or a.onrule
 			if onRule and not rule.external then
 				onRule(rule)
 			end
 		end
 
-		if act.execute then
-			act.execute()
+		if a.execute then
+			a.execute()
 		end
 
-		if act.onEnd then
-			act.onEnd()
+		if a.onEnd then
+			a.onEnd()
 		end
 	end
 

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -84,6 +84,7 @@
 
 		self.environ = {
 			sln = self,
+			wks = self,
 		}
 
 		context.compile(self)
@@ -142,6 +143,7 @@
 
 		self.environ = {
 			sln = sln,
+			wks = sln,
 			prj = self,
 		}
 
@@ -316,7 +318,8 @@
 
 		-- fill in any calculated values
 		for _, cfg in ipairs(configs) do
-			cfg.solution = sln
+			cfg.solution = sln  -- confused: doesn't happen automatically already?
+			cfg.workspace = sln
 			oven.finishConfig(cfg)
 		end
 
@@ -456,6 +459,7 @@
 
 		local environ = {
 			sln = prj.solution,
+			wks = prj.solution,
 			prj = prj,
 		}
 

--- a/src/base/solution.lua
+++ b/src/base/solution.lua
@@ -11,13 +11,24 @@
 	local tree = p.tree
 
 
+---
+-- Begin the switch from solution() to workspace()
+---
+
+	p.workspace = p.solution
+	local workspace = p.solution
+
+	p.alias(_G, "solution", "workspace")
+	p.alias(_G, "externalsolution", "externalworkspace")
+
+
 
 ---
 -- Create a new solution container instance.
 ---
 
-	function solution.new(name)
-		local sln = p.container.new(solution, name)
+	function workspace.new(name)
+		local sln = p.container.new(workspace, name)
 		return sln
 	end
 
@@ -32,7 +43,7 @@
 --    A configuration iteration function.
 --
 
-	function solution.eachconfig(sln)
+	function workspace.eachconfig(sln)
 		sln = premake.oven.bakeSolution(sln)
 
 		local i = 0
@@ -56,12 +67,12 @@
 --    An iterator function, returning project configurations.
 --
 
-	function solution.eachproject(sln)
+	function workspace.eachproject(sln)
 		local i = 0
 		return function ()
 			i = i + 1
 			if i <= #sln.projects then
-				return premake.solution.getproject(sln, i)
+				return p.workspace.getproject(sln, i)
 			end
 		end
 	end
@@ -78,7 +89,7 @@
 --    The project object, or nil if a matching project could not be found.
 --
 
-	function solution.findproject(sln, name)
+	function workspace.findproject(sln, name)
 		name = name:lower()
 		for _, prj in ipairs(sln.projects) do
 			if name == prj.name:lower() then
@@ -98,7 +109,7 @@
 --    The tree of project groups defined for the solution.
 --
 
-	function solution.grouptree(sln)
+	function workspace.grouptree(sln)
 		-- check for a previously cached tree
 		if sln.grouptree then
 			return sln.grouptree
@@ -107,7 +118,7 @@
 		-- build the tree of groups
 
 		local tr = tree.new()
-		for prj in solution.eachproject(sln) do
+		for prj in workspace.eachproject(sln) do
 			local prjpath = path.join(prj.group, prj.name)
 			local node = tree.add(tr, prjpath)
 			node.project = prj
@@ -136,8 +147,8 @@
 --    The project configuration at the given index.
 --
 
-	function solution.getproject(sln, idx)
-		sln = premake.oven.bakeSolution(sln)
+	function workspace.getproject(sln, idx)
+		sln = p.oven.bakeSolution(sln)
 		return sln.projects[idx]
 	end
 

--- a/src/base/workspace.lua
+++ b/src/base/workspace.lua
@@ -25,8 +25,8 @@
 ---
 
 	function workspace.new(name)
-		local wrk = p.container.new(workspace, name)
-		return wrk
+		local wks = p.container.new(workspace, name)
+		return wks
 	end
 
 

--- a/src/base/workspace.lua
+++ b/src/base/workspace.lua
@@ -1,14 +1,11 @@
 ---
--- solution.lua
--- Work with the list of solutions loaded from the script.
+-- workspace.lua
+-- Work with the list of workspaces loaded from the script.
 -- Copyright (c) 2002-2015 Jason Perkins and the Premake project
 ---
 
 	local p = premake
 	p.solution = p.api.container("solution", p.global)
-
-	local solution = p.solution
-	local tree = p.tree
 
 
 ---
@@ -24,55 +21,51 @@
 
 
 ---
--- Create a new solution container instance.
+-- Create a new workspace container instance.
 ---
 
 	function workspace.new(name)
-		local sln = p.container.new(workspace, name)
-		return sln
+		local wrk = p.container.new(workspace, name)
+		return wrk
 	end
 
 
 
 --
--- Iterate over the configurations of a solution.
+-- Iterate over the configurations of a workspace.
 --
--- @param sln
---    The solution to query.
 -- @return
 --    A configuration iteration function.
 --
 
-	function workspace.eachconfig(sln)
-		sln = premake.oven.bakeSolution(sln)
+	function workspace.eachconfig(self)
+		self = premake.oven.bakeSolution(self)
 
 		local i = 0
 		return function()
 			i = i + 1
-			if i > #sln.configs then
+			if i > #self.configs then
 				return nil
 			else
-				return sln.configs[i]
+				return self.configs[i]
 			end
 		end
 	end
 
 
 --
--- Iterate over the projects of a solution (next-gen).
+-- Iterate over the projects of a workspace.
 --
--- @param sln
---    The solution.
 -- @return
 --    An iterator function, returning project configurations.
 --
 
-	function workspace.eachproject(sln)
+	function workspace.eachproject(self)
 		local i = 0
 		return function ()
 			i = i + 1
-			if i <= #sln.projects then
-				return p.workspace.getproject(sln, i)
+			if i <= #self.projects then
+				return p.workspace.getproject(self, i)
 			end
 		end
 	end
@@ -81,17 +74,15 @@
 --
 -- Locate a project by name, case insensitive.
 --
--- @param sln
---    The solution to query.
 -- @param name
 --    The name of the projec to find.
 -- @return
 --    The project object, or nil if a matching project could not be found.
 --
 
-	function workspace.findproject(sln, name)
+	function workspace.findproject(self, name)
 		name = name:lower()
-		for _, prj in ipairs(sln.projects) do
+		for _, prj in ipairs(self.projects) do
 			if name == prj.name:lower() then
 				return prj
 			end
@@ -103,35 +94,33 @@
 --
 -- Retrieve the tree of project groups.
 --
--- @param sln
---    The solution to query.
 -- @return
---    The tree of project groups defined for the solution.
+--    The tree of project groups defined for the workspace.
 --
 
-	function workspace.grouptree(sln)
+	function workspace.grouptree(self)
 		-- check for a previously cached tree
-		if sln.grouptree then
-			return sln.grouptree
+		if self.grouptree then
+			return self.grouptree
 		end
 
 		-- build the tree of groups
 
-		local tr = tree.new()
-		for prj in workspace.eachproject(sln) do
+		local tr = p.tree.new()
+		for prj in workspace.eachproject(self) do
 			local prjpath = path.join(prj.group, prj.name)
-			local node = tree.add(tr, prjpath)
+			local node = p.tree.add(tr, prjpath)
 			node.project = prj
 		end
 
 		-- assign UUIDs to each node in the tree
-		tree.traverse(tr, {
+		p.tree.traverse(tr, {
 			onnode = function(node)
 				node.uuid = os.uuid(node.path)
 			end
 		})
 
-		sln.grouptree = tr
+		self.grouptree = tr
 		return tr
 	end
 
@@ -139,26 +128,22 @@
 --
 -- Retrieve the project configuration at a particular index.
 --
--- @param sln
---    The solution.
 -- @param idx
 --    An index into the array of projects.
 -- @return
 --    The project configuration at the given index.
 --
 
-	function workspace.getproject(sln, idx)
-		sln = p.oven.bakeSolution(sln)
-		return sln.projects[idx]
+	function workspace.getproject(self, idx)
+		self = p.oven.bakeSolution(self)
+		return self.projects[idx]
 	end
 
 
 
 ---
--- Determines if the solution contains a project that meets certain criteria.
+-- Determines if the workspace contains a project that meets certain criteria.
 --
--- @param self
---    The solution.
 -- @param func
 --    A test function. Receives a project as its only argument and returns a
 --    boolean indicating whether it meets to matching criteria.
@@ -166,6 +151,6 @@
 --    True if the test function returned true.
 ---
 
-	function solution.hasProject(self, func)
+	function workspace.hasProject(self, func)
 		return p.container.hasChild(self, p.project, func)
 	end

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -1,6 +1,7 @@
 return {
 	-- Base API tests
 	"test_string.lua",
+	"base/test_aliasing.lua",
 	"base/test_configset.lua",
 	"base/test_context.lua",
 	"base/test_criteria.lua",

--- a/tests/base/test_aliasing.lua
+++ b/tests/base/test_aliasing.lua
@@ -1,0 +1,64 @@
+--
+-- tests/base/test_aliasing.lua
+-- Verify handling of function aliases.
+-- Copyright (c) 2015 Jason Perkins and the Premake project
+--
+
+	local suite = test.declare("premake_alias")
+
+	local p = premake
+
+
+	function suite.setup()
+		suite.testfunc = function()
+			return 48
+		end
+		suite.aliased = nil
+		suite.aliased2 = nil
+	end
+
+
+	function suite.returnsOriginalFunction_onNoAlias()
+		local scope, f = p.resolveAlias(suite, "testfunc")
+		test.isequal("testfunc", f)
+	end
+
+
+	function suite.pointsAliasToOriginalFunction()
+		p.alias(suite, "testfunc", "aliased")
+		test.isequal(48, suite.aliased())
+	end
+
+
+	function suite.returnsOriginalFunction_onAlias()
+		p.alias(suite, "testfunc", "aliased")
+		local scope, f = p.resolveAlias(suite, "aliased")
+		test.isequal("testfunc", f)
+	end
+
+
+	function suite.returnsOriginalFunction_onChainedAliases()
+		p.alias(suite, "testfunc", "aliased")
+		p.alias(suite, "aliased", "aliased2")
+		local scope, f = p.resolveAlias(suite, "aliased2")
+		test.isequal("testfunc", f)
+	end
+
+
+	function suite.overrideResolvesAliases()
+		p.alias(suite, "testfunc", "aliased")
+		p.override(suite, "aliased", function(base)
+			return base() + 1
+		end)
+		test.isequal(49, suite.testfunc())
+	end
+
+
+	function suite.aliasTracksOverrides()
+		p.alias(suite, "testfunc", "aliased")
+		p.override(suite, "testfunc", function(base)
+			return base() + 1
+		end)
+		test.isequal(49, suite.aliased())
+	end
+

--- a/tests/testfx.lua
+++ b/tests/testfx.lua
@@ -247,14 +247,14 @@
 --
 
 	function test.createWorkspace()
-		local wrk = workspace("MySolution")
+		local wks = workspace("MySolution")
 		configurations { "Debug", "Release" }
 
 		local prj = project("MyProject")
 		language("C++")
 		kind("ConsoleApp")
 
-		return wrk, prj
+		return wks, prj
 	end
 
 	p.alias(test, "createWorkspace", "createsolution")

--- a/tests/testfx.lua
+++ b/tests/testfx.lua
@@ -1,8 +1,10 @@
 --
 -- tests/testfx.lua
 -- Automated test framework for Premake.
--- Copyright (c) 2008-2014 Jason Perkins and the Premake project
+-- Copyright (c) 2008-2015 Jason Perkins and the Premake project
 --
+
+	local p = premake
 
 
 --
@@ -244,16 +246,18 @@
 -- Some helper functions
 --
 
-	function test.createsolution()
-		local sln = solution "MySolution"
+	function test.createWorkspace()
+		local wrk = workspace("MySolution")
 		configurations { "Debug", "Release" }
 
-		local prj = project "MyProject"
-		language "C++"
-		kind "ConsoleApp"
+		local prj = project("MyProject")
+		language("C++")
+		kind("ConsoleApp")
 
-		return sln, prj
+		return wrk, prj
 	end
+
+	p.alias(test, "createWorkspace", "createsolution")
 
 
 	function test.createproject(sln)


### PR DESCRIPTION
Begin the switch from "solution" to "workspace" (see https://github.com/premake/premake-core/issues/37)

This change is going to touch a *lot* of code so I'm going to try and do it in phases and hopefully not mess anyone up too badly. This request changes the most visible names (the `solution()` API call and the `onSolution()` action callback) so that I can use the new names as I'm writing the action development tutorial. I also hit a few easy renames while I was in there.