### PR TITLE
Windows SSL support for HTTP

### DIFF
--- a/contrib/curl/premake5.lua
+++ b/contrib/curl/premake5.lua
@@ -2,7 +2,7 @@ project "curl-lib"
 	language    "C"
 	kind        "StaticLib"
 	includedirs {"include", "lib"}
-	defines     {"BUILDING_LIBCURL", "CURL_STATICLIB", "CURL_HTTP_ONLY", "CURL_DISABLE_LDAP" }
+	defines     {"BUILDING_LIBCURL", "CURL_STATICLIB", "HTTP_ONLY", "CURL_DISABLE_LDAP" }
 	flags       { "StaticRuntime" }
 	location    "build"
 

--- a/contrib/curl/premake5.lua
+++ b/contrib/curl/premake5.lua
@@ -14,6 +14,7 @@ project "curl-lib"
 	
 	configuration { 'windows' }
 		defines {"WIN32"}
+		defines {"USE_SSL", "USE_SCHANNEL", "USE_WINDOWS_SSPI"}
 
 	configuration { 'linux' }
 		defines {"HAVE_CONFIG_H", "CURL_HIDDEN_SYMBOLS"}


### PR DESCRIPTION
This enables SSL support on Windows for the HTTP APIs.

Also a compile-fix that's needed for SSL to compile.
