### PR TITLE
add logging in p.project.bake.

### DIFF
--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -118,6 +118,8 @@
 
 
 	function p.project.bake(self)
+		verbosef('    Baking %s...', self.name)
+
 		self.solution = self.workspace
 		local wks = self.workspace
 


### PR DESCRIPTION
It only logs this super useful line when you specify --verbose.
I've contemplated leaving this as one of our local changes, but the change has helped us so much in tracking down different issues, I figure I might as well commit this.