### PR TITLE
optimize copyFilters/mergeFilters

### DIFF
--- a/src/base/context.lua
+++ b/src/base/context.lua
@@ -94,7 +94,10 @@
 --
 
 	function context.copyFilters(ctx, src)
-		ctx.terms = table.deepcopy(src.terms)
+		ctx.terms = {}
+		for k,v in pairs(src.terms) do
+			ctx.terms[k] = v
+		end
 	end
 
 
@@ -109,22 +112,9 @@
 --
 
 	function context.mergeFilters(ctx, src)
-
-		local function mergeTable(dest, src)
-			for k,v in pairs(src) do
-				if type(v) == "table" then
-					if type(dest[k]) == "table" then
-						dest[k] = mergeTable(dest[k], v)
-					else
-						dest[k] = table.deepcopy(v)
-					end
-				else
-					dest[k] = v
-				end
-			end
+		for k,v in pairs(src.terms) do
+			ctx.terms[k] = v
 		end
-
-		mergeTable(ctx.terms, src.terms)
 	end
 
 


### PR DESCRIPTION
As discussed on the forum...

This is the change where it became a deepcopy:
https://github.com/premake/premake-core/commit/28cfa55886ba3534bee9f02acb68770e599f5221#diff-3d9540042f8ef52dc7d1387a1ecbf71bL89

table.arraycopy however does an indexed copy of the table, which is indeed not what we want, since this is a 'keyed' table.. so instead of looping with 'ipairs', we definitely need to loop using 'pairs', but I don't think a deep copy is required.

Our projects seem to function correctly with this change.

