### PR TITLE
Make version based on information from git.

### DIFF
--- a/scripts/embed.lua
+++ b/scripts/embed.lua
@@ -92,6 +92,19 @@
 	end
 
 
+	local function makeVersion(result)
+		local version = os.outputof('git rev-parse --short HEAD')
+		local branch  = path.getname(os.outputof('git describe --all'))
+
+		buffered.writeln(result, "// Version")
+		buffered.writeln(result, "#ifndef PREMAKE_NO_BUILTIN_SCRIPTS")
+		buffered.writeln(result, "const char* PREMAKE_VERSION = \"" .. branch .. " (" .. version .. ")\";")
+		buffered.writeln(result, "#endif")
+		buffered.writeln(result)
+	end
+
+
+
 -- Prepare the file header
 
 	local result = buffered.new()
@@ -101,6 +114,9 @@
 	buffered.writeln(result, "")
 	buffered.writeln(result, '#include "premake.h"')
 	buffered.writeln(result, "")
+
+-- add current branch version.
+	makeVersion(result)
 
 -- Find all of the _manifest.lua files within the project
 

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -13,8 +13,10 @@
 #include <CoreFoundation/CFBundle.h>
 #endif
 
+#ifdef PREMAKE_NO_BUILTIN_SCRIPTS
+const char* PREMAKE_VERSION = "bootstrap";
+#endif
 
-#define VERSION        "5.0.0-dev"
 #define COPYRIGHT      "Copyright (C) 2002-2015 Jason Perkins and the Premake Project"
 #define PROJECT_URL    "https://github.com/premake/premake-core/wiki"
 #define ERROR_MESSAGE  "Error: %s\n"
@@ -138,7 +140,7 @@ int premake_init(lua_State* L)
 	lua_pushstring(L, LUA_COPYRIGHT);
 	lua_setglobal(L, "_COPYRIGHT");
 
-	lua_pushstring(L, VERSION);
+	lua_pushstring(L, PREMAKE_VERSION);
 	lua_setglobal(L, "_PREMAKE_VERSION");
 
 	lua_pushstring(L, COPYRIGHT);

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -146,8 +146,8 @@ typedef struct
 	size_t               length;
 } buildin_mapping;
 
+extern const char* PREMAKE_VERSION;
 extern const buildin_mapping builtin_scripts[];
-
 
 int premake_init(lua_State* L);
 int premake_execute(lua_State* L, int argc, const char** argv, const char* script);


### PR DESCRIPTION
This actually works really well, and removed the need to set the VERSION define manually when making a tag/branch or release...

it does currently break the package.lua script though I think... We don't use that for internal releases here, since we just use the yaml file to make a build and we deploy the output from the buildfarm, so there this automation works really nicely.

Anyway, just a proposal at this point I guess..