### PR TITLE
Reverse operation of  bytecode embedding flag

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -74,8 +74,8 @@
 	}
 
 	newoption {
-		trigger     = "no-bytecode",
-		description = "Don't embed bytecode, but instead use the stripped souce code."
+		trigger     = "bytecode",
+		description = "Embed scripts as bytecode instead of stripped souce code"
 	}
 
 --

--- a/scripts/embed.lua
+++ b/scripts/embed.lua
@@ -1,8 +1,8 @@
 --
 -- Embed the Lua scripts into src/host/scripts.c as static data buffers.
--- I embed the actual scripts, rather than Lua bytecodes, because the
--- bytecodes are not portable to different architectures, which causes
--- issues in Mac OS X Universal builds.
+-- Embeds minified versions of the actual scripts by default, rather than
+-- bytecode, as bytecodes are not portable to different architectures. Use
+-- the `--bytecode` flag to override.
 --
 
 	local scriptCount = 0
@@ -67,7 +67,7 @@
 
 	local function addScript(result, filename, name, data)
 		if not data then
-			if not _OPTIONS["no-bytecode"] then
+			if _OPTIONS["bytecode"] then
 				verbosef("Compiling... " .. filename)
 				local output = path.replaceextension(filename, ".luac")
 				local res, err = os.compile(filename, output);

--- a/scripts/package.lua
+++ b/scripts/package.lua
@@ -111,7 +111,11 @@
 --
 
 	print("Updating embedded scripts...")
-	z = execQuiet("premake5 embed")
+	if kind == "source" then
+		z = execQuiet("premake5 embed")
+	else
+		z = execQuiet("premake5 --bytecode embed")
+	end
 	if z ~= 0 then
 		error("failed to update the embedded scripts", 0)
 	end


### PR DESCRIPTION
…: from `--no-bytecode` to `--bytecode`.

See [issue #384](https://github.com/premake/premake-core/issues/384) for more information