### PR TITLE
Windows copy function no longer uses /E when used on a file

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -66,7 +66,7 @@
 	function os.findlib(libname, libdirs)
 		-- libname: library name with or without prefix and suffix
 		-- libdirs: (array or string): A set of additional search paths
-				 
+
 		local path, formats
 
 		-- assemble a search path, depending on the platform
@@ -88,7 +88,7 @@
 					local conf_file = prefix .. "/etc/ld.so.conf"
 					if os.isfile(conf_file) then
 						for _, v in ipairs(parse_ld_so_conf(conf_file)) do
-							if (#path > 0) then 
+							if (#path > 0) then
 								path = path .. ":" .. v
 							else
 								path = v
@@ -112,13 +112,13 @@
 		end
 
 		local userpath = ""
-		
+
 		if type(libdirs) == "string" then
 			userpath = libdirs
 		elseif type(libdirs) == "table" then
 			userpath = table.implode(libdirs, "", "", ":")
 		end
-	
+
 		if (#userpath > 0) then
 			if (#path > 0) then
 				path = userpath .. ":" .. path
@@ -126,7 +126,7 @@
 				path = userpath
 			end
 		end
-		
+
 		for _, fmt in ipairs(formats) do
 			local name = string.format(fmt, libname)
 			local result = os.pathsearch(name, path)
@@ -497,7 +497,15 @@
 				return "chdir " .. path.translate(v)
 			end,
 			copy = function(v)
-				return "xcopy /Q /E /Y /I " .. path.translate(v) .. " > nul"
+				v = path.translate(v)
+
+				-- Detect if there's multiple parts to the input, if there is grab the first part else grab the whole thing
+				local src = string.match(v, '^".-"') or string.match(v, '^.- ') or v
+
+				-- Strip the trailing space from the second condition so that we don't have a space between src and '\\NUL'
+				src = string.match(src, '^.*%S')
+
+				return "IF EXIST " .. src .. "\\ (xcopy /Q /E /Y /I " .. v .. " > nul) ELSE (xcopy /Q /Y /I " .. v .. " > nul)"
 			end,
 			delete = function(v)
 				return "del " .. path.translate(v)

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -176,3 +176,47 @@
 		}
 		test.isequal("test a b", os.translateCommands("{COPY} a b", "test"))
 	end
+
+--
+-- os.translateCommand() windows COPY tests
+--
+
+	function suite.translateCommand_windowsCopyNoDst()
+		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a > nul) ELSE (xcopy /Q /Y /I a > nul)', os.translateCommands('{COPY} a', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyNoDst_ExtraSpace()
+		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a  > nul) ELSE (xcopy /Q /Y /I a  > nul)', os.translateCommands('{COPY} a ', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyNoQuotes()
+		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a b > nul) ELSE (xcopy /Q /Y /I a b > nul)', os.translateCommands('{COPY} a b', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyNoQuotes_ExtraSpace()
+		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a b  > nul) ELSE (xcopy /Q /Y /I a b  > nul)', os.translateCommands('{COPY} a b ', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyQuotes()
+		test.isequal('IF EXIST "a a"\\ (xcopy /Q /E /Y /I "a a" "b" > nul) ELSE (xcopy /Q /Y /I "a a" "b" > nul)', os.translateCommands('{COPY} "a a" "b"', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyQuotes_ExtraSpace()
+		test.isequal('IF EXIST "a a"\\ (xcopy /Q /E /Y /I "a a" "b"  > nul) ELSE (xcopy /Q /Y /I "a a" "b"  > nul)', os.translateCommands('{COPY} "a a" "b" ', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyNoQuotesDst()
+		test.isequal('IF EXIST "a a"\\ (xcopy /Q /E /Y /I "a a" b > nul) ELSE (xcopy /Q /Y /I "a a" b > nul)', os.translateCommands('{COPY} "a a" b', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyNoQuotesDst_ExtraSpace()
+		test.isequal('IF EXIST "a a"\\ (xcopy /Q /E /Y /I "a a" b  > nul) ELSE (xcopy /Q /Y /I "a a" b  > nul)', os.translateCommands('{COPY} "a a" b ', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyNoQuotesSrc()
+		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a "b" > nul) ELSE (xcopy /Q /Y /I a "b" > nul)', os.translateCommands('{COPY} a "b"', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyNoQuotesSrc_ExtraSpace()
+		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a "b"  > nul) ELSE (xcopy /Q /Y /I a "b"  > nul)', os.translateCommands('{COPY} a "b" ', "windows"))
+	end


### PR DESCRIPTION
* Added some basic tests to ensure combinations work
* Fixes: #124