### PR TITLE
Buffered I/O, and only write generated file if it changed.

### DIFF
--- a/src/host/buffered_io.c
+++ b/src/host/buffered_io.c
@@ -1,0 +1,105 @@
+/**
+ * \file   buffered_io.c
+ * \brief  provide buffered io.
+ * \author Copyright (c) 2014
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "premake.h"
+
+typedef struct struct_Buffer
+{
+	size_t capacity;
+	size_t length;
+	char*  data;
+} Buffer;
+
+
+int buffered_new(lua_State* L)
+{
+	Buffer* b = (Buffer*)malloc(sizeof(Buffer));
+	b->capacity = 0;
+	b->length = 0;
+	b->data = NULL;
+	lua_pushlightuserdata(L, b);
+	return 1;
+}
+
+
+static void do_write(Buffer* b, const char *s, size_t l)
+{
+	char* data;
+
+	if (b->length + l > b->capacity)
+	{
+		size_t cap = (b->capacity * 3) / 2;
+		if (cap <= 65536)
+			cap = 65536;
+
+		data = (char*)calloc(cap, 1);
+		if (b->length > 0)
+		{
+			memcpy(data, b->data, b->length);
+			free(b->data);
+		}
+		b->data = data;
+		b->capacity = cap;
+	}
+
+	memcpy(b->data + b->length, s, l);
+	b->length += l;
+}
+
+
+int buffered_write(lua_State* L)
+{
+	size_t l;
+	const char *s = luaL_checklstring(L, 2, &l);
+	Buffer* b = (Buffer*)lua_touserdata(L, 1);
+
+	do_write(b, s, l);
+	return 0;
+}
+
+
+int buffered_writeln(lua_State* L)
+{
+	size_t l;
+	const char *s = luaL_checklstring(L, 2, &l);
+	Buffer* b = (Buffer*)lua_touserdata(L, 1);
+
+	do_write(b, s, l);
+	do_write(b, "\r\n", 2);
+	return 0;
+}
+
+
+int buffered_close(lua_State* L)
+{
+	Buffer* b = (Buffer*)lua_touserdata(L, 1);
+	free(b->data);
+	free(b);
+	return 0;
+}
+
+
+int buffered_tostring(lua_State* L)
+{
+	Buffer* b = (Buffer*)lua_touserdata(L, 1);
+	size_t len = b->length;
+
+	// trim string for _eol of line at the end.
+	if (len > 0 && b->data[len-1] == '\n')
+		--len;
+	if (len > 0 && b->data[len-1] == '\r')
+		--len;
+
+	if (len > 0)
+		// push data into a string.
+		lua_pushlstring(L, b->data, len);
+	else
+		lua_pushstring(L, "");
+
+	return 1;
+}

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -86,6 +86,15 @@ static const luaL_Reg string_functions[] = {
 	{ NULL, NULL }
 };
 
+static const luaL_Reg buffered_functions[] = {
+	{ "new", buffered_new },
+	{ "write", buffered_write },
+	{ "writeln", buffered_writeln },
+	{ "tostring", buffered_tostring },
+	{ "close", buffered_close },
+	{ NULL, NULL }
+};
+
 #ifdef PREMAKE_CURL
 static const luaL_Reg http_functions[] = {
 	{ "get",  http_get },
@@ -106,6 +115,7 @@ int premake_init(lua_State* L)
 	luaL_register(L, "path",     path_functions);
 	luaL_register(L, "os",       os_functions);
 	luaL_register(L, "string",   string_functions);
+	luaL_register(L, "buffered", buffered_functions);
 
 #ifdef PREMAKE_CURL
 	luaL_register(L, "http",     http_functions);

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -121,6 +121,11 @@ int string_endswith(lua_State* L);
 int string_hash(lua_State* L);
 int string_sha1(lua_State* L);
 int string_startswith(lua_State* L);
+int buffered_new(lua_State* L);
+int buffered_write(lua_State* L);
+int buffered_writeln(lua_State* L);
+int buffered_close(lua_State* L);
+int buffered_tostring(lua_State* L);
 
 #ifdef PREMAKE_CURL
 int http_get(lua_State* L);

--- a/tests/testfx.lua
+++ b/tests/testfx.lua
@@ -310,6 +310,12 @@
 	local function stub_print(s)
 	end
 
+	local function stub_os_writefile_ifnotequal(content, fname)
+		test.value_openedfilename = fname;
+		test.value_closedfile = true
+		return 0;
+	end
+
 
 --
 -- Define a collection for the test suites
@@ -431,6 +437,7 @@
 		print = stub_print
 		io.open = stub_io_open
 		io.output = stub_io_output
+		os.writefile_ifnotequal = stub_os_writefile_ifnotequal
 
 		local numpassed = 0
 		local numfailed = 0


### PR DESCRIPTION
OK, so this adds Buffered I/O to premake, basically generating any file in memory first, then comparing it to existing data on disk, and only writing the file if it actually changed..

This isn't so much about performance, as it is about memory usage as well as making it such that if no changes were made, no files on disk were touched, and hence no reloads are caused in Visual Studio or xcode. 

I made this a native C type, because the existing lua tables are insufficiently memory efficient to support this at reasonable memory usage levels on a project the scale of SC2/Heroes.

Anyway, unfortunately this is going to break the unit-tests, due to a small error in the existing xcode back-end that emits a "\r\n" in the unit-tests where at runtime it would not... It's a single line fix.