### PR TITLE
Add support for DOS-style environment variables, e.g. %JAVA_HOME%

### DIFF
--- a/src/host/path_getabsolute.c
+++ b/src/host/path_getabsolute.c
@@ -40,7 +40,7 @@ void do_getabsolute(char* result, const char* value, const char* relative_to)
 	ch = strtok(buffer, "/");
 	while (ch) {
 		/* remove ".." where I can */
-		if (strcmp(ch, "..") == 0 && (prev == NULL || (prev[0] != '$' && strcmp(prev, "..") != 0))) {
+		if (strcmp(ch, "..") == 0 && (prev == NULL || (prev[0] != '$' && prev[0] != '%' && strcmp(prev, "..") != 0))) {
 			i = strlen(result) - 2;
 			while (i >= 0 && result[i] != '/') {
 				--i;

--- a/src/host/path_isabsolute.c
+++ b/src/host/path_isabsolute.c
@@ -21,7 +21,9 @@ int do_isabsolute(const char* path)
 		path[0] == '/' ||
 		path[0] == '\\' ||
 		path[0] == '$' ||
+		path[0] == '%' ||
 		(path[0] == '"' && path[1] == '$') ||
+		(path[0] == '"' && path[1] == '%') ||
 		(path[0] != '\0' && path[1] == ':')
 	);
 }

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -44,6 +44,10 @@
 		test.isequal("$(HOME)/user", path.getabsolute("$(HOME)/user"))
 	end
 
+	function suite.getabsolute_onLeadingEnvVar_dosStyle()
+		test.isequal("%HOME%/user", path.getabsolute("%HOME%/user"))
+	end
+
 	function suite.getabsolute_onMultipleEnvVar()
 		test.isequal("$(HOME)/$(USER)", path.getabsolute("$(HOME)/$(USER)"))
 	end
@@ -437,7 +441,7 @@
 		local p = path.normalize("../../../test/*.h")
 		test.isequal("../../../test/*.h", p)
 	end
-	
+
 	function suite.normalize_Test5()
 		test.isequal("test", path.normalize("./test"))
 		test.isequal("d:/", path.normalize("d:/"))
@@ -465,11 +469,11 @@
 		test.isequal("d:/ProjectB/bin", path.normalize("d:/ProjectA/../ProjectB/bin"))
 		test.isequal("/ProjectB/bin", path.normalize("/ProjectA/../ProjectB/bin"))
 	end
-	
+
 	function suite.normalize_leadingWhitespaces()
 		test.isequal("d:/game", path.normalize("\t\n d:/game"))
 	end
-	
+
 	function suite.normalize_multPath()
 		test.isequal("../a/b ../c/d", path.normalize("../a/b ../c/d"))
 		test.isequal("d:/test ../a/b", path.normalize("d:/game/../test ../a/b"))


### PR DESCRIPTION
We currently recognize paths that start with an environment variable like `$(HOME)` and treat them as absolute. This treats DOS-style variables like `%JAVA_HOME%` the same way.