### PR TITLE
Emit <TargetMachine> element to fix LNK4068 warnings in Visual Studio

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -406,6 +406,7 @@
 				m.treatLinkerWarningAsErrors,
 				m.ignoreDefaultLibraries,
 				m.largeAddressAware,
+				m.targetMachine,
 				m.additionalLinkOptions,
 			}
 		end
@@ -430,6 +431,7 @@
 		if cfg.kind == p.STATICLIB then
 			return {
 				m.treatLinkerWarningAsErrors,
+				m.targetMachine,
 				m.additionalLinkOptions,
 			}
 		else
@@ -1761,6 +1763,22 @@
 		else
 			p.w('<TargetExt>')
 			p.w('</TargetExt>')
+		end
+	end
+
+
+	function m.targetMachine(cfg)
+		-- If a static library project contains a resource file, VS will choke with
+		-- "LINK : warning LNK4068: /MACHINE not specified; defaulting to X86"
+		local targetmachine = {
+			x86 = "MachineX86",
+			x86_64 = "MachineX64",
+		}
+		if cfg.kind == p.STATICLIB then
+			local value = targetmachine[cfg.architecture]
+			if value ~= nil then
+				m.element("TargetMachine", nil, '%s', value)
+			end
 		end
 	end
 

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -129,6 +129,7 @@ return {
 	"actions/vstudio/vc2010/test_prop_sheet.lua",
 	"actions/vstudio/vc2010/test_resource_compile.lua",
 	"actions/vstudio/vc2010/test_rule_vars.lua",
+	"actions/vstudio/vc2010/test_target_machine.lua",
 	"actions/vstudio/vc2010/test_user_file.lua",
 	"actions/vstudio/vc2010/test_vectorextensions.lua",
 

--- a/tests/actions/vstudio/vc2010/test_target_machine.lua
+++ b/tests/actions/vstudio/vc2010/test_target_machine.lua
@@ -1,0 +1,87 @@
+---
+-- tests/actions/vstudio/vc2010/test_target_machine.lua
+-- Validate generation of the <TargetMachine> element
+-- Copyright (c) 2015 Jason Perkins and the Premake project
+---
+
+	local suite = test.declare("vstudio_vs2010_target_machine")
+	local vc2010 = premake.vstudio.vc2010
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare(platform)
+		local cfg = test.getconfig(prj, "Debug", platform)
+		vc2010.targetMachine(cfg)
+	end
+
+
+
+--
+-- Emit if a static lib project contains a resource file and an
+-- architecture is specified.
+--
+
+	function suite.emitsOnStaticLibWithX86()
+		kind "StaticLib"
+		architecture "x86"
+		prepare()
+		test.capture [[
+<TargetMachine>MachineX86</TargetMachine>
+		]]
+	end
+
+	function suite.emitsOnStaticLibWithX86_64()
+		kind "StaticLib"
+		architecture "x86_64"
+		prepare()
+		test.capture [[
+<TargetMachine>MachineX64</TargetMachine>
+		]]
+	end
+
+
+
+--
+-- Other combinations should NOT emit anything
+--
+
+	function suite.isIgnoredOnConsoleAppNoArch()
+		kind "ConsoleApp"
+		prepare()
+		test.isemptycapture()
+	end
+
+	function suite.isIgnoredOnConsoleAppWithX86()
+		kind "ConsoleApp"
+		architecture "x86"
+		prepare()
+		test.isemptycapture()
+	end
+
+	function suite.isIgnoredOnStaticLibNoArch()
+		kind "StaticLib"
+		prepare()
+		test.isemptycapture()
+	end
+
+	function suite.isIgnoredOnSharedLibNoArch()
+		kind "SharedLib"
+		prepare()
+		test.isemptycapture()
+	end
+
+	function suite.isIgnoredOnSharedLibWithX86()
+		kind "SharedLib"
+		architecture "x86"
+		prepare()
+		test.isemptycapture()
+	end


### PR DESCRIPTION
This is a replacement for PR #341 which was rolled back. It narrows the application of the change to fix the specific warning and incorrect behavior ("LINK : warning LNK4068: /MACHINE not specified; defaulting to X86")