### PR TITLE
Don't use cfg.libdirs directly, go through config.getlinks.

### DIFF
--- a/src/actions/vstudio/_vstudio.lua
+++ b/src/actions/vstudio/_vstudio.lua
@@ -338,7 +338,7 @@
 		end
 
 		-- Then the system libraries, which come undecorated
-		local system = config.getlinks(cfg, "system", "fullpath")
+		local system = config.getlinks(cfg, "system", "name")
 		for i = 1, #system do
 			-- Add extension if required
 			local link = system[i]
@@ -352,6 +352,18 @@
 		return links
 	end
 
+---
+-- Assemble the list of library directories.
+--
+-- @param cfg
+--    The active configuration.
+-- @return
+--    The list of library directories, ready to be used in Visual Studio's
+--    AdditionalLibraryDirectories element.
+---
+	function vstudio.getLibraryDirectories(cfg)
+		return table.filterempty(config.getlinks(cfg, "system", "directory"))
+	end
 
 
 --

--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -849,9 +849,10 @@
 
 
 	function m.additionalLibraryDirectories(cfg)
-		if #cfg.libdirs > 0 then
-			local dirs = vstudio.path(cfg, cfg.libdirs)
-			p.x('AdditionalLibraryDirectories="%s"', table.concat(dirs, ";"))
+		local dirs = vstudio.getLibraryDirectories(cfg)
+		if #dirs > 0 then
+			dirs = path.translate(table.concat(dirs, ";"))
+			p.x('AdditionalLibraryDirectories="%s"', dirs)
 		end
 	end
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -925,8 +925,9 @@
 
 
 	function m.additionalLibraryDirectories(cfg)
-		if #cfg.libdirs > 0 then
-			local dirs = table.concat(vstudio.path(cfg, cfg.libdirs), ";")
+		local dirs = vstudio.getLibraryDirectories(cfg)
+		if #dirs > 0 then
+			dirs = path.translate(table.concat(dirs, ";"))
 			m.element("AdditionalLibraryDirectories", nil, "%s;%%(AdditionalLibraryDirectories)", dirs)
 		end
 	end


### PR DESCRIPTION
This is more in line with the vstudio.getLinks(), but in addition it removes the need for full paths in the links, since all paths are already added to the AdditionalLibraryDirectories element.
