### PR TITLE
Added frameworkdirs option.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -672,6 +672,13 @@
 	}
 
 	api.register {
+		name = "frameworkdirs",
+		scope = "config",
+		kind = "list:directory",
+		tokens = true,
+	}
+
+	api.register {
 		name = "linkoptions",
 		scope = "config",
 		kind = "list:string",


### PR DESCRIPTION
This should now support FRAMEWORK_SEARCH_PATHS in xcode_common.lua. This will allow frameworks to exist in non sdk paths.

configuration "macosx"
	frameworkdirs { "Library/MacOS/SDL2-2.0.3" }
	linkoptions { "-framework SDL2" }
