### PR TITLE
Fix: Write pchheader to Makefile as reletive path

### DIFF
--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -467,12 +467,17 @@
 		-- add a conditional configuration to the project script.
 
 		local pch = cfg.pchheader
+		local found = false
 		for _, incdir in ipairs(cfg.includedirs) do
 			local testname = path.join(incdir, pch)
 			if os.isfile(testname) then
 				pch = project.getrelative(cfg.project, testname)
+				found = true
 				break
 			end
+		end
+		if not found then
+			pch = project.getrelative(cfg.project, path.getabsolute(pch))
 		end
 
 		_x('  PCH = %s', pch)


### PR DESCRIPTION
Because cfg.pchheader is "string" instead of "path", we need to resolve actual path before write it to the Makefile.

Without this, PCH variable in Makefile won't point actual file when Makefile is generated into different directory by the effect of "location" API function.