### PR TITLE
Fixed C# GNU Make backend response files to deal with platform path separators

### DIFF
--- a/src/actions/make/make_csharp.lua
+++ b/src/actions/make/make_csharp.lua
@@ -189,7 +189,7 @@
 		local toolset = premake.tools.dotnet
 		local ext = make.getmakefilename(prj, true)
 		local makefile = path.getname(premake.filename(prj, ext))
-		local response = path.translate(make.cs.getresponsefilename(prj))
+		local response = make.cs.getresponsefilename(prj)
 
 		_p('$(RESPONSE): %s', makefile)
 		_p('\t@echo Generating response file', prj.name)
@@ -197,14 +197,15 @@
 		_p('ifeq (posix,$(SHELLTYPE))')
 			_x('\t$(SILENT) rm -f $(RESPONSE)')
 		_p('else')
-			_x('\t$(SILENT) if exist $(RESPONSE) del %s', response)
+			_x('\t$(SILENT) if exist $(RESPONSE) del %s', path.translate(response, '\\'))
 		_p('endif')
 
+		local sep = os.is("windows") and "\\" or "/"
 		local tr = project.getsourcetree(prj)
 		premake.tree.traverse(tr, {
 			onleaf = function(node, depth)
 				if toolset.fileinfo(node).action == "Compile" then
-					_x('\t@echo %s >> $(RESPONSE)', path.translate(node.relpath))
+					_x('\t@echo %s >> $(RESPONSE)', path.translate(node.relpath, sep))
 				end
 			end
 		})

--- a/tests/actions/make/cs/test_response.lua
+++ b/tests/actions/make/cs/test_response.lua
@@ -6,7 +6,6 @@
 
 	local suite = test.declare("make_cs_response")
 	local make = premake.make
-	local project = premake.project
 
 
 --
@@ -49,9 +48,14 @@ $(TARGET): $(SOURCES) $(EMBEDFILES) $(DEPENDS) $(RESPONSE)
 	end
 
 	function suite.listResponseRules()
-		files { "foo.cs", "bar.cs" }
+		files { "foo.cs", "bar.cs", "dir/foo.cs" }
 		prepare()
 		make.csResponseRules(prj)
+	end
+
+	function suite.listResponseRulesPosix()
+		_OS = "linux"
+		suite.listResponseRules()
 		test.capture [[
 $(RESPONSE): MyProject.make
 	@echo Generating response file
@@ -61,6 +65,24 @@ else
 	$(SILENT) if exist $(RESPONSE) del $(OBJDIR)\MyProject.rsp
 endif
 	@echo bar.cs >> $(RESPONSE)
+	@echo dir/foo.cs >> $(RESPONSE)
+	@echo foo.cs >> $(RESPONSE)
+		]]
+	end
+
+	function suite.listResponseRulesWindows()
+		_OS = "windows"
+		suite.listResponseRules()
+		test.capture [[
+$(RESPONSE): MyProject.make
+	@echo Generating response file
+ifeq (posix,$(SHELLTYPE))
+	$(SILENT) rm -f $(RESPONSE)
+else
+	$(SILENT) if exist $(RESPONSE) del $(OBJDIR)\MyProject.rsp
+endif
+	@echo bar.cs >> $(RESPONSE)
+	@echo dir\foo.cs >> $(RESPONSE)
 	@echo foo.cs >> $(RESPONSE)
 		]]
 	end


### PR DESCRIPTION
Obsoletes pull request #292.

Aditionally, we should be able to remove the `local sep = os.is("windows") and "\\" or "/"` line once pull request #307 is merged.