### PR TITLE
add 'nested' kind for premake.api.register

### DIFF
--- a/src/_manifest.lua
+++ b/src/_manifest.lua
@@ -44,6 +44,7 @@
 		"base/config.lua",
 		"base/fileconfig.lua",
 		"base/rule.lua",
+		"base/nested.lua",
 
 		-- project script processing
 		"base/oven.lua",

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -1092,6 +1092,31 @@
 	})
 
 
+--
+-- nested data kind; wraps simple values into a table, returns others as-is.
+--
+	premake.field.kind("nested", {
+		store = function(field, current, value, processor)
+			-- create meta-table.
+			if not current then
+				current = p.nested.create(field)
+			end
+
+			-- copy values.
+			for name, v in pairs(value) do
+				current[name] = v
+			end
+
+			-- return result.
+			return current
+		end,
+		compare = function(field, a, b, processor)
+			-- TODO: is there a reliable way to check this?
+			return true
+		end
+	})
+
+
 
 ---
 -- Start a new block of configuration settings, using the old, "open"

--- a/src/base/nested.lua
+++ b/src/base/nested.lua
@@ -1,0 +1,43 @@
+--
+-- nested.lua
+-- Copyright (c) 2008-2016 Jason Perkins and the Premake project
+--
+
+	local p = premake
+
+	p.nested = {}
+	local nested = p.nested
+
+	function nested.create(field)
+		local fld = field
+		local mt = {
+			__newindex = function(tbl, key, value)
+				local f = fld.fields[key]
+				if f then
+					local t = rawget(tbl, 'values')
+					rawset(t, key, p.field.store(f, t[key], value))
+				else
+					error("Nested type '" .. field.name .. "' does not have field '".. name .. "'.")
+				end
+			end,
+			__index = function(tbl, key)
+				local f = fld.fields[key]
+				if f then
+					local t = rawget(tbl, 'values')
+					return rawget(t, key)
+				else
+					return rawget(tbl, key)
+				end
+			end
+		}
+
+		local result = {}
+		result.name = field.name
+		result.script = _SCRIPT
+		result.basedir = os.getcwd()
+		result.values = {}
+		setmetatable(result, mt)
+
+		return result
+	end
+


### PR DESCRIPTION
This allows you to do this:

```lua
premake.api.register {
    name     = "schemacompiler",
    scope    = "config",
    kind     = "nested",
    fields   = {
        template = {
            kind     = "path",
            tokens   = true,
            pathVars = true
        },
        inputs = {
            kind     = "list:path",
            tokens   = true,
            pathVars = true
        },
        outputs = {
            kind     = "list:path",
            tokens   = true,
            pathVars = true
        }
    }
}
```