### PR TITLE
Rename "framework" to "dotnetframework".

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -549,7 +549,7 @@
 	}
 
 	api.register {
-		name = "framework",
+		name = "dotnetframework",
 		scope = "config",
 		kind = "string",
 	}
@@ -1073,6 +1073,7 @@
 	api.alias("buildoutputs", "buildOutputs")
 	api.alias("cleanextensions", "cleanExtensions")
 	api.alias("configfile", "configFile")
+	api.alias("dotnetframework", "framework")
 	api.alias("editandcontinue", "editAndContinue")
 	api.alias("fileextension", "fileExtension")
 	api.alias("propertydefinition", "propertyDefinition")

--- a/src/actions/vstudio/vs2005_csproj.lua
+++ b/src/actions/vstudio/vs2005_csproj.lua
@@ -480,7 +480,7 @@
 
 	function cs2005.targetFrameworkVersion(cfg)
 		local action = premake.action.current()
-		local framework = cfg.framework or action.vstudio.targetFramework
+		local framework = cfg.dotnetframework or action.vstudio.targetFramework
 		if framework then
 			_p(2,'<TargetFrameworkVersion>v%s</TargetFrameworkVersion>', framework)
 		end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -110,7 +110,7 @@
 		local action = p.action.current()
 		local tools = string.format(' ToolsVersion="%s"', action.vstudio.toolsVersion)
 
-		local framework = prj.framework or action.vstudio.targetFramework or "4.0"
+		local framework = prj.dotnetframework or action.vstudio.targetFramework or "4.0"
 		p.w('<TargetFrameworkVersion>v%s</TargetFrameworkVersion>', framework)
 	end
 

--- a/tests/actions/vstudio/cs2005/projectsettings.lua
+++ b/tests/actions/vstudio/cs2005/projectsettings.lua
@@ -135,6 +135,26 @@
 	end
 
 
+	function suite.OnDotNetFrameworkVersion()
+		dotnetframework "3.0"
+		prepare()
+		test.capture [[
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProductVersion>8.0.50727</ProductVersion>
+		<SchemaVersion>2.0</SchemaVersion>
+		<ProjectGuid>{AE61726D-187C-E440-BD07-2556188A6565}</ProjectGuid>
+		<OutputType>Exe</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>MyProject</RootNamespace>
+		<AssemblyName>MyProject</AssemblyName>
+		<TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+	</PropertyGroup>
+		]]
+	end
+
+
 --
 -- Make sure the root namespace can be overridden.
 --

--- a/tests/actions/vstudio/vc2010/test_globals.lua
+++ b/tests/actions/vstudio/vc2010/test_globals.lua
@@ -65,7 +65,7 @@
 
 	function suite.frameworkVersionIsCorrect_onSpecificVersion()
 		clr "On"
-		framework "4.5"
+		dotnetframework "4.5"
 		prepare()
 		test.capture [[
 <PropertyGroup Label="Globals">


### PR DESCRIPTION
"framework" is a very generic term and hard to tell what it's actually about.

Keeps "framework" around for backwards compatibility.