### PR TITLE
Fixed os.outputof to redirect standard streams to capture all output

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -373,7 +373,7 @@
 	function os.outputof(cmd)
 		cmd = path.normalize(cmd)
 
-		local pipe = io.popen(cmd)
+		local pipe = io.popen(cmd .. " 2>&1")
 		local result = pipe:read('*a')
 		local b, exitcode = pipe:close()
 		if not b then


### PR DESCRIPTION
As the title says, this redirect the stream so that we can fully get the output of the command as it appears in the shell.

I've been using this fix in my code for a bit, without it the output of `outputof` does not match what is expected in a lot of cases.

For instance, in this pretty simple case Premake would only capture the last line of the output.

```>cl
Microsoft (R) C/C++ Optimizing Compiler Version 19.00.23506 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

usage: cl [ option... ] filename... [ /link linkoption... ]```
