### PR TITLE
Improve module loadfile() error messages

### DIFF
--- a/src/_premake_main.lua
+++ b/src/_premake_main.lua
@@ -68,6 +68,9 @@
 				if chunk then
 					return chunk
 				end
+				if err then
+					return "\n\tload error " .. err
+				end
 			end
 		end
 

--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -74,7 +74,10 @@
 ---
 
 	premake.override(_G, "require", function(base, modname, versions)
-		local mod = base(modname)
+		local result, mod = pcall(base,modname)
+		if not result then
+			error( mod, 3 )
+		end
 		if mod and versions and not premake.checkVersion(mod._VERSION, versions) then
 			error(string.format("module %s %s does not meet version criteria %s",
 				modname, mod._VERSION or "(none)", versions), 3)


### PR DESCRIPTION
Have the module package loader return the loadfile() error for file system modules,
and report the error from the calling script, rather than globals.lua.

This give marginally better errors when require()'ing modules with syntax errors.
The error will appear in the package loader list with the correct call site.

     Error: /Users/blah/premake5.lua:7: module 'wee' not found:
         no field package.preload['wee']
         load error /Users/blah/modules/wee/wee.lua:3: '=' expected near '<eof>'
	 ....

Fixes #143