### PR TITLE
The links API, for visual studio, no longer appends .lib if an extension already exists.

### DIFF
--- a/src/actions/vstudio/_vstudio.lua
+++ b/src/actions/vstudio/_vstudio.lua
@@ -340,7 +340,13 @@
 		-- Then the system libraries, which come undecorated
 		local system = config.getlinks(cfg, "system", "fullpath")
 		for i = 1, #system do
-			table.insert(links, path.appendextension(system[i], ".lib"))
+			-- Add extension if required
+			local link = system[i]
+			if not p.tools.msc.getLibraryExtensions()[link:match("[^.]+$")] then
+				link = path.appendextension(link, ".lib")
+			end
+
+			table.insert(links, link)
 		end
 
 		return links

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -237,13 +237,27 @@
 
 
 --
+-- Return a list of valid library extensions
+--
+
+	function msc.getLibraryExtensions()
+		return {
+			["lib"] = true,
+			["obj"] = true,
+		}
+	end
+
+--
 -- Return the list of libraries to link, decorated with flags as needed.
 --
 
 	function msc.getlinks(cfg)
 		local links = config.getlinks(cfg, "system", "fullpath")
 		for i = 1, #links do
-			links[i] = path.appendextension(links[i], ".lib")
+			-- Add extension if required
+			if not msc.getLibraryExtensions()[links[i]:match("[^.]+$")] then
+				links[i] = path.appendextension(links[i], ".lib")
+			end
 		end
 		return links
 	end

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -165,6 +165,40 @@
 
 
 --
+-- Any system libraries specified in links() with valid extensions should
+-- be listed with those extensions.
+--
+
+	function suite.additionalDependencies_onSystemLinksExtensions()
+		links { "lua.obj", "zlib.lib" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<AdditionalDependencies>lua.obj;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+		]]
+	end
+
+
+--
+-- Any system libraries specified in links() with multiple dots should
+-- only have .lib appended to the end when no valid extension is found
+--
+
+	function suite.additionalDependencies_onSystemLinksExtensionsMultipleDots()
+		links { "lua.5.3.lib", "lua.5.4" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>false</GenerateDebugInformation>
+	<AdditionalDependencies>lua.5.3.lib;lua.5.4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+		]]
+	end
+
+
+--
 -- Additional library directories should be specified, relative to the project.
 --
 


### PR DESCRIPTION
I believe this is the desired functionality mentioned in the issue.

Fixes #87