### PR TITLE
Only output NuGet project element if packages were listed by the project

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1434,16 +1434,18 @@
 
 
 	function m.ensureNuGetPackageBuildImports(prj)
-		p.push('<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">')
-		p.push('<PropertyGroup>')
-		p.x('<ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>')
-		p.pop('</PropertyGroup>')
+		if #prj.nuget > 0 then
+			p.push('<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">')
+			p.push('<PropertyGroup>')
+			p.x('<ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>')
+			p.pop('</PropertyGroup>')
 
-		for i = 1, #prj.nuget do
-			local targetsFile = nuGetTargetsFile(prj, prj.nuget[i])
-			p.x('<Error Condition="!Exists(\'%s\')" Text="$([System.String]::Format(\'$(ErrorText)\', \'%s\'))" />', targetsFile, targetsFile)
+			for i = 1, #prj.nuget do
+				local targetsFile = nuGetTargetsFile(prj, prj.nuget[i])
+				p.x('<Error Condition="!Exists(\'%s\')" Text="$([System.String]::Format(\'$(ErrorText)\', \'%s\'))" />', targetsFile, targetsFile)
+			end
+			p.pop('</Target>')
 		end
-		p.pop('</Target>')
 	end
 
 

--- a/tests/actions/vstudio/vc2010/test_ensure_nuget_imports.lua
+++ b/tests/actions/vstudio/vc2010/test_ensure_nuget_imports.lua
@@ -27,6 +27,17 @@
 
 
 --
+-- Should not output anything if no packages have been set.
+--
+
+	function suite.noOutputIfNoPackages()
+		prepare()
+		test.isemptycapture()
+	end
+
+
+
+--
 -- Writes the pre-build check that makes sure that all packages are installed.
 --
 


### PR DESCRIPTION
This makes the project output match Visual Studio's default (for VS 2010-2013); if no NuGet projects have been added, the NuGet Target element is skipped.