### PR TITLE
Remove debug settings from core build scripts

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -136,8 +136,6 @@
 			targetdir   "bin/debug"
 			defines     "_DEBUG"
 			flags       { "Symbols" }
-			debugargs   { "--scripts=" .. path.translate(os.getcwd()) .. " test"}
-			debugdir    ( os.getcwd() )
 
 		configuration "Release"
 			targetdir   "bin/release"


### PR DESCRIPTION
These debug settings cause the absolute path to the local premake-core project to be written into the Visual Studio .user file. This isn't a portable path, and shouldn't be generated by the distributed project scripts.