### PR TITLE
Fix a bug in 'premake_init'

### DIFF
--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -154,6 +154,7 @@ int premake_init(lua_State* L)
 	/* find the user's home directory */
 	value = getenv("HOME");
 	if (!value) value = getenv("USERPROFILE");
+	if (!value) value = "~";
 	lua_pushstring(L, value);
 	lua_setglobal(L, "_USER_HOME_DIR");
 


### PR DESCRIPTION
This prevent a null pointer from being pushed, which will causes issues later on in 'build_premake_path' on this line 'lua_concat(L, lua_gettop(L) - top);'.

Basically if neither "HOME" or "USERPROFILE" is set on the environment, the _USER_HOME_DIR variable will be 'nil', and this causes 'build_premake_path' to crash.

We ran into this on older CentOS 6.1 boxes used in our Jenkins build farm.