### PR TITLE
Link mode preference

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -331,7 +331,7 @@
 		if #static_syslibs > 1 then
 			table.insert(static_syslibs, "-Wl,-Bdynamic")
 			move(static_syslibs, result)
-	  end
+	    end
 		move(shared_syslibs, result)
 
 		return result

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -297,7 +297,6 @@
 		end
 
 		-- The "-l" flag is fine for system libraries
-
 		local links = config.getlinks(cfg, "system", "fullpath")
 		for _, link in ipairs(links) do
 			if path.isframework(link) then
@@ -305,7 +304,20 @@
 			elseif path.isobjectfile(link) then
 				table.insert(result, link)
 			else
-				table.insert(result, "-l" .. path.getname(link))
+				local endswith = function(s, ptrn)
+					 return ptrn == string.sub(s, -string.len(ptrn))
+				end
+				local name = path.getname(link)
+				-- Check link mode preference and set flags for linker accordingly
+				if endswith(name, ":static") then
+					name = string.sub(name, 0, -8)
+					table.insert(result, "-Wl,-Bstatic -l" .. name .. " -Wl,-Bdynamic")
+				elseif endswith(name, ":shared") then
+					name = string.sub(name, 0, -8)
+					table.insert(result, "-Wl,-Bdynamic -l" .. name)
+				else
+					table.insert(result, "-l" .. name)
+				end
 			end
 		end
 
@@ -360,4 +372,3 @@
 		end
 		return nil
 	end
-

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -298,6 +298,9 @@
 
 		-- The "-l" flag is fine for system libraries
 		local links = config.getlinks(cfg, "system", "fullpath")
+		local static_syslibs = {"-Wl,-Bstatic"}
+		local shared_syslibs = {}
+
 		for _, link in ipairs(links) do
 			if path.isframework(link) then
 				table.insert(result, "-framework " .. path.getbasename(link))
@@ -311,15 +314,25 @@
 				-- Check link mode preference and set flags for linker accordingly
 				if endswith(name, ":static") then
 					name = string.sub(name, 0, -8)
-					table.insert(result, "-Wl,-Bstatic -l" .. name .. " -Wl,-Bdynamic")
+					table.insert(static_syslibs, "-l" .. name)
 				elseif endswith(name, ":shared") then
 					name = string.sub(name, 0, -8)
-					table.insert(result, "-Wl,-Bdynamic -l" .. name)
+					table.insert(shared_syslibs, "-l" .. name)
 				else
-					table.insert(result, "-l" .. name)
+					table.insert(shared_syslibs, "-l" .. name)
 				end
 			end
 		end
+
+		local move = function(a1, a2)
+			local t = #a2
+			for i = 1, #a1 do a2[t + i] = a1[i] end
+		end
+		if #static_syslibs > 1 then
+			table.insert(static_syslibs, "-Wl,-Bdynamic")
+			move(static_syslibs, result)
+	  end
+		move(shared_syslibs, result)
 
 		return result
 	end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -308,10 +308,10 @@
 				table.insert(result, link)
 			else
 				local endswith = function(s, ptrn)
-					 return ptrn == string.sub(s, -string.len(ptrn))
+					return ptrn == string.sub(s, -string.len(ptrn))
 				end
 				local name = path.getname(link)
-				-- Check link mode preference and set flags for linker accordingly
+				-- Check whether link mode decorator is present 
 				if endswith(name, ":static") then
 					name = string.sub(name, 0, -8)
 					table.insert(static_syslibs, "-l" .. name)

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -510,3 +510,25 @@
 		prepare()
 		test.contains("-flto", gcc.getldflags(cfg))
 	end
+
+
+--
+-- Check link mode preference for system libraries.
+--
+	function suite.linksModePreference_onAllStatic()
+		links { "fs_stub:static", "net_stub:static" }
+		prepare()
+		test.contains({ "-Wl,-Bstatic -lfs_stub -Wl,-Bdynamic", "-Wl,-Bstatic -lnet_stub -Wl,-Bdynamic" }, gcc.getlinks(cfg))
+	end
+
+	function suite.linksModePreference_onStaticThenShared()
+		links { "fs_stub:static", "net_stub" }
+		prepare()
+		test.contains({ "-Wl,-Bstatic -lfs_stub -Wl,-Bdynamic", "-lnet_stub" }, gcc.getlinks(cfg))
+	end
+
+	function suite.linksModePreference_onSharedThenStatic()
+		links { "fs_stub:shared", "net_stub:static" }
+		prepare()
+		test.contains({ "-Wl,-Bdynamic -lfs_stub", "-Wl,-Bstatic -lnet_stub -Wl,-Bdynamic" }, gcc.getlinks(cfg))
+	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -518,17 +518,17 @@
 	function suite.linksModePreference_onAllStatic()
 		links { "fs_stub:static", "net_stub:static" }
 		prepare()
-		test.contains({ "-Wl,-Bstatic -lfs_stub -Wl,-Bdynamic", "-Wl,-Bstatic -lnet_stub -Wl,-Bdynamic" }, gcc.getlinks(cfg))
+		test.contains({ "-Wl,-Bstatic", "-lfs_stub", "-Wl,-Bdynamic", "-lnet_stub"}, gcc.getlinks(cfg))
 	end
 
-	function suite.linksModePreference_onStaticThenShared()
+	function suite.linksModePreference_onStaticAndShared()
 		links { "fs_stub:static", "net_stub" }
 		prepare()
-		test.contains({ "-Wl,-Bstatic -lfs_stub -Wl,-Bdynamic", "-lnet_stub" }, gcc.getlinks(cfg))
+		test.contains({ "-Wl,-Bstatic", "-lfs_stub", "-Wl,-Bdynamic", "-lnet_stub"}, gcc.getlinks(cfg))
 	end
 
-	function suite.linksModePreference_onSharedThenStatic()
-		links { "fs_stub:shared", "net_stub:static" }
+	function suite.linksModePreference_onAllShared()
+		links { "fs_stub:shared", "net_stub:shared" }
 		prepare()
-		test.contains({ "-Wl,-Bdynamic -lfs_stub", "-Wl,-Bstatic -lnet_stub -Wl,-Bdynamic" }, gcc.getlinks(cfg))
+		test.excludes({ "-Wl,-Bstatic" }, gcc.getlinks(cfg))
 	end


### PR DESCRIPTION
Possible #400 implementation. Now we can set a flag to control linker's behavior like this:
```lua
  links {"boost_system:shared"}
  links {"boost_thread:static"}
  links {"boost_regex"} -- flag is optional
```
Default link mode is shared, i.e. `-Wl,-Bdynamic`.
