### PR TITLE
Fix optimize "Debug" for Clang

### DIFF
--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -41,11 +41,36 @@
 --    An array of C compiler flags.
 --
 
+	clang.cflags = {
+		architecture = gcc.cflags.architecture,
+		flags = gcc.cflags.flags,
+		floatingpoint = gcc.cflags.floatingpoint,
+		strictaliasing = gcc.cflags.strictaliasing,
+		optimize = {
+			Off = "-O0",
+			On = "-O2",
+			Debug = "-O0",
+			Full = "-O3",
+			Size = "-Os",
+			Speed = "-O3",
+		},
+		pic = gcc.cflags.pic,
+		vectorextensions = gcc.cflags.vectorextensions,
+		warnings = gcc.cflags.warnings
+	}
+
 	function clang.getcflags(cfg)
 
-		-- Just pass through to GCC for now
-		local flags = gcc.getcflags(cfg)
+		local flags = config.mapFlags(cfg, clang.cflags)
+		flags = table.join(flags, clang.getwarnings(cfg))
 		return flags
+
+	end
+
+	function clang.getwarnings(cfg)
+
+		-- Just pass through to GCC for now
+		return gcc.getwarnings(cfg)
 
 	end
 


### PR DESCRIPTION
See [issue #252 on Bitbucket](https://bitbucket.org/premake/premake-dev/issues/252/optimize-debug-generates-invalid-option).

When using the "Debug" option for `optimize`, the flag `-Og` is generated for Clang. This is not a valid option (it is valid and appropriate for GCC). When trying to compile, Clang will throw the following error message:

```
error: integral value 'g' in '-Og'
```

Since Clang doesn't have an equivalent for `-Og`, this pull request will change Clang to use `-O0` when `optimize "Debug"` is specified.

This change will [break a test in the CodeLite module](https://github.com/premake/premake-codelite/blob/master/tests/test_codelite_config.lua#L47), which will need to be changed to check for `-O0` instead of `-Og`. Should I also create a pull request there to be merged simultaneously with this one?

Let me know if anything needs to be changed, or if this isn't the way to go about doing this.