### PR TITLE
Disable editorintegration() by default

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1365,9 +1365,9 @@
 -----------------------------------------------------------------------------
 
 	clr "Off"
+	editorintegration "Off"
 	exceptionhandling "Default"
 	rtti "Default"
-	editorintegration "On"
 
 	-- Setting a default language makes some validation easier later
 


### PR DESCRIPTION
I'd like to disable this new behavior by default, because...

* The values include an absolute path to the Premake executable. This is fine for situations where you have control over the development environment, but not when the solutions are pre-generated and distributed separately.

* I get validation warnings from Premake when I try to disable it globally (outside of any workspace). This is a bug in the validation code that I'll need to get fixed, I don't think it is handling workspace-level values correctly.

* [Tom's okay with it](https://github.com/premake/premake-core/pull/398#issuecomment-170965756) :) ("it's enabled by default, but I can go either way.")