### PR TITLE
Group sibling libs for GCC/Clang

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -296,6 +296,11 @@
 			end
 		end
 
+		if #result > 0 then
+			table.insert(result, 1, "-Wl,--start-group")
+			table.insert(result, "-Wl,--end-group")
+		end
+
 		-- The "-l" flag is fine for system libraries
 
 		local links = config.getlinks(cfg, "system", "fullpath")

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -296,7 +296,7 @@
 			end
 		end
 
-		if #result > 0 then
+		if #result > 1 then
 			table.insert(result, 1, "-Wl,--start-group")
 			table.insert(result, "-Wl,--end-group")
 		end

--- a/tests/actions/make/cpp/test_make_linking.lua
+++ b/tests/actions/make/cpp/test_make_linking.lua
@@ -145,6 +145,30 @@
     end
 
 --
+-- Check a linking multiple siblings.
+--
+
+	function suite.links_onSiblingStaticLib()
+		links "MyProject2"
+		links "MyProject3"
+
+		test.createproject(wks)
+		kind "StaticLib"
+		location "build"
+
+		test.createproject(wks)
+		kind "StaticLib"
+		location "build"
+
+		prepare { "ldFlags", "libs", "ldDeps" }
+		test.capture [[
+  ALL_LDFLAGS += $(LDFLAGS) -s
+  LIBS += -Wl,--start-group build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a -Wl,--end-group
+  LDDEPS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
+		]]
+	end
+
+--
 -- When referencing an external library via a path, the directory
 -- should be added to the library search paths, and the library
 -- itself included via an -l flag.


### PR DESCRIPTION
Wrap sibling dependencies in `--start-group`, `--end-group` (for GCC and Clang)

This approach is very simple, but pretty crude.
It actually works surprisingly well, I haven't seen any IDE's that reorder the dependencies as stated in their project files, so treating these like libs in the link list actually works fine.
Alternative is that the function that flattens the libs out into a string is contained in the tool, or this logic is duplicated in each action and further predicated by GCC/Clang.

Fixes #255