### PR TITLE
added support for preloading user modules

### DIFF
--- a/scripts/embed.lua
+++ b/scripts/embed.lua
@@ -111,6 +111,17 @@
 		end
 	end
 
+-- Try to look for _user_modules.lua files in the _MAIN_SCRIPT_DIR folder
+-- and it subfolders. If we find at least one, add the _embedded_user_modules.lua
+-- entry.
+
+	local userModuleFiles = {}
+	userModuleFiles = table.join(userModuleFiles, os.matchfiles(path.join(_MAIN_SCRIPT_DIR, "**/_user_modules.lua")))
+	userModuleFiles = table.join(userModuleFiles, os.matchfiles(path.join(_MAIN_SCRIPT_DIR, "_user_modules.lua")))
+	if #userModuleFiles > 0 then
+		table.insert(result, '\t"src/_embedded_user_modules.lua",')
+	end
+
 	table.insert(result, '\t"src/_premake_main.lua",')
 	table.insert(result, '\t"src/_manifest.lua",')
 	table.insert(result, '\t"src/_modules.lua",')
@@ -134,6 +145,16 @@
 			local scr = loadScript(filename)
 			appendScript(result, scr)
 		end
+	end
+
+-- Write he user modules.
+
+	if #userModuleFiles > 0 then
+		local userModules = {}
+		for _, userModuleFile in ipairs(userModuleFiles) do
+			userModules = table.join(userModules, dofile(userModuleFile))
+		end
+		appendScript(result, "return {" .. table.implode(userModules, "\\\"", "\\\"", ",\\n") .. "}")
 	end
 
 	appendScript(result, loadScript(path.join(_SCRIPT_DIR, "../src/_premake_main.lua")))

--- a/src/_premake_main.lua
+++ b/src/_premake_main.lua
@@ -17,6 +17,16 @@
 	end
 
 
+-- Adds optional user scripts
+
+	do
+		local chunk, err = loadfile("_embedded_user_modules.lua")
+		if chunk then
+			modules = table.join(modules, chunk())
+		end
+	end
+
+
 -- Create namespaces for myself
 
 	local p = premake

--- a/src/_premake_main.lua
+++ b/src/_premake_main.lua
@@ -17,16 +17,6 @@
 	end
 
 
--- Adds optional user scripts
-
-	do
-		local chunk, err = loadfile("_embedded_user_modules.lua")
-		if chunk then
-			modules = table.join(modules, chunk())
-		end
-	end
-
-
 -- Create namespaces for myself
 
 	local p = premake


### PR DESCRIPTION
With this modification, if we add a "_user_modules.lua" file (or more than one) somewhere in the _MAIN_SCRIPT_DIR or its children, the modules listed will be preloaded like the modules in "_modules.lua".

This means that when you create a version of Premake which embeds your custom modules, their help (if any) will be displayed when running "premake5 --help" (which wasn't the case until now, and which proved a bit annoying :p)

The code is fairly simple, so feel free to check and ask me questions if something seems wrong, or if you want me to do it another way. I tested it using only one _user_modules.lua file in my addons folder, but also with one _user_modules.lua in each of my addons.
All the stuff in _preload.lua got correctly loaded and the help for my actions / options were correctly displayed.

I don't know if there is a way to unit test this since it's something only usefull when embedded custom stuff ...