### PR TITLE
Rename container class from solution to workspace and propagate changes

### DIFF
--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -90,22 +90,11 @@
 
 
 ---
--- Return the global configuration container. You could just call global()
--- too, but this is much faster.
+-- Return the global configuration container.
 ---
 
 	function api.rootContainer()
 		return api.scope.global
-	end
-
-
-
-
-	function api._clearContainerChildren(class)
-		for childClass in p.container.eachChildClass(class) do
-			api.scope[childClass.name] = nil
-			api._clearContainerChildren(childClass)
-		end
 	end
 
 
@@ -178,10 +167,23 @@
 
 		while instance do
 			api.scope[instance.class.name] = instance
+			if instance.class.alias then
+				api.scope[instance.class.alias] = instance
+			end
 			instance = instance.parent
 		end
 
 		return api.scope.current
+	end
+
+	function api._clearContainerChildren(class)
+		for childClass in p.container.eachChildClass(class) do
+			api.scope[childClass.name] = nil
+			if childClass.alias then
+				api.scope[childClass.alias] = nil
+			end
+			api._clearContainerChildren(childClass)
+		end
 	end
 
 
@@ -655,9 +657,9 @@
 ---
 
 	function api.reset()
-		-- Clear out all top level objects, but keep the root config
-		api.scope.global.rules = {}
-		api.scope.global.solutions = {}
+		for containerClass in p.container.eachChildClass(p.global) do
+			api.scope.global[containerClass.pluralName] = {}
+		end
 	end
 
 

--- a/src/base/container.lua
+++ b/src/base/container.lua
@@ -106,6 +106,9 @@
 
 		child.parent = self
 		child[self.class.name] = self
+		if self.class.alias then
+			child[self.class.alias] = self
+		end
 	end
 
 
@@ -188,7 +191,7 @@
 			end
 		end
 
-		if class.name == scope then
+		if class.name == scope or class.alias == scope then
 			return true
 		end
 
@@ -218,7 +221,7 @@
 
 	function container.classIsA(class, scope)
 		while class do
-			if class.name == scope then
+			if class.name == scope or class.alias == scope then
 				return true
 			end
 			class = class.parent

--- a/src/base/global.lua
+++ b/src/base/global.lua
@@ -102,7 +102,7 @@
 
 	function global.getWorkspace(key)
 		local root = p.api.rootContainer()
-		return root.solutions[key]
+		return root.workspaces[key]
 	end
 
 	p.alias(global, "getWorkspace", "getSolution")

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -118,7 +118,7 @@
 
 
 	function p.project.bake(self)
-		self.workspace = self.solution
+		self.solution = self.workspace
 		local wks = self.workspace
 
 		-- Add filtering terms to the context to make it as specific as I can.

--- a/src/base/workspace.lua
+++ b/src/base/workspace.lua
@@ -5,18 +5,27 @@
 ---
 
 	local p = premake
-	p.solution = p.api.container("solution", p.global)
+	p.workspace = p.api.container("workspace", p.global)
+
+	local workspace = p.workspace
 
 
 ---
--- Begin the switch from solution() to workspace()
+-- Begin the switch from solution() to workspace().
+--
+-- We changed "solution" to "workspace" on 30 Jul 2015. While it might be
+-- nice to leave `solution()` around for VS folks and everyone used to the
+-- old system, it would be good to eventually deprecate and remove all of
+-- the other, more internal uses of "solution" and "sln". Probably including
+-- all uses of container class aliases, since we probably aren't going to
+-- need those again (right?).
 ---
 
-	p.workspace = p.solution
-	local workspace = p.solution
+	p.solution = workspace
+	workspace.alias = "solution"
 
-	p.alias(_G, "solution", "workspace")
-	p.alias(_G, "externalsolution", "externalworkspace")
+	p.alias(_G, "workspace", "solution")
+	p.alias(_G, "externalworkspace", "externalsolution")
 
 
 


### PR DESCRIPTION
Another step in switching from "solution" to "workspace": rename the container object, and fix up everything that touches it.