### PR TITLE
path.translate fix

### DIFF
--- a/src/host/path_translate.c
+++ b/src/host/path_translate.c
@@ -32,7 +32,20 @@ int path_translate(lua_State* L)
 	char buffer[0x4000];
 
 	if (lua_gettop(L) == 1) {
-		sep = "\\";
+		// Get target OS
+		lua_getglobal(L, "os");
+		lua_getfield(L, -1, "get");
+		lua_call(L, 0, 1);
+		const char* os = luaL_checkstring(L, -1);
+		lua_pop(L, 2);
+
+		// Use target OS separator
+		if (strcmp(os, "windows") == 0) {
+			sep = "\\";
+		}
+		else {
+			sep = "/";
+		}
 	}
 	else {
 		sep = luaL_checkstring(L, 2);

--- a/tests/actions/make/cs/test_response.lua
+++ b/tests/actions/make/cs/test_response.lua
@@ -15,6 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		wks = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/cs2005/projectelement.lua
+++ b/tests/actions/vstudio/cs2005/projectelement.lua
@@ -29,7 +29,7 @@
 --
 
 	function suite.on2005()
-		_ACTION = "vs2005"
+		premake.action.set("vs2005")
 		prepare()
 		test.capture [[
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -38,7 +38,7 @@
 
 
 	function suite.on2008()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		prepare()
 		test.capture [[
 <Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -47,7 +47,7 @@
 
 
 	function suite.on2010()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		prepare()
 		test.capture [[
 <?xml version="1.0" encoding="utf-8"?>
@@ -57,7 +57,7 @@
 
 
 	function suite.on2012()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		prepare()
 		test.capture [[
 <?xml version="1.0" encoding="utf-8"?>
@@ -67,7 +67,7 @@
 
 
 	function suite.on2013()
-		_ACTION = "vs2013"
+		premake.action.set("vs2013")
 		prepare()
 		test.capture [[
 <?xml version="1.0" encoding="utf-8"?>

--- a/tests/actions/vstudio/cs2005/projectsettings.lua
+++ b/tests/actions/vstudio/cs2005/projectsettings.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2005"
+		premake.action.set("vs2005")
 		wks = test.createWorkspace()
 		language "C#"
 		uuid "AE61726D-187C-E440-BD07-2556188A6565"
@@ -51,7 +51,7 @@
 
 
 	function suite.OnVs2008()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		prepare()
 		test.capture [[
 	<PropertyGroup>
@@ -70,7 +70,7 @@
 
 
 	function suite.OnVs2010()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		prepare()
 		test.capture [[
 	<PropertyGroup>
@@ -93,7 +93,7 @@
 
 
 	function suite.onVs2012()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		prepare()
 		test.capture [[
 	<PropertyGroup>
@@ -183,7 +183,7 @@
 --
 
 	function suite.projectTypeGuids_onWPF()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		flags { "WPF" }
 		prepare()
 		test.capture [[

--- a/tests/actions/vstudio/cs2005/test_assembly_refs.lua
+++ b/tests/actions/vstudio/cs2005/test_assembly_refs.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks = test.createWorkspace()
 		language "C#"
 	end

--- a/tests/actions/vstudio/cs2005/test_build_events.lua
+++ b/tests/actions/vstudio/cs2005/test_build_events.lua
@@ -15,6 +15,7 @@
 	local wks, prj, cfg
 
 	function suite.setup()
+		premake.action.set("vs2005")
 		premake.escaper(premake.vstudio.vs2010.esc)
 		wks = test.createWorkspace()
 	end

--- a/tests/actions/vstudio/cs2005/test_common_props.lua
+++ b/tests/actions/vstudio/cs2005/test_common_props.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		wks = test.createWorkspace()
 		language "C#"
 	end

--- a/tests/actions/vstudio/cs2005/test_compiler_props.lua
+++ b/tests/actions/vstudio/cs2005/test_compiler_props.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2005"
+		premake.action.set("vs2005")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/cs2005/test_debug_props.lua
+++ b/tests/actions/vstudio/cs2005/test_debug_props.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2005"
+		premake.action.set("vs2005")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/cs2005/test_files.lua
+++ b/tests/actions/vstudio/cs2005/test_files.lua
@@ -15,6 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2005")
 		wks = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/cs2005/test_output_props.lua
+++ b/tests/actions/vstudio/cs2005/test_output_props.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2005"
+		premake.action.set("vs2005")
 		wks, prj = test.createWorkspace()
 		language "C#"
 	end
@@ -45,7 +45,7 @@
 --
 
 	function suite.intermediateDirectory_onVs2008()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		prepare()
 		test.capture [[
 		<OutputPath>bin\Debug\</OutputPath>
@@ -54,7 +54,7 @@
 	end
 
 	function suite.intermediateDirectory_onVs2010()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		prepare()
 		test.capture [[
 		<OutputPath>bin\Debug\</OutputPath>

--- a/tests/actions/vstudio/cs2005/test_platform_groups.lua
+++ b/tests/actions/vstudio/cs2005/test_platform_groups.lua
@@ -14,7 +14,7 @@
 	local wks
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks = workspace("MyWorkspace")
 		configurations { "Debug", "Release" }
 		language "C#"
@@ -32,7 +32,7 @@
 --
 
 	function suite.vs2008()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		prepare()
 		test.capture [[
 <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -41,7 +41,7 @@
 
 
 	function suite.vs2010()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		prepare()
 		test.capture [[
 <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -55,7 +55,7 @@
 --
 
 	function suite.vs2008_onAnyCpu()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		platforms "Any CPU"
 		prepare("Any CPU")
 		test.capture [[
@@ -65,7 +65,7 @@
 
 
 	function suite.vs2010_onAnyCpu()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		platforms "Any CPU"
 		prepare("Any CPU")
 		test.capture [[

--- a/tests/actions/vstudio/cs2005/test_project_refs.lua
+++ b/tests/actions/vstudio/cs2005/test_project_refs.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks = test.createWorkspace()
 		uuid "00112233-4455-6677-8888-99AABBCCDDEE"
 		test.createproject(wks)

--- a/tests/actions/vstudio/cs2005/test_targets.lua
+++ b/tests/actions/vstudio/cs2005/test_targets.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		wks = test.createWorkspace()
 		language "C#"
 	end

--- a/tests/actions/vstudio/cs2005/test_user_file.lua
+++ b/tests/actions/vstudio/cs2005/test_user_file.lua
@@ -15,7 +15,7 @@
 	local wks
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks = test.createWorkspace()
 		language "C#"
 	end

--- a/tests/actions/vstudio/sln2005/test_dependencies.lua
+++ b/tests/actions/vstudio/sln2005/test_dependencies.lua
@@ -16,7 +16,7 @@
 	local wks, prj1, prj2
 
 	function suite.setup()
-		_ACTION = "vs2005"
+		premake.action.set("vs2005")
 		wks, prj1 = test.createWorkspace()
 		uuid "AE61726D-187C-E440-BD07-2556188A6565"
 		prj2 = test.createproject(wks)
@@ -71,7 +71,7 @@ EndProjectSection
 --
 
 	function suite.dependency_onCSharpProjectsVs2010()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		prepare("C#")
 		test.capture [[
 ProjectSection(ProjectDependencies) = postProject
@@ -87,7 +87,7 @@ EndProjectSection
 --
 
 	function suite.dependency_onCSharpProjectsVs2012()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		prepare("C#")
 		test.capture [[
 ProjectSection(ProjectDependencies) = postProject

--- a/tests/actions/vstudio/sln2005/test_header.lua
+++ b/tests/actions/vstudio/sln2005/test_header.lua
@@ -28,7 +28,7 @@
 --
 
 	function suite.on2005()
-		_ACTION = "vs2005"
+		premake.action.set("vs2005")
 		prepare()
 		test.capture [[
 Microsoft Visual Studio Solution File, Format Version 9.00
@@ -38,7 +38,7 @@ Microsoft Visual Studio Solution File, Format Version 9.00
 
 
 	function suite.on2008()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		prepare()
 		test.capture [[
 Microsoft Visual Studio Solution File, Format Version 10.00
@@ -48,7 +48,7 @@ Microsoft Visual Studio Solution File, Format Version 10.00
 
 
 	function suite.on2010()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		prepare()
 		test.capture [[
 Microsoft Visual Studio Solution File, Format Version 11.00
@@ -58,7 +58,7 @@ Microsoft Visual Studio Solution File, Format Version 11.00
 
 
 	function suite.on2012()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		prepare()
 		test.capture [[
 Microsoft Visual Studio Solution File, Format Version 12.00
@@ -68,7 +68,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 
 
 	function suite.on2013()
-		_ACTION = "vs2013"
+		premake.action.set("vs2013")
 		prepare()
 		test.capture [[
 Microsoft Visual Studio Solution File, Format Version 12.00

--- a/tests/actions/vstudio/sln2005/test_nested_projects.lua
+++ b/tests/actions/vstudio/sln2005/test_nested_projects.lua
@@ -16,7 +16,7 @@
 	local wks
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks = workspace("MyWorkspace")
 		configurations { "Debug", "Release" }
 		language "C++"

--- a/tests/actions/vstudio/sln2005/test_platforms.lua
+++ b/tests/actions/vstudio/sln2005/test_platforms.lua
@@ -15,7 +15,7 @@
 	local wks
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks = workspace("MyWorkspace")
 		configurations { "Debug", "Release" }
 		language "C++"

--- a/tests/actions/vstudio/sln2005/test_projects.lua
+++ b/tests/actions/vstudio/sln2005/test_projects.lua
@@ -15,6 +15,7 @@
 	local wks
 
 	function suite.setup()
+		premake.action.set("vs2005")
 		premake.escaper(premake.vstudio.vs2005.esc)
 		wks = workspace("MyWorkspace")
 		configurations { "Debug", "Release" }

--- a/tests/actions/vstudio/vc200x/test_assembly_refs.lua
+++ b/tests/actions/vstudio/vc200x/test_assembly_refs.lua
@@ -15,6 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2005")
 		wks = test.createWorkspace()
 		clr "On"
 	end

--- a/tests/actions/vstudio/vc200x/test_compiler_block.lua
+++ b/tests/actions/vstudio/vc200x/test_compiler_block.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks, prj = test.createWorkspace()
 	end
 
@@ -382,7 +382,7 @@
 --
 
 	function suite._64BitPortabilityOn_onVS2005()
-		_ACTION = "vs2005"
+		premake.action.set("vs2005")
 		prepare()
 		test.capture [[
 <Tool
@@ -400,7 +400,7 @@
 	end
 
 	function suite._64BitPortabilityOff_onVS2005_andCLR()
-		_ACTION = "vs2005"
+		premake.action.set("vs2005")
 		clr "On"
 		prepare()
 		test.capture [[
@@ -422,7 +422,7 @@
 --
 
 	function suite.runtimeLibraryIsDebug_onVS2005_NoWarnings()
-		_ACTION = "vs2005"
+		premake.action.set("vs2005")
 		warnings "Off"
 		prepare()
 		test.capture [[

--- a/tests/actions/vstudio/vc200x/test_configuration.lua
+++ b/tests/actions/vstudio/vc200x/test_configuration.lua
@@ -17,7 +17,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc200x/test_debug_settings.lua
+++ b/tests/actions/vstudio/vc200x/test_debug_settings.lua
@@ -16,6 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2005")
 		premake.escaper(premake.vstudio.vs2005.esc)
 		wks, prj = test.createWorkspace()
 	end

--- a/tests/actions/vstudio/vc200x/test_excluded_configs.lua
+++ b/tests/actions/vstudio/vc200x/test_excluded_configs.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 
 		wks = workspace("MyWorkspace")
 		configurations { "Debug", "Release" }

--- a/tests/actions/vstudio/vc200x/test_files.lua
+++ b/tests/actions/vstudio/vc200x/test_files.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		premake.escaper(premake.vstudio.vs2005.esc)
 		wks = test.createWorkspace()
 	end

--- a/tests/actions/vstudio/vc200x/test_linker_block.lua
+++ b/tests/actions/vstudio/vc200x/test_linker_block.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		premake.escaper(premake.vstudio.vs2005.esc)
 		wks, prj = test.createWorkspace()
 	end

--- a/tests/actions/vstudio/vc200x/test_manifest_block.lua
+++ b/tests/actions/vstudio/vc200x/test_manifest_block.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc200x/test_platforms.lua
+++ b/tests/actions/vstudio/vc200x/test_platforms.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc200x/test_project_refs.lua
+++ b/tests/actions/vstudio/vc200x/test_project_refs.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks = test.createWorkspace()
 		uuid "00112233-4455-6677-8888-99AABBCCDDEE"
 		test.createproject(wks)

--- a/tests/actions/vstudio/vc200x/test_resource_compiler.lua
+++ b/tests/actions/vstudio/vc200x/test_resource_compiler.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc200x/test_user_file.lua
+++ b/tests/actions/vstudio/vc200x/test_user_file.lua
@@ -15,7 +15,7 @@
 	local wks
 
 	function suite.setup()
-		_ACTION = "vs2008"
+		premake.action.set("vs2008")
 		wks = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_assembly_refs.lua
+++ b/tests/actions/vstudio/vc2010/test_assembly_refs.lua
@@ -15,6 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		wks = test.createWorkspace()
 		clr "On"
 	end

--- a/tests/actions/vstudio/vc2010/test_build_log.lua
+++ b/tests/actions/vstudio/vc2010/test_build_log.lua
@@ -15,6 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -16,6 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_config_props.lua
+++ b/tests/actions/vstudio/vc2010/test_config_props.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_debug_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_debug_settings.lua
@@ -16,6 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_excluded_configs.lua
+++ b/tests/actions/vstudio/vc2010/test_excluded_configs.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 
 		wks = workspace("MyWorkspace")
 		configurations { "Debug", "Release" }

--- a/tests/actions/vstudio/vc2010/test_extension_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_extension_settings.lua
@@ -16,6 +16,7 @@
 	local wks
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		rule "MyRules"
 		rule "MyOtherRules"
 		wks = test.createWorkspace()

--- a/tests/actions/vstudio/vc2010/test_extension_targets.lua
+++ b/tests/actions/vstudio/vc2010/test_extension_targets.lua
@@ -16,6 +16,7 @@
 	local wks
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		rule "MyRules"
 		rule "MyOtherRules"
 		wks = test.createWorkspace()

--- a/tests/actions/vstudio/vc2010/test_files.lua
+++ b/tests/actions/vstudio/vc2010/test_files.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 
 		rule "Animation"
 		fileextension ".dae"

--- a/tests/actions/vstudio/vc2010/test_filter_ids.lua
+++ b/tests/actions/vstudio/vc2010/test_filter_ids.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_filters.lua
+++ b/tests/actions/vstudio/vc2010/test_filters.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_floatingpoint.lua
+++ b/tests/actions/vstudio/vc2010/test_floatingpoint.lua
@@ -13,7 +13,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_globals.lua
+++ b/tests/actions/vstudio/vc2010/test_globals.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks = test.createWorkspace()
 	end
 
@@ -78,7 +78,7 @@
 	end
 
 	function suite.frameworkVersionIsCorrect_on2013()
-		_ACTION = "vs2013"
+		premake.action.set("vs2013")
 		clr "On"
 		prepare()
 		test.capture [[
@@ -180,7 +180,7 @@
 --
 
 	function suite.structureIsCorrect_on2013()
-		_ACTION = "vs2013"
+		premake.action.set("vs2013")
 		prepare()
 		test.capture [[
 <PropertyGroup Label="Globals">

--- a/tests/actions/vstudio/vc2010/test_header.lua
+++ b/tests/actions/vstudio/vc2010/test_header.lua
@@ -14,7 +14,7 @@
 --
 
 	function suite.project_on2010()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		vc2010.project()
 		test.capture [[
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -22,7 +22,7 @@
 	end
 
 	function suite.project_on2011()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		vc2010.project()
 		test.capture [[
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -30,7 +30,7 @@
 	end
 
 	function suite.project_on2013()
-		_ACTION = "vs2013"
+		premake.action.set("vs2013")
 		vc2010.project()
 		test.capture [[
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

--- a/tests/actions/vstudio/vc2010/test_language_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_language_settings.lua
@@ -16,6 +16,7 @@
 	local wks
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		rule "MyRules"
 		rule "MyOtherRules"
 		wks = test.createWorkspace()

--- a/tests/actions/vstudio/vc2010/test_language_targets.lua
+++ b/tests/actions/vstudio/vc2010/test_language_targets.lua
@@ -16,6 +16,7 @@
 	local wks
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		rule "MyRules"
 		rule "MyOtherRules"
 		wks = test.createWorkspace()

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 		kind "SharedLib"
 	end

--- a/tests/actions/vstudio/vc2010/test_manifest.lua
+++ b/tests/actions/vstudio/vc2010/test_manifest.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 		kind "ConsoleApp"
 	end

--- a/tests/actions/vstudio/vc2010/test_nmake_props.lua
+++ b/tests/actions/vstudio/vc2010/test_nmake_props.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 		kind "Makefile"
 	end

--- a/tests/actions/vstudio/vc2010/test_output_props.lua
+++ b/tests/actions/vstudio/vc2010/test_output_props.lua
@@ -15,7 +15,7 @@
 	local wks
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_platform_toolset.lua
+++ b/tests/actions/vstudio/vc2010/test_platform_toolset.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		wks, prj = test.createWorkspace()
 		files "hello.cpp"
 	end
@@ -32,14 +32,14 @@
 --
 
 	function suite.correctDefault_onVS2010()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		prepare()
 		test.isemptycapture()
 	end
 
 
 	function suite.correctDefault_onVS2012()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		prepare()
 		test.capture [[
 <PlatformToolset>v110</PlatformToolset>
@@ -48,7 +48,7 @@
 
 
 	function suite.correctDefault_onVS2013()
-		_ACTION = "vs2013"
+		premake.action.set("vs2013")
 		prepare()
 		test.capture [[
 <PlatformToolset>v120</PlatformToolset>

--- a/tests/actions/vstudio/vc2010/test_project_configs.lua
+++ b/tests/actions/vstudio/vc2010/test_project_configs.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_project_refs.lua
+++ b/tests/actions/vstudio/vc2010/test_project_refs.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks = test.createWorkspace()
 		uuid "00112233-4455-6677-8888-99AABBCCDDEE"
 		test.createproject(wks)

--- a/tests/actions/vstudio/vc2010/test_prop_sheet.lua
+++ b/tests/actions/vstudio/vc2010/test_prop_sheet.lua
@@ -16,6 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_resource_compile.lua
+++ b/tests/actions/vstudio/vc2010/test_resource_compile.lua
@@ -16,6 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		premake.escaper(premake.vstudio.vs2010.esc)
 		wks, prj = test.createWorkspace()
 	end

--- a/tests/actions/vstudio/vc2010/test_rule_vars.lua
+++ b/tests/actions/vstudio/vc2010/test_rule_vars.lua
@@ -18,6 +18,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		rule "MyRule"
 		wks, prj = test.createWorkspace()
 		rules { "MyRule" }

--- a/tests/actions/vstudio/vc2010/test_user_file.lua
+++ b/tests/actions/vstudio/vc2010/test_user_file.lua
@@ -15,7 +15,7 @@
 	local wks
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_vectorextensions.lua
+++ b/tests/actions/vstudio/vc2010/test_vectorextensions.lua
@@ -13,7 +13,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 
@@ -46,7 +46,7 @@
 	end
 
 	function suite.instructionSet_onAVX()
-		_ACTION = "vs2013"
+		premake.action.set("vs2013")
 		vectorextensions "AVX"
 		prepare()
 		test.capture [[
@@ -61,7 +61,7 @@
 	end
 
 	function suite.instructionSet_onAVX2()
-		_ACTION = "vs2013"
+		premake.action.set("vs2013")
 		vectorextensions "AVX2"
 		prepare()
 		test.capture [[
@@ -70,7 +70,7 @@
 	end
 
 	function suite.instructionSet_onAVX2_onVS2012()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		vectorextensions "AVX2"
 		prepare()
 		test.isemptycapture()

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -392,13 +392,11 @@
 	function suite.translate_ReturnsTargetOSSeparator_Windows()
 		_OPTIONS["os"] = "windows"
 		test.isequal("dir\\dir\\file", path.translate("dir/dir\\file"))
-		_OPTIONS["os"] = nil
 	end
 
 	function suite.translate_ReturnsTargetOSSeparator_Linux()
 		_OPTIONS["os"] = "linux"
 		test.isequal("dir/dir/file", path.translate("dir/dir\\file"))
-		_OPTIONS["os"] = nil
 	end
 
 

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -389,6 +389,18 @@
 		test.isequal("dir/dir/file", actual)
 	end
 
+	function suite.translate_ReturnsTargetOSSeparator_Windows()
+		_OPTIONS["os"] = "windows"
+		test.isequal("dir\\dir\\file", path.translate("dir/dir\\file"))
+		_OPTIONS["os"] = nil
+	end
+
+	function suite.translate_ReturnsTargetOSSeparator_Linux()
+		_OPTIONS["os"] = "linux"
+		test.isequal("dir/dir/file", path.translate("dir/dir\\file"))
+		_OPTIONS["os"] = nil
+	end
+
 
 --
 -- path.wildcards tests

--- a/tests/config/test_linkinfo.lua
+++ b/tests/config/test_linkinfo.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "test"
+		premake.action.set("test")
 		wks, prj = test.createWorkspace()
 		kind "StaticLib"
 		system "Windows"

--- a/tests/config/test_links.lua
+++ b/tests/config/test_links.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "test"
+		premake.action.set("test")
 		_OS = "windows"
 		wks, prj = test.createWorkspace()
 	end

--- a/tests/config/test_targetinfo.lua
+++ b/tests/config/test_targetinfo.lua
@@ -15,7 +15,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "test"
+		premake.action.set("test")
 		wks, prj = test.createWorkspace()
 		system "macosx"
 	end

--- a/tests/oven/test_filtering.lua
+++ b/tests/oven/test_filtering.lua
@@ -28,7 +28,7 @@
 --
 
 	function suite.onAction()
-		_ACTION = "vs2012"
+		premake.action.set("vs2012")
 		filter { "action:vs2012" }
 		defines { "USE_VS2012" }
 		prepare()
@@ -36,7 +36,7 @@
 	end
 
 	function suite.onActionMismatch()
-		_ACTION = "vs2010"
+		premake.action.set("vs2010")
 		filter { "action:vs2012" }
 		defines { "USE_VS2012" }
 		prepare()

--- a/tests/workspace/test_objdirs.lua
+++ b/tests/workspace/test_objdirs.lua
@@ -14,7 +14,7 @@
 	local wks
 
 	function suite.setup()
-		_ACTION = "test"
+		premake.action.set("test")
 		wks = workspace("MyWorkspace")
 		system "macosx"
 	end


### PR DESCRIPTION
path.translate now uses the target OS separator by default instead of Windows separator. Fixes #86

The wiki will need to be updated to reflect this change when/if it's merged.