### PR TITLE
Empty projects no longer ignore platform toolset when there are no "cpp" files present

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -143,6 +143,7 @@
 		if cfg.kind == p.UTILITY then
 			return {
 				m.configurationType,
+				m.platformToolset,
 			}
 		else
 			return {
@@ -1515,12 +1516,15 @@
 			version = action.vstudio.platformToolset
 		end
 		if version then
-			-- should only be written if there is a C/C++ file in the config
-			for i = 1, #cfg.files do
-				if path.iscppfile(cfg.files[i]) then
-					m.element("PlatformToolset", nil, version)
-					break
+			if cfg.kind == p.NONE or cfg.kind == p.MAKEFILE then
+				for i = 1, #cfg.files do
+					if path.iscppfile(cfg.files[i]) then
+						m.element("PlatformToolset", nil, version)
+						break
+					end
 				end
+			else
+				m.element("PlatformToolset", nil, version)
 			end
 		end
 	end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -348,7 +348,7 @@
 	end
 
 	function m.resourceCompile(cfg)
-		if cfg.system ~= p.XBOX360 and config.hasResourceFiles(cfg) then
+		if cfg.system ~= p.XBOX360 and p.config.hasFile(cfg, path.isresourcefile) then
 			local contents = p.capture(function ()
 				p.push()
 				p.callArray(m.elements.resourceCompile, cfg)
@@ -1517,11 +1517,8 @@
 		end
 		if version then
 			if cfg.kind == p.NONE or cfg.kind == p.MAKEFILE then
-				for i = 1, #cfg.files do
-					if path.iscppfile(cfg.files[i]) then
-						m.element("PlatformToolset", nil, version)
-						break
-					end
+				if p.config.hasFile(cfg, path.iscppfile) then
+					m.element("PlatformToolset", nil, version)
 				end
 			else
 				m.element("PlatformToolset", nil, version)

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -359,14 +359,15 @@
 
 
 
---
--- Determine if a configuration contains one or more resource files.
---
+---
+-- Returns true if any of the files in the provided container pass the
+-- provided test function.
+---
 
-	function config.hasResourceFiles(self)
+	function config.hasFile(self, testfn)
 		local files = self.files
 		for i = 1, #files do
-			if path.isresourcefile(files[i]) then
+			if testfn(files[i]) then
 				return true
 			end
 		end

--- a/tests/actions/vstudio/vc2010/test_platform_toolset.lua
+++ b/tests/actions/vstudio/vc2010/test_platform_toolset.lua
@@ -57,17 +57,6 @@
 
 
 --
--- Element should only be written if C++ files are present.
---
-
-	function suite.empty_onNoRelevantSources()
-		removefiles "hello.cpp"
-		prepare()
-		test.isemptycapture()
-	end
-
-
---
 -- Check for overrides from project scripts.
 --
 

--- a/tests/actions/vstudio/vc2010/test_platform_toolset.lua
+++ b/tests/actions/vstudio/vc2010/test_platform_toolset.lua
@@ -75,3 +75,32 @@
 <PlatformToolset>v100</PlatformToolset>
 		]]
 	end
+
+
+--
+-- Check if platform toolset element is being emitted correctly.
+--
+
+	function suite.output_onConsoleAppAndNoCpp()
+		kind "ConsoleApp"
+		removefiles "hello.cpp"
+		prepare()
+		test.capture [[
+<PlatformToolset>v110</PlatformToolset>
+		]]
+	end
+
+	function suite.skipped_onNoMakefileAndNoCpp()
+		kind "Makefile"
+		removefiles "hello.cpp"
+		prepare()
+		test.isemptycapture()
+	end
+
+	function suite.output_onNoMakefileAndCpp()
+		kind "Makefile"
+		prepare()
+		test.capture [[
+<PlatformToolset>v110</PlatformToolset>
+		]]
+	end


### PR DESCRIPTION
I'm unsure of the intended functionality of this code, but to me, if you specify the VS2013 action, it should make a VS2013 project regardless of the files you're adding.

Fixes #93