### PR TITLE
vs2010_vcxproj.lua: add onImportExtensionTargets

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -43,6 +43,7 @@
 			m.assemblyReferences,
 			m.files,
 			m.projectReferences,
+			m.importLanguageTargets,
 			m.importExtensionTargets,
 		}
 	end
@@ -1289,17 +1290,28 @@
 	end
 
 
-	function m.importExtensionTargets(prj)
+	function m.importLanguageTargets(prj)
 		p.w('<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />')
-		p.push('<ImportGroup Label="ExtensionTargets">')
+	end
 
+	m.elements.importExtensionTargets = function(prj)
+		return {
+			m.importRuleTargets,
+		}
+	end
+
+	function m.importExtensionTargets(prj)
+		p.push('<ImportGroup Label="ExtensionTargets">')
+		p.callArray(m.elements.importExtensionTargets, prj)
+		p.pop('</ImportGroup>')
+	end
+
+	function m.importRuleTargets(prj)
 		for i = 1, #prj.rules do
 			local rule = p.global.getRule(prj.rules[i])
 			local loc = vstudio.path(prj, p.filename(rule, ".targets"))
 			p.x('<Import Project="%s" />', loc)
 		end
-
-		p.pop('</ImportGroup>')
 	end
 
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -35,6 +35,7 @@
 			m.globals,
 			m.importDefaultProps,
 			m.configurationPropertiesGroup,
+			m.importLanguageSettings,
 			m.importExtensionSettings,
 			m.propertySheetGroup,
 			m.userMacros,
@@ -1322,17 +1323,28 @@
 
 
 
-	function m.importExtensionSettings(prj)
+	function m.importLanguageSettings(prj)
 		p.w('<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />')
-		p.push('<ImportGroup Label="ExtensionSettings">')
+	end
 
+	m.elements.importExtensionSettings = function(prj)
+		return {
+			m.importRuleSettings,
+		}
+	end
+
+	function m.importExtensionSettings(prj)
+		p.push('<ImportGroup Label="ExtensionSettings">')
+		p.callArray(m.elements.importExtensionSettings, prj)
+		p.pop('</ImportGroup>')
+	end
+
+	function m.importRuleSettings(prj)
 		for i = 1, #prj.rules do
 			local rule = p.global.getRule(prj.rules[i])
 			local loc = vstudio.path(prj, p.filename(rule, ".props"))
 			p.x('<Import Project="%s" />', loc)
 		end
-
-		p.pop('</ImportGroup>')
 	end
 
 

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -109,6 +109,7 @@ return {
 	"actions/vstudio/vc2010/test_excluded_configs.lua",
 	"actions/vstudio/vc2010/test_extension_settings.lua",
 	"actions/vstudio/vc2010/test_extension_targets.lua",
+	"actions/vstudio/vc2010/test_language_targets.lua",
 	"actions/vstudio/vc2010/test_floatingpoint.lua",
 	"actions/vstudio/vc2010/test_globals.lua",
 	"actions/vstudio/vc2010/test_header.lua",

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -109,6 +109,7 @@ return {
 	"actions/vstudio/vc2010/test_excluded_configs.lua",
 	"actions/vstudio/vc2010/test_extension_settings.lua",
 	"actions/vstudio/vc2010/test_extension_targets.lua",
+	"actions/vstudio/vc2010/test_language_settings.lua",
 	"actions/vstudio/vc2010/test_language_targets.lua",
 	"actions/vstudio/vc2010/test_floatingpoint.lua",
 	"actions/vstudio/vc2010/test_globals.lua",

--- a/tests/actions/vstudio/vc2010/test_extension_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_extension_settings.lua
@@ -4,7 +4,7 @@
 -- Copyright (c) 2014 Jason Perkins and the Premake project
 --
 
-	local suite = test.declare("vs2010_import_settings")
+	local suite = test.declare("vs2010_extension_settings")
 	local vc2010 = premake.vstudio.vc2010
 	local project = premake.project
 
@@ -34,7 +34,6 @@
 	function suite.structureIsCorrect_onDefaultValues()
 		prepare()
 		test.capture [[
-<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
 <ImportGroup Label="ExtensionSettings">
 </ImportGroup>
 		]]
@@ -50,7 +49,6 @@
 		rules { "MyRules", "MyOtherRules" }
 		prepare()
 		test.capture [[
-<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
 <ImportGroup Label="ExtensionSettings">
 	<Import Project="MyRules.props" />
 	<Import Project="MyOtherRules.props" />
@@ -68,7 +66,6 @@
 		location "build"
 		prepare()
 		test.capture [[
-<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
 <ImportGroup Label="ExtensionSettings">
 	<Import Project="..\MyRules.props" />
 </ImportGroup>

--- a/tests/actions/vstudio/vc2010/test_extension_targets.lua
+++ b/tests/actions/vstudio/vc2010/test_extension_targets.lua
@@ -4,7 +4,7 @@
 -- Copyright (c) 2014 Jason Perkins and the Premake project
 --
 
-	local suite = test.declare("vs2010_import_targets")
+	local suite = test.declare("vs2010_extension_targets")
 	local vc2010 = premake.vstudio.vc2010
 	local project = premake.project
 
@@ -34,7 +34,6 @@
 	function suite.structureIsCorrect_onDefaultValues()
 		prepare()
 		test.capture [[
-<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 <ImportGroup Label="ExtensionTargets">
 </ImportGroup>
 		]]
@@ -50,7 +49,6 @@
 		rules { "MyRules", "MyOtherRules" }
 		prepare()
 		test.capture [[
-<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 <ImportGroup Label="ExtensionTargets">
 	<Import Project="MyRules.targets" />
 	<Import Project="MyOtherRules.targets" />
@@ -68,7 +66,6 @@
 		location "build"
 		prepare()
 		test.capture [[
-<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 <ImportGroup Label="ExtensionTargets">
 	<Import Project="..\MyRules.targets" />
 </ImportGroup>

--- a/tests/actions/vstudio/vc2010/test_language_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_language_settings.lua
@@ -1,0 +1,39 @@
+--
+-- tests/actions/vstudio/vc2010/test_language_settings.lua
+-- Check the import language settings block of a VS 2010 project.
+-- Copyright (c) 2014 Jason Perkins and the Premake project
+--
+
+	local suite = test.declare("vs2010_language_settings")
+	local vc2010 = premake.vstudio.vc2010
+	local project = premake.project
+
+
+--
+-- Setup
+--
+
+	local wks
+
+	function suite.setup()
+		rule "MyRules"
+		rule "MyOtherRules"
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		local prj = test.getproject(wks)
+		vc2010.importLanguageSettings(prj)
+	end
+
+
+--
+-- Writes language settings.
+--
+
+	function suite.structureIsCorrect()
+		prepare()
+		test.capture [[
+<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+		]]
+	end

--- a/tests/actions/vstudio/vc2010/test_language_targets.lua
+++ b/tests/actions/vstudio/vc2010/test_language_targets.lua
@@ -1,0 +1,39 @@
+--
+-- tests/actions/vstudio/vc2010/test_language_targets.lua
+-- Check the import language targets block of a VS 2010 project.
+-- Copyright (c) 2014 Jason Perkins and the Premake project
+--
+
+	local suite = test.declare("vs2010_language_targets")
+	local vc2010 = premake.vstudio.vc2010
+	local project = premake.project
+
+
+--
+-- Setup
+--
+
+	local wks
+
+	function suite.setup()
+		rule "MyRules"
+		rule "MyOtherRules"
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		local prj = test.getproject(wks)
+		vc2010.importLanguageTargets(prj)
+	end
+
+
+--
+-- Writes language targets.
+--
+
+	function suite.structureIsCorrect()
+		prepare()
+		test.capture [[
+<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+		]]
+	end


### PR DESCRIPTION
As discussed in #197. Adds an empty function for overriding that
allows us to create new extension targets in overrides without
breaking rule generation.