### PR TITLE
Local queries

### DIFF
--- a/src/base/context.lua
+++ b/src/base/context.lua
@@ -168,26 +168,35 @@
 --    The context to query.
 -- @param key
 --    The property key to query.
+-- @param onlylocal
+--     If true, don't combine values from parent contexts.
 -- @return
 --    The value of the key, as determined by the configuration set.  If
 --    there is a corresponding Premake field, and it the field is enabled
 --    for tokens, any contained tokens will be expanded.
 --
 
-	function context.fetchvalue(ctx, key)
+	function context.fetchvalue(ctx, key, onlylocal)
+		if not onlylocal then
+			local value = rawget(ctx, key)
+			if value ~= nil then
+				return value
+			end
+		end
+
 		-- The underlying configuration set will only hold registered fields.
 		-- If the requested key doesn't have a corresponding field, it is just
 		-- a regular value to be stored and fetched from the table.
 
 		local field = p.field.get(key)
 		if not field then
-			return rawget(ctx, key)
+			return nil
 		end
 
 		-- If there is a matching field, then go fetch the aggregated value
 		-- from my configuration set, and then cache it future lookups.
 
-		local value = configset.fetch(ctx._cfgset, field, ctx.terms, ctx)
+		local value = configset.fetch(ctx._cfgset, field, ctx.terms, ctx, onlylocal and ctx._cfgset)
 		if value then
 			-- store the result for later lookups
 			ctx[key] = value


### PR DESCRIPTION
This allows our 'xcode' module to query for config values only for the local scope. So only things that were set specifically in a filter { configurations:debug }... but also allows you to query for values local to the solution...

This allows for solution, project & config independent queries, when generating the xcode project settings.