### PR TITLE
Revert "Switch 'require' to use xpcall for error handling."

### DIFF
--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -74,7 +74,10 @@
 ---
 
 	premake.override(_G, "require", function(base, modname, versions)
-		local result, mod = xpcall(base(modname), debug.traceback)
+		local result, mod = pcall(base,modname)
+		if not result then
+			error( mod, 3 )
+		end
 		if mod and versions and not premake.checkVersion(mod._VERSION, versions) then
 			error(string.format("module %s %s does not meet version criteria %s",
 				modname, mod._VERSION or "(none)", versions), 3)


### PR DESCRIPTION
This reverts commit 6aad3ef432990095848de89e8322ea183fc954e1 which, in hindsight, couldn't possibly work as described.

This could perhaps be rewritten as `xpcall(function() return base(modname) end, debug.traceback)` but in my testing didn't report the error properly, and returned the wrong values. Rolling back to get things working again.