### PR TITLE
Fix a new Visual Studio unused variable build warning

### DIFF
--- a/src/host/os_isfile.c
+++ b/src/host/os_isfile.c
@@ -18,7 +18,6 @@ int os_isfile(lua_State* L)
 
 int do_isfile(const char* filename)
 {
-	struct stat buf;
 #if PLATFORM_WINDOWS
 	DWORD attrib = GetFileAttributesA(filename);
 	if (attrib != INVALID_FILE_ATTRIBUTES)
@@ -26,6 +25,7 @@ int do_isfile(const char* filename)
 		return (attrib & FILE_ATTRIBUTE_DIRECTORY) == 0;
 	}
 #else
+	struct stat buf;
 	if (stat(filename, &buf) == 0)
 	{
 		return ((buf.st_mode & S_IFDIR) == 0);


### PR DESCRIPTION
We have warnings-as-errors turned on here; need these fixed.