### PR TITLE
Switch 'require' to use xpcall for error handling.

### DIFF
--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -74,10 +74,7 @@
 ---
 
 	premake.override(_G, "require", function(base, modname, versions)
-		local result, mod = pcall(base,modname)
-		if not result then
-			error( mod, 3 )
-		end
+		local result, mod = xpcall(base(modname), debug.traceback)
 		if mod and versions and not premake.checkVersion(mod._VERSION, versions) then
 			error(string.format("module %s %s does not meet version criteria %s",
 				modname, mod._VERSION or "(none)", versions), 3)


### PR DESCRIPTION
This gives the original stack trace where an error actually occurred instead of an incomplete trace where the error is handled in Premake.