### PR TITLE
We want the packages table to be in the order we specified.

### DIFF
--- a/src/actions/vstudio/vs2010_nuget.lua
+++ b/src/actions/vstudio/vs2010_nuget.lua
@@ -61,13 +61,15 @@
 	function nuget2010.generatePackagesConfig(obj)
 		local wks = obj.workspace
 
+		local done = {}
 		local packages = {}
 		for prj in p.workspace.eachproject(wks) do
 			for i = 1, #prj.nuget do
 				local package = prj.nuget[i]
 
-				if not packages[package] then
-					packages[package] = true
+				if not done[package] then
+					done[package] = true
+					table.insert(packages, package)
 				end
 			end
 		end
@@ -75,7 +77,7 @@
 		p.w('<?xml version="1.0" encoding="utf-8"?>')
 		p.push('<packages>')
 
-		for package in pairs(packages) do
+		for _, package in ipairs(packages) do
 			p.x('<package id="%s" version="%s" targetFramework="%s" />', nuget2010.packageId(package), nuget2010.packageVersion(package), nuget2010.packageFramework(wks, package))
 		end
 


### PR DESCRIPTION
So the "packages" table in the current implementation is in whatever order the hashtable sees fit... on newer version of lua, this seems to be a lot more unstable. The fixes below retains the order of the original prj.nuget list, while still achieving the same 'de-duplication' effects.

This made the tests on our buildfarm pass as well.