### PR TITLE
OSX and Linux SSL support and OSX fixes

### DIFF
--- a/contrib/curl/lib/curl_config.h
+++ b/contrib/curl/lib/curl_config.h
@@ -2,7 +2,7 @@
 /* lib/curl_config.h.in.  Generated from configure.ac by autoheader.  */
 
 /* Location of default ca bundle */
-/* #define CURL_CA_BUNDLE "/etc/pki/tls/certs/ca-bundle.crt" */
+/* #undef CURL_CA_BUNDLE */
 
 /* Location of default ca path */
 /* #undef CURL_CA_PATH */

--- a/contrib/curl/lib/curl_config.h
+++ b/contrib/curl/lib/curl_config.h
@@ -2,7 +2,7 @@
 /* lib/curl_config.h.in.  Generated from configure.ac by autoheader.  */
 
 /* Location of default ca bundle */
-#define CURL_CA_BUNDLE "/etc/pki/tls/certs/ca-bundle.crt"
+/* #define CURL_CA_BUNDLE "/etc/pki/tls/certs/ca-bundle.crt" */
 
 /* Location of default ca path */
 /* #undef CURL_CA_PATH */

--- a/contrib/curl/premake5.lua
+++ b/contrib/curl/premake5.lua
@@ -20,7 +20,7 @@ project "curl-lib"
 		defines {"HAVE_CONFIG_H", "CURL_HIDDEN_SYMBOLS"}
 
 	configuration { 'macosx' }
-		defines { 'HAVE_CONFIG_H' }	
+		defines { 'HAVE_CONFIG_H', 'USE_SSL', 'USE_DARWINSSL' }	
 
 	configuration "Release"
 		defines {"NDEBUG"}

--- a/contrib/curl/premake5.lua
+++ b/contrib/curl/premake5.lua
@@ -17,7 +17,28 @@ project "curl-lib"
 		defines {"USE_SSL", "USE_SCHANNEL", "USE_WINDOWS_SSPI"}
 
 	configuration { 'linux' }
-		defines {"HAVE_CONFIG_H", "CURL_HIDDEN_SYMBOLS"}
+		
+		defines {"HAVE_CONFIG_H", "CURL_HIDDEN_SYMBOLS" }
+		if os.findlib("ssl") then
+			defines { "USE_SSL", "USE_OPENSSL", "USE_SSLEAY" }
+
+			-- find the location of the ca bundle
+			local ca = nil
+			for _, f in ipairs {
+				'/etc/ssl/certs/ca-certificates.crt',
+				'/etc/pki/tls/certs/ca-bundle.crt',
+				'/usr/share/ssl/certs/ca-bundle.crt',
+				'/usr/local/share/certs/ca-root.crt',
+				'/etc/ssl/cert.pem' } do
+				if os.isfile(f) then
+					ca = f
+					break
+				end
+			end
+			if ca then
+				defines { 'CURL_CA_BUNDLE=\\"' .. ca .. '\\"' }
+			end
+		end
 
 	configuration { 'macosx' }
 		defines { 'HAVE_CONFIG_H', 'USE_SSL', 'USE_DARWINSSL' }	

--- a/premake5.lua
+++ b/premake5.lua
@@ -90,6 +90,10 @@
 		configurations { "Release", "Debug" }
 		location ( _OPTIONS["to"] )
 
+		configuration { "macosx", "gmake" }
+			buildoptions { "-mmacosx-version-min=10.4" }
+			linkoptions  { "-mmacosx-version-min=10.4" }
+
 	project "Premake5"
 		targetname  "premake5"
 		language    "C"
@@ -161,8 +165,6 @@
 
 		configuration { "macosx", "gmake" }
 			toolset "clang"
-			buildoptions { "-mmacosx-version-min=10.4" }
-			linkoptions  { "-mmacosx-version-min=10.4" }
 
 		configuration { "solaris" }
 			linkoptions { "-Wl,--export-dynamic" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -159,6 +159,11 @@
 		configuration "linux or hurd"
 			links       { "dl", "rt" }
 
+		configuration "linux"
+			if not _OPTIONS["no-curl"] and os.findlib("ssl") then
+				links       { "ssl", "crypto" }
+			end
+
 		configuration "macosx"
 			defines     { "LUA_USE_MACOSX" }
 			links       { "CoreServices.framework" }
@@ -175,6 +180,7 @@
 		configuration "aix"
 			defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }
 			links       { "m" }
+
 
 	-- optional 3rd party libraries
 	group "contrib"

--- a/premake5.lua
+++ b/premake5.lua
@@ -162,6 +162,9 @@
 		configuration "macosx"
 			defines     { "LUA_USE_MACOSX" }
 			links       { "CoreServices.framework" }
+			if not _OPTIONS["no-curl"] then
+				links   { "Security.framework" }
+			end
 
 		configuration { "macosx", "gmake" }
 			toolset "clang"

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -304,9 +304,11 @@
 			end
 		end
 
-		if #result > 1 then
-			table.insert(result, 1, "-Wl,--start-group")
-			table.insert(result, "-Wl,--end-group")
+		if cfg.system ~= premake.MACOSX then
+			if #result > 1 then
+				table.insert(result, 1, "-Wl,--start-group")
+				table.insert(result, "-Wl,--end-group")
+			end
 		end
 
 		-- The "-l" flag is fine for system libraries


### PR DESCRIPTION
Small changes to get premake-core compiling.
Support for SSL added using Darwin SSL.
Tested on OSX Yosemite with Xcode 7.1