### PR TITLE
Add Build Customizations option

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -78,6 +78,12 @@
 	}
 
 	api.register {
+		name = "buildcustomizations",
+		scope = "project",
+		kind = "list:string",
+	}
+
+	api.register {
 		name = "builddependencies",
 		scope = { "rule" },
 		kind = "list:string",

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1333,7 +1333,7 @@
 
 	function m.importBuildCustomizationsTargets(prj)
 		for i, build in ipairs(prj.buildcustomizations) do
-	      premake.w('<Import Project="$(VCTargetsPath)\\BuildCustomizations\\%s.targets" />', path.translate(build))
+	      premake.w('<Import Project="$(VCTargetsPath)\\%s.targets" />', path.translate(build))
 	   end
 	end
 
@@ -1372,7 +1372,7 @@
 
 	function m.importBuildCustomizationsProps(prj)
 		for i, build in ipairs(prj.buildcustomizations) do
-	      premake.w('<Import Project="$(VCTargetsPath)\\BuildCustomizations\\%s.props" />', path.translate(build))
+	      premake.w('<Import Project="$(VCTargetsPath)\\%s.props" />', path.translate(build))
 	   end
 	end
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1313,6 +1313,7 @@
 	m.elements.importExtensionTargets = function(prj)
 		return {
 			m.importRuleTargets,
+			m.importBuildCustomizationsTargets
 		}
 	end
 
@@ -1330,6 +1331,12 @@
 		end
 	end
 
+	function m.importBuildCustomizationsTargets(prj)
+		for i, build in ipairs(prj.buildcustomizations) do
+	      premake.w('<Import Project="$(VCTargetsPath)\\BuildCustomizations\\%s.targets" />', path.translate(build))
+	   end
+	end
+
 
 
 	function m.importDefaultProps(prj)
@@ -1345,6 +1352,7 @@
 	m.elements.importExtensionSettings = function(prj)
 		return {
 			m.importRuleSettings,
+			m.importBuildCustomizationsProps
 		}
 	end
 
@@ -1360,6 +1368,12 @@
 			local loc = vstudio.path(prj, p.filename(rule, ".props"))
 			p.x('<Import Project="%s" />', loc)
 		end
+	end
+
+	function m.importBuildCustomizationsProps(prj)
+		for i, build in ipairs(prj.buildcustomizations) do
+	      premake.w('<Import Project="$(VCTargetsPath)\\BuildCustomizations\\%s.props" />', path.translate(build))
+	   end
 	end
 
 


### PR DESCRIPTION
Support Build Customization settings for projects. Now Premake5 can
recognize Build Customizations File that 3rd party API (e.g. CUDA)
maded.

Use this like : 
buildcustomizations{ "CUDA 7.5" } in the project