### PR TITLE
Add basic support for the 'Utility' kind in gmake

### DIFF
--- a/src/actions/make/_make.lua
+++ b/src/actions/make/_make.lua
@@ -20,7 +20,7 @@
 		shortname       = "GNU Make",
 		description     = "Generate GNU makefiles for POSIX, MinGW, and Cygwin",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Utility" },
 
 		valid_languages = { "C", "C++", "C#" },
 

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -434,6 +434,9 @@
 			else
 				_p('  LINKCMD = $(AR) -rcs "$@" $(OBJECTS)')
 			end
+		elseif cfg.kind == premake.UTILITY then
+			-- Empty LINKCMD for Utility (only custom build rules)
+			_p('  LINKCMD =')
 		else
 			-- this was $(TARGET) $(LDFLAGS) $(OBJECTS)
 			--   but had trouble linking to certain static libs; $(OBJECTS) moved up

--- a/tests/actions/make/cpp/test_make_linking.lua
+++ b/tests/actions/make/cpp/test_make_linking.lua
@@ -71,6 +71,21 @@
 
 
 --
+-- Check link command for the Utility kind.
+--
+-- Utility projects should only run custom commands, and perform no linking.
+--
+
+	function suite.links_onUtility()
+		kind "Utility"
+		prepare { "linkCmd" }
+		test.capture [[
+  LINKCMD =
+		]]
+	end
+
+
+--
 -- Check link command for a Mac OS X universal static library.
 --
 


### PR DESCRIPTION
This adds (very) basic support for the "Utility" kind in gmake.

This is a very quick and dirty implementation and works in my use case, but may break in some others. I'm just getting started with Premake and haven't even read through all of the wiki yet, so please let me know if I should do something differently.

The main goal with this is to be able to use `prebuildcommands`, etc. in a project, without needing to compile something. See https://github.com/premake/premake-core/issues/286 for an example use case.