### PR TITLE
MSC character set support

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1364,6 +1364,7 @@
 --
 -----------------------------------------------------------------------------
 
+	characterset "Default"
 	clr "Off"
 	editorintegration "Off"
 	exceptionhandling "Default"

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -390,7 +390,7 @@
 
 
 	function make.defines(cfg, toolset)
-		_p('  DEFINES +=%s', make.list(table.join(toolset.getdefines(cfg.defines), toolset.getundefines(cfg.undefines))))
+		_p('  DEFINES +=%s', make.list(table.join(toolset.getdefines(cfg.defines, cfg), toolset.getundefines(cfg.undefines))))
 	end
 
 

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -29,11 +29,6 @@
 --
 
 	msc.cflags = {
-		characterset = {
-			Default = { '/D"_UNICODE"', '/D"UNICODE"' },
-			MBCS = '/D"_MBCS"',
-			Unicode = { '/D"_UNICODE"', '/D"UNICODE"' },
-		},
 		clr = {
 			On = "/clr",
 			Unsafe = "/clr",
@@ -133,8 +128,27 @@
 -- Decorate defines for the MSVC command line.
 --
 
-	function msc.getdefines(defines)
-		local result = {}
+	msc.defines = {
+		characterset = {
+			Default = { '/D"_UNICODE"', '/D"UNICODE"' },
+			MBCS = '/D"_MBCS"',
+			Unicode = { '/D"_UNICODE"', '/D"UNICODE"' },
+		}
+	}
+
+	function msc.getdefines(defines, cfg)
+		local result
+
+		-- HACK: I need the cfg to tell what the character set defines should be. But
+		-- there's lots of legacy code using the old getdefines(defines) signature.
+		-- For now, detect one or two arguments and apply the right behavior; will fix
+		-- it properly when the I roll out the adapter overhaul
+		if cfg and defines then
+			result = config.mapFlags(cfg, msc.defines)
+		else
+			result = {}
+		end
+
 		for _, define in ipairs(defines) do
 			table.insert(result, '/D"' .. define .. '"')
 		end

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -29,6 +29,11 @@
 --
 
 	msc.cflags = {
+		characterset = {
+			Default = { '/D"_UNICODE"', '/D"UNICODE"' },
+			MBCS = '/D"_MBCS"',
+			Unicode = { '/D"_UNICODE"', '/D"UNICODE"' },
+		},
 		clr = {
 			On = "/clr",
 			Unsafe = "/clr",

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -196,7 +196,7 @@
 	function suite.defines()
 		defines "DEF"
 		prepare()
-		test.contains({ '/D"DEF"' }, msc.getdefines(cfg.defines))
+		test.contains({ '/D"DEF"' }, msc.getdefines(cfg.defines, cfg))
 	end
 
 	function suite.undefines()
@@ -317,19 +317,19 @@
 
 	function suite.cflags_onCharSetDefault()
 		prepare()
-		test.contains('/D"_UNICODE"', msc.getcflags(cfg))
+		test.contains('/D"_UNICODE"', msc.getdefines(cfg.defines, cfg))
 	end
 
 	function suite.cflags_onCharSetUnicode()
 		characterset "Unicode"
 		prepare()
-		test.contains('/D"_UNICODE"', msc.getcflags(cfg))
+		test.contains('/D"_UNICODE"', msc.getdefines(cfg.defines, cfg))
 	end
 
 	function suite.cflags_onCharSetMBCS()
 		characterset "MBCS"
 		prepare()
-		test.contains('/D"_MBCS"', msc.getcflags(cfg))
+		test.contains('/D"_MBCS"', msc.getdefines(cfg.defines, cfg))
 	end
 
 

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -312,6 +312,28 @@
 
 
 --
+-- Check handling of character set switches
+--
+
+	function suite.cflags_onCharSetDefault()
+		prepare()
+		test.contains('/D"_UNICODE"', msc.getcflags(cfg))
+	end
+
+	function suite.cflags_onCharSetUnicode()
+		characterset "Unicode"
+		prepare()
+		test.contains('/D"_UNICODE"', msc.getcflags(cfg))
+	end
+
+	function suite.cflags_onCharSetMBCS()
+		characterset "MBCS"
+		prepare()
+		test.contains('/D"_MBCS"', msc.getcflags(cfg))
+	end
+
+
+--
 -- Check handling of system search paths.
 --
 
@@ -342,3 +364,4 @@
 		prepare()
 		test.contains('/NODEFAULTLIB:lib1.lib', msc.getldflags(cfg))
 	end
+


### PR DESCRIPTION
This completes the `characterset()` feature by adding the required `/D"_UNICODE" /D"UNICODE"` and `/D"_MBCS" ` flags to the MSC compiler command line.