### PR TITLE
getrelativepath specific rule 'return absolute when only filesystem root in common'

### DIFF
--- a/src/host/path_getrelative.c
+++ b/src/host/path_getrelative.c
@@ -48,9 +48,9 @@ int path_getrelative(lua_State* L)
 		++i;
 	}
 
-	/* if I end up with just the root of the filesystem, either a single
-	 * slash (/) or a drive letter (c:) then return the absolute path. */
-	if (last <= 0 || (last == 2 && src[1] == ':')) {
+	/* if they have nothing in common ( different drive by example ) 
+	 * return absolute path */
+	if (last <= 0) {
 		dst[strlen(dst) - 1] = '\0';
 		lua_pushstring(L, dst);
 		return 1;

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -213,8 +213,12 @@
 		 test.isequal("c", path.getrelative("/a/b/","/a/b/c"))
 	end
 
-	function suite.getrelative_returnsAbsPath_onContactWithFileSysRoot()
-		test.isequal("C:/Boost/Include", path.getrelative("C:/Code/MyApp", "C:/Boost/Include"))
+	function suite.getrelative_returnsRelativePath_onContactWithFileSysRoot()
+		test.isequal("../../Boost/Include", path.getrelative("C:/Code/MyApp", "C:/Boost/Include"))
+	end
+	
+	function suite.getrelative_returnsAbsPath_onContactWithDifferentFileSysRoot()
+		test.isequal("E:/Boost/Include", path.getrelative("C:/Code/MyApp", "E:/Boost/Include"))
 	end
 
 


### PR DESCRIPTION
return the relative path Even if the file system root is the only thing in common

fix problems when generating a vs2012 project referencing another project, both in i the samefile system root
C:\Lib
C:\Project referencing Lib stuff in libdirs
>> generate vcproj with absolute "C:\Lib" inside
Unexpected since generating with C:\Git\Lib and C:\Git\Project generate only relative stuff