### PR TITLE
Fix some C# lang about BUGs

### DIFF
--- a/src/actions/make/make_csharp.lua
+++ b/src/actions/make/make_csharp.lua
@@ -92,11 +92,12 @@
 --
 
 	function cs.getresourcefilename(cfg, fname)
+		local sep = os.is("windows") and "\\" or "/"
 		if path.getextension(fname) == ".resx" then
 		    local name = cfg.buildtarget.basename .. "."
 		    local dir = path.getdirectory(fname)
 		    if dir ~= "." then
-				name = name .. path.translate(dir, ".") .. "."
+				name = name .. path.translate(dir, ".", sep) .. "."
 			end
 			return "$(OBJDIR)/" .. premake.esc(name .. path.getbasename(fname)) .. ".resources"
 		else
@@ -191,16 +192,17 @@
 		local makefile = path.getname(premake.filename(prj, ext))
 		local response = make.cs.getresponsefilename(prj)
 
+		local sep = os.is("windows") and "\\" or "/"
+
 		_p('$(RESPONSE): %s', makefile)
 		_p('\t@echo Generating response file', prj.name)
 
 		_p('ifeq (posix,$(SHELLTYPE))')
 			_x('\t$(SILENT) rm -f $(RESPONSE)')
 		_p('else')
-			_x('\t$(SILENT) if exist $(RESPONSE) del %s', path.translate(response, '\\'))
+			_x('\t$(SILENT) if exist $(RESPONSE) del %s', path.translate(response, sep))
 		_p('endif')
 
-		local sep = os.is("windows") and "\\" or "/"
 		local tr = project.getsourcetree(prj)
 		premake.tree.traverse(tr, {
 			onleaf = function(node, depth)

--- a/src/actions/vstudio/_vstudio.lua
+++ b/src/actions/vstudio/_vstudio.lua
@@ -271,7 +271,7 @@
 
 		local arch = architecture(cfg.system, cfg.architecture)
 		if not arch then
-			arch = iif(isnative, "x86", "Any CPU")
+			arch = iif(isnative, "x86", "AnyCPU")
 		end
 
 		if win32 and isnative and arch == "x86" then

--- a/src/actions/vstudio/vs2005_csproj_user.lua
+++ b/src/actions/vstudio/vs2005_csproj_user.lua
@@ -57,6 +57,7 @@
 				if #contents[cfg] > 0 then
 					p.push('<PropertyGroup %s>', m.condition(cfg))
 					p.outln(contents[cfg])
+                    m.localDebuggerWorkingDirectory(cfg)
 					p.pop('</PropertyGroup>')
 				end
 			end
@@ -65,7 +66,11 @@
 		end
 	end
 
-
+    function m.localDebuggerWorkingDirectory(cfg)
+        if cfg.debugdir then
+            _x(2, '<StartWorkingDirectory>%s</StartWorkingDirectory>', path.translate(path.getrelative(cfg.buildtarget.directory, cfg.debugdir)))
+        end
+    end
 
 ---
 -- Output any reference paths required by the project.


### PR DESCRIPTION
Fix in vs c# project, 'debugdir' option invalid BUG;
FIx in linux c# project, generated makefile format error BUG(All path separator is back-slash[\], not adapted system type);
Fix vs c# project generate .user file format error BUG( The platform type is "Any CPU", but in .csproject, platform type is configured to "AnyCPU";