### PR TITLE
If action contains no valid language or kind lists, assume everything is supported

### DIFF
--- a/src/base/action.lua
+++ b/src/base/action.lua
@@ -222,6 +222,9 @@
 		if not self then
 			return false
 		end
+		if not self.valid_languages and not self.valid_kinds then
+			return true
+		end
 		if self.valid_languages then
 			if table.contains(self.valid_languages, feature) then
 				return true


### PR DESCRIPTION
This makes it easier to write and maintain small utility or reporting actions that don't actually care about project kinds of languages. If you really don't want your action to support any kinds or languages (which would be weird, but okay) you can do:

```lua
valid_languages = {}
valid_kinds = {}
```