### PR TITLE
Rollback link groups (-Wl,--start-group, -Wl,--end-group)

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -296,13 +296,6 @@
 			end
 		end
 
-		if cfg.system ~= premake.MACOSX then
-			if #result > 1 then
-				table.insert(result, 1, "-Wl,--start-group")
-				table.insert(result, "-Wl,--end-group")
-			end
-		end
-
 		-- The "-l" flag is fine for system libraries
 
 		local links = config.getlinks(cfg, "system", "fullpath")

--- a/tests/actions/make/cpp/test_make_linking.lua
+++ b/tests/actions/make/cpp/test_make_linking.lua
@@ -178,7 +178,7 @@
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s
-  LIBS += -Wl,--start-group build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a -Wl,--end-group
+  LIBS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
   LDDEPS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
 		]]
 	end


### PR DESCRIPTION
The --start-group and --end-group flags cause issues for anyone using alternate linkers with GCC or Clang. We need to come up with a better solution.