### PR TITLE
Add 'Installer' kind to support external vdproj files.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -667,6 +667,7 @@
 			"StaticLib",
 			"WindowedApp",
 			"Utility",
+			"Installer",
 		},
 	}
 

--- a/src/actions/vstudio/_vstudio.lua
+++ b/src/actions/vstudio/_vstudio.lua
@@ -473,7 +473,9 @@
 
 	function vstudio.projectfile(prj)
 		local extension
-		if project.isdotnet(prj) then
+		if project.isinstaller(prj) then
+			extension = ".vdproj"
+		elseif project.isdotnet(prj) then
 			extension = ".csproj"
 		elseif project.iscpp(prj) then
 			extension = iif(_ACTION > "vs2008", ".vcxproj", ".vcproj")
@@ -649,7 +651,9 @@
 --
 
 	function vstudio.tool(prj)
-		if project.isdotnet(prj) then
+		if project.isinstaller(prj) then
+			return "54435603-DBB4-11D2-8724-00A0C9A8B90C"
+		elseif project.isdotnet(prj) then
 			return "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC"
 		elseif project.iscpp(prj) then
 			return "8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942"

--- a/src/actions/vstudio/vs2010.lua
+++ b/src/actions/vstudio/vs2010.lua
@@ -119,7 +119,7 @@
 
 		-- The capabilities of this action
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "Installer" },
 		valid_languages = { "C", "C++", "C#" },
 		valid_tools     = {
 			cc     = { "msc"   },

--- a/src/actions/vstudio/vs2012.lua
+++ b/src/actions/vstudio/vs2012.lua
@@ -28,7 +28,7 @@
 
 		-- The capabilities of this action
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "Installer" },
 		valid_languages = { "C", "C++", "C#" },
 		valid_tools     = {
 			cc     = { "msc"   },

--- a/src/actions/vstudio/vs2013.lua
+++ b/src/actions/vstudio/vs2013.lua
@@ -30,7 +30,7 @@
 
 		-- The capabilities of this action
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "Installer" },
 		valid_languages = { "C", "C++", "C#" },
 		valid_tools     = {
 			cc     = { "msc"   },

--- a/src/actions/vstudio/vs2015.lua
+++ b/src/actions/vstudio/vs2015.lua
@@ -30,7 +30,7 @@
 
 		-- The capabilities of this action
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "Installer" },
 		valid_languages = { "C", "C++", "C#" },
 		valid_tools     = {
 			cc     = { "msc"   },
@@ -65,7 +65,7 @@
 
 		vstudio = {
 			solutionVersion = "12",
-			versionName     = "2015",
+			versionName     = "14",
 			targetFramework = "4.5",
 			toolsVersion    = "14.0",
 			filterToolsVersion = "4.0",

--- a/src/base/project.lua
+++ b/src/base/project.lua
@@ -450,6 +450,15 @@
 
 
 --
+-- Returns true if the project is an installer project.
+--
+
+	function project.isinstaller(prj)
+		return prj.kind == "Installer"
+	end
+
+
+--
 -- Returns true if the project uses a native language.
 --
 


### PR DESCRIPTION
This allows you to add .vdproj files as externalprojects.

I would like to fully generate vdproj in the future as well, but that is a whole different project.
And maybe this should really be done in a module instead, but a few of the methods used here are not really made to be extensible, so that will require a few other changes as well.

This is mostly a PR for visibility, not sure if we should merge it. 