### PR TITLE
Fix handling of arbitrary platform names in Visual Studio C# projects

### DIFF
--- a/src/actions/vstudio/vs2005_csproj.lua
+++ b/src/actions/vstudio/vs2005_csproj.lua
@@ -365,10 +365,11 @@
 --
 
 	function cs2005.propertyGroup(cfg)
+		local platform = vstudio.projectPlatform(cfg)
 		local arch = cs2005.arch(cfg)
-		_x(1,'<PropertyGroup Condition=" \'$(Configuration)|$(Platform)\' == \'%s|%s\' ">', cfg.buildcfg, arch)
+		p.push('<PropertyGroup Condition=" \'$(Configuration)|$(Platform)\' == \'%s|%s\' ">', platform, arch)
 		if arch ~= "AnyCPU" or _ACTION > "vs2008" then
-			_x(2,'<PlatformTarget>%s</PlatformTarget>', arch)
+			p.x('<PlatformTarget>%s</PlatformTarget>', arch)
 		end
 	end
 

--- a/tests/actions/vstudio/cs2005/test_platform_groups.lua
+++ b/tests/actions/vstudio/cs2005/test_platform_groups.lua
@@ -1,7 +1,7 @@
 --
 -- tests/actions/vstudio/cs2005/test_platform_groups.lua
 -- Check creation of per-platform property groups in VS2005+ C# projects.
--- Copyright (c) 2009-2013 Jason Perkins and the Premake project
+-- Copyright (c) 2009-2015 Jason Perkins and the Premake project
 --
 
 	local suite = test.declare("vstudio_cs2005_platform_groups")
@@ -11,16 +11,17 @@
 -- Setup
 --
 
+	local wks
+
 	function suite.setup()
-		_ACTION = "vs2008"
+		_ACTION = "vs2010"
+		wks = solution("MySolution")
+		configurations { "Debug", "Release" }
+		language "C#"
 	end
 
 	local function prepare(platform)
-		local sln = solution ("MySolution")
-		configurations ("Debug")
-		platforms (platform)
-		local prj = project ("MyProject")
-		language "C#"
+		local prj = project("MyProject")
 		local cfg = test.getconfig(prj, "Debug", platform)
 		cs2005.propertyGroup(cfg)
 	end
@@ -34,7 +35,7 @@
 		_ACTION = "vs2008"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		]]
 	end
 
@@ -43,8 +44,8 @@
 		_ACTION = "vs2010"
 		prepare()
 		test.capture [[
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-		<PlatformTarget>AnyCPU</PlatformTarget>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+	<PlatformTarget>AnyCPU</PlatformTarget>
 		]]
 	end
 
@@ -55,35 +56,52 @@
 
 	function suite.vs2008_onAnyCpu()
 		_ACTION = "vs2008"
+		platforms "Any CPU"
 		prepare("Any CPU")
 		test.capture [[
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		]]
 	end
 
 
 	function suite.vs2010_onAnyCpu()
 		_ACTION = "vs2010"
+		platforms "Any CPU"
 		prepare("Any CPU")
 		test.capture [[
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-		<PlatformTarget>AnyCPU</PlatformTarget>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+	<PlatformTarget>AnyCPU</PlatformTarget>
 		]]
 	end
 
 	function suite.onX86()
+		platforms "x86"
 		prepare("x86")
 		test.capture [[
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-		<PlatformTarget>x86</PlatformTarget>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+	<PlatformTarget>x86</PlatformTarget>
 		]]
 	end
 
 
 	function suite.onX86_64()
+		platforms "x86_64"
 		prepare("x86_64")
 		test.capture [[
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-		<PlatformTarget>x64</PlatformTarget>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+	<PlatformTarget>x64</PlatformTarget>
 		]]
 	end
+
+
+	function suite.onArbitrary64bitPlatform()
+		platforms "Win64"
+		system "Windows"
+		architecture "x86_64"
+		prepare("Win64")
+		test.capture [[
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug Win64|x64' ">
+	<PlatformTarget>x64</PlatformTarget>
+		]]
+	end
+


### PR DESCRIPTION
Fixes the platform handling bug reported on [this Stack Overflow question](http://stackoverflow.com/questions/31793740/premake-v5-with-vs2013-and-c-x64-platforms-not-being-set-to-64-bit-or-to-e).