### PR TITLE
add excludefrombuild filelist api.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -426,6 +426,13 @@
 	}
 
 	api.register {
+		name = "excludefrombuild",
+		scope = "config",
+		kind = "list:file",
+		tokens = true,
+	}
+
+	api.register {
 		name = "flags",
 		scope = "config",
 		kind  = "list:string",

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -544,7 +544,13 @@
 				p.fileconfig.addconfig(files[fname], cfg)
 
 			end)
+
+			-- process build file exclusions for this configuration
+			oven.processExcludes(cfg, files)
 		end
+
+		-- process build file exclusions for this project
+		oven.processExcludes(prj, files)
 
 		-- Alpha sort the indices, so I will get consistent results in
 		-- the exported project files.
@@ -554,6 +560,27 @@
 		end)
 
 		return files
+	end
+
+
+--
+-- Process the exclude from build files. This assigns the ExcludeFromBuild flag to files
+-- that are listed in the excludefrombuild command.
+--
+
+	function oven.processExcludes(ctx, files)
+		if ctx.excludefrombuild and #ctx.excludefrombuild > 0 then
+			table.foreachi(ctx.excludefrombuild, function(fname)
+				local f = files[fname]
+				if f then
+					if ctx.buildcfg then
+						f.configs[ctx].flags.ExcludeFromBuild = true
+					else
+						f.flags.ExcludeFromBuild = true
+					end
+				end
+			end)
+		end
 	end
 
 


### PR DESCRIPTION
I think in the long run we should just deprecate the ExcludeFromBuild flag, and use this API directly, however right now I bake this file list into the flags in the oven step...
