### PR TITLE
Update require to resolve modules that are placed in default location

### DIFF
--- a/src/_manifest.lua
+++ b/src/_manifest.lua
@@ -18,6 +18,7 @@
 		"base/io.lua",
 		"base/tools.lua",
 		"base/tree.lua",
+        "base/moduleresolver.lua",
 		"base/globals.lua",
 		"base/semver.lua",
 

--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -74,13 +74,24 @@
 ---
 
 	premake.override(_G, "require", function(base, modname, versions)
-		local result, mod = pcall(base,modname)
+        local result, resmod = pcall(premake.moduleresolver.resolveModule, modname)
+        
+        if result then
+            modname = resmod
+            resmod = ""
+        end
+        
+        local mod
+        result, mod, versions = pcall(base, modname, versions)
+        
 		if not result then
-			error( mod, 3 )
+			error(mod .. resmod, 3)
 		end
+        
 		if mod and versions and not premake.checkVersion(mod._VERSION, versions) then
 			error(string.format("module %s %s does not meet version criteria %s",
 				modname, mod._VERSION or "(none)", versions), 3)
 		end
+        
 		return mod
 	end)

--- a/src/base/moduleresolver.lua
+++ b/src/base/moduleresolver.lua
@@ -1,0 +1,90 @@
+--
+-- moduleresolver.lua
+-- 
+-- Provides a strategy for module resolution to modules that are placed within the default module's directory. 
+-- 
+-- Copyright (c) 2002-2014 Jason Perkins and the Premake project
+--
+
+    local p = premake
+
+    p.moduleresolver = {}
+
+    local moduleresolver = p.moduleresolver
+
+---
+-- Check whether the module is either a path to a module or a module's name.
+--
+
+    function moduleresolver.isModulePath(module)
+        return string.contains(module, "/") or string.contains(module, "\\")
+    end
+    
+--
+-- Get the name of the default module's directory.
+--
+
+    function moduleresolver.getDefaultModuleDirectory()
+        return ".premake"
+    end
+    
+---
+-- Get the path to the default module's directory.
+--
+
+    function moduleresolver.getDefaultModulePath(modulePath)
+        return modulePath and path.join(moduleresolver.getDefaultModuleDirectory(), path.appendExtension(modulePath, ".lua")) or modulePath
+    end
+    
+--
+-- Search the module recursively, 
+-- it starts at some unknown path and walks up to the root.
+--
+
+    local function searchModuleFile(searchPath, modulePath, trackedPaths)
+        trackedPaths = trackedPaths or {}
+        local fullpath = path.join(searchPath, modulePath)
+        table.insert(trackedPaths, fullpath)
+        if not os.isfile(fullpath) then
+            searchPath = path.getdirectory(searchPath) 
+            fullpath = searchPath ~= "." and searchModuleFile(searchPath, modulePath, trackedPaths) or nil
+        end
+        return fullpath, trackedPaths
+    end
+
+    moduleresolver.searchModuleFile = searchModuleFile
+    
+--
+-- Get the relative module's path.
+--
+
+    function moduleresolver.getRelativeModulePath(currentWorkingDir, modulePath)
+        return modulePath and path.getrelative(currentWorkingDir, modulePath) or modulePath
+    end
+    
+--
+-- The strategy for module resolution is as follow:
+--  1. When the module is a name then:
+--      1. It gets the default location that is .premake/<module> or .premake/<module>.lua
+--      2. It searches the module, starting at the current working directory and walks up to the root.
+--      3. It gets the relative path for the module.
+--      4. Finally, if there's an error it fail-fast.
+--  2. When the module is a path then it does nothing.
+--  3. Finally, returns with the module.
+--
+
+    function moduleresolver.resolveModule(module)
+        local originalModule = module
+        if not moduleresolver.isModulePath(module) then 
+            local trackedPaths
+            local currentWorkingDir = os.getcwd()
+            module = moduleresolver.getDefaultModulePath(module)
+            module, trackedPaths = moduleresolver.searchModuleFile(currentWorkingDir, module)
+            module = moduleresolver.getRelativeModulePath(currentWorkingDir, module)
+            if not module then
+                error(string.format("\nmodule '%s' not resolved:\n\t%s", originalModule, table.concat(trackedPaths, "\n\t")), 3)
+            end
+        end
+        return path.replaceextension(module, "")
+    end
+

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -8,6 +8,7 @@ return {
 	"base/test_detoken.lua",
 	"base/test_include.lua",
 	"base/test_module_loader.lua",
+    "base/test_moduleresolver.lua",
 	"base/test_option.lua",
 	"base/test_os.lua",
 	"base/test_override.lua",

--- a/tests/base/test_moduleresolver.lua
+++ b/tests/base/test_moduleresolver.lua
@@ -1,0 +1,171 @@
+--
+-- tests/base/test_moduleresolver.lua
+-- Test the module resolver.
+--
+-- Copyright (c) 2012-2015 Jason Perkins and the Premake project
+--
+
+    local suite = test.declare("moduleresolver")
+
+    local moduleresolver = premake.moduleresolver
+    
+    local _getcwd = os.getcwd
+    local _isfile = os.isfile
+    
+    function suite.teardown()
+        os.getcwd = _getcwd
+        os.isfile = _isfile
+	end
+    
+--
+-- isModulePath should return true when it contains slashes; otherwise, false.
+--
+    
+    function suite.isModulePath_ReturnTrue_OnLeftSlash()
+		test.istrue(moduleresolver.isModulePath("/foo"))
+	end
+    
+    function suite.isModulePath_ReturnTrue_OnRightSlash()
+		test.istrue(moduleresolver.isModulePath("foo\\"))
+	end
+    
+    function suite.isModulePath_ReturnFalse_OnFilenameWithoutSlashes()
+		test.isfalse(moduleresolver.isModulePath("foo"))
+	end
+    
+    function suite.isModulePath_ReturnFalse_OnFilenameWithExtButWithoutSlashes()
+		test.isfalse(moduleresolver.isModulePath("foo.lua"))
+	end
+    
+--
+-- getDefaultModuleDirectory should return the default module's directory.
+--
+
+    function suite.getDefaultModuleDirectory_ReturnDefaultDirectoryName()
+        test.isequal(".premake", moduleresolver.getDefaultModuleDirectory())
+	end
+    
+--
+-- getDefaultModulePath should return the default module's path.
+--
+
+    function suite.getDefaultModulePath_ReturnDefaultDirectoryName_OnPathWithoutExtension()
+        test.isequal(".premake/foo.lua", moduleresolver.getDefaultModulePath("foo"))
+	end
+    
+    function suite.getDefaultModulePath_ReturnDefaultDirectoryName_OnPathWithExtension()
+        test.isequal(".premake/foo.lua", moduleresolver.getDefaultModulePath("foo.lua"))
+	end
+    
+--
+-- searchModuleFile should return with a valid path; otherwise, when it is invalid it should return "." 
+--
+
+    function suite.searchModuleFile_ReturnWithValidPath_OnTop()
+        local expectedModuleFile = "d:/foo/bar/baz/.premake/foo.lua"
+        
+        os.isfile = function(file)
+            return file == expectedModuleFile
+        end
+        
+        local actualModuleFile, trackedPaths = moduleresolver.searchModuleFile("d:/foo/bar/baz", ".premake/foo.lua")
+        
+        test.isequal(expectedModuleFile, actualModuleFile)
+	end
+    
+    function suite.searchModuleFile_ReturnWithValidPath_OnBottom()
+        local expectedModuleFile = "d:/.premake/foo.lua"
+        
+        os.isfile = function(file)
+            return file == expectedModuleFile
+        end
+        
+        local actualModuleFile, trackedPaths = moduleresolver.searchModuleFile("d:/foo/bar/baz", ".premake/foo.lua")
+
+        test.isequal(expectedModuleFile, actualModuleFile) 
+	end
+    
+    function suite.searchModuleFile_ReturnWithInvalidPath()
+        os.isfile = function(file)
+            return false
+        end
+        
+        local moduleFile, trackedPaths = moduleresolver.searchModuleFile("d:/foo/bar/baz", ".premake/foo.lua")
+        
+        test.isnil(moduleFile)
+	end
+    
+--
+-- resolveModule should either return with the path that was provided by the user or the searched path; otherwise, it should fail-fast.
+--
+
+    function suite.resolveModule_ReturnWithUserProvidedPath()
+        test.isequal("bar/foo", moduleresolver.resolveModule("bar/foo"))
+	end
+    
+    function suite.resolveModule_ReturnWithNoExtension()
+        test.isequal("bar/foo", moduleresolver.resolveModule("bar/foo.lua"))
+	end
+    
+    function suite.resolveModule_ReturnWithSearchResults()
+        os.getcwd = function()
+            return "d:/foo/bar/baz"
+        end
+        
+        os.isfile = function(file)
+            return file == "d:/foo/.premake/foo.lua"
+        end
+
+        test.isequal("../../.premake/foo", moduleresolver.resolveModule("foo")) 
+	end
+    
+    function suite.resolveModule_FailWithError_OnNoSearchResults()
+        os.getcwd = function()
+            return "d:/foo/bar/baz"
+        end
+
+        os.isfile = function(file)
+            return false
+        end
+
+        local success = pcall(moduleresolver.resolveModule, "foo")
+        
+        test.isfalse(success) 
+	end
+    
+--
+-- require tests
+--
+
+    function suite.require_FailWithError_OnSuccessfulModuleResolution()
+        os.getcwd = function()
+            return "d:/foo/bar/baz"
+        end
+
+        os.isfile = function(file)
+            return true
+        end
+
+        local success, err = pcall(require, "foobaz")
+        
+        test.istrue(not success and string.contains(err, "module '.premake/foobaz' not found:") 
+                                and not string.contains(err, "module 'foobaz' not resolved:")) 
+	end
+    
+    function suite.require_FailWithError_OnFailedModuleResolution()
+        os.getcwd = function()
+            return "d:/foo/bar/baz"
+        end
+
+        os.isfile = function(file)
+            return false
+        end
+
+        local success, err = pcall(require, "foobaz")
+        
+        test.istrue(not success and string.contains(err, "module 'foobaz' not found") 
+                                and string.contains(err, "module 'foobaz' not resolved:")) 
+	end
+
+
+    


### PR DESCRIPTION
Provides a strategy for module resolution to modules that are placed within the default module's directory that is `.premake/<module>` or `.premake/<module>.lua`

The search starts at the current working directory of the running premake script and walks up to the root.