### PR TITLE
Adds the missing resource file test on PR #365

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1774,7 +1774,7 @@
 			x86 = "MachineX86",
 			x86_64 = "MachineX64",
 		}
-		if cfg.kind == p.STATICLIB then
+		if cfg.kind == p.STATICLIB and config.hasFile(cfg, path.isresourcefile) then
 			local value = targetmachine[cfg.architecture]
 			if value ~= nil then
 				m.element("TargetMachine", nil, '%s', value)

--- a/tests/actions/vstudio/vc2010/test_target_machine.lua
+++ b/tests/actions/vstudio/vc2010/test_target_machine.lua
@@ -33,6 +33,7 @@
 	function suite.emitsOnStaticLibWithX86()
 		kind "StaticLib"
 		architecture "x86"
+		files { "hello.rc" }
 		prepare()
 		test.capture [[
 <TargetMachine>MachineX86</TargetMachine>
@@ -42,6 +43,7 @@
 	function suite.emitsOnStaticLibWithX86_64()
 		kind "StaticLib"
 		architecture "x86_64"
+		files { "hello.rc" }
 		prepare()
 		test.capture [[
 <TargetMachine>MachineX64</TargetMachine>
@@ -54,34 +56,32 @@
 -- Other combinations should NOT emit anything
 --
 
-	function suite.isIgnoredOnConsoleAppNoArch()
-		kind "ConsoleApp"
-		prepare()
-		test.isemptycapture()
-	end
-
-	function suite.isIgnoredOnConsoleAppWithX86()
-		kind "ConsoleApp"
-		architecture "x86"
-		prepare()
-		test.isemptycapture()
-	end
-
 	function suite.isIgnoredOnStaticLibNoArch()
 		kind "StaticLib"
+		files { "hello.rc" }
 		prepare()
 		test.isemptycapture()
 	end
 
-	function suite.isIgnoredOnSharedLibNoArch()
-		kind "SharedLib"
+	function suite.isIgnoredOnStaticLibNoResource()
+		kind "StaticLib"
+		architecture "x86"
 		prepare()
 		test.isemptycapture()
 	end
 
-	function suite.isIgnoredOnSharedLibWithX86()
+	function suite.isIgnoredOnConsoleApp()
+		kind "ConsoleApp"
+		architecture "x86"
+		files { "hello.rc" }
+		prepare()
+		test.isemptycapture()
+	end
+
+	function suite.isIgnoredOnSharedLib()
 		kind "SharedLib"
 		architecture "x86"
+		files { "hello.rc" }
 		prepare()
 		test.isemptycapture()
 	end


### PR DESCRIPTION
I completely forgot the resource file check on the previous PR. This one limits the application of <TargetMachine> only to static libraries which ALSO have at least one resource file. Sorry about that!