### PR TITLE
Fix the oven to store the global container in the project and configs.

### DIFF
--- a/src/base/container.lua
+++ b/src/base/container.lua
@@ -132,7 +132,9 @@
 		end
 
 		local parent = self.parent
-		ctx[parent.class.name] = parent
+		if parent then
+			ctx[parent.class.name] = parent
+		end
 
 		for class in container.eachChildClass(self.class) do
 			for child in container.eachChild(self, class) do

--- a/src/base/global.lua
+++ b/src/base/global.lua
@@ -17,6 +17,12 @@
 		return p.container.new(p.global, name)
 	end
 
+---
+-- Bakes the global scope.
+---
+	function global.bake(self)
+		p.container.bakeChildren(self)
+	end
 
 
 ---

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -121,6 +121,8 @@
 		verbosef('    Baking %s...', self.name)
 
 		self.solution = self.workspace
+		self.global = self.workspace.global
+
 		local wks = self.workspace
 
 		-- Add filtering terms to the context to make it as specific as I can.
@@ -456,6 +458,7 @@
 		ctx.project = prj
 		ctx.workspace = wks
 		ctx.solution = wks
+		ctx.global = wks.global
 		ctx.buildcfg = buildcfg
 		ctx.platform = platform
 		ctx.action = _ACTION

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -43,7 +43,13 @@
 ---
 
 	function oven.bake()
-		p.container.bake(p.api.rootContainer())
+		-- reset the root _isBaked state.
+		-- this really only affects the unit-tests, since that is the only place
+		-- where multiple bakes per 'exe run' happen.
+		local root = p.api.rootContainer()
+		root._isBaked = false;
+
+		p.container.bake(root)
 	end
 
 	function oven.bakeWorkspace(wks)
@@ -51,14 +57,6 @@
 	end
 
 	p.alias(oven, "bakeWorkspace", "bakeSolution")
-
----
--- Bakes the global scope.
----
-	function p.global.bake(self)
-		p.container.bakeChildren(self)
-	end
-
 
 ---
 -- Bakes a specific workspace object.

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -43,7 +43,7 @@
 ---
 
 	function oven.bake()
-		p.container.bakeChildren(p.api.rootContainer())
+		p.container.bake(p.api.rootContainer())
 	end
 
 	function oven.bakeWorkspace(wks)
@@ -52,6 +52,12 @@
 
 	p.alias(oven, "bakeWorkspace", "bakeSolution")
 
+---
+-- Bakes the global scope.
+---
+	function p.global.bake(self)
+		p.container.bakeChildren(self)
+	end
 
 
 ---


### PR DESCRIPTION
I wanted to do:
```lua
premake.api.register {
	name = "packagecache",
	scope = "global",
	kind  = "path",
}
```

but that crashes in the validateScopes on this line:
```lua
okay = okay or p.field.compare(f, self[scope][f.name], self[f.name])
```
since self['global'] did not exist for the 'project' and 'config' scopes.