### PR TITLE
Allows an action to indicate Premake should be quiet on startup.

### DIFF
--- a/src/_premake_main.lua
+++ b/src/_premake_main.lua
@@ -247,7 +247,10 @@
 
 	function m.preBake()
 		if p.action.isConfigurable() then
-			print("Building configurations...")
+			local action = premake.action.current()
+			if not action.quiet then
+				print("Building configurations...")
+			end
 		end
 	end
 
@@ -308,7 +311,9 @@
 
 	function m.preAction()
 		local action = premake.action.current()
-		printf("Running action '%s'...", action.trigger)
+		if not action.quiet then
+			printf("Running action '%s'...", action.trigger)
+		end
 	end
 
 
@@ -328,7 +333,10 @@
 
 	function m.postAction()
 		if p.action.isConfigurable() then
-			print("Done.")
+			local action = premake.action.current()
+			if not action.quiet then
+				print("Done.")
+			end
 		end
 	end
 


### PR DESCRIPTION
This is really useful since it allows to write actions that behave like an independent tool (package manager) while using all of the Premake driver and infrastructure code.


