### PR TITLE
if premake table is not initialized use original loadfile

### DIFF
--- a/src/host/lua_auxlib.c
+++ b/src/host/lua_auxlib.c
@@ -32,9 +32,12 @@ LUALIB_API int luaL_loadfile (lua_State* L, const char* filename)
 
 	int bottom = lua_gettop(L);
 	int z = !OKAY;
+	int premake_nil = 0;
 
 	lua_getglobal(L, "premake");
-	if (lua_isnil(L, -1)) {
+	premake_nil = lua_isnil(L, -1);
+	lua_pop(L, 1);
+	if (premake_nil == 1) {
 		return original_luaL_loadfile(L, filename); /* if premake is not initialized use original loadfile */
 	}
 

--- a/src/host/lua_auxlib.c
+++ b/src/host/lua_auxlib.c
@@ -33,6 +33,11 @@ LUALIB_API int luaL_loadfile (lua_State* L, const char* filename)
 	int bottom = lua_gettop(L);
 	int z = !OKAY;
 
+	lua_getglobal(L, "premake");
+	if (lua_isnil(L, -1)) {
+		return original_luaL_loadfile(L, filename); /* if premake is not initialized use original loadfile */
+	}
+
 	/* If filename is starts with "$/" then we want to load the version that
 	 * was embedded into the executable and skip the local file system */
 	if (filename[0] == '$') {


### PR DESCRIPTION
We are customizing premake and using a different lua state for other requirements. We don't always initialize premake so it fails when trying to call loadfile.