### PR TITLE
Allow the pathVars to return a table that specifies explicitly that a token represents a relative or absolute path.

### DIFF
--- a/src/actions/vstudio/vs2010.lua
+++ b/src/actions/vstudio/vs2010.lua
@@ -18,13 +18,19 @@
 ---
 
 	vstudio.pathVars = {
-		["cfg.objdir"] = "$(IntDir)",
-		["prj.location"] = "$(ProjectDir)",
-		["sln.location"] = "$(SolutionDir)",
-		["wks.location"] = "$(SolutionDir)",
-		["cfg.buildtarget.directory"] = "$(TargetDir)",
-		["cfg.buildtarget.name"] = "$(TargetFileName)",
-		["cfg.buildtarget.basename"] = "$(TargetName)",
+		["cfg.objdir"]                  = { absolute = true,  token = "$(IntDir)" },
+		["prj.location"]                = { absolute = true,  token = "$(ProjectDir)" },
+		["prj.name"]                    = { absolute = false, token = "$(ProjectName)" },
+		["sln.location"]                = { absolute = true,  token = "$(SolutionDir)" },
+		["sln.name"]                    = { absolute = false, token = "$(SolutionName)" },
+		["wks.location"]                = { absolute = true,  token = "$(SolutionDir)" },
+		["wks.name"]                    = { absolute = false, token = "$(SolutionName)" },
+		["cfg.buildtarget.directory"]   = { absolute = false, token = "$(TargetDir)" },
+		["cfg.buildtarget.name"]        = { absolute = false, token = "$(TargetFileName)" },
+		["cfg.buildtarget.basename"]    = { absolute = false, token = "$(TargetName)" },
+		["file.basename"]               = { absolute = false, token = "%(Filename)" },
+		["file.abspath"]                = { absolute = true,  token = "%(FullPath)" },
+		["file.relpath"]                = { absolute = false, token = "%(Identity)" },
 	}
 
 

--- a/src/base/detoken.lua
+++ b/src/base/detoken.lua
@@ -90,9 +90,15 @@
 					success, result = pcall(result, e)
 					if not success then
 						return nil, result
-					end
+					end					
 				end
-				isAbs = path.isabsolute(result)
+
+				if (type(result) == "table") then
+					isAbs  = result.absolute
+					result = result.token
+				else
+					isAbs = path.isabsolute(result)
+				end
 			end
 
 			-- If the result is an absolute path, and it is being inserted into

--- a/src/host/path_isabsolute.c
+++ b/src/host/path_isabsolute.c
@@ -19,9 +19,9 @@ int do_isabsolute(const char* path)
 {
 	return (
 		path[0] == '/' ||
-	    path[0] == '\\' ||
-	    path[0] == '$' ||
-	    (path[0] == '"' && path[1] == '$') ||
-	    (path[0] != '\0' && path[1] == ':')
+		path[0] == '\\' ||
+		path[0] == '$' ||
+		(path[0] == '"' && path[1] == '$') ||
+		(path[0] != '\0' && path[1] == ':')
 	);
 }

--- a/tests/base/test_detoken.lua
+++ b/tests/base/test_detoken.lua
@@ -109,15 +109,21 @@
 --
 
 	function suite.replacesToken_onSupportedAndMapped()
-		action.pathVars = { ["cfg.objdir"] = "$(IntDir)" }
+		action.pathVars = { ["cfg.objdir"] = { absolute = true,  token = "$(IntDir)" }, }
 		x = detoken.expand("cmd %{cfg.objdir}/file", environ, {pathVars=true})
 		test.isequal("cmd $(IntDir)/file", x)
 	end
 
 	function suite.replacesToken_onSupportedAndMapped_inAbsPath()
-		action.pathVars = { ["cfg.objdir"] = "$(IntDir)" }
+		action.pathVars = { ["cfg.objdir"] = { absolute = true,  token = "$(IntDir)" }, }
 		x = detoken.expand(os.getcwd() .. "/%{cfg.objdir}/file", environ, {paths=true,pathVars=true})
 		test.isequal("$(IntDir)/file", x)
+	end
+
+	function suite.replacesToken_onSupportedAndMapped_inRelPath()
+		action.pathVars = { ["cfg.objdir"] = { absolute = false,  token = "$(IntDir)" }, }
+		x = detoken.expand(os.getcwd() .. "/%{cfg.objdir}/file", environ, {paths=true,pathVars=true})
+		test.isequal(os.getcwd() .. "/$(IntDir)/file", x)
 	end
 
 --


### PR DESCRIPTION
Not all paths that start with a $ are absolute paths in Visual Studio, so the path.isabsolute is incorrect in many cases.