### PR TITLE
Rollback PR #247 - support framework folders in gcc/clang

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -248,18 +248,10 @@
 		local flags = config.mapFlags(cfg, gcc.libraryDirectories)
 
 		-- Scan the list of linked libraries. If any are referenced with
-		-- paths, add those to the list of library search paths
-		local done = {}
-		for _, link in ipairs(config.getlinks(cfg, "system", "fullpath")) do
-			local dir = path.getdirectory(link)
-			if #dir > 1 and not done[dir] then
- 				done[dir] = true
-				if path.isframework(link) then
-					table.insert(flags, '-F' .. premake.quoted(dir))
-				else
-					table.insert(flags, '-L' .. premake.quoted(dir))
-				end
-			end
+		-- paths, add those to the list of library search paths. The call
+		-- config.getlinks() all includes cfg.libdirs.
+		for _, dir in ipairs(config.getlinks(cfg, "system", "directory")) do
+			table.insert(flags, '-L' .. premake.quoted(dir))
 		end
 
 		if cfg.flags.RelativeLinks then

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -147,6 +147,7 @@ return {
 	"actions/make/cpp/test_clang.lua",
 	"actions/make/cpp/test_file_rules.lua",
 	"actions/make/cpp/test_flags.lua",
+	"actions/make/cpp/test_ldflags.lua",
 	"actions/make/cpp/test_make_pch.lua",
 	"actions/make/cpp/test_make_linking.lua",
 	"actions/make/cpp/test_objects.lua",

--- a/tests/actions/make/cpp/test_flags.lua
+++ b/tests/actions/make/cpp/test_flags.lua
@@ -1,7 +1,7 @@
 --
 -- tests/actions/make/cpp/test_flags.lua
 -- Tests compiler and linker flags for Makefiles.
--- Copyright (c) 2012-2013 Jason Perkins and the Premake project
+-- Copyright (c) 2012-2015 Jason Perkins and the Premake project
 --
 
 	local suite = test.declare("make_flags")

--- a/tests/actions/make/cpp/test_ldflags.lua
+++ b/tests/actions/make/cpp/test_ldflags.lua
@@ -1,0 +1,49 @@
+--
+-- tests/actions/make/cpp/test_ldflags.lua
+-- Tests compiler and linker flags for Makefiles.
+-- Copyright (c) 2012-2015 Jason Perkins and the Premake project
+--
+
+	local suite = test.declare("make_ldflags")
+	local make = premake.make
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare(calls)
+		local cfg = test.getconfig(prj, "Debug")
+		local toolset = premake.tools.gcc
+		make.ldFlags(cfg, toolset)
+	end
+
+
+--
+-- Check the output from default project values.
+--
+
+	function suite.checkDefaultValues()
+		prepare()
+		test.capture [[
+  ALL_LDFLAGS += $(LDFLAGS)
+		]]
+	end
+
+--
+-- Check addition of library search directores.
+--
+
+	function suite.checkLibDirs()
+		libdirs { "../libs", "libs" }
+		prepare()
+		test.capture [[
+  ALL_LDFLAGS += $(LDFLAGS) -L../libs -Llibs
+		]]
+	end


### PR DESCRIPTION
Rolled back the change and added a unit test to make sure we catch this in future