### PR TITLE
Allow dot in path variables

### DIFF
--- a/src/host/path_isabsolute.c
+++ b/src/host/path_isabsolute.c
@@ -1,7 +1,7 @@
 /**
  * \file   path_isabsolute.c
  * \brief  Determines if a path is absolute or relative.
- * \author Copyright (c) 2002-2013 Jason Perkins and the Premake project
+ * \author Copyright (c) 2002-2016 Jason Perkins and the Premake project
  */
 
 #include "premake.h"
@@ -37,10 +37,10 @@ int do_isabsolute(const char* path)
 		if (closing == NULL)
 			return 0;
 
-		// only alpha, digits and _ allowed inside $()
+		// only alpha, digits, _ and . allowed inside $()
 		while (path < closing) {
 			c = *path++;
-			if (!isalpha(c) && !isdigit(c) && c != '_')
+			if (!isalpha(c) && !isdigit(c) && c != '_' && c != '.')
 				return 0;
 		}
 

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -242,6 +242,10 @@
 		test.istrue(path.isabsolute("$(SDK_HOME)/include"))
 	end
 
+	function suite.isabsolute_ReturnsTrue_OnDotInDollarToken()
+		test.istrue(path.isabsolute("$(configuration.libs)/include"))
+	end
+
 	function suite.isabsolute_ReturnsTrue_OnJustADollarSign()
 		test.istrue(path.isabsolute("$foo/include"))
 	end


### PR DESCRIPTION
Some environments and toolsets allow additional characters within $(.…) tokens. Adding the dot "."