### PR TITLE
Add NuGet submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "modules/d"]
 	path = modules/d
 	url = https://github.com/premake/premake-dlang.git
+[submodule "modules/nuget"]
+	path = modules/nuget
+	url = https://github.com/aleksijuvani/premake-nuget.git

--- a/src/_modules.lua
+++ b/src/_modules.lua
@@ -9,4 +9,5 @@
 		"monodevelop",
 		"codelite",
 		"d",
+		"nuget",
 	}


### PR DESCRIPTION
As discussed in issue #197. NuGet is the package manager included in recent versions of Visual&nbsp;Studio. This pull request will add a new function called `nuget` that can be used to specify these package dependencies for C++ and C# projects.

Syntax is as follows:

```lua
nuget { "package:version" } -- in project scope
```

Please review. I've tested this functionality with a personal project of mine, but it wouldn't hurt to have some more eyes on this.