### PR TITLE
Fix malloc-defining header for clang compilation on Mac.

### DIFF
--- a/src/host/path_wildcards.c
+++ b/src/host/path_wildcards.c
@@ -6,7 +6,7 @@
 
 #include "premake.h"
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 /*
 --Converts from a simple wildcard syntax, where * is "match any"


### PR DESCRIPTION
This fixes the use of a non-standard/platform-specific malloc.h by replacing it with the standard stdlib.h, which defines malloc.

Error encountered during compilation:
`src/host/path_wildcards.c:9:10: fatal error: 'malloc.h' file not found`