### PR TITLE
Fix VS warnings

### DIFF
--- a/contrib/libzip/zip_close.c
+++ b/contrib/libzip/zip_close.c
@@ -541,7 +541,7 @@ write_cdir(struct zip *za, const struct zip_filelist *filelist, zip_uint64_t sur
 
     /* fix up torrentzip comment */
 
-    if (_zip_filerange_crc(out, cd_start, size, &crc, &za->error) < 0)
+    if (_zip_filerange_crc(out, cd_start, (off_t)size, &crc, &za->error) < 0)
 	return -1;
 
     snprintf(buf, sizeof(buf), "%08lX", (long)crc);

--- a/contrib/libzip/zip_error_to_str.c
+++ b/contrib/libzip/zip_error_to_str.c
@@ -48,7 +48,7 @@ zip_error_to_str(char *buf, zip_uint64_t len, int ze, int se)
     const char *zs, *ss;
 
     if (ze < 0 || ze >= _zip_nerr_str)
-	return snprintf(buf, len, "Unknown error %d", ze);
+	return snprintf(buf, (size_t)len, "Unknown error %d", ze);
 
     zs = _zip_err_str[ze];
 	
@@ -65,6 +65,6 @@ zip_error_to_str(char *buf, zip_uint64_t len, int ze, int se)
 	ss = NULL;
     }
 
-    return snprintf(buf, len, "%s%s%s",
+    return snprintf(buf, (size_t)len, "%s%s%s",
 		    zs, (ss ? ": " : ""), (ss ? ss : ""));
 }

--- a/contrib/libzip/zip_file_get_external_attributes.c
+++ b/contrib/libzip/zip_file_get_external_attributes.c
@@ -37,8 +37,6 @@ int
 zip_file_get_external_attributes(struct zip *za, zip_uint64_t idx, zip_flags_t flags, zip_uint8_t *opsys, zip_uint32_t *attributes)
 {
     struct zip_dirent *de;
-    zip_uint32_t len;
-    const zip_uint8_t *str;
 
     if ((de=_zip_get_dirent(za, idx, flags, NULL)) == NULL)
 	return -1;

--- a/contrib/libzip/zip_source_buffer.c
+++ b/contrib/libzip/zip_source_buffer.c
@@ -103,7 +103,7 @@ read_data(void *state, void *data, zip_uint64_t len, enum zip_source_cmd cmd)
 	    n = len;
 
 	if (n) {
-	    memcpy(buf, z->buf, n);
+	    memcpy(buf, z->buf, (size_t)n);
 	    z->buf += n;
 	}
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -94,6 +94,9 @@
 			buildoptions { "-mmacosx-version-min=10.4" }
 			linkoptions  { "-mmacosx-version-min=10.4" }
 
+		configuration "vs*"
+			defines     { "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_WARNINGS" }
+
 	project "Premake5"
 		targetname  "premake5"
 		language    "C"
@@ -140,9 +143,6 @@
 			targetdir   "bin/release"
 			defines     "NDEBUG"
 			flags       { "OptimizeSize" }
-
-		configuration "vs*"
-			defines     { "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_WARNINGS" }
 
 		configuration "vs2005"
 			defines	{"_CRT_SECURE_NO_DEPRECATE" }

--- a/src/host/os_chdir.c
+++ b/src/host/os_chdir.c
@@ -14,7 +14,7 @@ int do_chdir(lua_State* L, const char* path)
 	(void)(L);  /* warning: unused parameter */
 
 #if PLATFORM_WINDOWS
-	z = SetCurrentDirectory(path);
+	z = SetCurrentDirectoryA(path);
 #else
 	z = !chdir(path);
 #endif

--- a/src/host/os_copyfile.c
+++ b/src/host/os_copyfile.c
@@ -14,7 +14,7 @@ int os_copyfile(lua_State* L)
 	const char* dst = luaL_checkstring(L, 2);
 
 #if PLATFORM_WINDOWS
-	z = CopyFile(src, dst, FALSE);
+	z = CopyFileA(src, dst, FALSE);
 #else
 	lua_pushfstring(L, "cp %s %s", src, dst);
 	z = (system(lua_tostring(L, -1)) == 0);

--- a/src/host/os_getcwd.c
+++ b/src/host/os_getcwd.c
@@ -24,7 +24,7 @@ int do_getcwd(char* buffer, size_t size)
 	int result;
 
 #if PLATFORM_WINDOWS
-	result = (GetCurrentDirectory(size, buffer) != 0);
+	result = (GetCurrentDirectoryA(size, buffer) != 0);
 	if (result) {
 		do_translate(buffer, '/');
 	}

--- a/src/host/os_isdir.c
+++ b/src/host/os_isdir.c
@@ -27,7 +27,7 @@ int os_isdir(lua_State* L)
 	}
 #ifdef _WIN32
 	// Use Windows-specific GetFileAttributes since it deals with symbolic links.
-	else if ((attr = GetFileAttributes(path)) != INVALID_FILE_ATTRIBUTES)
+	else if ((attr = GetFileAttributesA(path)) != INVALID_FILE_ATTRIBUTES)
 	{
 		int isdir = (attr & FILE_ATTRIBUTE_DIRECTORY) != 0;
 		lua_pushboolean(L, isdir);

--- a/src/host/os_islink.c
+++ b/src/host/os_islink.c
@@ -14,7 +14,7 @@ int os_islink(lua_State* L)
 
 #if PLATFORM_WINDOWS
 	{
-		DWORD attr = GetFileAttributes(path);
+		DWORD attr = GetFileAttributesA(path);
 		if (attr != INVALID_FILE_ATTRIBUTES) {
 			lua_pushboolean(L, (attr & FILE_ATTRIBUTE_REPARSE_POINT) != 0);
 			return 1;

--- a/src/host/os_match.c
+++ b/src/host/os_match.c
@@ -15,14 +15,14 @@ typedef struct struct_MatchInfo
 {
 	HANDLE handle;
 	int    is_first;
-	WIN32_FIND_DATA entry;
+	WIN32_FIND_DATAA entry;
 } MatchInfo;
 
 int os_matchstart(lua_State* L)
 {
 	const char* mask = luaL_checkstring(L, 1);
 	MatchInfo* m = (MatchInfo*)malloc(sizeof(MatchInfo));
-	m->handle = FindFirstFile(mask, &m->entry);
+	m->handle = FindFirstFileA(mask, &m->entry);
 	m->is_first = 1;
 	lua_pushlightuserdata(L, m);
 	return 1;
@@ -64,7 +64,7 @@ int os_matchnext(lua_State* L)
 			m->is_first = 0;
 		else
 		{
-			if (!FindNextFile(m->handle, &m->entry))
+			if (!FindNextFileA(m->handle, &m->entry))
 				return 0;
 		}
 

--- a/src/host/os_rmdir.c
+++ b/src/host/os_rmdir.c
@@ -14,7 +14,7 @@ int os_rmdir(lua_State* L)
 	const char* path = luaL_checkstring(L, 1);
 
 #if PLATFORM_WINDOWS
-	z = RemoveDirectory(path);
+	z = RemoveDirectoryA(path);
 #else
 	z = (0 == rmdir(path));
 #endif

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -230,7 +230,7 @@ int premake_locate_executable(lua_State* L, const char* argv0)
 	const char* path = NULL;
 
 #if PLATFORM_WINDOWS
-	DWORD len = GetModuleFileName(NULL, buffer, PATH_MAX);
+	DWORD len = GetModuleFileNameA(NULL, buffer, PATH_MAX);
 	if (len > 0)
 	{
 		buffer[len] = 0;


### PR DESCRIPTION
Clean up the build warnings from Visual Studio, so I can turn in warnings-as-errors for my local builds.