### PR TITLE
Fix default entry point for Windows console applications

### DIFF
--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -1121,7 +1121,7 @@
 
 
 	function m.entryPointSymbol(cfg, toolset)
-		if (cfg.kind == "ConsoleApp" or cfg.kind == "WindowedApp") and
+		if cfg.kind == "WindowedApp" and
 			not cfg.flags.WinMain and
 			not toolset
 		then

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1221,7 +1221,7 @@
 		if cfg.entrypoint then
 			m.element("EntryPointSymbol", nil, cfg.entrypoint)
 		else
-			if (cfg.kind == premake.CONSOLEAPP or cfg.kind == premake.WINDOWEDAPP) and
+			if cfg.kind == premake.WINDOWEDAPP and
 				not cfg.flags.WinMain and
 				cfg.clr == p.OFF and
 				cfg.system ~= p.XBOX360

--- a/tests/actions/vstudio/vc200x/test_linker_block.lua
+++ b/tests/actions/vstudio/vc200x/test_linker_block.lua
@@ -40,7 +40,6 @@
 	LinkIncremental="2"
 	GenerateDebugInformation="false"
 	SubSystem="1"
-	EntryPointSymbol="mainCRTStartup"
 	TargetMachine="1"
 />
 		]]
@@ -137,7 +136,6 @@
 	LinkIncremental="2"
 	GenerateDebugInformation="true"
 	SubSystem="1"
-	EntryPointSymbol="mainCRTStartup"
 	TargetMachine="1"
 />
 		]]

--- a/tests/actions/vstudio/vc2010/test_excluded_configs.lua
+++ b/tests/actions/vstudio/vc2010/test_excluded_configs.lua
@@ -52,7 +52,6 @@
 <Link>
 	<SubSystem>Console</SubSystem>
 	<GenerateDebugInformation>false</GenerateDebugInformation>
-	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 </Link>
 		]]
 	end
@@ -72,7 +71,6 @@
 	<SubSystem>Console</SubSystem>
 	<GenerateDebugInformation>false</GenerateDebugInformation>
 	<AdditionalDependencies>bin\Ares\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
-	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 </Link>
 <ProjectReference>
 	<LinkLibraryDependencies>false</LinkLibraryDependencies>

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -74,7 +74,6 @@
 <Link>
 	<SubSystem>Console</SubSystem>
 	<GenerateDebugInformation>false</GenerateDebugInformation>
-	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 		]]
 	end
 
@@ -423,7 +422,6 @@
 <Link>
 	<SubSystem>Console</SubSystem>
 	<GenerateDebugInformation>false</GenerateDebugInformation>
-	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 	<TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
 		]]
 	end


### PR DESCRIPTION
By default, projects created for console applications through Visual Studio don't explicitly specify the entry point symbol; the linker automatically detects whether `mainCRTStartup` or `wmainCRTStartup` should be used based on whether `main()` or the Windows-specific `wmain()` is defined. The current behavior of Premake is to explicitly use `mainCRTStartup` in both windowed and console applications if the `WinMain` flag is not set, preventing the use of `wmain()` in console applications unless the entry point is explicitly set in the project configuration.

This change makes it so Premake does not explicitly specify the entry point symbol for Windows console applications, allowing `wmain()` to be used without the need for additional configuration settings.

This doesn't address the use of `mainCRTStartup` or `wmainCRTStartup` for windowed applications if the `WinMain` flag is not set, as that would likely break existing projects (explicitly specifying one or the other forces the use of either `main()` or `wmain()`, respectively).
