### PR TITLE
submodule merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ syntax: glob
 
 build
 bin
-modules
 obj
 release
 ipch

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "modules/d"]
-	path = modules/d
-	url = https://github.com/premake/premake-dlang.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "modules/codelite"]
-	path = modules/codelite
-	url = https://github.com/premake/premake-codelite.git
 [submodule "modules/d"]
 	path = modules/d
 	url = https://github.com/premake/premake-dlang.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "modules/monodevelop"]
-	path = modules/monodevelop
-	url = https://github.com/premake/premake-monodevelop.git
 [submodule "modules/codelite"]
 	path = modules/codelite
 	url = https://github.com/premake/premake-codelite.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "modules/xcode"]
-	path = modules/xcode
-	url = https://github.com/premake/premake-xcode.git
 [submodule "modules/monodevelop"]
 	path = modules/monodevelop
 	url = https://github.com/premake/premake-monodevelop.git

--- a/modules/codelite/README.md
+++ b/modules/codelite/README.md
@@ -1,0 +1,13 @@
+Premake extension to support the [CodeLite](http://www.codelite.org/) IDE
+
+### Features ###
+
+* Support for C/C++ language projects
+
+### Usage ###
+
+Simply generate your project using the `codelite` action:
+```bash
+premake5 codelite
+```
+and open the generated project file in CodeLite.

--- a/modules/codelite/_manifest.lua
+++ b/modules/codelite/_manifest.lua
@@ -1,0 +1,6 @@
+return {
+	"_preload.lua",
+	"codelite.lua",
+	"codelite_workspace.lua",
+	"codelite_project.lua",
+}

--- a/modules/codelite/_preload.lua
+++ b/modules/codelite/_preload.lua
@@ -1,0 +1,57 @@
+--
+-- Name:        codelite/_preload.lua
+-- Purpose:     Define the CodeLite action.
+-- Author:      Ryan Pusztai
+-- Modified by: Andrea Zanellato
+--              Andrew Gough
+--              Manu Evans
+-- Created:     2013/05/06
+-- Copyright:   (c) 2008-2015 Jason Perkins and the Premake project
+--
+
+	local p = premake
+
+	newaction
+	{
+		-- Metadata for the command line and help system
+
+		trigger         = "codelite",
+		shortname       = "CodeLite",
+		description     = "Generate CodeLite project files",
+
+		-- The capabilities of this action
+
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "Makefile", "SharedLib", "StaticLib" },
+		valid_languages = { "C", "C++" },
+		valid_tools     = {
+		    cc = { "gcc", "clang", "msc" }
+		},
+
+		-- Workspace and project generation logic
+
+		onWorkspace = function(wks)
+			p.modules.codelite.generateWorkspace(wks)
+		end,
+		onProject = function(prj)
+			p.modules.codelite.generateProject(prj)
+		end,
+
+		onCleanWorkspace = function(wks)
+			p.modules.codelite.cleanWorkspace(wks)
+		end,
+		onCleanProject = function(prj)
+			p.modules.codelite.cleanProject(prj)
+		end,
+		onCleanTarget = function(prj)
+			p.modules.codelite.cleanTarget(prj)
+		end,
+	}
+
+
+--
+-- Decide when the full module should be loaded.
+--
+
+	return function(cfg)
+		return (_ACTION == "codelite")
+	end

--- a/modules/codelite/codelite.lua
+++ b/modules/codelite/codelite.lua
@@ -1,0 +1,72 @@
+--
+-- Name:        codelite/codelite.lua
+-- Purpose:     Define the CodeLite action(s).
+-- Author:      Ryan Pusztai
+-- Modified by: Andrea Zanellato
+--              Andrew Gough
+--              Manu Evans
+-- Created:     2013/05/06
+-- Copyright:   (c) 2008-2015 Jason Perkins and the Premake project
+--
+
+	local p = premake
+
+	p.modules.codelite = {}
+	p.modules.codelite._VERSION = p._VERSION
+
+	local codelite = p.modules.codelite
+	local project = p.project
+
+
+	function codelite.cfgname(cfg)
+		local cfgname = cfg.buildcfg
+		if codelite.workspace.multiplePlatforms then
+			cfgname = string.format("%s|%s", cfg.platform, cfg.buildcfg)
+		end
+		return cfgname
+	end
+
+	function codelite.esc(value)
+		return value
+	end
+
+	function codelite.generateWorkspace(wks)
+		p.eol("\r\n")
+		p.indent("  ")
+		p.escaper(codelite.esc)
+
+		p.generate(wks, ".workspace", codelite.workspace.generate)
+	end
+
+	function codelite.generateProject(prj)
+		p.eol("\r\n")
+		p.indent("  ")
+		p.escaper(codelite.esc)
+
+		if project.iscpp(prj) then
+			p.generate(prj, ".project", codelite.project.generate)
+		end
+	end
+
+	function codelite.cleanWorkspace(wks)
+		p.clean.file(wks, wks.name .. ".workspace")
+		p.clean.file(wks, wks.name .. "_wsp.mk")
+		p.clean.file(wks, wks.name .. ".tags")
+		p.clean.file(wks, ".clang")
+	end
+
+	function codelite.cleanProject(prj)
+		p.clean.file(prj, prj.name .. ".project")
+		p.clean.file(prj, prj.name .. ".mk")
+		p.clean.file(prj, prj.name .. ".list")
+		p.clean.file(prj, prj.name .. ".out")
+	end
+
+	function codelite.cleanTarget(prj)
+		-- TODO..
+	end
+
+	include("codelite_workspace.lua")
+	include("codelite_project.lua")
+
+	return codelite

--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -1,0 +1,440 @@
+--
+-- Name:        codelite/codelite_project.lua
+-- Purpose:     Generate a CodeLite C/C++ project file.
+-- Author:      Ryan Pusztai
+-- Modified by: Andrea Zanellato
+--              Manu Evans
+-- Created:     2013/05/06
+-- Copyright:   (c) 2008-2015 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local tree = p.tree
+	local project = p.project
+	local config = p.config
+	local codelite = p.modules.codelite
+
+	codelite.project = {}
+	local m = codelite.project
+
+
+	function codelite.getLinks(cfg)
+		-- System libraries are undecorated, add the required extension
+		return config.getlinks(cfg, "system", "fullpath")
+	end
+
+	function codelite.getSiblingLinks(cfg)
+		-- If we need sibling projects to be listed explicitly, add them on
+		return config.getlinks(cfg, "siblings", "fullpath")
+	end
+
+
+	m.elements = {}
+
+	m.ctools = {
+		gcc = "gnu gcc",
+		clang = "clang",
+		msc = "Visual C++",
+	}
+	m.cxxtools = {
+		gcc = "gnu g++",
+		clang = "clang++",
+		msc = "Visual C++",
+	}
+
+	function m.getcompilername(cfg)
+		local tool = _OPTIONS.cc or cfg.toolset or p.CLANG
+
+		local toolset = p.tools[tool]
+		if not toolset then
+			error("Invalid toolset '" + (_OPTIONS.cc or cfg.toolset) + "'")
+		end
+
+		if cfg.language == "C" then
+			return m.ctools[tool]
+		elseif cfg.language == "C++" then
+			return m.cxxtools[tool]
+		end
+	end
+
+	function m.getcompiler(cfg)
+		local toolset = p.tools[_OPTIONS.cc or cfg.toolset or p.CLANG]
+		if not toolset then
+			error("Invalid toolset '" + (_OPTIONS.cc or cfg.toolset) + "'")
+		end
+		return toolset
+	end
+
+	local function configuration_iscustombuild(cfg)
+
+		return cfg and (cfg.kind == p.MAKEFILE) and (#cfg.buildcommands > 0)
+	end
+
+	local function configuration_isfilelist(cfg)
+
+		return cfg and (cfg.buildaction == "None") and not configuration_iscustombuild(cfg)
+	end
+
+	local function configuration_needresoptions(cfg)
+
+		return cfg and config.findfile(cfg, ".rc") and not configuration_iscustombuild(cfg)
+	end
+
+
+	m.internalTypeMap = {
+		ConsoleApp = "Console",
+		WindowedApp = "Console",
+		Makefile = "",
+		SharedLib = "Library",
+		StaticLib = "Library"
+	}
+
+	function m.header(prj)
+		_p('<?xml version="1.0" encoding="UTF-8"?>')
+
+		local type = m.internalTypeMap[prj.kind] or ""
+		_x('<CodeLite_Project Name="%s" InternalType="%s">', prj.name, type)
+	end
+
+	function m.plugins(prj)
+--		_p(1, '<Plugins>')
+			-- <Plugin Name="CMakePlugin">
+			-- <Plugin Name="qmake">
+--		_p(1, '</Plugins>')
+
+		_p(1, '<Plugins/>')
+	end
+
+	function m.description(prj)
+		_p(1, '<Description/>')
+
+		-- TODO: ...
+	end
+
+	function m.files(prj)
+		local tr = project.getsourcetree(prj)
+		tree.traverse(tr, {
+			-- folders are handled at the internal nodes
+			onbranchenter = function(node, depth)
+				_p(depth, '<VirtualDirectory Name="%s">', node.name)
+			end,
+			onbranchexit = function(node, depth)
+				_p(depth, '</VirtualDirectory>')
+			end,
+			-- source files are handled at the leaves
+			onleaf = function(node, depth)
+				_p(depth, '<File Name="%s"/>', node.relpath)
+			end,
+		}, false, 1)
+	end
+
+	function m.dependencies(prj)
+
+		-- TODO: dependencies don't emit a line for each config if there aren't any...
+
+--		_p(1, '<Dependencies/>')
+
+		local dependencies = project.getdependencies(prj)
+		for cfg in project.eachconfig(prj) do
+			cfgname = codelite.cfgname(cfg)
+			if #dependencies > 0 then
+				_p(1, '<Dependencies Name="%s">', cfgname)
+					for _, dependency in ipairs(dependencies) do
+						_p(2, '<Project Name="%s"/>', dependency.name)
+					end
+				_p(1, '</Dependencies>')
+			else
+				_p(1, '<Dependencies Name="%s"/>', cfgname)
+			end
+		end
+	end
+
+
+	function m.global_compiler(prj)
+		_p(3, '<Compiler Options="" C_Options="" Assembler="">')
+		_p(4, '<IncludePath Value="."/>')
+		_p(3, '</Compiler>')
+	end
+
+	function m.global_linker(prj)
+		_p(3, '<Linker Options="">')
+		_p(4, '<LibraryPath Value="."/>')
+		_p(3, '</Linker>')
+	end
+
+	function m.global_resourceCompiler(prj)
+		_p(3, '<ResourceCompiler Options=""/>')
+	end
+
+	m.elements.globalSettings = function(prj)
+		return {
+			m.global_compiler,
+			m.global_linker,
+			m.global_resourceCompiler,
+		}
+	end
+
+
+	function m.compiler(cfg)
+		if configuration_iscustombuild(cfg) or configuration_isfilelist(cfg) then
+			_p(3, '<Compiler Required="no"/>')
+			return
+		end
+
+		local toolset = m.getcompiler(cfg)
+		local cxxflags = table.concat(table.join(toolset.getcflags(cfg), toolset.getcxxflags(cfg), cfg.buildoptions), ";")
+		local cflags   = table.concat(table.join(toolset.getcflags(cfg), cfg.buildoptions), ";")
+		local asmflags = ""
+		local pch      = ""
+
+		_x(3, '<Compiler Options="%s" C_Options="%s" Assembler="%s" Required="yes" PreCompiledHeader="%s" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">', cxxflags, cflags, asmflags, pch)
+
+		for _, includedir in ipairs(cfg.includedirs) do
+			_x(4, '<IncludePath Value="%s"/>', project.getrelative(cfg.project, includedir))
+		end
+		for _, define in ipairs(cfg.defines) do
+			_x(4, '<Preprocessor Value="%s"/>', define)
+		end
+		_p(3, '</Compiler>')
+	end
+
+	function m.linker(cfg)
+		if configuration_iscustombuild(cfg) or configuration_isfilelist(cfg) then
+			_p(3, '<Linker Required="no"/>')
+			return
+		end
+
+		local toolset = m.getcompiler(cfg)
+		local flags = table.join(toolset.getldflags(cfg), cfg.linkoptions)
+		local withdeps = table.join(flags, codelite.getSiblingLinks(cfg))
+		local ldflags = table.concat(withdeps, ";")
+
+		_x(3, '<Linker Required="yes" Options="%s">', ldflags)
+
+		if #cfg.libdirs > 0 then
+			local libdirs = project.getrelative(cfg.project, cfg.libdirs)
+			for _, libpath in ipairs(libdirs) do
+				_x(4, '<LibraryPath Value="%s" />', libpath)
+			end
+		end
+
+		local links = codelite.getLinks(cfg)
+		for _, libname in ipairs(links) do
+			_x(4, '<Library Value="%s" />', libname)
+		end
+		_p(3, '</Linker>')
+	end
+
+	function m.resourceCompiler(cfg)
+		if not configuration_needresoptions(cfg) then
+			_p(3, '<ResourceCompiler Options="" Required="no"/>')
+			return
+		end
+
+		local toolset = m.getcompiler(cfg)
+		local defines = table.implode(toolset.getdefines(table.join(cfg.defines, cfg.resdefines)), "", ";", "")
+		local options = table.concat(cfg.resoptions, ";")
+
+		_x(3, '<ResourceCompiler Options="%s%s" Required="yes">', defines, options)
+		for _, includepath in ipairs(table.join(cfg.includedirs, cfg.resincludedirs)) do
+			_x(4, '<IncludePath Value="%s"/>', project.getrelative(cfg.project, includepath))
+		end
+		_p(3, '</ResourceCompiler>')
+	end
+
+	function m.general(cfg)
+		if configuration_isfilelist(cfg) then
+			_p(3, '<General IntermediateDirectory="." WorkingDirectory="." PauseExecWhenProcTerminates="no"/>')
+			return
+		end
+
+		local prj = cfg.project
+
+		local isExe = prj.kind == "WindowedApp" or prj.kind == "ConsoleApp"
+		local targetpath = project.getrelative(prj, cfg.buildtarget.directory)
+		local objdir     = project.getrelative(prj, cfg.objdir)
+		local targetname = project.getrelative(prj, cfg.buildtarget.abspath)
+		local command    = iif(isExe, targetname, "")
+		local cmdargs    = iif(isExe, table.concat(cfg.debugargs, " "), "") -- TODO: should this be debugargs instead?
+		local useseparatedebugargs = "no"
+		local debugargs  = ""
+		local workingdir = iif(isExe, project.getrelative(prj, cfg.debugdir), "")
+		local pauseexec  = iif(prj.kind == "ConsoleApp", "yes", "no")
+		local isguiprogram = iif(prj.kind == "WindowedApp", "yes", "no")
+		local isenabled  = iif(cfg.flags.ExcludeFromBuild, "no", "yes")
+
+		_x(3, '<General OutputFile="%s" IntermediateDirectory="%s" Command="%s" CommandArguments="%s" UseSeparateDebugArgs="%s" DebugArguments="%s" WorkingDirectory="%s" PauseExecWhenProcTerminates="%s" IsGUIProgram="%s" IsEnabled="%s"/>',
+			targetname, objdir, command, cmdargs, useseparatedebugargs, debugargs, workingdir, pauseexec, isguiprogram, isenabled)
+	end
+
+	function m.environment(cfg)
+		_p(3, '<Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">')
+		local variables = ""
+		_x(4, '<![CDATA[%s]]>', variables)
+		_p(3, '</Environment>')
+	end
+
+	function m.debugger(cfg)
+
+		_p(3, '<Debugger IsRemote="%s" RemoteHostName="%s" RemoteHostPort="%s" DebuggerPath="" IsExtended="%s">', iif(cfg.debugremotehost, "yes", "no"), cfg.debugremotehost or "", iif(cfg.debugport, tostring(cfg.debugport), ""), iif(cfg.debugextendedprotocol, "yes", "no"))
+		if #cfg.debugsearchpaths > 0 then
+			_p(4, '<DebuggerSearchPaths>%s</DebuggerSearchPaths>', table.concat(premake.esc(project.getrelative(cfg.project, cfg.debugsearchpaths)), "\n"))
+		else
+			_p(4, '<DebuggerSearchPaths/>')
+		end
+		if #cfg.debugconnectcommands > 0 then
+			_p(4, '<PostConnectCommands>%s</PostConnectCommands>', table.concat(premake.esc(cfg.debugconnectcommands), "\n"))
+		else
+			_p(4, '<PostConnectCommands/>')
+		end
+		if #cfg.debugstartupcommands > 0 then
+			_p(4, '<StartupCommands>%s</StartupCommands>', table.concat(premake.esc(cfg.debugstartupcommands), "\n"))
+		else
+			_p(4, '<StartupCommands/>')
+		end
+		_p(3, '</Debugger>')
+	end
+
+	function m.preBuild(cfg)
+		if #cfg.prebuildcommands > 0 then
+			_p(3, '<PreBuild>')
+			for _, commands in ipairs(cfg.prebuildcommands) do
+				_x(4, '<Command Enabled="yes">%s</Command>',
+				p.esc(commands))
+			end
+			_p(3, '</PreBuild>')
+		end
+	end
+
+	function m.postBuild(cfg)
+		if #cfg.postbuildcommands > 0 then
+			_p(3, '<PostBuild>')
+			for _, commands in ipairs(cfg.postbuildcommands) do
+				_x(4, '<Command Enabled="yes">%s</Command>',
+				p.esc(commands))
+			end
+			_p(3, '</PostBuild>')
+		end
+	end
+
+	function m.customBuild(cfg)
+		if not configuration_iscustombuild(cfg) then
+			_p(3, '<CustomBuild Enabled="no"/>')
+			return
+		end
+
+		local build   = table.implode(cfg.buildcommands,"","","")
+		local clean   = table.implode(cfg.cleancommands,"","","")
+		local rebuild = table.implode(cfg.rebuildcommands,"","","")
+
+		_p(3, '<CustomBuild Enabled="yes">')
+		_x(4, '<BuildCommand>%s</BuildCommand>', build)
+		_x(4, '<CleanCommand>%s</CleanCommand>', clean)
+		_x(4, '<RebuildCommand>%s</RebuildCommand>', rebuild)
+		_p(4, '<PreprocessFileCommand></PreprocessFileCommand>')
+		_p(4, '<SingleFileCommand></SingleFileCommand>')
+		_p(4, '<MakefileGenerationCommand></MakefileGenerationCommand>')
+		_p(4, '<ThirdPartyToolName></ThirdPartyToolName>')
+		_p(4, '<WorkingDirectory></WorkingDirectory>')
+		_p(3, '</CustomBuild>')
+	end
+
+	function m.additionalRules(cfg)
+		if configuration_iscustombuild(cfg) then
+			_p(3, '<AdditionalRules/>')
+			return
+		end
+
+		_p(3, '<AdditionalRules>')
+		_p(4, '<CustomPostBuild/>')
+		_p(4, '<CustomPreBuild/>')
+		_p(3, '</AdditionalRules>')
+	end
+
+	function m.completion(cfg)
+		_p(3, '<Completion EnableCpp11="%s" EnableCpp14="%s">', iif(cfg.flags["C++11"], "yes", "no"), iif(cfg.flags["C++14"], "yes", "no"))
+		_p(4, '<ClangCmpFlagsC/>')
+		_p(4, '<ClangCmpFlags/>')
+		_p(4, '<ClangPP/>') -- TODO: we might want to set special code completion macros...?
+		_p(4, '<SearchPaths/>') -- TODO: search paths for code completion?
+		_p(3, '</Completion>')
+	end
+
+	m.elements.settings = function(cfg)
+		return {
+			m.compiler,
+			m.linker,
+			m.resourceCompiler,
+			m.general,
+			m.environment,
+			m.debugger,
+			m.preBuild,
+			m.postBuild,
+			m.customBuild,
+			m.additionalRules,
+			m.completion,
+		}
+	end
+
+	m.types =
+	{
+		ConsoleApp  = "Executable",
+		Makefile    = "",
+		SharedLib   = "Dynamic Library",
+		StaticLib   = "Static Library",
+		WindowedApp = "Executable"
+	}
+
+	m.debuggers =
+	{
+		Default = "GNU gdb debugger",
+		GDB = "GNU gdb debugger",
+		LLDB = "LLDB Debugger",
+	}
+
+	function m.settings(prj)
+		_p(1, '<Settings Type="%s">', m.types[prj.kind] or "")
+
+		_p(2, '<GlobalSettings>')
+		p.callArray(m.elements.globalSettings, prj)
+		_p(2, '</GlobalSettings>')
+
+		for cfg in project.eachconfig(prj) do
+
+			local cfgname  = codelite.cfgname(cfg)
+			local compiler = m.getcompilername(cfg)
+			local debugger = m.debuggers[cfg.debugger] or m.debuggers.Default
+			local type = m.types[cfg.kind]
+
+			_x(2, '<Configuration Name="%s" CompilerType="%s" DebuggerType="%s" Type="%s" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">', cfgname, compiler, debugger, type)
+
+			p.callArray(m.elements.settings, cfg)
+
+			_p(2, '</Configuration>')
+		end
+
+		_p(1, '</Settings>')
+	end
+
+
+	m.elements.project = function(prj)
+		return {
+			m.header,
+			m.plugins,
+			m.description,
+			m.files,
+			m.dependencies,
+			m.settings,
+		}
+	end
+
+--
+-- Project: Generate the CodeLite project file.
+--
+	function m.generate(prj)
+		p.utf8()
+
+		p.callArray(m.elements.project, prj)
+
+		_p('</CodeLite_Project>')
+	end

--- a/modules/codelite/codelite_workspace.lua
+++ b/modules/codelite/codelite_workspace.lua
@@ -1,0 +1,97 @@
+--
+-- Name:        codelite/codelite_workspace.lua
+-- Purpose:     Generate a CodeLite workspace.
+-- Author:      Ryan Pusztai
+-- Modified by: Andrea Zanellato
+--              Manu Evans
+-- Created:     2013/05/06
+-- Copyright:   (c) 2008-2015 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local project = p.project
+	local workspace = p.workspace
+	local tree = p.tree
+	local codelite = p.modules.codelite
+
+	codelite.workspace = {}
+	local m = codelite.workspace
+
+--
+-- Generate a CodeLite workspace
+--
+	function m.generate(wks)
+		p.utf8()
+
+		--
+		-- Header
+		--
+		_p('<?xml version="1.0" encoding="UTF-8"?>')
+
+		local tagsdb = ""
+--		local tagsdb = "./" .. wks.name .. ".tags"
+		_p('<CodeLite_Workspace Name="%s" Database="%s" SWTLW="No">', wks.name, tagsdb)
+
+		--
+		-- Project list
+		--
+		local tr = workspace.grouptree(wks)
+		tree.traverse(tr, {
+			onleaf = function(n)
+				local prj = n.project
+
+				-- Build a relative path from the workspace file to the project file
+				local prjpath = p.filename(prj, ".project")
+				prjpath = path.getrelative(prj.workspace.location, prjpath)
+
+				local active  = iif(prj.name == wks.startproject, ' Active="Yes"', '')
+				_x(1, '<Project Name="%s" Path="%s"%s/>', prj.name, prjpath, active)
+			end,
+
+			onbranch = function(n)
+				-- TODO: not sure what situation this appears...?
+				-- premake5.lua emit's one of these for 'contrib', which is a top-level folder with the zip projects
+			end,
+		})
+
+		--
+		-- Configurations
+		--
+
+		-- count the number of platforms
+		local platformsPresent = {}
+		local numPlatforms = 0
+
+		for cfg in workspace.eachconfig(wks) do
+			local platform = cfg.platform
+			if platform and not platformsPresent[platform] then
+				numPlatforms = numPlatforms + 1
+				platformsPresent[platform] = true
+			end
+		end
+
+		if numPlatforms >= 2 then
+			codelite.workspace.multiplePlatforms = true
+		end
+
+		-- for each workspace config
+		_p(1, '<BuildMatrix>')
+		for cfg in workspace.eachconfig(wks) do
+
+			local cfgname = codelite.cfgname(cfg)
+			_p(2, '<WorkspaceConfiguration Name="%s" Selected="yes">', cfgname)
+
+			local tr = workspace.grouptree(wks)
+			tree.traverse(tr, {
+				onleaf = function(n)
+					local prj = n.project
+					_p(3, '<Project Name="%s" ConfigName="%s"/>', prj.name, cfgname)
+				end
+			})
+			_p(2, '</WorkspaceConfiguration>')
+
+		end
+		_p(1, '</BuildMatrix>')
+
+		_p('</CodeLite_Workspace>')
+	end

--- a/modules/codelite/tests/_tests.lua
+++ b/modules/codelite/tests/_tests.lua
@@ -1,0 +1,7 @@
+require ("codelite")
+
+return {
+	"test_codelite_workspace.lua",
+	"test_codelite_project.lua",
+	"test_codelite_config.lua",
+}

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -1,0 +1,234 @@
+---
+-- codelite/tests/test_codelite_config.lua
+-- Automated test suite for CodeLite project generation.
+-- Copyright (c) 2015 Manu Evans and the Premake project
+---
+
+
+	local suite = test.declare("codelite_cproj_config")
+	local codelite = premake.modules.codelite
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		premake.action.set("codelite")
+		premake.indent("  ")
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare()
+		cfg = test.getconfig(prj, "Debug")
+	end
+
+
+	function suite.OnProjectCfg_Compiler()
+		prepare()
+		codelite.project.compiler(cfg)
+		test.capture [[
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
+      </Compiler>
+		]]
+	end
+
+	function suite.OnProjectCfg_Flags()
+		optimize "Debug"
+		exceptionhandling "Off"
+		rtti "Off"
+		pic "On"
+		flags { "Symbols", "NoBufferSecurityCheck", "C++11" }
+		buildoptions { "-opt1", "-opt2" }
+		prepare()
+		codelite.project.compiler(cfg)
+		test.capture [[
+      <Compiler Options="-g;-O0;-fPIC;-fno-exceptions;-fno-stack-protector;-std=c++11;-fno-rtti;-opt1;-opt2" C_Options="-g;-O0;-fPIC;-opt1;-opt2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
+      </Compiler>
+		]]
+	end
+
+	function suite.OnProjectCfg_Includes()
+		includedirs { "dir/", "dir2" }
+		prepare()
+		codelite.project.compiler(cfg)
+		test.capture [[
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
+        <IncludePath Value="dir"/>
+        <IncludePath Value="dir2"/>
+      </Compiler>
+		]]
+	end
+
+	function suite.OnProjectCfg_Defines()
+		defines { "TEST", "DEF" }
+		prepare()
+		codelite.project.compiler(cfg)
+		test.capture [[
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
+        <Preprocessor Value="TEST"/>
+        <Preprocessor Value="DEF"/>
+      </Compiler>
+		]]
+	end
+
+	function suite.OnProjectCfg_Linker()
+		prepare()
+		codelite.project.linker(cfg)
+		test.capture [[
+      <Linker Required="yes" Options="">
+      </Linker>
+		]]
+	end
+
+	function suite.OnProjectCfg_LibPath()
+		libdirs { "test/", "test2" }
+		prepare()
+		codelite.project.linker(cfg)
+		test.capture [[
+      <Linker Required="yes" Options="">
+        <LibraryPath Value="test" />
+        <LibraryPath Value="test2" />
+      </Linker>
+		]]
+	end
+
+	function suite.OnProjectCfg_Libs()
+		links { "lib", "lib2" }
+		prepare()
+		codelite.project.linker(cfg)
+		test.capture [[
+      <Linker Required="yes" Options="">
+        <Library Value="lib" />
+        <Library Value="lib2" />
+      </Linker>
+		]]
+	end
+
+	-- TODO: test sibling lib project links
+
+
+	function suite.OnProjectCfg_ResCompiler()
+		prepare()
+		codelite.project.resourceCompiler(cfg)
+		test.capture [[
+      <ResourceCompiler Options="" Required="no"/>
+		]]
+	end
+
+	function suite.OnProjectCfg_ResInclude()
+		files { "x.rc" }
+		resincludedirs { "dir/" }
+		prepare()
+		codelite.project.resourceCompiler(cfg)
+		test.capture [[
+      <ResourceCompiler Options="" Required="yes">
+        <IncludePath Value="dir"/>
+      </ResourceCompiler>
+		]]
+	end
+
+	function suite.OnProjectCfg_General()
+		system "Windows"
+		prepare()
+		codelite.project.general(cfg)
+		test.capture [[
+      <General OutputFile="bin/Debug/MyProject.exe" IntermediateDirectory="obj/Debug" Command="bin/Debug/MyProject.exe" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+		]]
+	end
+
+	function suite.OnProjectCfg_Environment()
+		prepare()
+		codelite.project.environment(cfg)
+		test.capture(
+'      <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">\n' ..
+'        <![CDATA[]]>\n' ..
+'      </Environment>'
+		)
+	end
+
+	function suite.OnProjectCfg_Debugger()
+		prepare()
+		codelite.project.debugger(cfg)
+		test.capture [[
+      <Debugger IsRemote="no" RemoteHostName="" RemoteHostPort="" DebuggerPath="" IsExtended="no">
+        <DebuggerSearchPaths/>
+        <PostConnectCommands/>
+        <StartupCommands/>
+      </Debugger>
+		]]
+	end
+
+	function suite.OnProjectCfg_DebuggerOpts()
+		debugremotehost "localhost"
+		debugport(2345)
+		debugextendedprotocol(true)
+		debugsearchpaths { "search/", "path" }
+		debugconnectcommands { "connectcmd1", "cmd2" }
+		debugstartupcommands { "startcmd1", "cmd2" }
+		prepare()
+		codelite.project.debugger(cfg)
+		test.capture [[
+      <Debugger IsRemote="yes" RemoteHostName="localhost" RemoteHostPort="2345" DebuggerPath="" IsExtended="yes">
+        <DebuggerSearchPaths>search
+path</DebuggerSearchPaths>
+        <PostConnectCommands>connectcmd1
+cmd2</PostConnectCommands>
+        <StartupCommands>startcmd1
+cmd2</StartupCommands>
+      </Debugger>
+		]]
+	end
+
+	function suite.OnProject_PreBuild()
+		prebuildcommands { "cmd0", "cmd1" }
+		prepare()
+		codelite.project.preBuild(prj)
+		test.capture [[
+      <PreBuild>
+        <Command Enabled="yes">cmd0</Command>
+        <Command Enabled="yes">cmd1</Command>
+      </PreBuild>
+		]]
+	end
+
+	function suite.OnProject_PreBuild()
+		postbuildcommands { "cmd0", "cmd1" }
+		prepare()
+		codelite.project.postBuild(prj)
+		test.capture [[
+      <PostBuild>
+        <Command Enabled="yes">cmd0</Command>
+        <Command Enabled="yes">cmd1</Command>
+      </PostBuild>
+		]]
+	end
+
+	-- TODO: test custom build
+
+
+	function suite.OnProject_AdditionalRules()
+		prepare()
+		codelite.project.additionalRules(prj)
+		test.capture [[
+      <AdditionalRules>
+        <CustomPostBuild/>
+        <CustomPreBuild/>
+      </AdditionalRules>
+		]]
+	end
+
+	function suite.OnProject_Completion()
+		flags { "C++11" }
+		prepare()
+		codelite.project.completion(prj)
+		test.capture [[
+      <Completion EnableCpp11="yes" EnableCpp14="no">
+        <ClangCmpFlagsC/>
+        <ClangCmpFlags/>
+        <ClangPP/>
+        <SearchPaths/>
+      </Completion>
+		]]
+	end

--- a/modules/codelite/tests/test_codelite_project.lua
+++ b/modules/codelite/tests/test_codelite_project.lua
@@ -1,0 +1,100 @@
+---
+-- codelite/tests/test_codelite_project.lua
+-- Automated test suite for CodeLite project generation.
+-- Copyright (c) 2015 Manu Evans and the Premake project
+---
+
+
+	local suite = test.declare("codelite_cproj")
+	local codelite = premake.modules.codelite
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj
+
+	function suite.setup()
+		premake.action.set("codelite")
+		premake.indent("  ")
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		wks = premake.oven.bakeWorkspace(wks)
+		prj = test.getproject(wks, 1)
+	end
+
+
+	function suite.OnProject_Header()
+		prepare()
+		codelite.project.header(prj)
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Project Name="MyProject" InternalType="Console">
+		]]
+	end
+	function suite.OnProject_Header_Windowed()
+		kind "WindowedApp"
+		prepare()
+		codelite.project.header(prj)
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Project Name="MyProject" InternalType="Console">
+		]]
+	end
+	function suite.OnProject_Header_Shared()
+		kind "SharedLib"
+		prepare()
+		codelite.project.header(prj)
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Project Name="MyProject" InternalType="Library">
+		]]
+	end
+
+	function suite.OnProject_Plugins()
+		prepare()
+		codelite.project.plugins(prj)
+		test.capture [[
+  <Plugins/>
+		]]
+	end
+
+	function suite.OnProject_Description()
+		prepare()
+		codelite.project.description(prj)
+		test.capture [[
+  <Description/>
+		]]
+	end
+
+	function suite.OnProject_Dependencies()
+		prepare()
+		codelite.project.dependencies(prj)
+		test.capture [[
+  <Dependencies Name="Debug"/>
+  <Dependencies Name="Release"/>
+		]]
+	end
+
+	-- TODO: dependencies with actual dependencies...
+
+
+	-- GlobalSettings is currently constants, so we'll just test it here
+	function suite.OnProject_Settings()
+		prepare()
+		codelite.project.settings(prj)
+		test.capture [[
+  <Settings Type="Executable">
+    <GlobalSettings>
+      <Compiler Options="" C_Options="" Assembler="">
+        <IncludePath Value="."/>
+      </Compiler>
+      <Linker Options="">
+        <LibraryPath Value="."/>
+      </Linker>
+      <ResourceCompiler Options=""/>
+    </GlobalSettings>
+		]]
+	end

--- a/modules/codelite/tests/test_codelite_workspace.lua
+++ b/modules/codelite/tests/test_codelite_workspace.lua
@@ -1,0 +1,131 @@
+---
+-- codelite/tests/test_codelite_workspace.lua
+-- Validate generation for CodeLite workspaces.
+-- Author Manu Evans
+-- Copyright (c) 2015 Manu Evans and the Premake project
+---
+
+	local suite = test.declare("codelite_workspace")
+	local codelite = premake.modules.codelite
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		premake.action.set("codelite")
+		premake.indent("  ")
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		wks = test.getWorkspace(wks)
+		codelite.workspace.generate(wks)
+	end
+
+
+--
+-- Check the basic structure of a workspace.
+--
+
+	function suite.onEmptyWorkspace()
+		wks.projects = {}
+		prepare()
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+  <BuildMatrix>
+    <WorkspaceConfiguration Name="Debug" Selected="yes">
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="Release" Selected="yes">
+    </WorkspaceConfiguration>
+  </BuildMatrix>
+</CodeLite_Workspace>
+		]]
+	end
+
+	function suite.onDefaultWorkspace()
+		prepare()
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+  <Project Name="MyProject" Path="MyProject.project"/>
+  <BuildMatrix>
+    <WorkspaceConfiguration Name="Debug" Selected="yes">
+      <Project Name="MyProject" ConfigName="Debug"/>
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="Release" Selected="yes">
+      <Project Name="MyProject" ConfigName="Release"/>
+    </WorkspaceConfiguration>
+  </BuildMatrix>
+</CodeLite_Workspace>
+		]]
+	end
+
+	function suite.onMultipleProjects()
+		test.createproject(wks)
+		prepare()
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+  <Project Name="MyProject" Path="MyProject.project"/>
+  <Project Name="MyProject2" Path="MyProject2.project"/>
+  <BuildMatrix>
+    <WorkspaceConfiguration Name="Debug" Selected="yes">
+      <Project Name="MyProject" ConfigName="Debug"/>
+      <Project Name="MyProject2" ConfigName="Debug"/>
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="Release" Selected="yes">
+      <Project Name="MyProject" ConfigName="Release"/>
+      <Project Name="MyProject2" ConfigName="Release"/>
+    </WorkspaceConfiguration>
+  </BuildMatrix>
+</CodeLite_Workspace>
+		]]
+	end
+
+
+--
+-- Projects should include relative path from workspace.
+--
+
+	function suite.onNestedProjectPath()
+		location "MyProject"
+		prepare()
+		test.capture([[
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+  <Project Name="MyProject" Path="MyProject/MyProject.project"/>
+  <BuildMatrix>
+    <WorkspaceConfiguration Name="Debug" Selected="yes">
+      <Project Name="MyProject" ConfigName="Debug"/>
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="Release" Selected="yes">
+      <Project Name="MyProject" ConfigName="Release"/>
+    </WorkspaceConfiguration>
+  </BuildMatrix>
+</CodeLite_Workspace>
+		]])
+	end
+
+	function suite.onExternalProjectPath()
+		location "../MyProject"
+		prepare()
+		test.capture([[
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+  <Project Name="MyProject" Path="../MyProject/MyProject.project"/>
+  <BuildMatrix>
+    <WorkspaceConfiguration Name="Debug" Selected="yes">
+      <Project Name="MyProject" ConfigName="Debug"/>
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="Release" Selected="yes">
+      <Project Name="MyProject" ConfigName="Release"/>
+    </WorkspaceConfiguration>
+  </BuildMatrix>
+</CodeLite_Workspace>
+		]])
+	end

--- a/modules/d/LICENSE.txt
+++ b/modules/d/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2013-2015 Andrew Gough, Manu Evans, and individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of Premake nor the names of its contributors may be
+     used to endorse or promote products derived from this software without
+     specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/modules/d/README.md
+++ b/modules/d/README.md
@@ -1,0 +1,55 @@
+Premake Extension to support the [D](http://dlang.org) language
+
+### Features ###
+
+* Support actions: gmake, vs20xx (VisualD), monodevelop (Mono-D)
+* Support all compilers; DMD, LDC, GDC
+* Support combined and separate compilation
+
+### Usage ###
+
+Simply add:
+```lua
+language "D"
+```
+to your project definition and populate with .d files.
+
+### APIs ###
+
+* [flags](https://github.com/premake/premake-dlang/wiki/flags)
+  * CodeCoverage
+  * Deprecated
+  * Documentation
+  * GenerateHeader
+  * GenerateJSON
+  * GenerateMap
+  * NoBoundsCheck
+  * Profile
+  * Quiet
+  * RetainPaths
+  * SeparateCompilation
+  * SymbolsLikeC
+  * UnitTest
+  * Verbose
+* [versionconstants](https://github.com/premake/premake-dlang/wiki/versionconstants)
+* [versionlevel](https://github.com/premake/premake-dlang/wiki/versionlevel)
+* [debugconstants](https://github.com/premake/premake-dlang/wiki/debugconstants)
+* [debuglevel](https://github.com/premake/premake-dlang/wiki/debuglevel)
+* [docdir](https://github.com/premake/premake-dlang/wiki/docdir)
+* [docname](https://github.com/premake/premake-dlang/wiki/docname)
+* [headerdir](https://github.com/premake/premake-dlang/wiki/headerdir)
+* [headername](https://github.com/premake/premake-dlang/wiki/headername)
+
+### Example ###
+
+The contents of your premake5.lua file would be:
+
+```lua
+solution "MySolution"
+    configurations { "release", "debug" }
+
+    project "MyDProject"
+        kind "ConsoleApp"
+        language "D"
+        files { "src/main.d", "src/extra.d" }
+```

--- a/modules/d/_manifest.lua
+++ b/modules/d/_manifest.lua
@@ -1,0 +1,10 @@
+return {
+	"_preload.lua",
+	"d.lua",
+	"actions/gmake.lua",
+	"actions/monodev.lua",
+	"actions/vstudio.lua",
+	"tools/dmd.lua",
+	"tools/gdc.lua",
+	"tools/ldc.lua",
+}

--- a/modules/d/_preload.lua
+++ b/modules/d/_preload.lua
@@ -1,0 +1,126 @@
+--
+-- Name:        d/_preload.lua
+-- Purpose:     Define the D language API's.
+-- Author:      Manu Evans
+-- Created:     2013/10/28
+-- Copyright:   (c) 2013-2015 Manu Evans and the Premake project
+--
+
+-- TODO:
+-- MonoDevelop/Xamarin Studio has 'workspaces', which correspond to collections
+-- of Premake workspaces. If premake supports multiple workspaces, we should
+-- write out a workspace file...
+
+	local p = premake
+	local api = p.api
+
+--
+-- Register the D extension
+--
+
+	p.D = "D"
+
+	api.addAllowed("language", p.D)
+	api.addAllowed("floatingpoint", "None")
+	api.addAllowed("flags", {
+		"CodeCoverage",
+		"Deprecated",
+		"Documentation",
+		"GenerateHeader",
+		"GenerateJSON",
+		"GenerateMap",
+		"NoBoundsCheck",
+--		"PIC",		// Note: this should be supported elsewhere...
+		"Profile",
+		"Quiet",
+--		"Release",	// Note: We infer this flag from config.isDebugBuild()
+		"RetainPaths",
+		"SeparateCompilation",
+		"SymbolsLikeC",
+		"UnitTest",
+		"Verbose",
+	})
+
+
+--
+-- Register some D specific properties
+--
+
+	api.register {
+		name = "versionconstants",
+		scope = "config",
+		kind = "list:string",
+		tokens = true,
+	}
+
+	api.register {
+		name = "versionlevel",
+		scope = "config",
+		kind = "integer",
+	}
+
+	api.register {
+		name = "debugconstants",
+		scope = "config",
+		kind = "list:string",
+		tokens = true,
+	}
+
+	api.register {
+		name = "debuglevel",
+		scope = "config",
+		kind = "integer",
+	}
+
+	api.register {
+		name = "docdir",
+		scope = "config",
+		kind = "path",
+		tokens = true,
+	}
+
+	api.register {
+		name = "docname",
+		scope = "config",
+		kind = "string",
+		tokens = true,
+	}
+
+	api.register {
+		name = "headerdir",
+		scope = "config",
+		kind = "path",
+		tokens = true,
+	}
+
+	api.register {
+		name = "headername",
+		scope = "config",
+		kind = "string",
+		tokens = true,
+	}
+
+
+--
+-- Provide information for the help output
+--
+	newoption
+	{
+		trigger		= "dc",
+		value		= "VALUE",
+		description	= "Choose a D compiler",
+		allowed = {
+			{ "dmd", "Digital Mars (dmd)" },
+			{ "gdc", "GNU GDC (gdc)" },
+			{ "ldc", "LLVM LDC (ldc2)" },
+		}
+	}
+
+
+--
+-- Decide when to load the full module
+--
+
+	return function (cfg)
+		return (cfg.language == p.D)
+	end

--- a/modules/d/actions/gmake.lua
+++ b/modules/d/actions/gmake.lua
@@ -1,0 +1,370 @@
+--
+-- d/actions/gmake.lua
+-- Define the D makefile action(s).
+-- Copyright (c) 2013-2015 Andrew Gough, Manu Evans, and the Premake project
+--
+
+	local p = premake
+	local m = p.modules.d
+
+	m.make = {}
+
+	local dmake = m.make
+
+	local make = p.make
+	local cpp = p.make.cpp
+	local project = p.project
+	local config = p.config
+	local fileconfig = p.fileconfig
+
+-- This check may be unnecessary as we only 'require' this file from d.lua
+-- IFF the action already exists, however this may help if this file is
+-- directly required, rather than d.lua itself.
+	local gmake = p.action.get( 'gmake' )
+	if gmake == nil then
+		error( "Failed to locate prequisite action 'gmake'" )
+	end
+
+--
+-- Patch the gmake action with the allowed tools...
+--
+	gmake.valid_languages = table.join(gmake.valid_languages, { p.D } )
+	gmake.valid_tools.dc = { "dmd", "gdc", "ldc" }
+
+
+	function m.make.separateCompilation(prj)
+		local some = false
+		local all = true
+		for cfg in project.eachconfig(prj) do
+			if cfg.flags.SeparateCompilation then
+				some = true
+			else
+				all = false
+			end
+		end
+		return iif(all, "all", iif(some, "some", "none"))
+	end
+
+
+--
+-- Override the GMake action 'onProject' funtion to provide
+-- D knowledge...
+--
+	p.override( gmake, "onProject", function(oldfn, prj)
+		p.escaper(make.esc)
+		if project.isd(prj) then
+			local makefile = make.getmakefilename(prj, true)
+			p.generate(prj, makefile, m.make.generate)
+			return
+		end
+		oldfn(prj)
+	end)
+
+	p.override( make, "objdir", function(oldfn, cfg)
+		if cfg.project.language ~= "D" or cfg.flags.SeparateCompilation then
+			oldfn(cfg)
+		end
+	end)
+
+	p.override( make, "objDirRules", function(oldfn, prj)
+		if prj.language ~= "D" or m.make.separateCompilation(prj) ~= "none" then
+			oldfn(prj)
+		end
+	end)
+
+
+---
+-- Add namespace for element definition lists for p.callarray()
+---
+
+	m.elements = {}
+
+--
+-- Generate a GNU make C++ project makefile, with support for the new platforms API.
+--
+
+	m.elements.makefile = function(prj)
+		return {
+			make.header,
+			make.phonyRules,
+			m.make.configs,
+			m.make.objects,		-- TODO: This is basically identical to make.cppObjects(), and should ideally be merged/shared
+			make.shellType,
+			m.make.targetRules,
+			make.targetDirRules,
+			make.objDirRules,
+			make.cppCleanRules,	-- D clean code is identical to C/C++
+			make.preBuildRules,
+			make.preLinkRules,
+			m.make.dFileRules,
+		}
+	end
+
+	function m.make.generate(prj)
+		p.callArray(m.elements.makefile, prj)
+	end
+
+
+	function m.make.buildRule(prj)
+		_p('$(TARGET): $(SOURCEFILES) $(LDDEPS)')
+		_p('\t@echo Building %s', prj.name)
+		_p('\t$(SILENT) $(BUILDCMD)')
+		_p('\t$(POSTBUILDCMDS)')
+	end
+
+	function m.make.linkRule(prj)
+		_p('$(TARGET): $(OBJECTS) $(LDDEPS)')
+		_p('\t@echo Linking %s', prj.name)
+		_p('\t$(SILENT) $(LINKCMD)')
+		_p('\t$(POSTBUILDCMDS)')
+	end
+
+	function m.make.targetRules(prj)
+		local separateCompilation = m.make.separateCompilation(prj)
+		if separateCompilation == "all" then
+			m.make.linkRule(prj)
+		elseif separateCompilation == "none" then
+			m.make.buildRule(prj)
+		else
+			for cfg in project.eachconfig(prj) do
+				_x('ifeq ($(config),%s)', cfg.shortname)
+				if cfg.flags.SeparateCompilation then
+					m.make.linkRule(prj)
+				else
+					m.make.buildRule(prj)
+				end
+				_p('endif')
+			end
+		end
+		_p('')
+	end
+
+	function m.make.dFileRules(prj)
+		local separateCompilation = m.make.separateCompilation(prj)
+		if separateCompilation ~= "none" then
+			make.cppFileRules(prj)
+		end
+	end
+
+--
+-- Override the 'standard' file rule to support D source files
+--
+
+	p.override(cpp, "standardFileRules", function(oldfn, prj, node)
+		-- D file
+		if path.isdfile(node.abspath) then
+			_x('$(OBJDIR)/%s.o: %s', node.objname, node.relpath)
+			_p('\t@echo $(notdir $<)')
+			_p('\t$(SILENT) $(DC) $(ALL_DFLAGS) $(OUTPUTFLAG) -c $<')
+		else
+	 		oldfn(prj, node)
+	 	end
+	end)
+
+
+--
+-- Write out the settings for a particular configuration.
+--
+
+	m.elements.makeconfig = function(cfg)
+		return {
+			m.make.dTools,
+			make.target,
+			m.make.target,
+			make.objdir,
+			m.make.versions,
+			m.make.debug,
+			m.make.imports,
+			m.make.dFlags,
+			make.libs,
+			make.ldDeps,
+			make.ldFlags,
+			m.make.linkCmd,
+			make.preBuildCmds,
+			make.preLinkCmds,
+			make.postBuildCmds,
+			m.make.allRules,
+			make.settings,
+		}
+	end
+
+	function m.make.configs(prj)
+		for cfg in project.eachconfig(prj) do
+			-- identify the toolset used by this configurations (would be nicer if
+			-- this were computed and stored with the configuration up front)
+
+			local toolset = p.tools[_OPTIONS.dc or cfg.toolset or "dmd"]
+			if not toolset then
+				error("Invalid toolset '" + (_OPTIONS.dc or cfg.toolset) + "'")
+			end
+
+			_x('ifeq ($(config),%s)', cfg.shortname)
+			p.callArray(m.elements.makeconfig, cfg, toolset)
+			_p('endif')
+			_p('')
+		end
+	end
+
+	function m.make.dTools(cfg, toolset)
+		local tool = toolset.gettoolname(cfg, "dc")
+		if tool then
+			_p('  DC = %s', tool)
+		end
+	end
+
+	function m.make.target(cfg, toolset)
+		if cfg.flags.SeparateCompilation then
+			_p('  OUTPUTFLAG = %s', toolset.gettarget('"$@"'))
+		end
+	end
+
+	function m.make.versions(cfg, toolset)
+		_p('  VERSIONS +=%s', make.list(toolset.getversions(cfg.versionconstants, cfg.versionlevel)))
+	end
+
+	function m.make.debug(cfg, toolset)
+		_p('  DEBUG +=%s', make.list(toolset.getdebug(cfg.debugconstants, cfg.debuglevel)))
+	end
+
+	function m.make.imports(cfg, toolset)
+		local includes = p.esc(toolset.getimportdirs(cfg, cfg.includedirs))
+		_p('  IMPORTS +=%s', make.list(includes))
+	end
+
+	function m.make.dFlags(cfg, toolset)
+		_p('  ALL_DFLAGS += $(DFLAGS)%s $(VERSIONS) $(DEBUG) $(IMPORTS) $(ARCH)', make.list(table.join(toolset.getdflags(cfg), cfg.buildoptions)))
+	end
+
+	function m.make.linkCmd(cfg, toolset)
+		if cfg.flags.SeparateCompilation then
+			_p('  LINKCMD = $(DC) ' .. toolset.gettarget("$(TARGET)") .. ' $(ALL_LDFLAGS) $(LIBS) $(OBJECTS)')
+
+--			local cc = iif(cfg.language == "C", "CC", "CXX")
+--			_p('  LINKCMD = $(%s) -o $(TARGET) $(OBJECTS) $(RESOURCES) $(ARCH) $(ALL_LDFLAGS) $(LIBS)', cc)
+		else
+			_p('  BUILDCMD = $(DC) ' .. toolset.gettarget("$(TARGET)") .. ' $(ALL_DFLAGS) $(ALL_LDFLAGS) $(LIBS) $(SOURCEFILES)')
+		end
+	end
+
+	function m.make.allRules(cfg, toolset)
+		-- TODO: The C++ version has some special cases for OSX and Windows... check whether they should be here too?
+		if cfg.flags.SeparateCompilation then
+			_p('all: $(TARGETDIR) $(OBJDIR) prebuild prelink $(TARGET)')
+		else
+			_p('all: $(TARGETDIR) prebuild prelink $(TARGET)')
+		end
+		_p('\t@:')
+--		_p('')
+	end
+
+
+--
+-- List the objects file for the project, and each configuration.
+--
+
+-- TODO: This is basically identical to make.cppObjects(), and should ideally be merged/shared
+
+	function m.make.objects(prj)
+		-- create lists for intermediate files, at the project level and
+		-- for each configuration
+		local root = { sourcefiles={}, objects={} }
+		local configs = {}
+		for cfg in project.eachconfig(prj) do
+			configs[cfg] = { sourcefiles={}, objects={} }
+		end
+
+		-- now walk the list of files in the project
+		local tr = project.getsourcetree(prj)
+		p.tree.traverse(tr, {
+			onleaf = function(node, depth)
+				-- figure out what configurations contain this file, and
+				-- if it uses custom build rules
+				local incfg = {}
+				local inall = true
+				local custom = false
+				for cfg in project.eachconfig(prj) do
+					local filecfg = fileconfig.getconfig(node, cfg)
+					if filecfg and not filecfg.flags.ExcludeFromBuild then
+						incfg[cfg] = filecfg
+						custom = fileconfig.hasCustomBuildRule(filecfg)
+					else
+						inall = false
+					end
+				end
+
+				if not custom then
+					-- skip files that aren't compiled
+					if not path.isdfile(node.abspath) then
+						return
+					end
+
+					local sourcename = node.relpath
+
+					-- TODO: assign a unique object file name to avoid collisions
+					local objectname = "$(OBJDIR)/" .. node.objname .. ".o"
+
+					-- if this file exists in all configurations, write it to
+					-- the project's list of files, else add to specific cfgs
+					if inall then
+						table.insert(root.sourcefiles, sourcename)
+						table.insert(root.objects, objectname)
+					else
+						for cfg in project.eachconfig(prj) do
+							if incfg[cfg] then
+								table.insert(configs[cfg].sourcefiles, sourcename)
+								table.insert(configs[cfg].objects, objectname)
+							end
+						end
+					end
+
+				else
+					for cfg in project.eachconfig(prj) do
+						local filecfg = incfg[cfg]
+						if filecfg then
+							-- if the custom build outputs an object file, add it to
+							-- the link step automatically to match Visual Studio
+							local output = project.getrelative(prj, filecfg.buildoutputs[1])
+							if path.isobjectfile(output) then
+								table.insert(configs[cfg].objects, output)
+							end
+						end
+					end
+				end
+
+			end
+		})
+
+		local separateCompilation = m.make.separateCompilation(prj)
+
+		-- now I can write out the lists, project level first...
+		function listobjects(var, list)
+			_p('%s \\', var)
+			for _, objectname in ipairs(list) do
+				_x('\t%s \\', objectname)
+			end
+			_p('')
+		end
+
+		if separateCompilation ~= "all" then
+			listobjects('SOURCEFILES :=', root.sourcefiles)
+		end
+		if separateCompilation ~= "none" then
+			listobjects('OBJECTS :=', root.objects, 'o')
+		end
+
+		-- ...then individual configurations, as needed
+		for cfg in project.eachconfig(prj) do
+			local files = configs[cfg]
+			if (#files.sourcefiles > 0 and separateCompilation ~= "all") or (#files.objects > 0 and separateCompilation ~= "none") then
+				_x('ifeq ($(config),%s)', cfg.shortname)
+				if #files.sourcefiles > 0 and separateCompilation ~= "all" then
+					listobjects('  SOURCEFILES +=', files.sourcefiles)
+				end
+				if #files.objects > 0 and separateCompilation ~= "none" then
+					listobjects('  OBJECTS +=', files.objects)
+				end
+				_p('endif')
+			end
+		end
+		_p('')
+	end

--- a/modules/d/actions/monodev.lua
+++ b/modules/d/actions/monodev.lua
@@ -1,0 +1,254 @@
+--
+-- d/actions/monodev.lua
+-- Generate a Mono-D .dproj project.
+-- Copyright (c) 2012-2015 Manu Evans and the Premake project
+--
+
+	local p = premake
+	local m = p.modules.d
+
+	m.monod = {}
+
+	local monodevelop = p.modules.monodevelop
+	local vstudio = p.vstudio
+	local project = p.project
+	local config = p.config
+	local fileconfig = p.fileconfig
+	local tree = p.tree
+
+--
+-- Patch the monodevelop action with D support...
+--
+
+	local md = p.action.get("monodevelop")
+	if md ~= nil then
+		table.insert( md.valid_languages, p.D )
+		md.valid_tools.dc = { "dmd", "gdc", "ldc" }
+
+		p.override(md, "onProject", function(oldfn, prj)
+			oldfn(prj)
+			if project.isd(prj) then
+				p.generate(prj, ".dproj", monodevelop.generate)
+			end
+		end)
+	end
+
+
+--
+-- Patch a bunch of functions
+--
+
+	p.override(vstudio, "projectfile", function(oldfn, prj)
+		if _ACTION == "monodevelop" then
+			if project.isd(prj) then
+				return p.filename(prj, ".dproj")
+			end
+		end
+		return oldfn(prj)
+	end)
+
+
+	p.override(vstudio, "tool", function(oldfn, prj)
+		if _ACTION == "monodevelop" then
+			if project.isd(prj) then
+				return "3947E667-4C90-4C3A-BEB9-7148D6FE0D7C"
+			end
+		end
+		return oldfn(prj)
+	end)
+
+
+	p.override(monodevelop, "getTargetGroup", function(oldfn, node, prj, groups)
+		if project.isd(prj) then
+			-- if any configuration of this file uses a custom build rule,
+			-- then they all must be marked as custom build
+			local hasbuildrule = false
+			for cfg in project.eachconfig(prj) do
+				local filecfg = fileconfig.getconfig(node, cfg)
+				if filecfg and fileconfig.hasCustomBuildRule(filecfg) then
+					hasbuildrule = true
+					break
+				end
+			end
+
+			if hasbuildrule then
+				return groups.CustomBuild
+			elseif path.isdfile(node.name) then
+				return groups.Compile
+--			elseif path.isdheader(node.name) then -- TODO: do .di files belong in here?
+--				return groups.Include
+			elseif path.isresourcefile(node.name) then
+				return groups.ResourceCompile
+			else
+				return groups.None
+			end
+		else
+			return oldfn(node, prj, groups)
+		end
+	end)
+
+
+--
+-- Override projectProperties element functions.
+--
+
+	p.override(monodevelop.elements, "projectProperties", function(oldfn, prj)
+		if project.isd(prj) then
+			return {
+				monodevelop.cproj.projectGuid,
+				m.monod.useDefaultCompiler,
+				m.monod.incrementalLinking,
+				m.monod.preferOneStepBuild,
+--				m.monod.baseDirectory,
+				m.monod.compiler,
+				monodevelop.cproj.version,
+				monodevelop.cproj.synchWksVersion,
+				monodevelop.cproj.description,
+			}
+		end
+		return oldfn(prj)
+	end)
+
+	function m.monod.useDefaultCompiler(prj)
+		_p(2,'<UseDefaultCompiler>%s</UseDefaultCompiler>', iif(_OPTIONS.dc, 'false', 'true'))
+	end
+
+	function m.monod.incrementalLinking(prj)
+		_p(2,'<IncrementalLinking>true</IncrementalLinking>')
+	end
+
+	function m.monod.preferOneStepBuild(prj)
+		_p(2,'<PreferOneStepBuild>true</PreferOneStepBuild>')
+	end
+
+	function m.monod.baseDirectory(prj)
+		_p(2,'<BaseDirectory>.</BaseDirectory>')
+	end
+
+	function m.monod.compiler(prj)
+		local compiler = { dmd="DMD2", gdc="GDC", ldc="ldc2" }
+		-- TODO: support compiler selection from 'toolset' declaration
+		--       problem; toolset is at config, this is project level
+		_p(2,'<Compiler>%s</Compiler>', compiler[_OPTIONS.dc or "dmd"])
+	end
+
+
+--
+-- Override configurationProperties element functions.
+--
+
+	p.override(monodevelop.elements, "configurationProperties", function(oldfn, cfg)
+		if project.isd(cfg.project) then
+			return {
+				monodevelop.cproj.debuginfo,
+				monodevelop.cproj.outputPath,
+				m.monod.unittestMode,
+				m.monod.objectsDirectory, -- TODO: should this be moved into the .cproj options?
+				m.monod.debugLevel,
+				monodevelop.cproj.externalconsole,
+				m.monod.target,
+				m.monod.thirdParty,
+				monodevelop.cproj.outputName,
+				m.monod.additionalOptions,
+				m.monod.dDocDirectory,
+				m.monod.versionIds,
+				m.monod.debugIds,
+				monodevelop.cproj.additionalLinkOptions,
+				monodevelop.cproj.additionalDependencies,
+				monodevelop.cproj.buildEvents,
+
+--				sourceDirectory, -- not used by D?
+			}
+		end
+		return oldfn(cfg)
+	end)
+
+	function m.monod.unittestMode(cfg)
+		-- should this be present if it's set to default?
+		_p(2,'<UnittestMode>%s</UnittestMode>', iif(cfg.flags.UnitTest, 'true', 'false'))
+	end
+
+	function m.monod.objectsDirectory(cfg)
+		local objdir = project.getrelative(cfg.project, cfg.objdir)
+		_p(2,'<ObjectsDirectory>%s</ObjectsDirectory>', path.translate(objdir))
+	end
+
+	function m.monod.debugLevel(cfg)
+		_p(2,'<DebugLevel>%d</DebugLevel>', iif(cfg.debuglevel, cfg.debuglevel, 0))
+	end
+
+	function m.monod.target(cfg)
+		local map = {
+			SharedLib = "SharedLibrary",
+			StaticLib = "StaticLibrary",
+			ConsoleApp = "Executable",
+			WindowedApp = "Executable"
+		}
+		_p(2,'<Target>%s</Target>', map[cfg.kind])
+	end
+
+	function m.monod.thirdParty(cfg)
+		-- TODO: what is this for?
+		local linkThirdParty = "false"
+		_p(2,'<LinkinThirdPartyLibraries>%s</LinkinThirdPartyLibraries>', linkThirdParty)
+	end
+
+	function m.monod.additionalOptions(cfg)
+		local opts = { }
+
+		-- TODO: handle all those options, and they also need to be compiler-specific!
+
+		-- float mode
+		-- SIMD
+		-- etc
+		-- like this: table.insert(opts, "-msse2")
+
+		local options
+		if #opts > 0 then
+			options = table.concat(opts, " ")
+		end
+		if #cfg.buildoptions > 0 then
+			local buildOpts = table.concat(cfg.buildoptions, " ")
+			options = (options and options .. " " .. buildOpts) or buildOpts
+		end
+
+		if options then
+			_x(2,'<ExtraCompilerArguments>%s</ExtraCompilerArguments>', options)
+		end
+	end
+
+	function m.monod.dDocDirectory(cfg)
+		if cfg.docdir then
+			local docdir = project.getrelative(cfg.project, cfg.docdir)
+			_x(2,'<DDocDirectory>%s</DDocDirectory>', path.translate(docdir))
+		end
+	end
+
+	function m.monod.versionIds(cfg)
+		if #cfg.versionconstants > 0 then
+			_x(2,'<VersionIds>')
+			_x(3,'<VersionIds>')
+
+			for _, v in ipairs(cfg.versionconstants) do
+				_x(4,'<String>%s</String>', v)
+			end
+
+			_x(3,'</VersionIds>')
+			_x(2,'</VersionIds>')
+		end
+	end
+
+	function m.monod.debugIds(cfg)
+		if #cfg.debugconstants > 0 then
+			_x(2,'<DebugIds>')
+			_x(3,'<DebugIds>')
+
+			for _, d in ipairs(cfg.debugconstants) do
+				_x(4,'<String>%s</String>', d)
+			end
+
+			_x(3,'</DebugIds>')
+			_x(2,'</DebugIds>')
+		end
+	end
+

--- a/modules/d/actions/vstudio.lua
+++ b/modules/d/actions/vstudio.lua
@@ -1,0 +1,353 @@
+--
+-- d/actions/vstudio.lua
+-- Generate a VisualD .visualdproj project.
+-- Copyright (c) 2012-2015 Manu Evans and the Premake project
+--
+
+	local p = premake
+	local m = p.modules.d
+
+	m.visuald = {}
+
+	local vstudio = p.vstudio
+	local workspace = p.workspace
+	local project = p.project
+	local config = p.config
+	local tree = p.tree
+
+--
+-- Patch the vstudio actions with D support...
+--
+
+	for k,v in pairs({ "vs2005", "vs2008", "vs2010", "vs2012", "vs2013", "vs2015" }) do
+		local vs = p.action.get(v)
+		if vs ~= nil then
+			table.insert( vs.valid_languages, p.D )
+			vs.valid_tools.dc = { "dmd", "gdc", "ldc" }
+
+			p.override(vs, "onProject", function(oldfn, prj)
+				oldfn(prj)
+				if project.isd(prj) then
+					p.generate(prj, ".visualdproj", m.visuald.generate)
+				end
+			end)
+		end
+	end
+
+
+--
+-- Patch a bunch of other functions
+--
+
+	p.override(project, "isnative", function(oldfn, prj)
+		return project.isd(prj) or oldfn(prj)
+	end)
+
+	p.override(vstudio, "projectfile", function(oldfn, prj)
+		if project.isd(prj) then
+			return p.filename(prj, ".visualdproj")
+		end
+		return oldfn(prj)
+	end)
+
+	p.override(vstudio, "tool", function(oldfn, prj)
+		if project.isd(prj) then
+			return "002A2DE9-8BB6-484D-9802-7E4AD4084715"
+		end
+		return oldfn(prj)
+	end)
+
+
+--
+-- Generate a Visual D project.
+--
+
+	m.elements.project = function(prj)
+		return {
+			m.visuald.header,
+			m.visuald.globals,
+			m.visuald.projectConfigurations,
+			m.visuald.files,
+		}
+
+	end
+
+	function m.visuald.generate(prj)
+		p.eol("\r\n")
+		p.indent(" ")
+
+		p.callArray(m.elements.project, prj)
+
+		_p('</DProject>')
+	end
+
+
+	function m.visuald.header(prj)
+		-- for some reason Visual D projects don't seem to have an xml header
+		--_p('<?xml version="1.0" encoding="utf-8"?>')
+		_p('<DProject>')
+	end
+
+	function m.visuald.globals(prj)
+		_p(1,'<ProjectGuid>{%s}</ProjectGuid>', prj.uuid)
+	end
+
+
+--
+-- Write out the list of project configurations, which pairs build
+-- configurations with architectures.
+--
+
+	function m.visuald.projectConfigurations(prj)
+		-- build a list of all architectures used in this project
+
+		for cfg in project.eachconfig(prj) do
+			local prjPlatform = p.esc(vstudio.projectPlatform(cfg))
+			local slnPlatform = vstudio.solutionPlatform(cfg)
+			local is64bit = slnPlatform == "x64" -- TODO: this seems like a hack
+
+			_p(1,'<Config name="%s" platform="%s">', prjPlatform, slnPlatform)
+
+			_p(2,'<obj>0</obj>')
+			_p(2,'<link>0</link>')
+
+			local isWindows = false
+			local isDebug = string.find(cfg.buildcfg, 'Debug') ~= nil
+			local isOptimised = config.isOptimizedBuild(cfg)
+
+			if cfg.kind == p.CONSOLEAPP then
+				_p(2,'<lib>0</lib>')
+				_p(2,'<subsystem>1</subsystem>')
+			elseif cfg.kind == p.STATICLIB then
+				_p(2,'<lib>1</lib>')
+				_p(2,'<subsystem>0</subsystem>')
+			elseif cfg.kind == p.SHAREDLIB then
+				_p(2,'<lib>2</lib>')
+				_p(2,'<subsystem>0</subsystem>') -- SHOULD THIS BE '2' (windows)??
+			else
+				_p(2,'<lib>0</lib>')
+				_p(2,'<subsystem>2</subsystem>')
+				isWindows = true
+			end
+
+			_p(2,'<multiobj>0</multiobj>')
+			_p(2,'<singleFileCompilation>0</singleFileCompilation>')
+			_p(2,'<oneobj>0</oneobj>')
+			_p(2,'<trace>%s</trace>', iif(cfg.flags.Profile, '1', '0'))
+			_p(2,'<quiet>%s</quiet>', iif(cfg.flags.Quiet, '1', '0'))
+			_p(2,'<verbose>%s</verbose>', iif(cfg.flags.Verbose, '1', '0'))
+			_p(2,'<vtls>0</vtls>')
+			_p(2,'<symdebug>%s</symdebug>', iif(cfg.flags.Symbols or cfg.flags.SymbolsLikeC, iif(cfg.flags.SymbolsLikeC, '2', '1'), '0'))
+			_p(2,'<optimize>%s</optimize>', iif(isOptimised, '1', '0'))
+			_p(2,'<cpu>0</cpu>')
+			_p(2,'<isX86_64>%s</isX86_64>', iif(is64bit, '1', '0'))
+			_p(2,'<isLinux>0</isLinux>')
+			_p(2,'<isOSX>0</isOSX>')
+			_p(2,'<isWindows>%s</isWindows>', iif(isWindows, '1', '0'))
+			_p(2,'<isFreeBSD>0</isFreeBSD>')
+			_p(2,'<isSolaris>0</isSolaris>')
+			_p(2,'<scheduler>0</scheduler>')
+			_p(2,'<useDeprecated>%s</useDeprecated>', iif(cfg.flags.Deprecated, '1', '0'))
+			_p(2,'<errDeprecated>0</errDeprecated>')
+			_p(2,'<useAssert>0</useAssert>')
+			_p(2,'<useInvariants>0</useInvariants>')
+			_p(2,'<useIn>0</useIn>')
+			_p(2,'<useOut>0</useOut>')
+			_p(2,'<useArrayBounds>0</useArrayBounds>')
+			_p(2,'<noboundscheck>%s</noboundscheck>', iif(cfg.flags.NoBoundsCheck, '1', '0'))
+			_p(2,'<useSwitchError>0</useSwitchError>')
+			_p(2,'<useUnitTests>%s</useUnitTests>', iif(cfg.flags.UnitTest, '1', '0'))
+			_p(2,'<useInline>%s</useInline>', iif(cfg.flags.Inline or isOptimised, '1', '0'))
+			_p(2,'<release>%s</release>', iif(cfg.flags.Release or not isDebug, '1', '0'))
+			_p(2,'<preservePaths>0</preservePaths>')
+
+			_p(2,'<warnings>%s</warnings>', iif(cfg.flags.FatalCompileWarnings, '1', '0'))
+			_p(2,'<infowarnings>%s</infowarnings>', iif(cfg.warnings and cfg.warnings ~= "Off", '1', '0'))
+
+			_p(2,'<checkProperty>0</checkProperty>')
+			_p(2,'<genStackFrame>0</genStackFrame>')
+			_p(2,'<pic>%s</pic>', iif(cfg.pic == "On", '1', '0'))
+			_p(2,'<cov>%s</cov>', iif(cfg.flags.CodeCoverage, '1', '0'))
+			_p(2,'<nofloat>%s</nofloat>', iif(cfg.floatingpoint and cfg.floatingpoint == "None", '1', '0'))
+			_p(2,'<Dversion>2</Dversion>')
+			_p(2,'<ignoreUnsupportedPragmas>0</ignoreUnsupportedPragmas>')
+
+			local compiler = { dmd="0", gdc="1", ldc="2" }
+			m.visuald.element(2, "compiler", compiler[_OPTIONS.dc or cfg.toolset or "dmd"])
+
+			m.visuald.element(2, "otherDMD", '0')
+			m.visuald.element(2, "program", '$(DMDInstallDir)windows\\bin\\dmd.exe')
+
+			m.visuald.element(2, "imppath", cfg.includedirs)
+
+			m.visuald.element(2, "fileImppath")
+			m.visuald.element(2, "outdir", path.translate(project.getrelative(cfg.project, cfg.buildtarget.directory)))
+			m.visuald.element(2, "objdir", path.translate(project.getrelative(cfg.project, cfg.objdir)))
+			m.visuald.element(2, "objname")
+			m.visuald.element(2, "libname")
+
+			m.visuald.element(2, "doDocComments", iif(cfg.flags.Documentation, '1', '0'))
+			m.visuald.element(2, "docdir", cfg.docdir)
+			m.visuald.element(2, "docname", cfg.docname)
+			m.visuald.element(2, "modules_ddoc")
+			m.visuald.element(2, "ddocfiles")
+
+			m.visuald.element(2, "doHdrGeneration", iif(cfg.flags.GenerateHeader, '1', '0'))
+			m.visuald.element(2, "hdrdir", cfg.headerdir)
+			m.visuald.element(2, "hdrname", cfg.headername)
+
+			m.visuald.element(2, "doXGeneration", iif(cfg.flags.GenerateJSON, '1', '0'))
+			m.visuald.element(2, "xfilename", '$(IntDir)\\$(TargetName).json')
+
+			m.visuald.element(2, "debuglevel", iif(cfg.debuglevel, tostring(cfg.debuglevel), '0'))
+			m.visuald.element(2, "debugids", cfg.debugconstants)
+			m.visuald.element(2, "versionlevel", iif(cfg.versionlevel, tostring(cfg.versionlevel), '0'))
+			m.visuald.element(2, "versionids", cfg.versionconstants)
+
+			_p(2,'<dump_source>0</dump_source>')
+			_p(2,'<mapverbosity>0</mapverbosity>')
+			_p(2,'<createImplib>%s</createImplib>', iif(cfg.kind ~= p.SHAREDLIB or cfg.flags.NoImportLib, '0', '1'))
+			_p(2,'<defaultlibname />')
+			_p(2,'<debuglibname />')
+			_p(2,'<moduleDepsFile />')
+
+			_p(2,'<run>0</run>')
+			_p(2,'<runargs />')
+
+--			_p(2,'<runCv2pdb>%s</runCv2pdb>', iif(cfg.flags.Symbols, '1', '0'))
+			_p(2,'<runCv2pdb>1</runCv2pdb>') -- we will just leave this always enabled, since it's ignored if no debuginfo is written
+			_p(2,'<pathCv2pdb>$(VisualDInstallDir)cv2pdb\\cv2pdb.exe</pathCv2pdb>')
+			_p(2,'<cv2pdbPre2043>0</cv2pdbPre2043>')
+			_p(2,'<cv2pdbNoDemangle>0</cv2pdbNoDemangle>')
+			_p(2,'<cv2pdbEnumType>0</cv2pdbEnumType>')
+			_p(2,'<cv2pdbOptions />')
+
+			_p(2,'<objfiles />')
+			_p(2,'<linkswitches />')
+
+			local links
+			local explicit = vstudio.needsExplicitLink(cfg)
+			-- check to see if this project uses an external toolset. If so, let the
+			-- toolset define the format of the links
+			local toolset = config.toolset(cfg)
+			if toolset then
+				links = toolset.getlinks(cfg, not explicit)
+			else
+				local scope = iif(explicit, "all", "system")
+				links = config.getlinks(cfg, scope, "fullpath")
+			end
+			m.visuald.element(2, "libfiles", table.concat(links, " "))
+
+			m.visuald.element(2, "libpaths", cfg.libdirs)
+			_p(2,'<deffile />')
+			_p(2,'<resfile />')
+
+			local target = config.gettargetinfo(cfg)
+			_p(2,'<exefile>$(OutDir)\\%s</exefile>', target.name)
+
+			_p(2,'<useStdLibPath>1</useStdLibPath>')
+
+			local runtime = 0
+			if not cfg.flags.OmitDefaultLibrary then
+				if config.isDebugBuild(cfg) then
+					runtime = iif(cfg.flags.StaticRuntime, "2", "4")
+				else
+					runtime = iif(cfg.flags.StaticRuntime, "1", "3")
+				end
+			end
+			m.visuald.element(2, "cRuntime", runtime)
+
+			local additionalOptions
+			if #cfg.buildoptions > 0 then
+				additionalOptions = table.concat(cfg.buildoptions, " ")
+			end
+			if #cfg.linkoptions > 0 then
+				local linkOpts = table.implode(cfg.linkoptions, "-L", "", " ")
+				if additionalOptions then
+					additionalOptions = additionalOptions .. " " .. linkOpts
+				else
+					additionalOptions = linkOpts
+				end
+			end
+			m.visuald.element(2, "additionalOptions", additionalOptions)
+
+			if #cfg.prebuildcommands > 0 then
+				_p(2,'<preBuildCommand>%s</preBuildCommand>',p.esc(table.implode(cfg.prebuildcommands, "", "", "\r\n")))
+			else
+				_p(2,'<preBuildCommand />')
+			end
+
+			if #cfg.postbuildcommands > 0 then
+				_p(2,'<postBuildCommand>%s</postBuildCommand>',p.esc(table.implode(cfg.postbuildcommands, "", "", "\r\n")))
+			else
+				_p(2,'<postBuildCommand />')
+			end
+
+			_p(2,'<filesToClean>*.obj;*.cmd;*.build;*.json;*.dep;*.o</filesToClean>')
+
+			_p(1,'</Config>')
+		end
+	end
+
+
+--
+-- Write out the source file tree.
+--
+
+	function m.visuald.files(prj)
+		_p(1,'<Folder name="%s">', prj.name)
+
+		local tr = project.getsourcetree(prj)
+
+		tree.traverse(tr, {
+
+			-- folders, virtual or otherwise, are handled at the internal nodes
+			onbranchenter = function(node, depth)
+				_p(depth, '<Folder name="%s">', node.name)
+			end,
+
+			onbranchexit = function(node, depth)
+				_p(depth, '</Folder>')
+			end,
+
+			-- source files are handled at the leaves
+			onleaf = function(node, depth)
+				_p(depth, '<File path="%s" />', path.translate(node.relpath))
+
+--				_p(depth, '<File path="%s">', path.translate(node.relpath))
+--				m.visuald.fileConfiguration(prj, node, depth + 1)
+--				_p(depth, '</File>')
+			end
+
+		}, false, 2)
+
+		_p(1,'</Folder>')
+	end
+
+	function m.visuald.fileConfiguration(prj, node, depth)
+
+		-- maybe we'll need this in the future...
+
+	end
+
+
+--
+-- Output an individual project XML element.
+--
+
+	function m.visuald.element(depth, name, value, ...)
+		local isTable = type(value) == "table"
+		if not value or (isTable and #value == 0) then
+			_p(depth, '<%s />', name)
+		else
+			if isTable then
+				value = p.esc(table.implode(value, "", "", ";"))
+				_p(depth, '<%s>%s</%s>', name, value, name)
+			else
+				if select('#',...) == 0 then
+					value = p.esc(value)
+				end
+				_x(depth, string.format('<%s>%s</%s>', name, value, name), ...)
+			end
+		end
+	end

--- a/modules/d/d.lua
+++ b/modules/d/d.lua
@@ -1,0 +1,48 @@
+--
+-- d/d.lua
+-- Define the D makefile action(s).
+-- Copyright (c) 2013-2015 Andrew Gough, Manu Evans, and the Premake project
+--
+
+	local p = premake
+
+	p.modules.d = {}
+
+	local m = p.modules.d
+
+	m._VERSION = p._VERSION
+	m.elements = {}
+
+	local api = p.api
+
+
+--
+-- Patch the project table to provide knowledge of D projects
+--
+	function p.project.isd(prj)
+		return prj.language == premake.D
+	end
+
+--
+-- Patch the path table to provide knowledge of D file extenstions
+--
+	function path.isdfile(fname)
+		return path.hasextension(fname, { ".d", ".di" })
+	end
+
+
+--
+-- Patch actions
+--
+	include( "tools/dmd.lua" )
+	include( "tools/gdc.lua" )
+	include( "tools/ldc.lua" )
+
+	include( "actions/gmake.lua" )
+	include( "actions/vstudio.lua" )
+	-- this one depends on the monodevelop extension
+	if p.modules.monodevelop then
+		include( "actions/monodev.lua" )
+	end
+
+	return m

--- a/modules/d/tests/_tests.lua
+++ b/modules/d/tests/_tests.lua
@@ -1,0 +1,11 @@
+require ("monodevelop")
+require ("d")
+
+return {
+	"test_visualstudio.lua",
+	"test_monodevelop.lua",
+	"test_gmake.lua",
+	"test_dmd.lua",
+	"test_gdc.lua",
+	"test_ldc.lua",
+}

--- a/modules/d/tests/test_dmd.lua
+++ b/modules/d/tests/test_dmd.lua
@@ -1,0 +1,105 @@
+---
+-- d/tests/test_dmd.lua
+-- Automated test suite for dmd.
+-- Copyright (c) 2011-2015 Manu Evans and the Premake project
+---
+
+	local suite = test.declare("d_dmd")
+	local m = premake.modules.d
+
+	local make = premake.make
+	local project = premake.project
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		premake.escaper(make.esc)
+		wks = test.createWorkspace()
+	end
+
+	local function prepare_cfg(calls)
+		prj = premake.workspace.getproject(wks, 1)
+		local cfg = test.getconfig(prj, "Debug")
+		local toolset = premake.tools.dmd
+		premake.callArray(calls, cfg, toolset)
+	end
+
+
+--
+-- Check configuration generation
+--
+
+	function suite.dmd_dTools()
+		prepare_cfg({ m.make.dTools })
+		test.capture [[
+  DC = dmd
+		]]
+	end
+
+	function suite.dmd_target()
+		prepare_cfg({ m.make.target })
+		test.capture [[
+
+		]]
+	end
+
+	function suite.dmd_target_separateCompilation()
+		flags { "SeparateCompilation" }
+		prepare_cfg({ m.make.target })
+		test.capture [[
+  OUTPUTFLAG = -of"$@"
+		]]
+	end
+
+	function suite.dmd_versions()
+		versionlevel (10)
+		versionconstants { "A", "B" }
+		prepare_cfg({ m.make.versions })
+		test.capture [[
+  VERSIONS += -version=A -version=B -version=10
+		]]
+	end
+
+	function suite.dmd_debug()
+		debuglevel (10)
+		debugconstants { "A", "B" }
+		prepare_cfg({ m.make.debug })
+		test.capture [[
+  DEBUG += -debug=A -debug=B -debug=10
+		]]
+	end
+
+	function suite.dmd_imports()
+		includedirs { "dir1", "dir2/" }
+		prepare_cfg({ m.make.imports })
+		test.capture [[
+  IMPORTS += -Idir1 -Idir2
+		]]
+	end
+
+	function suite.dmd_dFlags()
+		prepare_cfg({ m.make.dFlags })
+		test.capture [[
+  ALL_DFLAGS += $(DFLAGS) -release $(VERSIONS) $(DEBUG) $(IMPORTS) $(ARCH)
+		]]
+	end
+
+	function suite.dmd_linkCmd()
+		prepare_cfg({ m.make.linkCmd })
+		test.capture [[
+  BUILDCMD = $(DC) -of$(TARGET) $(ALL_DFLAGS) $(ALL_LDFLAGS) $(LIBS) $(SOURCEFILES)
+		]]
+	end
+
+	function suite.dmd_linkCmd_separateCompilation()
+		flags { "SeparateCompilation" }
+		prepare_cfg({ m.make.linkCmd })
+		test.capture [[
+  LINKCMD = $(DC) -of$(TARGET) $(ALL_LDFLAGS) $(LIBS) $(OBJECTS)
+		]]
+	end

--- a/modules/d/tests/test_gdc.lua
+++ b/modules/d/tests/test_gdc.lua
@@ -1,0 +1,105 @@
+---
+-- d/tests/test_dmd.lua
+-- Automated test suite for dmd.
+-- Copyright (c) 2011-2015 Manu Evans and the Premake project
+---
+
+	local suite = test.declare("d_gdc")
+	local m = premake.modules.d
+
+	local make = premake.make
+	local project = premake.project
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		premake.escaper(make.esc)
+		wks = test.createWorkspace()
+	end
+
+	local function prepare_cfg(calls)
+		prj = premake.workspace.getproject(wks, 1)
+		local cfg = test.getconfig(prj, "Debug")
+		local toolset = premake.tools.gdc
+		premake.callArray(calls, cfg, toolset)
+	end
+
+
+--
+-- Check configuration generation
+--
+
+	function suite.dmd_dTools()
+		prepare_cfg({ m.make.dTools })
+		test.capture [[
+  DC = gdc
+		]]
+	end
+
+	function suite.dmd_target()
+		prepare_cfg({ m.make.target })
+		test.capture [[
+
+		]]
+	end
+
+	function suite.dmd_target_separateCompilation()
+		flags { "SeparateCompilation" }
+		prepare_cfg({ m.make.target })
+		test.capture [[
+  OUTPUTFLAG = -o "$@"
+		]]
+	end
+
+	function suite.dmd_versions()
+		versionlevel (10)
+		versionconstants { "A", "B" }
+		prepare_cfg({ m.make.versions })
+		test.capture [[
+  VERSIONS += -fversion=A -fversion=B -fversion=10
+		]]
+	end
+
+	function suite.dmd_debug()
+		debuglevel (10)
+		debugconstants { "A", "B" }
+		prepare_cfg({ m.make.debug })
+		test.capture [[
+  DEBUG += -fdebug=A -fdebug=B -fdebug=10
+		]]
+	end
+
+	function suite.dmd_imports()
+		includedirs { "dir1", "dir2/" }
+		prepare_cfg({ m.make.imports })
+		test.capture [[
+  IMPORTS += -Idir1 -Idir2
+		]]
+	end
+
+	function suite.dmd_dFlags()
+		prepare_cfg({ m.make.dFlags })
+		test.capture [[
+  ALL_DFLAGS += $(DFLAGS) -frelease $(VERSIONS) $(DEBUG) $(IMPORTS) $(ARCH)
+		]]
+	end
+
+	function suite.dmd_linkCmd()
+		prepare_cfg({ m.make.linkCmd })
+		test.capture [[
+  BUILDCMD = $(DC) -o $(TARGET) $(ALL_DFLAGS) $(ALL_LDFLAGS) $(LIBS) $(SOURCEFILES)
+		]]
+	end
+
+	function suite.dmd_linkCmd_separateCompilation()
+		flags { "SeparateCompilation" }
+		prepare_cfg({ m.make.linkCmd })
+		test.capture [[
+  LINKCMD = $(DC) -o $(TARGET) $(ALL_LDFLAGS) $(LIBS) $(OBJECTS)
+		]]
+	end

--- a/modules/d/tests/test_gmake.lua
+++ b/modules/d/tests/test_gmake.lua
@@ -1,0 +1,194 @@
+---
+-- d/tests/test_gmake.lua
+-- Automated test suite for gmake project generation.
+-- Copyright (c) 2011-2015 Manu Evans and the Premake project
+---
+
+	local suite = test.declare("d_make")
+	local m = premake.modules.d
+
+	local make = premake.make
+	local project = premake.project
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		premake.escaper(make.esc)
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		prj = premake.workspace.getproject(wks, 1)
+	end
+
+	local function prepare_cfg(calls)
+		prj = premake.workspace.getproject(wks, 1)
+		local cfg = test.getconfig(prj, "Debug")
+		local toolset = premake.tools.dmd
+		premake.callArray(calls, cfg, toolset)
+	end
+
+
+
+--
+-- Check project generation
+--
+
+	function suite.make_targetRules()
+		prepare()
+		m.make.targetRules(prj)
+		test.capture [[
+$(TARGET): $(SOURCEFILES) $(LDDEPS)
+	@echo Building MyProject
+	$(SILENT) $(BUILDCMD)
+	$(POSTBUILDCMDS)
+
+		]]
+	end
+
+	function suite.make_targetRules_separateCompilation()
+		flags { "SeparateCompilation" }
+		prepare()
+		m.make.targetRules(prj)
+		test.capture [[
+$(TARGET): $(OBJECTS) $(LDDEPS)
+	@echo Linking MyProject
+	$(SILENT) $(LINKCMD)
+	$(POSTBUILDCMDS)
+
+		]]
+	end
+
+	function suite.make_targetRules_mixedCompilation()
+		configuration { "Release" }
+			flags { "SeparateCompilation" }
+		prepare()
+		m.make.targetRules(prj)
+		test.capture [[
+ifeq ($(config),debug)
+$(TARGET): $(SOURCEFILES) $(LDDEPS)
+	@echo Building MyProject
+	$(SILENT) $(BUILDCMD)
+	$(POSTBUILDCMDS)
+endif
+ifeq ($(config),release)
+$(TARGET): $(OBJECTS) $(LDDEPS)
+	@echo Linking MyProject
+	$(SILENT) $(LINKCMD)
+	$(POSTBUILDCMDS)
+endif
+
+		]]
+	end
+
+
+	function suite.make_fileRules()
+		files { "blah.d" }
+		prepare()
+		m.make.dFileRules(prj)
+		test.capture [[
+
+		]]
+	end
+
+	function suite.make_fileRules_separateCompilation()
+		files { "blah.d" }
+		flags { "SeparateCompilation" }
+		prepare()
+		m.make.dFileRules(prj)
+		test.capture [[
+$(OBJDIR)/blah.o: blah.d
+	@echo $(notdir $<)
+	$(SILENT) $(DC) $(ALL_DFLAGS) $(OUTPUTFLAG) -c $<
+		]]
+	end
+
+	function suite.make_fileRules_mixedCompilation()
+		files { "blah.d" }
+		configuration { "Release" }
+			flags { "SeparateCompilation" }
+		prepare()
+		m.make.dFileRules(prj)
+		test.capture [[
+$(OBJDIR)/blah.o: blah.d
+	@echo $(notdir $<)
+	$(SILENT) $(DC) $(ALL_DFLAGS) $(OUTPUTFLAG) -c $<
+		]]
+	end
+
+
+	function suite.make_objects()
+		files { "blah.d" }
+		prepare()
+		m.make.objects(prj)
+		test.capture [[
+SOURCEFILES := \
+	blah.d \
+
+		]]
+	end
+
+	function suite.make_objects_separateCompilation()
+		files { "blah.d" }
+		flags { "SeparateCompilation" }
+		prepare()
+		m.make.objects(prj)
+		test.capture [[
+OBJECTS := \
+	$(OBJDIR)/blah.o \
+
+		]]
+	end
+
+	function suite.make_objects_mixedCompilation()
+		files { "blah.d" }
+		configuration { "Release" }
+			flags { "SeparateCompilation" }
+			files { "blah2.d" }
+		prepare()
+		m.make.objects(prj)
+		test.capture [[
+SOURCEFILES := \
+	blah.d \
+
+OBJECTS := \
+	$(OBJDIR)/blah.o \
+
+ifeq ($(config),release)
+  SOURCEFILES += \
+	blah2.d \
+
+  OBJECTS += \
+	$(OBJDIR)/blah2.o \
+
+endif
+
+		]]
+	end
+
+
+--
+-- Check configuration generation
+--
+
+	function suite.make_allRules()
+		prepare_cfg({ m.make.allRules })
+		test.capture [[
+all: $(TARGETDIR) prebuild prelink $(TARGET)
+	@:
+		]]
+	end
+
+	function suite.make_allRules_separateCompilation()
+		flags { "SeparateCompilation" }
+		prepare_cfg({ m.make.allRules })
+		test.capture [[
+all: $(TARGETDIR) $(OBJDIR) prebuild prelink $(TARGET)
+	@:
+		]]
+	end

--- a/modules/d/tests/test_ldc.lua
+++ b/modules/d/tests/test_ldc.lua
@@ -1,0 +1,105 @@
+---
+-- d/tests/test_dmd.lua
+-- Automated test suite for dmd.
+-- Copyright (c) 2011-2015 Manu Evans and the Premake project
+---
+
+	local suite = test.declare("d_ldc")
+	local m = premake.modules.d
+
+	local make = premake.make
+	local project = premake.project
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		premake.escaper(make.esc)
+		wks = test.createWorkspace()
+	end
+
+	local function prepare_cfg(calls)
+		prj = premake.workspace.getproject(wks, 1)
+		local cfg = test.getconfig(prj, "Debug")
+		local toolset = premake.tools.ldc
+		premake.callArray(calls, cfg, toolset)
+	end
+
+
+--
+-- Check configuration generation
+--
+
+	function suite.dmd_dTools()
+		prepare_cfg({ m.make.dTools })
+		test.capture [[
+  DC = ldc2
+		]]
+	end
+
+	function suite.dmd_target()
+		prepare_cfg({ m.make.target })
+		test.capture [[
+
+		]]
+	end
+
+	function suite.dmd_target_separateCompilation()
+		flags { "SeparateCompilation" }
+		prepare_cfg({ m.make.target })
+		test.capture [[
+  OUTPUTFLAG = -of="$@"
+		]]
+	end
+
+	function suite.dmd_versions()
+		versionlevel (10)
+		versionconstants { "A", "B" }
+		prepare_cfg({ m.make.versions })
+		test.capture [[
+  VERSIONS += -d-version=A -d-version=B -d-version=10
+		]]
+	end
+
+	function suite.dmd_debug()
+		debuglevel (10)
+		debugconstants { "A", "B" }
+		prepare_cfg({ m.make.debug })
+		test.capture [[
+  DEBUG += -d-debug=A -d-debug=B -d-debug=10
+		]]
+	end
+
+	function suite.dmd_imports()
+		includedirs { "dir1", "dir2/" }
+		prepare_cfg({ m.make.imports })
+		test.capture [[
+  IMPORTS += -I=dir1 -I=dir2
+		]]
+	end
+
+	function suite.dmd_dFlags()
+		prepare_cfg({ m.make.dFlags })
+		test.capture [[
+  ALL_DFLAGS += $(DFLAGS) -release $(VERSIONS) $(DEBUG) $(IMPORTS) $(ARCH)
+		]]
+	end
+
+	function suite.dmd_linkCmd()
+		prepare_cfg({ m.make.linkCmd })
+		test.capture [[
+  BUILDCMD = $(DC) -of=$(TARGET) $(ALL_DFLAGS) $(ALL_LDFLAGS) $(LIBS) $(SOURCEFILES)
+		]]
+	end
+
+	function suite.dmd_linkCmd_separateCompilation()
+		flags { "SeparateCompilation" }
+		prepare_cfg({ m.make.linkCmd })
+		test.capture [[
+  LINKCMD = $(DC) -of=$(TARGET) $(ALL_LDFLAGS) $(LIBS) $(OBJECTS)
+		]]
+	end

--- a/modules/d/tests/test_monodevelop.lua
+++ b/modules/d/tests/test_monodevelop.lua
@@ -1,0 +1,190 @@
+---
+-- d/tests/test_monodevelop.lua
+-- Automated test suite for Mono-D project generation.
+-- Copyright (c) 2011-2015 Manu Evans and the Premake project
+---
+
+	local suite = test.declare("mono_d")
+	local m = premake.modules.d
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		premake.action.set("monodevelop")
+		premake.indent("  ")
+		wks = workspace "MyWorkspace"
+		configurations { "Debug", "Release" }
+		language "D"
+		kind "ConsoleApp"
+	end
+
+	local function prepare()
+		prj = project "MyProject"
+	end
+
+	local function prepare_cfg()
+		prj = project "MyProject"
+		cfg = test.getconfig(prj, "Debug")
+	end
+
+
+--
+-- Check sln for the proper project entry
+--
+
+	function suite.slnProj()
+		project "MyProject"
+		premake.vstudio.sln2005.reorderProjects(wks)
+		premake.vstudio.sln2005.projects(wks)
+		test.capture [[
+Project("{3947E667-4C90-4C3A-BEB9-7148D6FE0D7C}") = "MyProject", "MyProject.dproj", "{42B5DBC6-AE1F-903D-F75D-41E363076E92}"
+EndProject
+		]]
+	end
+
+
+--
+-- Project tests
+--
+
+	function suite.OnProject_useDefaultCompiler()
+		prepare()
+		m.monod.useDefaultCompiler(prj)
+		test.capture [[
+    <UseDefaultCompiler>true</UseDefaultCompiler>
+		]]
+	end
+
+	function suite.OnProject_incrementalLinking()
+		prepare()
+		m.monod.incrementalLinking(prj)
+		test.capture [[
+    <IncrementalLinking>true</IncrementalLinking>
+		]]
+	end
+
+	function suite.OnProject_preferOneStepBuild()
+		prepare()
+		m.monod.preferOneStepBuild(prj)
+		test.capture [[
+    <PreferOneStepBuild>true</PreferOneStepBuild>
+		]]
+	end
+
+	function suite.OnProject_compiler()
+		prepare()
+		m.monod.compiler(prj)
+		test.capture [[
+    <Compiler>DMD2</Compiler>
+		]]
+	end
+
+	-- TODO: test other compilers when 'toolset' works
+
+
+--
+-- Configuration tests
+--
+
+	function suite.OnProject_unittestMode()
+		flags { "UnitTest" }
+		prepare_cfg()
+		m.monod.unittestMode(cfg)
+		test.capture [[
+    <UnittestMode>true</UnittestMode>
+		]]
+	end
+
+	function suite.OnProject_objectsDirectory()
+		prepare_cfg()
+		m.monod.objectsDirectory(cfg)
+		test.capture([[
+    <ObjectsDirectory>]] .. path.translate("obj\\Debug") .. [[</ObjectsDirectory>
+		]])
+	end
+
+	function suite.OnProject_debugLevel()
+		debuglevel(2)
+		prepare_cfg()
+		m.monod.debugLevel(cfg)
+		test.capture [[
+    <DebugLevel>2</DebugLevel>
+		]]
+	end
+
+	function suite.OnProject_target()
+		kind "WindowedApp"
+		prepare_cfg()
+		m.monod.target(cfg)
+		test.capture [[
+    <Target>Executable</Target>
+		]]
+	end
+
+	function suite.OnProject_target()
+		kind "SharedLib"
+		prepare_cfg()
+		m.monod.target(cfg)
+		test.capture [[
+    <Target>SharedLibrary</Target>
+		]]
+	end
+
+	function suite.OnProject_thirdParty()
+		prepare_cfg()
+		m.monod.thirdParty(cfg)
+		test.capture [[
+    <LinkinThirdPartyLibraries>false</LinkinThirdPartyLibraries>
+		]]
+	end
+
+	function suite.OnProject_additionalOptions()
+		buildoptions { "-opt1", "-opt2" }
+		prepare_cfg()
+		m.monod.additionalOptions(cfg)
+		test.capture [[
+    <ExtraCompilerArguments>-opt1 -opt2</ExtraCompilerArguments>
+		]]
+	end
+
+	function suite.OnProject_dDocDirectory()
+		docdir "path"
+		prepare_cfg()
+		m.monod.dDocDirectory(cfg)
+		test.capture [[
+    <DDocDirectory>path</DDocDirectory>
+		]]
+	end
+
+	function suite.OnProject_versionIds()
+		versionconstants { "A", "B" }
+		prepare_cfg()
+		m.monod.versionIds(cfg)
+		test.capture [[
+    <VersionIds>
+      <VersionIds>
+        <String>A</String>
+        <String>B</String>
+      </VersionIds>
+    </VersionIds>
+		]]
+	end
+
+	function suite.OnProject_debugIds()
+		debugconstants { "A", "B" }
+		prepare_cfg()
+		m.monod.debugIds(cfg)
+		test.capture [[
+    <DebugIds>
+      <DebugIds>
+        <String>A</String>
+        <String>B</String>
+      </DebugIds>
+    </DebugIds>
+		]]
+	end

--- a/modules/d/tests/test_visualstudio.lua
+++ b/modules/d/tests/test_visualstudio.lua
@@ -1,0 +1,74 @@
+---
+-- d/tests/test_visualstudio.lua
+-- Automated test suite for VisualD project generation.
+-- Copyright (c) 2011-2015 Manu Evans and the Premake project
+---
+
+	local suite = test.declare("visual_d")
+	local m = premake.modules.d
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		premake.action.set("vs2010")
+--		premake.escaper(premake.vstudio.vs2005.esc)
+		premake.indent(" ")
+		wks = workspace "MyWorkspace"
+		configurations { "Debug", "Release" }
+		language "D"
+		kind "ConsoleApp"
+	end
+
+	local function prepare()
+		prj = project "MyProject"
+	end
+
+	local function prepare_cfg()
+		prj = project "MyProject"
+		cfg = test.getconfig(prj, "Debug")
+	end
+
+
+--
+-- Check sln for the proper project entry
+--
+
+	function suite.slnProj()
+		project "MyProject"
+		language "D"
+		premake.vstudio.sln2005.reorderProjects(wks)
+		premake.vstudio.sln2005.projects(wks)
+		test.capture [[
+Project("{002A2DE9-8BB6-484D-9802-7E4AD4084715}") = "MyProject", "MyProject.visualdproj", "{42B5DBC6-AE1F-903D-F75D-41E363076E92}"
+EndProject
+		]]
+	end
+
+
+--
+-- Project tests
+--
+
+	function suite.OnProject_header()
+		prepare()
+		m.visuald.header(prj)
+		test.capture [[
+<DProject>
+		]]
+	end
+
+	function suite.OnProject_globals()
+		prepare()
+		m.visuald.globals(prj)
+		test.capture [[
+ <ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+		]]
+	end
+
+
+	-- TODO: break up the project gen and make lots more tests...

--- a/modules/d/tools/dmd.lua
+++ b/modules/d/tools/dmd.lua
@@ -1,0 +1,374 @@
+--
+-- d/tools/dmd.lua
+-- Provides dmd-specific configuration strings.
+-- Copyright (c) 2013-2015 Andrew Gough, Manu Evans, and the Premake project
+--
+
+	local tdmd = {}
+
+	local project = premake.project
+	local config = premake.config
+    local d = premake.modules.d
+
+--
+-- Set default tools
+--
+	tdmd.gcc = {}
+	tdmd.gcc.dc = "dmd"
+
+	tdmd.optlink = {}
+	tdmd.optlink.dc = "dmd"
+
+
+-- /////////////////////////////////////////////////////////////////////////
+-- dmd + GCC toolchain
+-- /////////////////////////////////////////////////////////////////////////
+
+--
+-- Return a list of LDFLAGS for a specific configuration.
+--
+
+	tdmd.gcc.ldflags = {
+		architecture = {
+			x86 = { "-m32" },
+			x86_64 = { "-m64" },
+		},
+		kind = {
+			SharedLib = "-shared",
+			StaticLib = "-lib",
+		}
+	}
+
+	function tdmd.gcc.getldflags(cfg)
+		local flags = config.mapFlags(cfg, tdmd.gcc.ldflags)
+		return flags
+	end
+
+
+--
+-- Return a list of decorated additional libraries directories.
+--
+
+	tdmd.gcc.libraryDirectories = {
+		architecture = {
+			x86 = "-L-L/usr/lib",
+			x86_64 = "-L-L/usr/lib64",
+		}
+	}
+
+	function tdmd.gcc.getLibraryDirectories(cfg)
+		local flags = config.mapFlags(cfg, tdmd.gcc.libraryDirectories)
+
+		-- Scan the list of linked libraries. If any are referenced with
+		-- paths, add those to the list of library search paths
+		for _, dir in ipairs(config.getlinks(cfg, "system", "directory")) do
+			table.insert(flags, '-L-L' .. project.getrelative(cfg.project, dir))
+		end
+
+		return flags
+	end
+
+
+--
+-- Return the list of libraries to link, decorated with flags as needed.
+--
+
+	function tdmd.gcc.getlinks(cfg, systemonly)
+		local result = {}
+
+		local links
+		if not systemonly then
+			links = config.getlinks(cfg, "siblings", "object")
+			for _, link in ipairs(links) do
+				-- skip external project references, since I have no way
+				-- to know the actual output target path
+				if not link.project.external then
+					if link.kind == premake.STATICLIB then
+						-- Don't use "-l" flag when linking static libraries; instead use
+						-- path/libname.a to avoid linking a shared library of the same
+						-- name if one is present
+						table.insert(result, "-L" .. project.getrelative(cfg.project, link.linktarget.abspath))
+					else
+						table.insert(result, "-L-l" .. link.linktarget.basename)
+					end
+				end
+			end
+		end
+
+		-- The "-l" flag is fine for system libraries
+		links = config.getlinks(cfg, "system", "fullpath")
+		for _, link in ipairs(links) do
+			if path.isframework(link) then
+				table.insert(result, "-framework " .. path.getbasename(link))
+			elseif path.isobjectfile(link) then
+				table.insert(result, "-L" .. link)
+			else
+				table.insert(result, "-L-l" .. path.getbasename(link))
+			end
+		end
+
+		return result
+	end
+
+
+-- /////////////////////////////////////////////////////////////////////////
+-- tdmd + OPTLINK toolchain
+-- /////////////////////////////////////////////////////////////////////////
+
+--
+-- Return a list of LDFLAGS for a specific configuration.
+--
+
+	tdmd.optlink.ldflags = {
+		architecture = {
+			x86 = { "-m32" },
+			x86_64 = { "-m64" },
+		},
+		kind = {
+			SharedLib = "-shared",
+			StaticLib = "-lib",
+		}
+	}
+
+	function tdmd.optlink.getldflags(cfg)
+		local flags = config.mapFlags(cfg, tdmd.optlink.ldflags)
+		return flags
+	end
+
+
+--
+-- Return a list of decorated additional libraries directories.
+--
+
+	function tdmd.optlink.getLibraryDirectories(cfg)
+		local flags = {}
+
+		-- Scan the list of linked libraries. If any are referenced with
+		-- paths, add those to the list of library search paths
+		for _, dir in ipairs(config.getlinks(cfg, "system", "directory")) do
+			table.insert(flags, '-Llib "' .. project.getrelative(cfg.project, dir) .. '"')
+		end
+
+		return flags
+	end
+
+
+--
+-- Returns a list of linker flags for library names.
+--
+
+	function tdmd.optlink.getlinks(cfg)
+		local result = {}
+
+		local links = config.getlinks(cfg, "dependencies", "object")
+		for _, link in ipairs(links) do
+			-- skip external project references, since I have no way
+			-- to know the actual output target path
+			if not link.project.externalname then
+				local linkinfo = config.getlinkinfo(link)
+				if link.kind == premake.STATICLIB then
+					table.insert(result, project.getrelative(cfg.project, linkinfo.abspath))
+				end
+			end
+		end
+
+		-- The "-l" flag is fine for system libraries
+		links = config.getlinks(cfg, "system", "basename")
+		for _, link in ipairs(links) do
+			if path.isobjectfile(link) then
+				table.insert(result, link)
+			elseif path.hasextension(link, premake.systems[cfg.system].staticlib.extension) then
+				table.insert(result, link)
+			end
+		end
+
+		return result
+
+	end
+
+
+-- /////////////////////////////////////////////////////////////////////////
+-- common dmd code (either toolchain)
+-- /////////////////////////////////////////////////////////////////////////
+
+	-- if we are compiling on windows, we need to specialise to OPTLINK as the linker
+-- OR!!!			if cfg.system ~= premake.WINDOWS then
+	if string.match( os.getversion().description, "Windows" ) ~= nil then
+		-- TODO: on windows, we may use OPTLINK or MSLINK (for Win64)...
+--		printf("TODO: select proper linker for 32/64 bit code")
+
+		premake.tools.dmd = tdmd.optlink
+	else
+		premake.tools.dmd = tdmd.gcc
+	end
+
+	local dmd = premake.tools.dmd
+
+
+--
+-- Returns list of D compiler flags for a configuration.
+--
+
+	dmd.dflags = {
+		architecture = {
+			x86 = "-m32",
+			x86_64 = "-m64",
+		},
+		flags = {
+			CodeCoverage	= "-cov",
+			Deprecated		= "-d",
+			Documentation	= "-D",
+			FatalWarnings	= "-w",
+			GenerateHeader	= "-H",
+			GenerateJSON	= "-X",
+			GenerateMap		= "-map",
+			NoBoundsCheck	= "-noboundscheck",
+			Profile			= "-profile",
+			Quiet			= "-quiet",
+--			Release			= "-release",
+			RetainPaths		= "-op",
+			Symbols			= "-g",
+			SymbolsLikeC	= "-gc",
+			UnitTest		= "-unittest",
+			Verbose			= "-v",
+		},
+		floatingpoint = {
+			None = "-nofloat",
+		},
+		optimize = {
+			On = "-O -inline",
+			Full = "-O -inline",
+			Size = "-O -inline",
+			Speed = "-O -inline",
+		},
+		pic = {
+			On = "-fPIC",
+		},
+		warnings = {
+			Default = "-wi",
+			Extra = "-wi",
+		}
+	}
+
+	function dmd.getdflags(cfg)
+		local flags = config.mapFlags(cfg, dmd.dflags)
+
+		if config.isDebugBuild(cfg) then
+			table.insert(flags, "-debug")
+		else
+			table.insert(flags, "-release")
+		end
+
+		-- TODO: When DMD gets CRT options, map StaticRuntime and DebugRuntime
+
+		if cfg.flags.Documentation then
+			if cfg.docname then
+				table.insert(flags, "-Df" .. premake.quoted(cfg.docname))
+			end
+			if cfg.docdir then
+				table.insert(flags, "-Dd" .. premake.quoted(cfg.docdir))
+			end
+		end
+		if cfg.flags.GenerateHeader then
+			if cfg.headername then
+				table.insert(flags, "-Hf" .. premake.quoted(cfg.headername))
+			end
+			if cfg.headerdir then
+				table.insert(flags, "-Hd" .. premake.quoted(cfg.headerdir))
+			end
+		end
+
+		return flags
+	end
+
+
+--
+-- Decorate versions for the DMD command line.
+--
+
+	function dmd.getversions(versions, level)
+		local result = {}
+		for _, version in ipairs(versions) do
+			table.insert(result, '-version=' .. version)
+		end
+		if level then
+			table.insert(result, '-version=' .. level)
+		end
+		return result
+	end
+
+
+--
+-- Decorate debug constants for the DMD command line.
+--
+
+	function dmd.getdebug(constants, level)
+		local result = {}
+		for _, constant in ipairs(constants) do
+			table.insert(result, '-debug=' .. constant)
+		end
+		if level then
+			table.insert(result, '-debug=' .. level)
+		end
+		return result
+	end
+
+
+--
+-- Decorate import file search paths for the DMD command line.
+--
+
+	function dmd.getimportdirs(cfg, dirs)
+		local result = {}
+		for _, dir in ipairs(dirs) do
+			dir = project.getrelative(cfg.project, dir)
+			table.insert(result, '-I' .. premake.quoted(dir))
+		end
+		return result
+	end
+
+
+--
+-- Returns the target name specific to compiler
+--
+
+	function dmd.gettarget(name)
+		return "-of" .. name
+	end
+
+
+--
+-- Returns makefile-specific configuration rules.
+--
+
+	dmd.makesettings = {
+	}
+
+	function dmd.getmakesettings(cfg)
+		local settings = config.mapFlags(cfg, dmd.makesettings)
+		return table.concat(settings)
+	end
+
+
+--
+-- Retrieves the executable command name for a tool, based on the
+-- provided configuration and the operating environment.
+--
+-- @param cfg
+--    The configuration to query.
+-- @param tool
+--    The tool to fetch, one of "dc" for the D compiler, or "ar" for the static linker.
+-- @return
+--    The executable command name for a tool, or nil if the system's
+--    default value should be used.
+--
+
+	dmd.tools = {
+		-- dmd will probably never support any foreign architectures...?
+	}
+
+	function dmd.gettoolname(cfg, tool)
+		local names = dmd.tools[cfg.architecture] or dmd.tools[cfg.system] or {}
+		local name = names[tool]
+		return name or dmd[tool]
+	end

--- a/modules/d/tools/gdc.lua
+++ b/modules/d/tools/gdc.lua
@@ -1,0 +1,290 @@
+--
+-- d/tools/gdc.lua
+-- Provides GDC-specific configuration strings.
+-- Copyright (c) 2013-2015 Andrew Gough, Manu Evans, and the Premake project
+--
+
+	premake.tools.gdc = { }
+
+	local gdc = premake.tools.gdc
+	local project = premake.project
+	local config = premake.config
+    local d = premake.modules.d
+
+	--
+	-- Set default tools
+	--
+
+	gdc.dc = "gdc"
+
+
+--
+-- Returns list of D compiler flags for a configuration.
+--
+
+	gdc.dflags = {
+		architecture = {
+			x86 = "-m32",
+			x86_64 = "-m64",
+		},
+		flags = {
+			Deprecated		= "-fdeprecated",
+			Documentation	= "-fdoc",
+			FatalWarnings	= "-Werror",
+			GenerateHeader	= "-fintfc",
+			GenerateJSON	= "-fX",
+			NoBoundsCheck	= "-fno-bounds-check",
+--			Release			= "-frelease",
+			RetainPaths		= "-op",
+			Symbols			= "-g",
+			SymbolsLikeC	= "-fdebug-c",
+			UnitTest		= "-funittest",
+			Verbose			= "-fd-verbose",
+		},
+		floatingpoint = {
+			Fast = "-ffast-math",
+			Strict = "-ffloat-store",
+		},
+		optimize = {
+			Off = "-O0",
+			On = "-O2 -finline-functions",
+			Debug = "-Og",
+			Full = "-O3 -finline-functions",
+			Size = "-Os -finline-functions",
+			Speed = "-O3 -finline-functions",
+		},
+		pic = {
+			On = "-fPIC",
+		},
+		vectorextensions = {
+			AVX = "-mavx",
+			SSE = "-msse",
+			SSE2 = "-msse2",
+		},
+		warnings = {
+--			Off = "-w",
+--			Default = "-w",	-- TODO: check this...
+			Extra = "-Wall -Wextra",
+		}
+	}
+
+	function gdc.getdflags(cfg)
+		local flags = config.mapFlags(cfg, gdc.dflags)
+
+		if config.isDebugBuild(cfg) then
+			table.insert(flags, "-fdebug")
+		else
+			table.insert(flags, "-frelease")
+		end
+
+		-- TODO: When DMD gets CRT options, map StaticRuntime and DebugRuntime
+
+		if cfg.flags.Documentation then
+			if cfg.docname then
+				table.insert(flags, "-fdoc-file=" .. premake.quoted(cfg.docname))
+			end
+			if cfg.docdir then
+				table.insert(flags, "-fdoc-dir=" .. premake.quoted(cfg.docdir))
+			end
+		end
+		if cfg.flags.GenerateHeader then
+			if cfg.headername then
+				table.insert(flags, "-fintfc-file=" .. premake.quoted(cfg.headername))
+			end
+			if cfg.headerdir then
+				table.insert(flags, "-fintfc-dir=" .. premake.quoted(cfg.headerdir))
+			end
+		end
+
+		return flags
+	end
+
+
+--
+-- Decorate versions for the DMD command line.
+--
+
+	function gdc.getversions(versions, level)
+		local result = {}
+		for _, version in ipairs(versions) do
+			table.insert(result, '-fversion=' .. version)
+		end
+		if level then
+			table.insert(result, '-fversion=' .. level)
+		end
+		return result
+	end
+
+
+--
+-- Decorate debug constants for the DMD command line.
+--
+
+	function gdc.getdebug(constants, level)
+		local result = {}
+		for _, constant in ipairs(constants) do
+			table.insert(result, '-fdebug=' .. constant)
+		end
+		if level then
+			table.insert(result, '-fdebug=' .. level)
+		end
+		return result
+	end
+
+
+--
+-- Decorate import file search paths for the DMD command line.
+--
+
+	function gdc.getimportdirs(cfg, dirs)
+		local result = {}
+		for _, dir in ipairs(dirs) do
+			dir = project.getrelative(cfg.project, dir)
+			table.insert(result, '-I' .. premake.quoted(dir))
+		end
+		return result
+	end
+
+
+--
+-- Returns the target name specific to compiler
+--
+
+	function gdc.gettarget(name)
+		return "-o " .. name
+	end
+
+
+--
+-- Return a list of LDFLAGS for a specific configuration.
+--
+
+	gdc.ldflags = {
+		architecture = {
+			x86 = { "-m32" },
+			x86_64 = { "-m64" },
+		},
+		kind = {
+			SharedLib = function(cfg)
+				local r = { iif(cfg.system == premake.MACOSX, "-dynamiclib", "-shared") }
+				if cfg.system == "windows" and not cfg.flags.NoImportLib then
+					table.insert(r, '-Wl,--out-implib="' .. cfg.linktarget.relpath .. '"')
+				end
+				return r
+			end,
+			WindowedApp = function(cfg)
+				if cfg.system == premake.WINDOWS then return "-mwindows" end
+			end,
+		},
+	}
+
+	function gdc.getldflags(cfg)
+		local flags = config.mapFlags(cfg, gdc.ldflags)
+		return flags
+	end
+
+
+--
+-- Return a list of decorated additional libraries directories.
+--
+
+	gdc.libraryDirectories = {
+		architecture = {
+			x86 = "-L/usr/lib",
+			x86_64 = "-L/usr/lib64",
+		}
+	}
+
+	function gdc.getLibraryDirectories(cfg)
+		local flags = config.mapFlags(cfg, gdc.libraryDirectories)
+
+		-- Scan the list of linked libraries. If any are referenced with
+		-- paths, add those to the list of library search paths
+		for _, dir in ipairs(config.getlinks(cfg, "system", "directory")) do
+			table.insert(flags, '-Wl,-L' .. project.getrelative(cfg.project, dir))
+		end
+
+		return flags
+	end
+
+
+--
+-- Return the list of libraries to link, decorated with flags as needed.
+--
+
+	function gdc.getlinks(cfg, systemonly)
+		local result = {}
+
+		local links
+		if not systemonly then
+			links = config.getlinks(cfg, "siblings", "object")
+			for _, link in ipairs(links) do
+				-- skip external project references, since I have no way
+				-- to know the actual output target path
+				if not link.project.external then
+					if link.kind == premake.STATICLIB then
+						-- Don't use "-l" flag when linking static libraries; instead use
+						-- path/libname.a to avoid linking a shared library of the same
+						-- name if one is present
+						table.insert(result, "-Wl," .. project.getrelative(cfg.project, link.linktarget.abspath))
+					else
+						table.insert(result, "-Wl,-l" .. link.linktarget.basename)
+					end
+				end
+			end
+		end
+
+		-- The "-l" flag is fine for system libraries
+		links = config.getlinks(cfg, "system", "fullpath")
+		for _, link in ipairs(links) do
+			if path.isframework(link) then
+				table.insert(result, "-framework " .. path.getbasename(link))
+			elseif path.isobjectfile(link) then
+				table.insert(result, "-Wl," .. link)
+			else
+				table.insert(result, "-Wl,-l" .. path.getbasename(link))
+			end
+		end
+
+		return result
+	end
+
+
+--
+-- Returns makefile-specific configuration rules.
+--
+
+	gdc.makesettings = {
+	}
+
+	function gdc.getmakesettings(cfg)
+		local settings = config.mapFlags(cfg, gdc.makesettings)
+		return table.concat(settings)
+	end
+
+
+--
+-- Retrieves the executable command name for a tool, based on the
+-- provided configuration and the operating environment.
+--
+-- @param cfg
+--    The configuration to query.
+-- @param tool
+--    The tool to fetch, one of "dc" for the D compiler, or "ar" for the static linker.
+-- @return
+--    The executable command name for a tool, or nil if the system's
+--    default value should be used.
+--
+
+	gdc.tools = {
+		ps3 = {
+			dc = "ppu-lv2-gdc",
+			ar = "ppu-lv2-ar",
+		},
+	}
+
+	function gdc.gettoolname(cfg, tool)
+		local names = gdc.tools[cfg.architecture] or gdc.tools[cfg.system] or {}
+		local name = names[tool]
+		return name or gdc[tool]
+	end

--- a/modules/d/tools/ldc.lua
+++ b/modules/d/tools/ldc.lua
@@ -1,0 +1,284 @@
+--
+-- d/tools/ldc.lua
+-- Provides LDC-specific configuration strings.
+-- Copyright (c) 2013-2015 Andrew Gough, Manu Evans, and the Premake project
+--
+
+	premake.tools.ldc = { }
+
+	local ldc = premake.tools.ldc
+	local project = premake.project
+	local config = premake.config
+    local d = premake.modules.d
+
+
+--
+-- Set default tools
+--
+
+	ldc.namestyle = "posix"
+
+
+--
+-- Returns list of D compiler flags for a configuration.
+--
+
+
+	ldc.dflags = {
+		architecture = {
+			x86 = "-m32",
+			x86_64 = "-m64",
+--			arm = "-march=arm",
+--			ppc = "-march=ppc32",
+--			ppc64 = "-march=ppc64",
+--			spu = "-march=cellspu",
+--			mips = "-march=mips",	-- -march=mipsel?
+		},
+		flags = {
+			Deprecated		= "-d",
+			Documentation	= "-D",
+			FatalWarnings	= "-w", -- Use LLVM flag? : "-fatal-assembler-warnings",
+			GenerateHeader	= "-H",
+			GenerateJSON	= "-X",
+			NoBoundsCheck	= "-disable-boundscheck",
+--			Release			= "-release",
+			RetainPaths		= "-op",
+			Symbols			= "-g",
+			SymbolsLikeC	= "-gc",
+			UnitTest		= "-unittest",
+			Verbose			= "-v",
+		},
+		floatingpoint = {
+			Fast = "-fp-contract=fast -enable-unsafe-fp-math",
+--			Strict = "-ffloat-store",
+		},
+		optimize = {
+			Off = "-O0",
+			On = "-O2",
+			Debug = "-O0",
+			Full = "-O3",
+			Size = "-Oz",
+			Speed = "-O3",
+		},
+		pic = {
+			On = "-relocation-model=pic",
+		},
+		vectorextensions = {
+			AVX = "-mattr=+avx",
+			SSE = "-mattr=+sse",
+			SSE2 = "-mattr=+sse2",
+		},
+		warnings = {
+			Default = "-wi",
+			Extra = "-wi",	-- TODO: is there a way to get extra warnings?
+		}
+	}
+
+	function ldc.getdflags(cfg)
+		local flags = config.mapFlags(cfg, ldc.dflags)
+
+		if config.isDebugBuild(cfg) then
+			table.insert(flags, "-d-debug")
+		else
+			table.insert(flags, "-release")
+		end
+
+		-- TODO: When DMD gets CRT options, map StaticRuntime and DebugRuntime
+
+		if cfg.flags.Documentation then
+			if cfg.docname then
+				table.insert(flags, "-Df=" .. premake.quoted(cfg.docname))
+			end
+			if cfg.docdir then
+				table.insert(flags, "-Dd=" .. premake.quoted(cfg.docdir))
+			end
+		end
+		if cfg.flags.GenerateHeader then
+			if cfg.headername then
+				table.insert(flags, "-Hf=" .. premake.quoted(cfg.headername))
+			end
+			if cfg.headerdir then
+				table.insert(flags, "-Hd=" .. premake.quoted(cfg.headerdir))
+			end
+		end
+
+		return flags
+	end
+
+
+--
+-- Decorate versions for the DMD command line.
+--
+
+	function ldc.getversions(versions, level)
+		local result = {}
+		for _, version in ipairs(versions) do
+			table.insert(result, '-d-version=' .. version)
+		end
+		if level then
+			table.insert(result, '-d-version=' .. level)
+		end
+		return result
+	end
+
+
+--
+-- Decorate debug constants for the DMD command line.
+--
+
+	function ldc.getdebug(constants, level)
+		local result = {}
+		for _, constant in ipairs(constants) do
+			table.insert(result, '-d-debug=' .. constant)
+		end
+		if level then
+			table.insert(result, '-d-debug=' .. level)
+		end
+		return result
+	end
+
+
+--
+-- Decorate import file search paths for the DMD command line.
+--
+
+	function ldc.getimportdirs(cfg, dirs)
+		local result = {}
+		for _, dir in ipairs(dirs) do
+			dir = project.getrelative(cfg.project, dir)
+			table.insert(result, '-I=' .. premake.quoted(dir))
+		end
+		return result
+	end
+
+
+--
+-- Returns the target name specific to compiler
+--
+
+	function ldc.gettarget(name)
+		return "-of=" .. name
+	end
+
+
+--
+-- Return a list of LDFLAGS for a specific configuration.
+--
+
+	ldc.ldflags = {
+		architecture = {
+			x86 = { "-m32" },
+			x86_64 = { "-m64" },
+		},
+		kind = {
+			SharedLib = "-shared",
+			StaticLib = "-lib",
+		},
+	}
+
+	function ldc.getldflags(cfg)
+		local flags = config.mapFlags(cfg, ldc.ldflags)
+		return flags
+	end
+
+
+--
+-- Return a list of decorated additional libraries directories.
+--
+
+	ldc.libraryDirectories = {
+		architecture = {
+			x86 = "-L=-L/usr/lib",
+			x86_64 = "-L=-L/usr/lib64",
+		}
+	}
+
+	function ldc.getLibraryDirectories(cfg)
+		local flags = config.mapFlags(cfg, ldc.libraryDirectories)
+
+		-- Scan the list of linked libraries. If any are referenced with
+		-- paths, add those to the list of library search paths
+		for _, dir in ipairs(config.getlinks(cfg, "system", "directory")) do
+			table.insert(flags, '-L=-L' .. project.getrelative(cfg.project, dir))
+		end
+
+		return flags
+	end
+
+
+--
+-- Return the list of libraries to link, decorated with flags as needed.
+--
+
+	function ldc.getlinks(cfg, systemonly)
+		local result = {}
+
+		local links
+		if not systemonly then
+			links = config.getlinks(cfg, "siblings", "object")
+			for _, link in ipairs(links) do
+				-- skip external project references, since I have no way
+				-- to know the actual output target path
+				if not link.project.external then
+					if link.kind == premake.STATICLIB then
+						-- Don't use "-l" flag when linking static libraries; instead use
+						-- path/libname.a to avoid linking a shared library of the same
+						-- name if one is present
+						table.insert(result, "-L=" .. project.getrelative(cfg.project, link.linktarget.abspath))
+					else
+						table.insert(result, "-L=-l" .. link.linktarget.basename)
+					end
+				end
+			end
+		end
+
+		-- The "-l" flag is fine for system libraries
+		links = config.getlinks(cfg, "system", "fullpath")
+		for _, link in ipairs(links) do
+			if path.isframework(link) then
+				table.insert(result, "-framework " .. path.getbasename(link))
+			elseif path.isobjectfile(link) then
+				table.insert(result, "-L=" .. link)
+			else
+				table.insert(result, "-L=-l" .. path.getbasename(link))
+			end
+		end
+
+		return result
+	end
+
+
+--
+-- Returns makefile-specific configuration rules.
+--
+
+	ldc.makesettings = {
+	}
+
+	function ldc.getmakesettings(cfg)
+		local settings = config.mapFlags(cfg, ldc.makesettings)
+		return table.concat(settings)
+	end
+
+
+--
+-- Retrieves the executable command name for a tool, based on the
+-- provided configuration and the operating environment.
+--
+-- @param cfg
+--    The configuration to query.
+-- @param tool
+--    The tool to fetch, one of "dc" for the D compiler, or "ar" for the static linker.
+-- @return
+--    The executable command name for a tool, or nil if the system's
+--    default value should be used.
+--
+
+	ldc.tools = {
+		dc = "ldc2",
+		ar = "ar",
+	}
+
+	function ldc.gettoolname(cfg, tool)
+		return ldc.tools[tool]
+	end

--- a/modules/monodevelop/LICENSE.txt
+++ b/modules/monodevelop/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2013-2015 Manu Evans and individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of Premake nor the names of its contributors may be
+     used to endorse or promote products derived from this software without
+     specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/modules/monodevelop/README.md
+++ b/modules/monodevelop/README.md
@@ -1,0 +1,13 @@
+Premake extension to support the [MonoDevelop](http://www.monodevelop.com)/[Xamarin Studio](http://xamarin.com/studio) IDE
+
+### Features ###
+
+* Support C/C++, C# and D (Mono-D) language projects
+
+### Usage ###
+
+Simply generate your project using the `monodevelop` action:
+```bash
+premake5 monodevelop
+```
+and open the generated project file in MonoDevelop/Xamarin Studio.

--- a/modules/monodevelop/_manifest.lua
+++ b/modules/monodevelop/_manifest.lua
@@ -1,0 +1,5 @@
+return {
+	"_preload.lua",
+	"monodevelop.lua",
+	"monodevelop_cproj.lua",
+}

--- a/modules/monodevelop/_preload.lua
+++ b/modules/monodevelop/_preload.lua
@@ -1,0 +1,71 @@
+--
+-- Name:        monodevelop/_preload.lua
+-- Purpose:     Define the MonoDevelop action.
+-- Author:      Manu Evans
+-- Created:     2013/10/28
+-- Copyright:   (c) 2013-2015 Manu Evans and the Premake project
+--
+
+-- TODO:
+-- MonoDevelop/Xamarin Studio has 'workspaces', which act like collections of
+-- Premake workspaces. If Premake supports multiple workspaces, we should
+-- write out a workspace file...
+
+	local p = premake
+
+	newaction
+	{
+		-- Metadata for the command line and help system
+
+		trigger         = "monodevelop", -- TODO: I'd kinda like an alias 'xamarinstudio' aswell...
+		shortname       = "MonoDevelop",
+		description     = "Generate MonoDevelop/Xamarin Studio project files",
+
+		-- The capabilities of this action
+
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+		valid_languages = { "C", "C++", "C#" },
+		valid_tools     = {
+			cc     = { "gcc" },
+			dotnet = { "mono", "msnet" },
+		},
+
+		-- Workspace and project generation logic
+
+		onWorkspace = function(wks)
+			p.vstudio.vs2005.generateWorkspace(wks)
+		end,
+		onProject = function(prj)
+			p.modules.monodevelop.generateProject(prj)
+		end,
+
+		onCleanWorkspace = function(wks)
+			p.vstudio.cleanWorkspace(wks)
+		end,
+		onCleanProject = function(prj)
+			p.vstudio.cleanProject(prj)
+		end,
+		onCleanTarget = function(prj)
+			p.vstudio.cleanTarget(prj)
+		end,
+
+		-- This stuff is specific to the Visual Studio exporters
+
+		vstudio = {
+			csprojSchemaVersion = "2.0",
+			productVersion      = "10.0.0",
+			solutionVersion     = "12",
+			versionName         = "2012",
+			targetFramework     = "4.5",
+			toolsVersion        = "4.0",
+		},
+	}
+
+
+--
+-- Decide when the full module should be loaded.
+--
+
+	return function(cfg)
+		return (_ACTION == "monodevelop")
+	end

--- a/modules/monodevelop/monodevelop.lua
+++ b/modules/monodevelop/monodevelop.lua
@@ -1,0 +1,132 @@
+--
+-- Name:        monodevelop/monodevelop.lua
+-- Purpose:     Define the MonoDevelop action.
+-- Author:      Manu Evans
+-- Created:     2013/10/28
+-- Copyright:   (c) 2013-2015 Manu Evans and the Premake project
+--
+
+	local p = premake
+
+	p.modules.monodevelop = {}
+
+	local m = p.modules.monodevelop
+
+	m._VERSION = p._VERSION
+	m.elements = {}
+
+	local vs2010 = p.vstudio.vs2010
+	local vstudio = p.vstudio
+	local sln2005 = p.vstudio.sln2005
+	local project = p.project
+	local config = p.config
+
+
+--
+-- Write out contents of the SolutionProperties section; currently unused.
+--
+
+	function m.MonoDevelopProperties(wks)
+		_p('\tGlobalSection(MonoDevelopProperties) = preSolution')
+		if wks.startproject then
+			for prj in p.workspace.eachproject(wks) do
+				if prj.name == wks.startproject then
+-- TODO: fix me!
+--					local prjpath = vstudio.projectfile_ng(prj)
+--					prjpath = path.translate(path.getrelative(slnpath, prjpath))
+--					_p('\t\tStartupItem = %s', prjpath )
+				end
+			end
+		end
+
+		-- NOTE: multiline descriptions, or descriptions with tab's (/n, /t, etc) need to be escaped with @
+		-- Looks like: description = @descriptopn with\nnewline and\ttab's.
+--		_p('\t\tdescription = %s', 'workspace description')
+
+--		_p('\t\tversion = %s', '0.1')
+		_p('\tEndGlobalSection')
+	end
+
+
+--
+-- Patch some functions
+--
+
+	p.override(vstudio, "projectPlatform", function(oldfn, cfg)
+		if _ACTION == "monodevelop" then
+			if cfg.platform then
+				return cfg.buildcfg .. " " .. cfg.platform
+			else
+				return cfg.buildcfg
+			end
+		end
+		return oldfn(cfg)
+	end)
+
+	p.override(vstudio, "archFromConfig", function(oldfn, cfg, win32)
+		if _ACTION == "monodevelop" then
+			return "Any CPU"
+		end
+		return oldfn(cfg, win32)
+	end)
+
+	p.override(sln2005, "solutionSections", function(oldfn, wks)
+		if _ACTION == "monodevelop" then
+			return {
+				"ConfigurationPlatforms",
+--				"SolutionProperties", -- this doesn't seem to be used by MonoDevelop
+				"MonoDevelopProperties",
+				"NestedProjects",
+			}
+		end
+		return oldfn(prj)
+	end)
+
+	p.override(sln2005.elements, "sections", function(oldfn, wks)
+		local elements = oldfn(wks)
+		elements = table.join(elements, {
+			m.MonoDevelopProperties,
+		})
+		return elements
+	end)
+
+	p.override(vstudio, "projectfile", function(oldfn, prj)
+		if _ACTION == "monodevelop" then
+			if project.iscpp(prj) then
+				return p.filename(prj, ".cproj")
+			end
+		end
+		return oldfn(prj)
+	end)
+
+	p.override(vstudio, "tool", function(oldfn, prj)
+		if _ACTION == "monodevelop" then
+			if project.iscpp(prj) then
+				return "2857B73E-F847-4B02-9238-064979017E93"
+			end
+		end
+		return oldfn(prj)
+	end)
+
+
+---
+-- Identify the type of project being exported and hand it off
+-- the right generator.
+---
+
+	function m.generateProject(prj)
+		p.eol("\r\n")
+		p.indent("  ")
+		p.escaper(vs2010.esc)
+
+		if project.isdotnet(prj) then
+			p.generate(prj, ".csproj", vstudio.cs2005.generate)
+			p.generate(prj, ".csproj.user", vstudio.cs2005.generateUser)
+		elseif project.iscpp(prj) then
+			p.generate(prj, ".cproj", m.generate)
+		end
+	end
+
+	include("monodevelop_cproj.lua")
+
+	return m

--- a/modules/monodevelop/monodevelop_cproj.lua
+++ b/modules/monodevelop/monodevelop_cproj.lua
@@ -1,0 +1,497 @@
+--
+-- monodevelop/monodevelop_cproj.lua
+-- Generate a MonoDevelop C/C++ cproj project.
+-- Copyright (c) 2012-2015 Manu Evans and the Premake project
+--
+
+	local p = premake
+	local m = p.modules.monodevelop
+
+	m.cproj = {}
+
+	local vstudio = p.vstudio
+	local project = p.project
+	local config = p.config
+	local fileconfig = p.fileconfig
+	local tree = p.tree
+
+--
+-- Generate a MonoDevelop C/C++ project.
+--
+
+	function m.generate(prj)
+		m.header("Build")
+		
+		m.projectProperties(prj)
+
+		for cfg in project.eachconfig(prj) do
+			m.configurationProperties(cfg)
+		end
+
+		m.files(prj)
+--		m.projectReferences(prj)
+
+		_p('</Project>')
+	end
+
+
+
+--
+-- Output the XML declaration and opening <Project> tag.
+--
+
+	function m.header(target)
+		_p('<?xml version="1.0" encoding="utf-8"?>')
+
+		local defaultTargets = ""
+		if target then
+			defaultTargets = string.format(' DefaultTargets="%s"', target)
+		end
+
+		_p('<Project%s ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">', defaultTargets)
+	end
+
+
+--
+-- Write out the project properties: what kind of binary it 
+-- produces, and some global settings.
+--
+
+	m.elements.projectProperties = function(prj)
+		if project.iscpp(prj) then
+			return {
+				m.cproj.productVersion,
+				m.cproj.schemaVersion,
+				m.cproj.projectGuid,
+				m.cproj.compiler,
+				m.cproj.language,
+				m.cproj.target,
+				m.cproj.version,
+				m.cproj.synchSlnVersion,
+				m.cproj.description,
+			}
+		end
+	end
+
+	function m.projectProperties(prj)
+		_p(1,'<PropertyGroup>')
+
+		_p(2,'<Configuration Condition=" \'$(Configuration)\' == \'\' ">%s</Configuration>', 'Debug')
+		_p(2,'<Platform Condition=" \'$(Platform)\' == \'\' ">%s</Platform>', 'AnyCPU')
+
+		p.callArray(m.elements.projectProperties, prj)
+
+		-- packages ...?
+
+		_p(1,'</PropertyGroup>')
+	end
+
+
+--
+-- Write out the configuration property group: what kind of binary it 
+-- produces, and some global settings.
+--
+
+	m.elements.configurationProperties = function(cfg)
+		if project.iscpp(cfg.project) then
+			return {
+				m.cproj.debuginfo,
+				m.cproj.outputPath,
+				m.cproj.outputName,
+				m.cproj.config_type,
+				m.cproj.preprocessorDefinitions,
+				m.cproj.sourceDirectory,
+				m.cproj.warnings,
+				m.cproj.optimization,
+				m.cproj.externalconsole,
+				m.cproj.additionalOptions,
+				m.cproj.additionalLinkOptions,
+				m.cproj.additionalIncludeDirectories,
+				m.cproj.additionalLibraryDirectories,
+				m.cproj.additionalDependencies,
+				m.cproj.buildEvents,
+			}
+		end
+	end
+
+	function m.configurationProperties(cfg)
+		_p(1,'<PropertyGroup %s>', m.condition(cfg))
+		p.callArray(m.elements.configurationProperties, cfg)
+		_p(1,'</PropertyGroup>')
+	end
+
+
+--
+-- Format and return a MonoDevelop Condition attribute.
+--
+
+	function m.condition(cfg)
+		return string.format('Condition=" \'$(Configuration)|$(Platform)\' == \'%s|AnyCPU\' "', p.esc(vstudio.projectPlatform(cfg)))
+	end
+
+
+--
+-- Write out the list of source code files, and any associated configuration.
+--
+
+	function m.files(prj)
+		m.filegroup(prj, "Include", "None")
+		m.filegroup(prj, "Compile", "Compile")
+		m.filegroup(prj, "Folder", "None")
+		m.filegroup(prj, "None", "None")
+		m.filegroup(prj, "ResourceCompile", "None")
+		m.filegroup(prj, "CustomBuild", "None")
+	end
+
+	function m.filegroup(prj, group, action)
+		local files = m.getfilegroup(prj, group)
+		if #files > 0  then
+			_p(1,'<ItemGroup>')
+			for _, file in ipairs(files) do
+				m.putfile(action, file)
+			end
+			_p(1,'</ItemGroup>')
+		end
+	end
+
+	function m.putfile(action, file)
+		local filename = file.relpath
+
+		if not string.startswith(filename, '..') then
+			_x(2,'<%s Include=\"%s\" />', action, path.translate(filename))
+		else
+			_x(2,'<%s Include=\"%s\">', action, path.translate(filename))
+
+			-- Relative paths referring to parent directories need to use the special
+			--   'Link' option to present them in the project hierarchy nicely
+			while string.startswith(filename, '..') do
+				filename = filename:sub(4)
+			end
+			_x(3,'<Link>%s</Link>', filename)
+
+-- TODO: MonoDevelop really doesn't handle custom build tools very well (yet)
+--			for cfg in project.eachconfig(prj) do
+--				local condition = m.condition(cfg)					
+--				local filecfg = config.getfileconfig(cfg, file.abspath)
+--				if filecfg and filecfg.buildrule then
+--					local commands = table.concat(filecfg.buildrule.commands,'\r\n')
+--					_p(3,'<Generator %s>%s</Generator>', condition, p.esc(commands))
+--				end
+--			end
+
+			_x(2,'</%s>', action)
+		end
+	end
+
+
+	function m.getTargetGroup(node, prj, groups)
+		-- if any configuration of this file uses a custom build rule,
+		-- then they all must be marked as custom build
+		local hasbuildrule = false
+		for cfg in project.eachconfig(prj) do				
+			local filecfg = fileconfig.getconfig(node, cfg)
+			if filecfg and fileconfig.hasCustomBuildRule(filecfg) then
+				hasbuildrule = true
+				break
+			end
+		end
+
+		if hasbuildrule then
+			return groups.CustomBuild
+		elseif path.iscppfile(node.name) then
+			return groups.Compile
+		elseif path.iscppheader(node.name) then
+			return groups.Include
+		elseif path.isresourcefile(node.name) then
+			return groups.ResourceCompile
+		else
+			return groups.None
+		end
+	end
+
+
+	function m.getfilegroup(prj, group)
+		-- check for a cached copy before creating
+		local groups = prj.monodevelop_file_groups
+		if not groups then
+			groups = {
+				Compile = {},
+				Include = {},
+				Folder = {},
+				None = {},
+				ResourceCompile = {},
+				CustomBuild = {},
+			}
+			prj.monodevelop_file_groups = groups
+
+			local tr = project.getsourcetree(prj)
+			tree.traverse(tr, {
+				onleaf = function(node)
+					table.insert(m.getTargetGroup(node, prj, groups), node)
+				end
+			})
+		end
+
+		return groups[group]
+	end
+
+
+--
+-- Generate the list of project dependencies.
+--
+
+	function m.projectReferences(prj)
+		local deps = project.getdependencies(prj)
+		if #deps > 0 then
+			local prjpath = project.getlocation(prj)
+			
+			_p(1,'<ItemGroup>')
+			for _, dep in ipairs(deps) do
+				local relpath = path.getrelative(prjpath, vstudio.projectfile(dep))
+				_x(2,'<ProjectReference Include=\"%s\">', path.translate(relpath))
+				_p(3,'<Project>{%s}</Project>', dep.uuid)
+				_p(2,'</ProjectReference>')
+			end
+			_p(1,'</ItemGroup>')
+		end
+	end
+
+
+--
+-- projectProperties element functions.
+--
+
+	function m.cproj.productVersion(prj)
+		local action = p.action.current()
+		_p(2,'<ProductVersion>%s</ProductVersion>', action.vstudio.productVersion)
+	end
+
+	function m.cproj.schemaVersion(prj)
+		local action = p.action.current()
+		_p(2,'<SchemaVersion>%s</SchemaVersion>', action.vstudio.csprojSchemaVersion)
+	end
+
+	function m.cproj.projectGuid(prj)
+		_p(2,'<ProjectGuid>{%s}</ProjectGuid>', prj.uuid)
+	end
+
+	function m.cproj.compiler(prj)
+		_p(2,'<Compiler>')
+		_p(3,'<Compiler ctype="%s" />', iif(prj.language == 'C', 'GccCompiler', 'GppCompiler'))
+		_p(2,'</Compiler>')
+	end
+
+	function m.cproj.language(prj)
+		_p(2,'<Language>%s</Language>', iif(prj.language == 'C', 'C', 'CPP'))
+	end
+
+	function m.cproj.target(prj)
+		_p(2,'<Target>%s</Target>', 'Bin')
+	end
+
+	function m.cproj.version(prj)
+		-- TODO: write a project version number into the project
+--		_p(2,'<ReleaseVersion>%s</ReleaseVersion>', '0.1')
+	end
+
+	function m.cproj.synchSlnVersion(prj)
+		-- TODO: true = use solution version
+--		_p(2,'<SynchReleaseVersion>%s</SynchReleaseVersion>', 'false')
+	end
+
+	function m.cproj.description(prj)
+		-- TODO: project description
+--		_p(2,'<Description>%s</Description>', 'project description')
+	end
+
+
+--
+-- configurationProperties element functions.
+--
+
+	function m.cproj.debuginfo(cfg)
+		if cfg.flags.Symbols then
+			_p(2,'<DebugSymbols>%s</DebugSymbols>', iif(cfg.flags.Symbols, 'true', 'false'))
+		end
+	end
+
+	function m.cproj.outputPath(cfg)
+		local outdir = project.getrelative(cfg.project, cfg.buildtarget.directory)
+		_x(2,'<OutputPath>%s</OutputPath>', path.translate(outdir))
+	end
+
+	function m.cproj.outputName(cfg)
+		_x(2,'<OutputName>%s</OutputName>', cfg.buildtarget.name)
+	end
+
+	function m.cproj.config_type(cfg)
+		local map = {
+			SharedLib = "SharedLibrary",
+			StaticLib = "StaticLibrary",
+			ConsoleApp = "Bin",
+			WindowedApp = "Bin"
+		}
+		_p(2,'<CompileTarget>%s</CompileTarget>', map[cfg.kind])
+	end
+
+	function m.cproj.preprocessorDefinitions(cfg)
+		local defines = cfg.defines
+		if #defines > 0 then
+			defines = table.concat(defines, ' ')
+			_x(2,'<DefineSymbols>%s</DefineSymbols>', defines)
+		end
+	end
+
+	function m.cproj.sourceDirectory(cfg)
+		_x(2,'<SourceDirectory>%s</SourceDirectory>', '.')
+	end
+
+	function m.cproj.warnings(cfg)
+		local map = { Off = "None", Extra = "All" }
+		if cfg.warnings ~= nil and map[cfg.warnings] ~= nil then
+			_p(2,'<WarningLevel>%s</WarningLevel>', map[cfg.warnings])
+		end
+
+		-- other warning blocks only when warnings are not disabled
+		if cfg.warnings ~= "Off" and cfg.flags.FatalCompileWarnings then
+			_p(2,'<WarningsAsErrors>%s</WarningsAsErrors>', iif(cfg.flags.FatalCompileWarnings, 'true', 'false'))
+		end
+	end
+
+	function m.cproj.optimization(cfg)
+		-- TODO: 'size' should be Os, but this option just seems to be a numeric value
+		local map = { Off = "0", On = "2", Debug = "0", Size = "2", Speed = "3", Full = "3" }
+		if cfg.optimize ~= nil and map[cfg.optimize] then
+			_p(2,'<OptimizationLevel>%s</OptimizationLevel>', map[cfg.optimize])
+		end
+	end
+
+	function m.cproj.externalconsole(cfg)
+		_x(2,'<Externalconsole>%s</Externalconsole>', 'true')
+	end
+
+	function m.cproj.additionalOptions(cfg)
+		local opts = { }
+
+		if cfg.project.language == 'C++' then
+			if cfg.exceptionhandling == p.OFF then
+				table.insert(opts, "-fno-exceptions")
+			end
+			if cfg.rtti == p.OFF then
+				table.insert(opts, "-fno-rtti")
+			end
+		end
+
+		-- TODO: Validate these flags are what is intended by these options...
+--		if cfg.flags.FloatFast then
+--			table.insert(opts, "-mno-ieee-fp")
+--		elseif cfg.flags.FloatStrict then
+--			table.insert(opts, "-mieee-fp")
+--		end
+
+		if cfg.vectorextensions == "SSE2" then
+			table.insert(opts, "-msse2")
+		elseif cfg.vectorextensions == "SSE" then
+			table.insert(opts, "-msse")
+		end
+
+		local options
+		if #opts > 0 then
+			options = table.concat(opts, " ")
+		end
+		if #cfg.buildoptions > 0 then
+			local buildOpts = table.concat(cfg.buildoptions, " ")
+			if options then
+				options = options .. " " .. buildOpts
+			else
+				options = buildOpts
+			end
+		end
+
+		if options then
+			_x(2,'<ExtraCompilerArguments>%s</ExtraCompilerArguments>', options)
+		end
+	end
+
+	function m.cproj.additionalLinkOptions(cfg)
+		if #cfg.linkoptions > 0 then
+			local opts = table.concat(cfg.linkoptions, " ")
+			_x(2, '<ExtraLinkerArguments>%s</ExtraLinkerArguments>', opts)
+		end
+	end
+
+	function m.cproj.additionalIncludeDirectories(cfg)
+		if #cfg.includedirs > 0 then
+			_x(2,'<Includes>')
+			_x(3,'<Includes>')
+
+			for _, i in ipairs(project.getrelative(cfg.project, cfg.includedirs)) do
+				_x(4,'<Include>%s</Include>', path.translate(i))
+			end
+
+			_x(3,'</Includes>')
+			_x(2,'</Includes>')
+		end
+	end
+
+	function m.cproj.additionalLibraryDirectories(cfg)
+		if #cfg.libdirs > 0 then
+			_x(2,'<LibPaths>')
+			_x(3,'<LibPaths>')
+
+			for _, l in ipairs(project.getrelative(cfg.project, cfg.libdirs)) do
+				_x(4,'<LibPath>%s</LibPath>', path.translate(l))
+			end
+
+			_x(3,'</LibPaths>')
+			_x(2,'</LibPaths>')
+		end
+	end
+
+	function m.cproj.additionalDependencies(cfg)
+		local links
+
+		-- check to see if this project uses an external toolset. If so, let the
+		-- toolset define the format of the links
+		local toolset = config.toolset(cfg)
+		if toolset then
+			links = toolset.getlinks(cfg, false)
+		else
+			-- VS always tries to link against project dependencies, even when those
+			-- projects are excluded from the build. To work around, linking dependent
+			-- projects is disabled, and sibling projects link explicitly
+			links = config.getlinks(cfg, "all", "fullpath")
+		end
+
+		if #links > 0 then
+			_x(2,'<Libs>')
+			_x(3,'<Libs>')
+			for _, lib in ipairs(links) do
+				_x(4,'<Lib>%s</Lib>', path.translate(lib))
+			end
+			_x(3,'</Libs>')
+			_x(2,'</Libs>')
+		end
+	end
+
+	function m.cproj.buildEvents(cfg)
+
+		-- TODO: handle cfg.prelinkcommands...
+
+		if #cfg.prebuildcommands > 0 or #cfg.postbuildcommands > 0 then
+			_x(2,'<CustomCommands>')
+			_x(3,'<CustomCommands>')
+
+			for _, c in ipairs(cfg.prebuildcommands) do
+				_x(4,'<Command type="BeforeBuild" command="%s" />', c)
+			end
+
+			for _, c in ipairs(cfg.postbuildcommands) do
+				_x(4,'<Command type="AfterBuild" command="%s" />', c)
+			end
+
+			_x(3,'</CustomCommands>')
+			_x(2,'</CustomCommands>')
+		end
+	end
+

--- a/modules/monodevelop/tests/_tests.lua
+++ b/modules/monodevelop/tests/_tests.lua
@@ -1,0 +1,7 @@
+require ("monodevelop")
+
+return {
+	"test_sln.lua",
+	"test_project.lua",
+	"test_config.lua",
+}

--- a/modules/monodevelop/tests/test_config.lua
+++ b/modules/monodevelop/tests/test_config.lua
@@ -1,0 +1,199 @@
+---
+-- monodevelop/tests/test_config.lua
+-- Automated test suite for MonoDevelop project generation.
+-- Copyright (c) 2011-2015 Manu Evans and the Premake project
+---
+
+	local suite = test.declare("monodevelop_project_config")
+	local monodevelop = premake.modules.monodevelop
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		_ACTION = "monodevelop"
+		premake.indent("  ")
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare()
+		cfg = test.getconfig(prj, "Debug")
+	end
+
+
+	function suite.OnProject_Config()
+		prepare()
+		monodevelop.configurationProperties(cfg)
+		test.capture [[
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		]]
+	end
+
+	function suite.OnProject_DebugInfo()
+		flags { "Symbols" }
+		prepare()
+		monodevelop.cproj.debuginfo(cfg)
+		test.capture [[
+    <DebugSymbols>true</DebugSymbols>
+		]]
+	end
+
+	function suite.OnProject_OutputPath()
+		prepare()
+		monodevelop.cproj.outputPath(cfg)
+		test.capture([[
+    <OutputPath>]] .. path.translate("bin\\Debug") .. [[</OutputPath>
+		]])
+	end
+
+	function suite.OnProject_OutputName()
+		system "Windows"
+		prepare()
+		monodevelop.cproj.outputName(cfg)
+		test.capture [[
+    <OutputName>MyProject.exe</OutputName>
+		]]
+	end
+
+	function suite.OnProject_ConfigType_Bin()
+		kind "WindowedApp"
+		prepare()
+		monodevelop.cproj.config_type(cfg)
+		test.capture [[
+    <CompileTarget>Bin</CompileTarget>
+		]]
+	end
+	function suite.OnProject_ConfigType_Lib()
+		kind "StaticLib"
+		prepare()
+		monodevelop.cproj.config_type(cfg)
+		test.capture [[
+    <CompileTarget>StaticLibrary</CompileTarget>
+		]]
+	end
+	function suite.OnProject_ConfigType_SO()
+		kind "SharedLib"
+		prepare()
+		monodevelop.cproj.config_type(cfg)
+		test.capture [[
+    <CompileTarget>SharedLibrary</CompileTarget>
+		]]
+	end
+
+	function suite.OnProject_Defines()
+		defines { "DEF1", "DEF2" }
+		prepare()
+		monodevelop.cproj.preprocessorDefinitions(cfg)
+		test.capture [[
+    <DefineSymbols>DEF1 DEF2</DefineSymbols>
+		]]
+	end
+
+	function suite.OnProject_Warnings()
+		warnings "Extra"
+		flags { "FatalCompileWarnings" }
+		prepare()
+		monodevelop.cproj.warnings(cfg)
+		test.capture [[
+    <WarningLevel>All</WarningLevel>
+    <WarningsAsErrors>true</WarningsAsErrors>
+		]]
+	end
+
+	function suite.OnProject_Optimization()
+		optimize "Debug"
+		prepare()
+		monodevelop.cproj.optimization(cfg)
+		test.capture [[
+    <OptimizationLevel>0</OptimizationLevel>
+		]]
+	end
+
+	function suite.OnProject_AdditionalOptions()
+		rtti "Off"
+		exceptionhandling "Off"
+		vectorextensions "SSE2"
+		buildoptions { "-opt1", "-opt2" }
+		prepare()
+		monodevelop.cproj.additionalOptions(cfg)
+		test.capture [[
+    <ExtraCompilerArguments>-fno-exceptions -fno-rtti -msse2 -opt1 -opt2</ExtraCompilerArguments>
+		]]
+	end
+
+	function suite.OnProject_AdditionalLinkOptions()
+		linkoptions { "-opt1", "-opt2" }
+		prepare()
+		monodevelop.cproj.additionalLinkOptions(cfg)
+		test.capture [[
+    <ExtraLinkerArguments>-opt1 -opt2</ExtraLinkerArguments>
+		]]
+	end
+
+	function suite.OnProject_IncludeDirs()
+		includedirs { "path/", "inc" }
+		prepare()
+		monodevelop.cproj.additionalIncludeDirectories(cfg)
+		test.capture [[
+    <Includes>
+      <Includes>
+        <Include>path</Include>
+        <Include>inc</Include>
+      </Includes>
+    </Includes>
+		]]
+	end
+
+	function suite.OnProject_LibDirs()
+		libdirs { "path/", "lib" }
+		prepare()
+		monodevelop.cproj.additionalLibraryDirectories(cfg)
+		test.capture [[
+    <LibPaths>
+      <LibPaths>
+        <LibPath>path</LibPath>
+        <LibPath>lib</LibPath>
+      </LibPaths>
+    </LibPaths>
+		]]
+	end
+
+	function suite.OnProject_Libs()
+		links { "lib1", "lib2" }
+		prepare()
+		monodevelop.cproj.additionalDependencies(cfg)
+		test.capture [[
+    <Libs>
+      <Libs>
+        <Lib>lib1</Lib>
+        <Lib>lib2</Lib>
+      </Libs>
+    </Libs>
+		]]
+	end
+
+	-- TODO: test subling (lib) projects
+
+
+	function suite.OnProject_BuildEvents()
+		prebuildcommands { "pre1", "pre2" }
+		postbuildcommands { "post1", "post2" }
+		prepare()
+		monodevelop.cproj.buildEvents(cfg)
+		test.capture [[
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="BeforeBuild" command="pre1" />
+        <Command type="BeforeBuild" command="pre2" />
+        <Command type="AfterBuild" command="post1" />
+        <Command type="AfterBuild" command="post2" />
+      </CustomCommands>
+    </CustomCommands>
+		]]
+	end
+
+	-- TODO: test dependent project build order

--- a/modules/monodevelop/tests/test_project.lua
+++ b/modules/monodevelop/tests/test_project.lua
@@ -1,0 +1,118 @@
+---
+-- monodevelop/tests/test_project.lua
+-- Automated test suite for MonoDevelop project generation.
+-- Copyright (c) 2011-2015 Manu Evans and the Premake project
+---
+
+	local suite = test.declare("monodevelop_project")
+	local monodevelop = premake.modules.monodevelop
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj
+
+	function suite.setup()
+		_ACTION = "monodevelop"
+		premake.indent("  ")
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		wks = premake.oven.bakeWorkspace(wks)
+		prj = premake.workspace.getproject(wks, 1)
+	end
+
+
+	function suite.OnProject_Header()
+		prepare()
+		monodevelop.header("Build")
+		test.capture [[
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+		]]
+	end
+
+	function suite.OnProject_Properties()
+		prepare()
+		monodevelop.projectProperties(prj)
+		test.capture [[
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		]]
+	end
+
+	function suite.OnProject_ProductVersion()
+		prepare()
+		monodevelop.cproj.productVersion(prj)
+		test.capture [[
+    <ProductVersion>10.0.0</ProductVersion>
+		]]
+	end
+
+	function suite.OnProject_SchemaVersion()
+		prepare()
+		monodevelop.cproj.schemaVersion(prj)
+		test.capture [[
+    <SchemaVersion>2.0</SchemaVersion>
+		]]
+	end
+
+	-- TODO: test <ProjectGUID>
+
+
+	function suite.OnProject_Compiler_C()
+		language "C"
+		prepare()
+		monodevelop.cproj.compiler(prj)
+		test.capture [[
+    <Compiler>
+      <Compiler ctype="GccCompiler" />
+    </Compiler>
+		]]
+	end
+	function suite.OnProject_Compiler_CPP()
+		prepare()
+		monodevelop.cproj.compiler(prj)
+		test.capture [[
+    <Compiler>
+      <Compiler ctype="GppCompiler" />
+    </Compiler>
+		]]
+	end
+
+	function suite.OnProject_Language_C()
+		language "C"
+		prepare()
+		monodevelop.cproj.language(prj)
+		test.capture [[
+    <Language>C</Language>
+		]]
+	end
+	function suite.OnProject_Language_CPP()
+		language "C++"
+		prepare()
+		monodevelop.cproj.language(prj)
+		test.capture [[
+    <Language>CPP</Language>
+		]]
+	end
+
+	function suite.OnProject_Target()
+		prepare()
+		monodevelop.cproj.target(prj)
+		test.capture [[
+    <Target>Bin</Target>
+		]]
+	end
+
+
+	-- Ensure we don't crash generating the C# project files
+	function suite.OnProject_CS_UserFile()
+		language "C#"
+		prepare()
+		monodevelop.generateProject(prj)
+	end

--- a/modules/monodevelop/tests/test_sln.lua
+++ b/modules/monodevelop/tests/test_sln.lua
@@ -1,0 +1,43 @@
+---
+-- monodevelop/tests/test_sln.lua
+-- Automated test suite for MonoDevelop workspace generation.
+-- Copyright (c) 2011-2015 Manu Evans and the Premake project
+---
+
+	local suite = test.declare("monodevelop_workspace")
+	local monodevelop = premake.modules.monodevelop
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		_ACTION = "monodevelop"
+		premake.indent("  ")
+		wks = workspace "MyWorkspace"
+		configurations { "Debug", "Release" }
+		kind "ConsoleApp"
+	end
+
+
+	function suite.slnProj()
+		project "MyProject"
+		premake.vstudio.sln2005.reorderProjects(wks)
+		premake.vstudio.sln2005.projects(wks)
+		test.capture [[
+Project("{2857B73E-F847-4B02-9238-064979017E93}") = "MyProject", "MyProject.cproj", "{42B5DBC6-AE1F-903D-F75D-41E363076E92}"
+EndProject
+		]]
+	end
+
+	function suite.monoDevelopProperties()
+		project "MyProject"
+		monodevelop.MonoDevelopProperties(wks)
+		test.capture [[
+	GlobalSection(MonoDevelopProperties) = preSolution
+	EndGlobalSection
+		]]
+	end

--- a/modules/xcode/LICENSE.TXT
+++ b/modules/xcode/LICENSE.TXT
@@ -1,0 +1,27 @@
+Copyright (c) 2003-2015 Jason Perkins, Mihai Sebea and individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of Premake nor the names of its contributors may be
+     used to endorse or promote products derived from this software without
+     specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/modules/xcode/_manifest.lua
+++ b/modules/xcode/_manifest.lua
@@ -1,0 +1,7 @@
+return {
+	"_preload.lua",
+	"xcode.lua",
+	"xcode4_workspace.lua",
+	"xcode_common.lua",
+	"xcode_project.lua",
+}

--- a/modules/xcode/_preload.lua
+++ b/modules/xcode/_preload.lua
@@ -1,0 +1,66 @@
+---
+-- xcode/_preload.lua
+-- Define the Apple XCode actions and new APIs.
+-- Copyright (c) 2009-2015 Jason Perkins and the Premake project
+---
+
+	local p = premake
+
+
+--
+-- Register new Xcode-specific project fields.
+--
+
+	p.api.register {
+		name = "xcodebuildsettings",
+		scope = "config",
+		kind = "key-array",
+	}
+
+	p.api.register {
+		name = "xcodebuildresources",
+		scope = "config",
+		kind = "list",
+	}
+
+
+--
+-- Register the Xcode exporters.
+--
+
+	newaction {
+		trigger     = "xcode4",
+		shortname   = "Apple Xcode 4",
+		description = "Generate Apple Xcode 4 project files",
+
+		-- Xcode always uses Mac OS X path and naming conventions
+
+		os = "macosx",
+
+		-- The capabilities of this action
+
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "SharedLib", "StaticLib", "Makefile", "None" },
+		valid_languages = { "C", "C++" },
+		valid_tools     = {
+			cc = { "gcc", "clang" },
+		},
+
+		-- Workspace and project generation logic
+
+		onWorkspace = function(wks)
+			p.generate(wks, ".xcworkspace/contents.xcworkspacedata", p.modules.xcode.generateWorkspace)
+		end,
+
+		onProject = function(prj)
+			p.generate(prj, ".xcodeproj/project.pbxproj", p.modules.xcode.generateProject)
+		end,
+	}
+
+
+--
+-- Decide when the full module should be loaded.
+--
+
+	return function(cfg)
+		return (_ACTION == "xcode4")
+	end

--- a/modules/xcode/tests/_tests.lua
+++ b/modules/xcode/tests/_tests.lua
@@ -1,0 +1,9 @@
+require ("xcode")
+
+return {
+	"test_header_footer.lua",
+	"test_xcode4_project.lua",
+	"test_xcode4_workspace.lua",
+	"test_xcode_dependencies.lua",
+	"test_xcode_project.lua",
+}

--- a/modules/xcode/tests/test_header_footer.lua
+++ b/modules/xcode/tests/test_header_footer.lua
@@ -1,0 +1,48 @@
+---
+-- xcode/tests/test_header.lua
+-- Validate generation for Xcode workspaces.
+-- Author Jason Perkins
+-- Copyright (c) 2009-2015 Jason Perkins and the Premake project
+---
+
+	local suite = test.declare("xcode_header")
+	local xcode = premake.modules.xcode
+
+
+--
+-- Setup
+--
+
+	local wks
+
+	function suite.setup()
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		prj = test.getproject(wks, 1)
+		xcode.header(prj)
+		xcode.footer(prj)
+	end
+
+
+--
+-- Check basic structure
+--
+
+	function suite.onDefaults()
+		prepare()
+		test.capture [[
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+	};
+	rootObject = 08FB7793FE84155DC02AAC07 /* Project object */;
+}
+		]]
+	end

--- a/modules/xcode/tests/test_xcode4_project.lua
+++ b/modules/xcode/tests/test_xcode4_project.lua
@@ -1,0 +1,94 @@
+---
+-- tests/actions/xcode/test_xcode4_project.lua
+-- Automated test suite for Xcode project generation.
+-- Copyright (c) 2011-2015 Jason Perkins and the Premake project
+---
+
+
+	local suite = test.declare("xcode4_proj")
+	local xcode = premake.modules.xcode
+
+
+--
+-- Replacement for xcode.newid(). Creates a synthetic ID based on the node name,
+-- its intended usage (file ID, build ID, etc.) and its place in the tree. This
+-- makes it easier to tell if the right ID is being used in the right places.
+--
+
+	xcode.used_ids = {}
+
+	xcode.newid = function(node, usage)
+		local name = node
+		if usage then
+			name = name .. ":" .. usage
+		end
+
+		if xcode.used_ids[name] then
+			local count = xcode.used_ids[name] + 1
+			xcode.used_ids[name] = count
+			name = name .. "(" .. count .. ")"
+		else
+			xcode.used_ids[name] = 1
+		end
+
+		return "[" .. name .. "]"
+	end
+
+
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local tr, wks
+
+	function suite.teardown()
+		tr = nil
+	end
+
+	function suite.setup()
+		_OS = "macosx"
+		_ACTION = "xcode4"
+		io.eol = "\n"
+		xcode.used_ids = { } -- reset the list of generated IDs
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		wks = premake.oven.bakeWorkspace(wks)
+		xcode.prepareWorkspace(wks)
+		local prj = premake.workspace.getproject(wks, 1)
+		tr = xcode.buildprjtree(prj)
+	end
+
+---------------------------------------------------------------------------
+-- XCBuildConfiguration_Project tests
+---------------------------------------------------------------------------
+
+	function suite.XCBuildConfigurationProject_OnSymbols()
+		flags { "Symbols" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_FIX_AND_CONTINUE = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = YES;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end

--- a/modules/xcode/tests/test_xcode4_workspace.lua
+++ b/modules/xcode/tests/test_xcode4_workspace.lua
@@ -1,0 +1,109 @@
+---
+-- xcode/tests/test_xcode4_workspace.lua
+-- Validate generation for Xcode workspaces.
+-- Author Mihai Sebea
+-- Modified by Jason Perkins
+-- Copyright (c) 2014-2015 Jason Perkins and the Premake project
+---
+
+	local suite = test.declare("xcode4_workspace")
+	local xcode = premake.modules.xcode
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		_ACTION = "xcode4"
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		wks = test.getWorkspace(wks)
+		xcode.generateWorkspace(wks)
+	end
+
+
+--
+-- Check the basic structure of a workspace.
+--
+
+	function suite.onEmptyWorkspace()
+		wks.projects = {}
+		prepare()
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+	version = "1.0">
+</Workspace>
+		]]
+	end
+
+
+	function suite.onDefaultWorkspace()
+		prepare()
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+	version = "1.0">
+	<FileRef
+		location = "group:MyProject.xcodeproj">
+	</FileRef>
+</Workspace>
+		]]
+	end
+
+
+	function suite.onMultipleProjects()
+		test.createproject(wks)
+		prepare()
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+	version = "1.0">
+	<FileRef
+		location = "group:MyProject.xcodeproj">
+	</FileRef>
+	<FileRef
+		location = "group:MyProject2.xcodeproj">
+	</FileRef>
+</Workspace>
+		]]
+	end
+
+
+
+--
+-- Projects should include relative path from workspace.
+--
+
+	function suite.onNestedProjectPath()
+		location "MyProject"
+		prepare()
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+	version = "1.0">
+	<FileRef
+		location = "group:MyProject/MyProject.xcodeproj">
+	</FileRef>
+</Workspace>
+		]]
+	end
+
+	function suite.onExternalProjectPath()
+		location "../MyProject"
+		prepare()
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+	version = "1.0">
+	<FileRef
+		location = "group:../MyProject/MyProject.xcodeproj">
+	</FileRef>
+</Workspace>
+		]]
+	end

--- a/modules/xcode/tests/test_xcode_dependencies.lua
+++ b/modules/xcode/tests/test_xcode_dependencies.lua
@@ -1,0 +1,317 @@
+--
+-- tests/actions/xcode/test_xcode_dependencies.lua
+-- Automated test suite for Xcode project dependencies.
+-- Copyright (c) 2009-2011 Jason Perkins and the Premake project
+--
+
+	local suite = test.declare("xcode_deps")
+	local xcode = premake.modules.xcode
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local wks, prj, prj2, tr
+
+	function suite.teardown()
+		wks = nil
+		prj = nil
+		prj2 = nil
+		tr = nil
+	end
+
+	function suite.setup()
+		_ACTION = "xcode4"
+		xcode.used_ids = { } -- reset the list of generated IDs
+
+		wks, prj = test.createWorkspace()
+		links { "MyProject2" }
+
+		prj2 = test.createproject(wks)
+		kind "StaticLib"
+		configuration "Debug"
+		targetsuffix "-d"
+	end
+
+	local function prepare()
+		wks = premake.oven.bakeWorkspace(wks)
+		xcode.prepareWorkspace(wks)
+		local prj3 = premake.workspace.getproject(wks, 1)
+		--prj2 = test.getproject(wks, 2)
+		tr = xcode.buildprjtree(prj3)
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXBuildFile tests
+---------------------------------------------------------------------------
+
+	function suite.PBXBuildFile_ListsDependencyTargets_OnStaticLib()
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		[libMyProject2-d.a:build] /* libMyProject2-d.a in Frameworks */ = {isa = PBXBuildFile; fileRef = [libMyProject2-d.a] /* libMyProject2-d.a */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
+	function suite.PBXBuildFile_ListsDependencyTargets_OnSharedLib()
+		kind "SharedLib"
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		[libMyProject2-d.dylib:build] /* libMyProject2-d.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = [libMyProject2-d.dylib] /* libMyProject2-d.dylib */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXContainerItemProxy tests
+---------------------------------------------------------------------------
+
+	function suite.PBXContainerItemProxy_ListsProjectConfigs()
+		prepare()
+		xcode.PBXContainerItemProxy(tr)
+		test.capture [[
+/* Begin PBXContainerItemProxy section */
+		[MyProject2.xcodeproj:prodprox] /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = [MyProject2.xcodeproj] /* MyProject2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = [libMyProject2-d.a:product];
+			remoteInfo = "libMyProject2-d.a";
+		};
+		[MyProject2.xcodeproj:targprox] /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = [MyProject2.xcodeproj] /* MyProject2.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = [libMyProject2-d.a:target];
+			remoteInfo = "libMyProject2-d.a";
+		};
+/* End PBXContainerItemProxy section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXFileReference tests
+---------------------------------------------------------------------------
+
+	function suite.PBXFileReference_ListsDependencies()
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[MyProject2.xcodeproj] /* libMyProject2-d.a */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "MyProject2.xcodeproj"; path = MyProject2.xcodeproj; sourceTree = SOURCE_ROOT; };
+		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+	function suite.PBXFileReference_UsesRelativePaths()
+		prj.location = "MyProject"
+		prj2.location = "MyProject2"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[MyProject2.xcodeproj] /* libMyProject2-d.a */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "MyProject2.xcodeproj"; path = ../MyProject2.xcodeproj; sourceTree = SOURCE_ROOT; };
+		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXFrameworksBuildPhase tests
+---------------------------------------------------------------------------
+
+	function suite.PBXFrameworksBuildPhase_ListsDependencies_OnStaticLib()
+		prepare()
+		xcode.PBXFrameworksBuildPhase(tr)
+		test.capture [[
+/* Begin PBXFrameworksBuildPhase section */
+		[MyProject:fxs] /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				[libMyProject2-d.a:build] /* libMyProject2-d.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+		]]
+	end
+
+	function suite.PBXFrameworksBuildPhase_ListsDependencies_OnSharedLib()
+		kind "SharedLib"
+		prepare()
+		xcode.PBXFrameworksBuildPhase(tr)
+		test.capture [[
+/* Begin PBXFrameworksBuildPhase section */
+		[MyProject:fxs] /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				[libMyProject2-d.dylib:build] /* libMyProject2-d.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+		]]
+	end
+
+---------------------------------------------------------------------------
+-- PBXGroup tests
+---------------------------------------------------------------------------
+
+	function suite.PBXGroup_ListsDependencies()
+		prepare()
+		xcode.PBXGroup(tr)
+		test.capture [[
+/* Begin PBXGroup section */
+		[MyProject2.xcodeproj:prodgrp] /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				[libMyProject2-d.a] /* libMyProject2-d.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		[MyProject] /* MyProject */ = {
+			isa = PBXGroup;
+			children = (
+				[Products] /* Products */,
+				[Projects] /* Projects */,
+			);
+			name = MyProject;
+			sourceTree = "<group>";
+		};
+		[Products] /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				[MyProject:product] /* MyProject */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		[Projects] /* Projects */ = {
+			isa = PBXGroup;
+			children = (
+				[MyProject2.xcodeproj] /* MyProject2.xcodeproj */,
+			);
+			name = Projects;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXNativeTarget tests
+---------------------------------------------------------------------------
+
+	function suite.PBXNativeTarget_ListsDependencies()
+		prepare()
+		xcode.PBXNativeTarget(tr)
+		test.capture [[
+/* Begin PBXNativeTarget section */
+		[MyProject:target] /* MyProject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = [MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildPhases = (
+				[MyProject:rez] /* Resources */,
+				[MyProject:src] /* Sources */,
+				[MyProject:fxs] /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				[MyProject2.xcodeproj:targdep] /* PBXTargetDependency */,
+			);
+			name = MyProject;
+			productInstallPath = "$(HOME)/bin";
+			productName = MyProject;
+			productReference = [MyProject:product] /* MyProject */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXProject tests
+---------------------------------------------------------------------------
+
+	function suite.PBXProject_ListsDependencies()
+		prepare()
+		xcode.PBXProject(tr)
+		test.capture [[
+/* Begin PBXProject section */
+		08FB7793FE84155DC02AAC07 /* Project object */ = {
+			isa = PBXProject;
+			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */;
+			compatibilityVersion = "Xcode 3.2";
+			hasScannedForEncodings = 1;
+			mainGroup = [MyProject] /* MyProject */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = [MyProject2.xcodeproj:prodgrp] /* Products */;
+					ProjectRef = [MyProject2.xcodeproj] /* MyProject2.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				[MyProject:target] /* MyProject */,
+			);
+		};
+/* End PBXProject section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXReferenceProxy tests
+---------------------------------------------------------------------------
+
+	function suite.PBXReferenceProxy_ListsDependencies()
+		prepare()
+		xcode.PBXReferenceProxy(tr)
+		test.capture [[
+/* Begin PBXReferenceProxy section */
+		[libMyProject2-d.a] /* libMyProject2-d.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libMyProject2-d.a";
+			remoteRef = [MyProject2.xcodeproj:prodprox] /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXTargetDependency tests
+---------------------------------------------------------------------------
+
+	function suite.PBXTargetDependency_ListsDependencies()
+		prepare()
+		xcode.PBXTargetDependency(tr)
+		test.capture [[
+/* Begin PBXTargetDependency section */
+		[MyProject2.xcodeproj:targdep] /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "libMyProject2-d.a";
+			targetProxy = [MyProject2.xcodeproj:targprox] /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+		]]
+	end

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -1,0 +1,2061 @@
+--
+-- tests/actions/xcode/test_xcode_project.lua
+-- Automated test suite for Xcode project generation.
+-- Copyright (c) 2009-2011 Jason Perkins and the Premake project
+--
+	local suite = test.declare("xcode_project")
+	local xcode = premake.modules.xcode
+
+
+
+---------------------------------------------------------------------------
+-- Setup/Teardown
+---------------------------------------------------------------------------
+
+	local tr, wks
+
+	function suite.teardown()
+		tr = nil
+	end
+
+	function suite.setup()
+		_OS = "macosx"
+		_ACTION = "xcode4"
+		premake.eol("\n")
+		xcode.used_ids = { } -- reset the list of generated IDs
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		wks = premake.oven.bakeWorkspace(wks)
+		xcode.prepareWorkspace(wks)
+		local prj = test.getproject(wks, 1)
+		tr = xcode.buildprjtree(prj)
+	end
+
+---------------------------------------------------------------------------
+-- PBXBuildFile tests
+---------------------------------------------------------------------------
+
+	function suite.PBXBuildFile_ListsCppSources()
+		files { "source.h", "source.c", "source.cpp", "Info.plist" }
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		[source.c:build] /* source.c in Sources */ = {isa = PBXBuildFile; fileRef = [source.c] /* source.c */; };
+		[source.cpp:build] /* source.cpp in Sources */ = {isa = PBXBuildFile; fileRef = [source.cpp] /* source.cpp */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
+	function suite.PBXBuildFile_ListsObjCSources()
+		files { "source.h", "source.m", "source.mm", "Info.plist" }
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		[source.m:build] /* source.m in Sources */ = {isa = PBXBuildFile; fileRef = [source.m] /* source.m */; };
+		[source.mm:build] /* source.mm in Sources */ = {isa = PBXBuildFile; fileRef = [source.mm] /* source.mm */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
+	function suite.PBXBuildFile_ListsResourceFilesOnlyOnceWithGroupID()
+		files { "English.lproj/MainMenu.xib", "French.lproj/MainMenu.xib" }
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		[MainMenu.xib:build] /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = [MainMenu.xib] /* MainMenu.xib */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
+
+	function suite.PBXBuildFile_ListsFrameworks()
+		links { "Cocoa.framework", "ldap" }
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		[Cocoa.framework:build] /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = [Cocoa.framework] /* Cocoa.framework */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
+	function suite.PBXBuildFile_IgnoresVpaths()
+		files { "source.h", "source.c", "source.cpp", "Info.plist" }
+		vpaths { ["Source Files"] = { "**.c", "**.cpp" } }
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		[source.c:build] /* source.c in Sources */ = {isa = PBXBuildFile; fileRef = [source.c] /* source.c */; };
+		[source.cpp:build] /* source.cpp in Sources */ = {isa = PBXBuildFile; fileRef = [source.cpp] /* source.cpp */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXFileReference tests
+---------------------------------------------------------------------------
+
+	function suite.PBXFileReference_ListsConsoleTarget()
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
+	function suite.PBXFileReference_ListsWindowedTarget()
+		kind "WindowedApp"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[MyProject.app:product] /* MyProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = MyProject.app; path = MyProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
+	function suite.PBXFileReference_ListsStaticLibTarget()
+		kind "StaticLib"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[libMyProject.a:product] /* libMyProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libMyProject.a; path = libMyProject.a; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
+	function suite.PBXFileReference_ListsSharedLibTarget()
+		kind "SharedLib"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[libMyProject.dylib:product] /* libMyProject.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libMyProject.dylib; path = libMyProject.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
+	function suite.PBXFileReference_ListsSourceFiles()
+		files { "source.c" }
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		[source.c] /* source.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = source.c; path = source.c; sourceTree = "<group>"; };
+		]]
+	end
+
+
+	function suite.PBXFileReference_ListsXibCorrectly()
+		files { "English.lproj/MainMenu.xib", "French.lproj/MainMenu.xib" }
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[English] /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		[French] /* French */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = French; path = French.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		]]
+	end
+
+
+	function suite.PBXFileReference_ListsStringsCorrectly()
+		files { "English.lproj/InfoPlist.strings", "French.lproj/InfoPlist.strings" }
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[English] /* English */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		[French] /* French */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = French; path = French.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		]]
+	end
+
+
+	function suite.PBXFileReference_ListFrameworksCorrectly()
+		links { "Cocoa.framework/" }
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[Cocoa.framework] /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		]]
+	end
+
+
+	function suite.PBXFileReference_leavesFrameworkLocationsAsIsWhenSupplied_pathIsSetToInput()
+		local inputFrameWork = 'somedir/Foo.framework'
+		links(inputFrameWork)
+		prepare()
+
+		--io.capture()
+		xcode.PBXFileReference(tr)
+		--local str = io.captured()
+		--test.istrue(str:find('path = "'..inputFrameWork..'"'))
+
+		--ms check
+	end
+
+
+	function suite.PBXFileReference_relativeFrameworkPathSupplied_callsError()
+		local inputFrameWork = '../somedir/Foo.framework'
+		links(inputFrameWork)
+		prepare()
+		-- ms no longer and error
+		-- valid case for linking relative frameworks
+		--local error_called = false
+		--local old_error = error
+		--error = function( ... )error_called = true end
+		xcode.PBXFileReference(tr)
+		--error = old_error
+		--test.istrue(error_called)
+	end
+
+	function suite.PBXFileReference_ListsIconFiles()
+		files { "Icon.icns" }
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[Icon.icns] /* Icon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = Icon.icns; path = Icon.icns; sourceTree = "<group>"; };
+		]]
+	end
+
+	function suite.PBXFileReference_IgnoresTargetDir()
+		targetdir "bin"
+		kind "WindowedApp"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[MyProject.app:product] /* MyProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = MyProject.app; path = MyProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
+	function suite.PBXFileReference_UsesTargetSuffix()
+		targetsuffix "-d"
+		kind "SharedLib"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[libMyProject-d.dylib:product] /* libMyProject-d.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = "libMyProject-d.dylib"; path = "libMyProject-d.dylib"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
+	function suite.PBXFileReference_UsesFullPath_WhenParentIsVirtual()
+		files { "src/source.c" }
+		vpaths { ["Source Files"] = "**.c" }
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		[source.c] /* source.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = source.c; path = src/source.c; sourceTree = "<group>"; };
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXFrameworksBuildPhase tests
+---------------------------------------------------------------------------
+
+	function suite.PBXFrameworksBuildPhase_OnNoFiles()
+		prepare()
+		xcode.PBXFrameworksBuildPhase(tr)
+		test.capture [[
+/* Begin PBXFrameworksBuildPhase section */
+		[MyProject:fxs] /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+		]]
+	end
+
+
+	function suite.PBXFrameworksBuild_ListsFrameworksCorrectly()
+		links { "Cocoa.framework" }
+		prepare()
+		xcode.PBXFrameworksBuildPhase(tr)
+		test.capture [[
+/* Begin PBXFrameworksBuildPhase section */
+		[MyProject:fxs] /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				[Cocoa.framework:build] /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXGroup tests
+---------------------------------------------------------------------------
+
+	function suite.PBXGroup_OnNoFiles()
+		prepare()
+		xcode.PBXGroup(tr)
+		test.capture [[
+/* Begin PBXGroup section */
+		[MyProject] /* MyProject */ = {
+			isa = PBXGroup;
+			children = (
+				[Products] /* Products */,
+			);
+			name = MyProject;
+			sourceTree = "<group>";
+		};
+		[Products] /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				[MyProject:product] /* MyProject */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+		]]
+	end
+
+
+	function suite.PBXGroup_OnSourceFiles()
+		files { "source.h" }
+		prepare()
+		xcode.PBXGroup(tr)
+		test.capture [[
+/* Begin PBXGroup section */
+		[MyProject] /* MyProject */ = {
+			isa = PBXGroup;
+			children = (
+				[source.h] /* source.h */,
+				[Products] /* Products */,
+			);
+			name = MyProject;
+			sourceTree = "<group>";
+		};
+		[Products] /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				[MyProject:product] /* MyProject */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+		]]
+	end
+
+
+	function suite.PBXGroup_OnSourceSubdirs()
+		files { "include/premake/source.h" }
+		prepare()
+		xcode.PBXGroup(tr)
+		test.capture [[
+/* Begin PBXGroup section */
+		[MyProject] /* MyProject */ = {
+			isa = PBXGroup;
+			children = (
+				[source.h] /* source.h */,
+				[Products] /* Products */,
+			);
+			name = MyProject;
+			sourceTree = "<group>";
+		};
+		[Products] /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				[MyProject:product] /* MyProject */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+		]]
+	end
+
+
+	function suite.PBXGroup_pathHasPlusPlus_PathIsQuoted()
+		files { "RequiresQuoting++/h.h" }
+		prepare()
+		xcode.PBXGroup(tr)
+
+		local str = premake.captured()
+		--test.istrue(str:find('path = "RequiresQuoting%+%+";'))
+
+	end
+
+	function suite.PBXGroup_SortsFiles()
+		files { "test.h", "source.h", "source.cpp" }
+		prepare()
+		xcode.PBXGroup(tr)
+		test.capture [[
+/* Begin PBXGroup section */
+		[MyProject] /* MyProject */ = {
+			isa = PBXGroup;
+			children = (
+				[source.cpp] /* source.cpp */,
+				[source.h] /* source.h */,
+				[test.h] /* test.h */,
+				[Products] /* Products */,
+			);
+			name = MyProject;
+			sourceTree = "<group>";
+		};
+		[Products] /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				[MyProject:product] /* MyProject */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+		]]
+	end
+
+
+	function suite.PBXGroup_OnResourceFiles()
+		files { "English.lproj/MainMenu.xib", "French.lproj/MainMenu.xib", "Info.plist" }
+		prepare()
+		xcode.PBXGroup(tr)
+		test.capture [[
+/* Begin PBXGroup section */
+		[MyProject] /* MyProject */ = {
+			isa = PBXGroup;
+			children = (
+				[Info.plist] /* Info.plist */,
+				[MainMenu.xib] /* MainMenu.xib */,
+				[Products] /* Products */,
+			);
+			name = MyProject;
+			sourceTree = "<group>";
+		};
+		[Products] /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				[MyProject:product] /* MyProject */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+		]]
+	end
+
+
+	function suite.PBXGroup_OnFrameworks()
+		links { "Cocoa.framework" }
+		prepare()
+		xcode.PBXGroup(tr)
+		test.capture [[
+/* Begin PBXGroup section */
+		[Frameworks] /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				[Cocoa.framework] /* Cocoa.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		[MyProject] /* MyProject */ = {
+			isa = PBXGroup;
+			children = (
+				[Frameworks] /* Frameworks */,
+				[Products] /* Products */,
+			);
+			name = MyProject;
+			sourceTree = "<group>";
+		};
+		]]
+	end
+
+
+	function suite.PBXGroup_OnVpaths()
+		files { "include/premake/source.h" }
+		vpaths { ["Headers"] = "**.h" }
+		prepare()
+		xcode.PBXGroup(tr)
+		test.capture [[
+/* Begin PBXGroup section */
+		[Headers] /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				[source.h] /* source.h */,
+			);
+			name = Headers;
+			sourceTree = "<group>";
+		};
+		[MyProject] /* MyProject */ = {
+			isa = PBXGroup;
+			children = (
+				[Headers] /* Headers */,
+				[Products] /* Products */,
+			);
+			name = MyProject;
+			sourceTree = "<group>";
+		};
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXNativeTarget tests
+---------------------------------------------------------------------------
+
+	function suite.PBXNativeTarget_OnConsoleApp()
+		prepare()
+		xcode.PBXNativeTarget(tr)
+		test.capture [[
+/* Begin PBXNativeTarget section */
+		[MyProject:target] /* MyProject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = [MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildPhases = (
+				[MyProject:rez] /* Resources */,
+				[MyProject:src] /* Sources */,
+				[MyProject:fxs] /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MyProject;
+			productInstallPath = "$(HOME)/bin";
+			productName = MyProject;
+			productReference = [MyProject:product] /* MyProject */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+		]]
+	end
+
+
+	function suite.PBXNativeTarget_OnWindowedApp()
+		kind "WindowedApp"
+		prepare()
+		xcode.PBXNativeTarget(tr)
+		test.capture [[
+/* Begin PBXNativeTarget section */
+		[MyProject.app:target] /* MyProject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = [MyProject.app:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildPhases = (
+				[MyProject.app:rez] /* Resources */,
+				[MyProject.app:src] /* Sources */,
+				[MyProject.app:fxs] /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MyProject;
+			productInstallPath = "$(HOME)/Applications";
+			productName = MyProject;
+			productReference = [MyProject.app:product] /* MyProject.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+		]]
+	end
+
+
+	function suite.PBXNativeTarget_OnSharedLib()
+		kind "SharedLib"
+		prepare()
+		xcode.PBXNativeTarget(tr)
+		test.capture [[
+/* Begin PBXNativeTarget section */
+		[libMyProject.dylib:target] /* MyProject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = [libMyProject.dylib:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildPhases = (
+				[libMyProject.dylib:rez] /* Resources */,
+				[libMyProject.dylib:src] /* Sources */,
+				[libMyProject.dylib:fxs] /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MyProject;
+			productName = MyProject;
+			productReference = [libMyProject.dylib:product] /* libMyProject.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+/* End PBXNativeTarget section */
+		]]
+	end
+
+
+	function suite.PBXNativeTarget_OnBuildCommands()
+		prebuildcommands { "prebuildcmd" }
+		prelinkcommands { "prelinkcmd" }
+		postbuildcommands { "postbuildcmd" }
+		prepare()
+		xcode.PBXNativeTarget(tr)
+		test.capture [[
+/* Begin PBXNativeTarget section */
+		[MyProject:target] /* MyProject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = [MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildPhases = (
+				9607AE1010C857E500CD1376 /* Prebuild */,
+				[MyProject:rez] /* Resources */,
+				[MyProject:src] /* Sources */,
+				9607AE3510C85E7E00CD1376 /* Prelink */,
+				[MyProject:fxs] /* Frameworks */,
+				9607AE3710C85E8F00CD1376 /* Postbuild */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MyProject;
+			productInstallPath = "$(HOME)/bin";
+			productName = MyProject;
+			productReference = [MyProject:product] /* MyProject */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXProject tests
+---------------------------------------------------------------------------
+
+	function suite.PBXProject_OnProject()
+		prepare()
+		xcode.PBXProject(tr)
+		test.capture [[
+/* Begin PBXProject section */
+		08FB7793FE84155DC02AAC07 /* Project object */ = {
+			isa = PBXProject;
+			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */;
+			compatibilityVersion = "Xcode 3.2";
+			hasScannedForEncodings = 1;
+			mainGroup = [MyProject] /* MyProject */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				[MyProject:target] /* MyProject */,
+			);
+		};
+/* End PBXProject section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXResourceBuildPhase tests
+---------------------------------------------------------------------------
+
+	function suite.PBXResourcesBuildPhase_OnNoResources()
+		prepare()
+		xcode.PBXResourcesBuildPhase(tr)
+		test.capture [[
+/* Begin PBXResourcesBuildPhase section */
+		[MyProject:rez] /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+		]]
+	end
+
+
+	function suite.PBXResourcesBuildPhase_OnResources()
+		files { "English.lproj/MainMenu.xib", "French.lproj/MainMenu.xib", "Info.plist" }
+		prepare()
+		xcode.PBXResourcesBuildPhase(tr)
+		test.capture [[
+/* Begin PBXResourcesBuildPhase section */
+		[MyProject:rez] /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				[MainMenu.xib:build] /* MainMenu.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXShellScriptBuildPhase tests
+---------------------------------------------------------------------------
+
+	function suite.PBXShellScriptBuildPhase_OnNoScripts()
+		prepare()
+		xcode.PBXShellScriptBuildPhase(tr)
+		test.capture [[
+		]]
+	end
+
+
+	function suite.PBXShellScriptBuildPhase_OnPrebuildScripts()
+		prebuildcommands { 'ls src', 'cp "a" "b"' }
+		prepare()
+		xcode.PBXShellScriptBuildPhase(tr)
+		test.capture [[
+/* Begin PBXShellScriptBuildPhase section */
+		9607AE1010C857E500CD1376 /* Prebuild */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Prebuild;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "ls src\ncp \"a\" \"b\"";
+		};
+/* End PBXShellScriptBuildPhase section */
+		]]
+	end
+
+
+	function suite.PBXShellScriptBuildPhase_OnPerConfigCmds()
+		prebuildcommands { 'ls src' }
+		configuration "Debug"
+		prebuildcommands { 'cp a b' }
+		prepare()
+		xcode.PBXShellScriptBuildPhase(tr)
+		test.capture [[
+/* Begin PBXShellScriptBuildPhase section */
+		9607AE1010C857E500CD1376 /* Prebuild */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Prebuild;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "ls src\nif [ \"${CONFIGURATION}\" = \"Debug\" ]; then\ncp a b\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXSourcesBuildPhase tests
+---------------------------------------------------------------------------
+
+	function suite.PBXSourcesBuildPhase_OnNoSources()
+		prepare()
+		xcode.PBXSourcesBuildPhase(tr)
+		test.capture [[
+/* Begin PBXSourcesBuildPhase section */
+		[MyProject:src] /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+		]]
+	end
+
+
+	function suite.PBXSourcesBuildPhase_OnSources()
+		files { "hello.cpp", "goodbye.cpp" }
+		prepare()
+		xcode.PBXSourcesBuildPhase(tr)
+		test.capture [[
+/* Begin PBXSourcesBuildPhase section */
+		[MyProject:src] /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				[goodbye.cpp:build] /* goodbye.cpp in Sources */,
+				[hello.cpp:build] /* hello.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- PBXVariantGroup tests
+---------------------------------------------------------------------------
+
+	function suite.PBXVariantGroup_OnNoGroups()
+		prepare()
+		xcode.PBXVariantGroup(tr)
+		test.capture [[
+/* Begin PBXVariantGroup section */
+/* End PBXVariantGroup section */
+		]]
+	end
+
+
+	function suite.PBXVariantGroup_OnNoResourceGroups()
+		files { "English.lproj/MainMenu.xib", "French.lproj/MainMenu.xib" }
+		prepare()
+		xcode.PBXVariantGroup(tr)
+		test.capture [[
+/* Begin PBXVariantGroup section */
+		[MainMenu.xib] /* MainMenu.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				[English] /* English */,
+				[French] /* French */,
+			);
+			name = MainMenu.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- XCBuildConfiguration_Target tests
+---------------------------------------------------------------------------
+
+	function suite.XCBuildConfigurationTarget_OnConsoleApp()
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnWindowedApp()
+		kind "WindowedApp"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject.app:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = "\"$(HOME)/Applications\"";
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnStaticLib()
+		kind "StaticLib"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[libMyProject.a:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/lib;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnSharedLib()
+		kind "SharedLib"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[libMyProject.dylib:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_PREFIX = lib;
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/lib;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnTargetPrefix()
+		kind "SharedLib"
+		targetprefix "xyz"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[xyzMyProject.dylib:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_PREFIX = xyz;
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/lib;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnTargetExtension()
+		kind "SharedLib"
+		targetextension ".xyz"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+
+		--ms removed for now
+		--EXECUTABLE_EXTENSION = xyz;
+
+		test.capture [[
+		[libMyProject.xyz:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_PREFIX = lib;
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/lib;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnInfoPlist()
+		files { "../../MyProject-Info.plist" }
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INFOPLIST_FILE = "../../MyProject-Info.plist";
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnSymbols()
+		flags { "Symbols" }
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnTargetSuffix()
+		targetsuffix "-d"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject-d:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = "MyProject-d";
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnSinglePlatform()
+		platforms { "Universal32" }
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Universal32/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnMultiplePlatforms()
+		workspace("MyWorkspace")
+		platforms { "Universal32", "Universal64" }
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Universal32/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- XCBuildConfiguration_Project tests
+---------------------------------------------------------------------------
+
+	function suite.XCBuildConfigurationProject_OnConsoleApp()
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnOptimize()
+		--flags { "Optimize" }
+		optimize "Size"
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnOptimizeSpeed()
+		flags { "OptimizeSpeed" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnStaticRuntime()
+		flags { "StaticRuntime" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = static;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnTargetDir()
+		targetdir "bin"
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnDefines()
+		defines { "_DEBUG", "DEBUG" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					_DEBUG,
+					DEBUG,
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnIncludeDirs()
+		includedirs { "../include", "../libs", "../name with spaces" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+				USER_HEADER_SEARCH_PATHS = (
+					../include,
+					../libs,
+					"\"../name with spaces\"",
+				);
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationProject_OnSysIncludeDirs()
+		sysincludedirs { "../include", "../libs", "../name with spaces" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					../include,
+					../libs,
+					"\"../name with spaces\"",
+					"$(inherited)",
+				);
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationProject_OnBuildOptions()
+		buildoptions { "build option 1", "build option 2" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = (
+					"build option 1",
+					"build option 2",
+				);
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnLinks()
+		links { "Cocoa.framework", "ldap" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = (
+					"-lldap",
+				);
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationProject_OnLinkOptions()
+		linkoptions { "link option 1", "link option 2" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = (
+					"link option 1",
+					"link option 2",
+				);
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnExtraWarnings()
+		--flags { "ExtraWarnings" }
+		warnings "Extra"
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+				WARNING_CFLAGS = "-Wall -Wextra";
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnFatalWarnings()
+		flags { "FatalWarnings" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnFloatFast()
+		flags { "FloatFast" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = (
+					"-ffast-math",
+				);
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnFloatStrict()
+		flags { "FloatStrict" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = (
+					"-ffloat-store",
+				);
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnNoEditAndContinue()
+		flags { "Symbols", "NoEditAndContinue" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = YES;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnNoExceptions()
+		exceptionhandling "Off"
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_CPP_EXCEPTIONS = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnNoFramePointer()
+		flags { "NoFramePointer" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = (
+					"-fomit-frame-pointer",
+				);
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnNoPCH()
+		pchheader "MyProject_Prefix.pch"
+		flags { "NoPCH" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnNoRTTI()
+		rtti "Off"
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_CPP_RTTI = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnSymbols()
+		flags { "Symbols" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_FIX_AND_CONTINUE = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = YES;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnLibDirs()
+		libdirs { "mylibs1", "mylibs2" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LIBRARY_SEARCH_PATHS = (
+					mylibs1,
+					mylibs2,
+				);
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnPCH()
+		pchheader "MyProject_Prefix.pch"
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = MyProject_Prefix.pch;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnUniversal()
+		workspace("MyWorkspace")
+		platforms { "Universal" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Universal/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Universal/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnUniversal32()
+		workspace("MyWorkspace")
+		platforms { "Universal32" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Universal32/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Universal32/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnUniversal64()
+		workspace("MyWorkspace")
+		platforms { "Universal64" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Universal64/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Universal64/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnNative()
+		workspace("MyWorkspace")
+		platforms { "Native" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Native/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Native/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnX86()
+		workspace("MyWorkspace")
+		platforms { "x86" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = i386;
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/x86/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/x86/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnX86_64()
+		workspace("MyWorkspace")
+		platforms { "x86_64" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/x86_64/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/x86_64/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationProject_OnMultiplePlatforms()
+		workspace("MyWorkspace")
+		platforms { "Universal32", "Universal64" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Universal32/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Universal32/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+---------------------------------------------------------------------------
+-- XCBuildConfigurationList tests
+---------------------------------------------------------------------------
+
+	function suite.XCBuildConfigurationList_OnNoPlatforms()
+		prepare()
+		xcode.XCBuildConfigurationList(tr)
+		test.capture [[
+/* Begin XCConfigurationList section */
+		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				[MyProject:Debug(2)] /* Debug */,
+				[MyProject:Release(2)] /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		[MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				[MyProject:Debug] /* Debug */,
+				[MyProject:Release] /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationList_OnSinglePlatforms()
+		platforms { "Universal32" }
+		prepare()
+		xcode.XCBuildConfigurationList(tr)
+		test.capture [[
+/* Begin XCConfigurationList section */
+		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				[MyProject:Debug(2)] /* Debug */,
+				[MyProject:Release(2)] /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		[MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				[MyProject:Debug] /* Debug */,
+				[MyProject:Release] /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationList_OnMultiplePlatforms()
+		workspace("MyWorkspace")
+		platforms { "Universal32", "Universal64" }
+		prepare()
+		xcode.XCBuildConfigurationList(tr)
+		test.capture [[
+/* Begin XCConfigurationList section */
+		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				[MyProject:Debug(2)] /* Debug */,
+				[MyProject:Debug(4)] /* Debug */,
+				[MyProject:Release(2)] /* Release */,
+				[MyProject:Release(4)] /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		[MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				[MyProject:Debug] /* Debug */,
+				[MyProject:Debug(3)] /* Debug */,
+				[MyProject:Release] /* Release */,
+				[MyProject:Release(3)] /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+		]]
+	end
+
+function suite.defaultVisibility_settingIsFound()
+	prepare()
+	xcode.XCBuildConfiguration(tr)
+	local str = premake.captured()
+	test.istrue(str:find('GCC_SYMBOLS_PRIVATE_EXTERN'))
+end
+
+
+function suite.defaultVisibilitySetting_setToNo()
+	prepare()
+	xcode.XCBuildConfiguration(tr)
+	local str = premake.captured()
+	test.istrue(str:find('GCC_SYMBOLS_PRIVATE_EXTERN = NO;'))
+end
+
+function suite.releaseBuild_onlyDefaultArch_equalsNo()
+	flags { "Optimize" }
+	prepare()
+	xcode.XCBuildConfiguration_Project(tr, tr.configs[2])
+	local str = premake.captured()
+	test.istrue(str:find('ONLY_ACTIVE_ARCH = NO;'))
+end
+
+function suite.debugBuild_onlyDefaultArch_equalsYes()
+	flags { "Symbols" }
+	prepare()
+	xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+
+	local str = premake.captured()
+	test.istrue(str:find('ONLY_ACTIVE_ARCH = YES;'))
+end

--- a/modules/xcode/xcode.lua
+++ b/modules/xcode/xcode.lua
@@ -1,0 +1,19 @@
+---
+-- xcode/xcode.lua
+-- Common support code for the Apple Xcode exporters.
+-- Copyright (c) 2009-2015 Jason Perkins and the Premake project
+---
+
+	local p = premake
+
+	p.modules.xcode = {}
+
+	local m = p.modules.xcode
+	m._VERSION = p._VERSION
+	m.elements = {}
+
+	include("xcode_common.lua")
+	include("xcode4_workspace.lua")
+	include("xcode_project.lua")
+
+	return m

--- a/modules/xcode/xcode4_workspace.lua
+++ b/modules/xcode/xcode4_workspace.lua
@@ -1,0 +1,84 @@
+---
+-- xcode/xcode4_workspace.lua
+-- Generate an Xcode workspace.
+-- Author Mihai Sebea
+-- Modified by Jason Perkins
+-- Copyright (c) 2014-2015 Jason Perkins and the Premake project
+---
+
+	local p = premake
+	local m = p.modules.xcode
+
+
+
+---
+-- Generate an Xcode contents.xcworkspacedata file.
+---
+
+	m.elements.workspace = function(wks)
+		return {
+			m.xmlDeclaration,
+			m.workspace,
+			m.workspaceFileRefs,
+			m.workspaceTail,
+		}
+	end
+
+	function m.generateWorkspace(wks)
+		m.prepareWorkspace(wks)
+		p.callArray(m.elements.workspace, wks)
+	end
+
+
+	function m.workspace()
+		p.push('<Workspace')
+		p.w('version = "1.0">')
+	end
+
+
+	function m.workspaceTail()
+		-- Don't output final newline.  Xcode doesn't.
+		premake.out('</Workspace>')
+	end
+
+
+---
+-- Generate the list of project references.
+---
+
+	m.elements.workspaceFileRef = function(prj)
+		return {
+			m.workspaceLocation,
+		}
+	end
+
+	function m.workspaceFileRefs(wks)
+		for prj in p.workspace.eachproject(wks) do
+			p.push('<FileRef')
+			local contents = p.capture(function()
+				p.callArray(m.elements.workspaceFileRef, prj)
+			end)
+			p.outln(contents .. ">")
+			p.pop('</FileRef>')
+		end
+	end
+
+
+
+---------------------------------------------------------------------------
+--
+-- Handlers for individual project elements
+--
+---------------------------------------------------------------------------
+
+
+	function m.workspaceLocation(prj)
+		local fname = p.filename(prj, ".xcodeproj")
+		fname = path.getrelative(prj.workspace.location, fname)
+		p.w('location = "group:%s"', fname)
+	end
+
+
+	function m.xmlDeclaration()
+		p.xmlUtf8(true)
+	end

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1,0 +1,1186 @@
+--
+-- xcode_common.lua
+-- Functions to generate the different sections of an Xcode project.
+-- Copyright (c) 2009-2015 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local xcode = p.modules.xcode
+	local tree  = p.tree
+    local workspace = p.workspace
+	local project = p.project
+    local config = p.config
+	local fileconfig = p.fileconfig
+
+
+--
+-- Return the Xcode build category for a given file, based on the file extension.
+--
+-- @param node
+--    The node to identify.
+-- @returns
+--    An Xcode build category, one of "Sources", "Resources", "Frameworks", or nil.
+--
+
+	function xcode.getbuildcategory(node)
+		local categories = {
+			[".a"] = "Frameworks",
+			[".c"] = "Sources",
+			[".cc"] = "Sources",
+			[".cpp"] = "Sources",
+			[".cxx"] = "Sources",
+			[".dylib"] = "Frameworks",
+			[".framework"] = "Frameworks",
+			[".m"] = "Sources",
+			[".mm"] = "Sources",
+			[".strings"] = "Resources",
+			[".nib"] = "Resources",
+			[".xib"] = "Resources",
+			[".storyboard"] = "Resources",
+			[".icns"] = "Resources",
+			[".s"] = "Sources",
+			[".S"] = "Sources",
+		}
+		if node.isResource then
+			return "Resources"
+		end
+		return categories[path.getextension(node.name)]
+	end
+
+	function xcode.isItemResource(project, node)
+
+		local res;
+
+		if project and project.xcodebuildresources then
+			if type(project.xcodebuildresources) == "table" then
+				res = project.xcodebuildresources
+			end
+		end
+
+		local function checkItemInList(item, list)
+			if item then
+				if list then
+					if type(list) == "table" then
+						for _,v in pairs(list) do
+							if string.find(item, v) then
+								return true
+							end
+						end
+					end
+				end
+			end
+			return false
+		end
+
+		--print (node.path, node.buildid, node.cfg, res)
+		if (checkItemInList(node.path, res)) then
+			return true
+		end
+
+		return false
+	end
+--
+-- Return the Xcode type for a given file, based on the file extension.
+--
+-- @param fname
+--    The file name to identify.
+-- @returns
+--    An Xcode file type, string.
+--
+
+	function xcode.getfiletype(node, cfg)
+
+		if node.configs then
+			local filecfg = fileconfig.getconfig(node, cfg)
+			if filecfg then
+				if filecfg.language == "ObjC" then
+					return "sourcecode.c.objc"
+				elseif 	filecfg.language == "ObjCpp" then
+					return "sourcecode.cpp.objcpp"
+				end
+			end
+		end
+
+		local types = {
+			[".c"]         = "sourcecode.c.c",
+			[".cc"]        = "sourcecode.cpp.cpp",
+			[".cpp"]       = "sourcecode.cpp.cpp",
+			[".css"]       = "text.css",
+			[".cxx"]       = "sourcecode.cpp.cpp",
+			[".S"]         = "sourcecode.asm.asm",
+			[".framework"] = "wrapper.framework",
+			[".gif"]       = "image.gif",
+			[".h"]         = "sourcecode.c.h",
+			[".html"]      = "text.html",
+			[".lua"]       = "sourcecode.lua",
+			[".m"]         = "sourcecode.c.objc",
+			[".mm"]        = "sourcecode.cpp.objc",
+			[".nib"]       = "wrapper.nib",
+			[".storyboard"] = "file.storyboard",
+			[".pch"]       = "sourcecode.c.h",
+			[".plist"]     = "text.plist.xml",
+			[".strings"]   = "text.plist.strings",
+			[".xib"]       = "file.xib",
+			[".icns"]      = "image.icns",
+			[".s"]         = "sourcecode.asm",
+			[".bmp"]       = "image.bmp",
+			[".wav"]       = "audio.wav",
+			[".xcassets"]  = "folder.assetcatalog",
+
+		}
+		return types[path.getextension(node.path)] or "text"
+	end
+
+--
+-- Print user configuration references contained in xcodeconfigreferences
+-- @param offset
+--    offset used by function _p
+-- @param cfg
+--    configuration
+--
+
+	local function xcodePrintUserConfigReferences(offset, cfg, tr, kind)
+		local referenceName
+		if kind == "project" then
+			referenceName = cfg.xcodeconfigreferenceproject
+		elseif kind == "target" then
+			referenceName = cfg.xcodeconfigreferencetarget
+		end
+		tree.traverse(tr, {
+			onleaf = function(node)
+				filename = node.name
+				if node.id and path.getextension(filename) == ".xcconfig" then
+					if filename == referenceName then
+						_p(offset, 'baseConfigurationReference = %s /* %s */;', node.id, filename)
+						return
+					end
+				end
+			end
+		}, false)
+	end
+
+
+
+	local escapeSpecialChars = {
+		['\n'] = '\\n',
+		['\r'] = '\\r',
+		['\t'] = '\\t',
+	}
+
+	local function escapeChar(c)
+		return escapeSpecialChars[c] or '\\'..c
+	end
+
+	local function escapeArg(value)
+		value = value:gsub('[\'"\\\n\r\t ]', escapeChar)
+		return value
+	end
+
+	local function escapeSetting(value)
+		value = value:gsub('["\\\n\r\t]', escapeChar)
+		return value
+	end
+
+	local function stringifySetting(value)
+		value = value..''
+		if not value:match('^[%a%d_./]+$') then
+			value = '"'..escapeSetting(value)..'"'
+		end
+		return value
+	end
+
+	local function customStringifySetting(value)
+		value = value..''
+
+		local test = value:match('^[%a%d_./%+]+$')
+		if test then
+			value = '"'..escapeSetting(value)..'"'
+		end
+		return value
+	end
+
+	local function printSetting(level, name, value)
+		if type(value) == 'function' then
+			value(level, name)
+		elseif type(value) ~= 'table' then
+			_p(level, '%s = %s;', stringifySetting(name), stringifySetting(value))
+		--elseif #value == 1 then
+			--_p(level, '%s = %s;', stringifySetting(name), stringifySetting(value[1]))
+		elseif #value >= 1 then
+			_p(level, '%s = (', stringifySetting(name))
+			for _, item in ipairs(value) do
+				_p(level + 1, '%s,', stringifySetting(item))
+			end
+			_p(level, ');')
+		end
+	end
+
+	local function printSettingsTable(level, settings)
+		-- Maintain alphabetic order to be consistent
+		local keys = table.keys(settings)
+		table.sort(keys)
+		for _, k in ipairs(keys) do
+			printSetting(level, k, settings[k])
+		end
+	end
+
+	local function overrideSettings(settings, overrides)
+		if type(overrides) == 'table' then
+			for name, value in pairs(overrides) do
+				-- Allow an override to remove a value by using false
+				settings[name] = iif(value ~= false, value, nil)
+			end
+		end
+	end
+
+--
+-- Return the Xcode product type, based target kind.
+--
+-- @param node
+--    The product node to identify.
+-- @returns
+--    An Xcode product type, string.
+--
+
+	function xcode.getproducttype(node)
+		local types = {
+			ConsoleApp  = "com.apple.product-type.tool",
+			WindowedApp = "com.apple.product-type.application",
+			StaticLib   = "com.apple.product-type.library.static",
+			SharedLib   = "com.apple.product-type.library.dynamic",
+		}
+		return types[node.cfg.kind]
+	end
+
+
+--
+-- Return the Xcode target type, based on the target file extension.
+--
+-- @param node
+--    The product node to identify.
+-- @returns
+--    An Xcode target type, string.
+--
+
+	function xcode.gettargettype(node)
+		local types = {
+			ConsoleApp  = "\"compiled.mach-o.executable\"",
+			WindowedApp = "wrapper.application",
+			StaticLib   = "archive.ar",
+			SharedLib   = "\"compiled.mach-o.dylib\"",
+		}
+		return types[node.cfg.kind]
+	end
+
+
+--
+-- Return a unique file name for a project. Since Xcode uses .xcodeproj's to
+-- represent both workspaces and projects there is a likely change of a name
+-- collision. Tack on a number to differentiate them.
+--
+-- @param prj
+--    The project being queried.
+-- @returns
+--    A uniqued file name
+--
+
+	function xcode.getxcodeprojname(prj)
+		-- if there is a workspace with matching name, then use "projectname1.xcodeproj"
+		-- just get something working for now
+		local fname = premake.filename(prj, ".xcodeproj")
+		return fname
+	end
+
+
+--
+-- Returns true if the file name represents a framework.
+--
+-- @param fname
+--    The name of the file to test.
+--
+
+	function xcode.isframework(fname)
+		return (path.getextension(fname) == ".framework")
+	end
+
+
+--
+-- Retrieves a unique 12 byte ID for an object.
+-- This function accepts an array of parameters that will be used to generate the id.
+--
+-- @returns
+--    A 24-character string representing the 12 byte ID.
+--
+
+	function xcode.newid(...)
+		local name = ''
+		local arg = {...}
+		for i, v in pairs(arg) do
+			name = name..v..'****'
+		end
+
+
+		return ("%08X%08X%08X"):format(name:hash(16777619), name:hash(2166136261), name:hash(46577619))
+	end
+
+
+--
+-- Create a product tree node and all projects in a workspace; assigning IDs
+-- that are needed for inter-project dependencies.
+--
+-- @param wks
+--    The workspace to prepare.
+--
+
+	function xcode.prepareWorkspace(wks)
+		-- create and cache a list of supported platforms
+		wks.xcode = { }
+
+		for prj in premake.workspace.eachproject(wks) do
+			-- need a configuration to get the target information
+			local cfg = project.getconfig(prj, prj.configurations[1], prj.platforms[1])
+
+			-- build the product tree node
+			local bundlepath = cfg.buildtarget.bundlename ~= "" and cfg.buildtarget.bundlename or cfg.buildtarget.name;
+			if (prj.external) then
+				bundlepath = cfg.project.name
+			end
+
+			local node = premake.tree.new(path.getname(bundlepath))
+
+			node.cfg = cfg
+			node.id = xcode.newid(node.name, "product")
+			node.targetid = xcode.newid(node.name, "target")
+
+			-- attach it to the project
+			prj.xcode = {}
+			prj.xcode.projectnode = node
+		end
+	end
+
+
+---------------------------------------------------------------------------
+-- Section generator functions, in the same order in which they appear
+-- in the .pbxproj file
+---------------------------------------------------------------------------
+
+	function xcode.PBXBuildFile(tr)
+		local settings = {};
+		tree.traverse(tr, {
+			onnode = function(node)
+				if node.buildid then
+					settings[node.buildid] = function(level)
+						_p(level,'%s /* %s in %s */ = {isa = PBXBuildFile; fileRef = %s /* %s */; };',
+							node.buildid, node.name, xcode.getbuildcategory(node), node.id, node.name)
+					end
+				end
+			end
+		})
+
+		if not table.isempty(settings) then
+			_p('/* Begin PBXBuildFile section */')
+			printSettingsTable(2, settings);
+			_p('/* End PBXBuildFile section */')
+			_p('')
+		end
+	end
+
+
+	function xcode.PBXContainerItemProxy(tr)
+		local settings = {}
+		for _, node in ipairs(tr.projects.children) do
+			settings[node.productproxyid] = function()
+				_p(2,'%s /* PBXContainerItemProxy */ = {', node.productproxyid)
+				_p(3,'isa = PBXContainerItemProxy;')
+				_p(3,'containerPortal = %s /* %s */;', node.id, path.getrelative(node.parent.parent.project.location, node.path))
+				_p(3,'proxyType = 2;')
+				_p(3,'remoteGlobalIDString = %s;', node.project.xcode.projectnode.id)
+				_p(3,'remoteInfo = %s;', stringifySetting(node.project.xcode.projectnode.name))
+				_p(2,'};')
+			end
+			settings[node.targetproxyid] = function()
+				_p(2,'%s /* PBXContainerItemProxy */ = {', node.targetproxyid)
+				_p(3,'isa = PBXContainerItemProxy;')
+				_p(3,'containerPortal = %s /* %s */;', node.id, path.getrelative(node.parent.parent.project.location, node.path))
+				_p(3,'proxyType = 1;')
+				_p(3,'remoteGlobalIDString = %s;', node.project.xcode.projectnode.targetid)
+				_p(3,'remoteInfo = %s;', stringifySetting(node.project.xcode.projectnode.name))
+				_p(2,'};')
+			end
+		end
+
+		if not table.isempty(settings) then
+			_p('/* Begin PBXContainerItemProxy section */')
+			printSettingsTable(2, settings);
+			_p('/* End PBXContainerItemProxy section */')
+			_p('')
+		end
+	end
+
+
+	function xcode.PBXFileReference(tr)
+		local cfg = project.getfirstconfig(tr.project)
+		local settings = {}
+
+		tree.traverse(tr, {
+			onleaf = function(node)
+				-- I'm only listing files here, so ignore anything without a path
+				if not node.path then
+					return
+				end
+
+				-- is this the product node, describing the output target?
+				if node.kind == "product" then
+					settings[node.id] = function(level)
+						_p(level,'%s /* %s */ = {isa = PBXFileReference; explicitFileType = %s; includeInIndex = 0; name = %s; path = %s; sourceTree = BUILT_PRODUCTS_DIR; };',
+							node.id, node.name, xcode.gettargettype(node), stringifySetting(node.name), stringifySetting(path.getname(node.cfg.buildtarget.bundlename ~= "" and node.cfg.buildtarget.bundlename or node.cfg.buildtarget.relpath)))
+					end
+				-- is this a project dependency?
+				elseif node.parent.parent == tr.projects then
+					settings[node.parent.id] = function(level)
+						-- ms Is there something wrong with path is relative ?
+						-- if we have a and b without slashes get relative should assume the same parent folder and return ../
+						-- this works if we put it like below
+						local relpath = path.getrelative(path.getabsolute(tr.project.location), path.getabsolute(node.parent.project.location))
+						_p(level,'%s /* %s */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = %s; path = %s; sourceTree = SOURCE_ROOT; };',
+							node.parent.id, node.name, customStringifySetting(node.parent.name), stringifySetting(path.join(relpath, node.parent.name)))
+					end
+				-- something else
+				else
+					settings[node.id] = function(level)
+					local pth, src
+					if xcode.isframework(node.path) then
+						--respect user supplied paths
+						-- look for special variable-starting paths for different sources
+						local nodePath = node.path
+						local _, matchEnd, variable = string.find(nodePath, "^%$%((.+)%)/")
+						if variable then
+							-- by skipping the last '/' we support the same absolute/relative
+							-- paths as before
+							nodePath = string.sub(nodePath, matchEnd + 1)
+						end
+						if string.find(nodePath,'/')  then
+							if string.find(nodePath,'^%.')then
+								--error('relative paths are not currently supported for frameworks')
+								pth = path.getrelative(tr.project.location, node.path)
+								--print(tr.project.location, node.path , pth)
+								src = "SOURCE_ROOT"
+								variable = src
+							else
+								pth = nodePath
+								src = "<absolute>"
+							end
+						end
+						-- if it starts with a variable, use that as the src instead
+						if variable then
+							src = variable
+							-- if we are using a different source tree, it has to be relative
+							-- to that source tree, so get rid of any leading '/'
+							if string.find(pth, '^/') then
+								pth = string.sub(pth, 2)
+							end
+						else
+							pth = "System/Library/Frameworks/" .. node.path
+							src = "SDKROOT"
+						end
+					else
+						-- something else; probably a source code file
+						src = "<group>"
+
+						if node.abspath then
+							pth = path.getrelative(tr.project.location, node.abspath)
+						else
+							pth = node.path
+						end
+						--end
+						end
+						_p(level,'%s /* %s */ = {isa = PBXFileReference; lastKnownFileType = %s; name = %s; path = %s; sourceTree = %s; };',
+							node.id, node.name, xcode.getfiletype(node, cfg), stringifySetting(node.name), stringifySetting(pth), stringifySetting(src))
+					end
+				end
+			end
+		})
+
+		if not table.isempty(settings) then
+			_p('/* Begin PBXFileReference section */')
+			printSettingsTable(2, settings)
+			_p('/* End PBXFileReference section */')
+			_p('')
+		end
+	end
+
+
+	function xcode.PBXFrameworksBuildPhase(tr)
+		_p('/* Begin PBXFrameworksBuildPhase section */')
+		_p(2,'%s /* Frameworks */ = {', tr.products.children[1].fxstageid)
+		_p(3,'isa = PBXFrameworksBuildPhase;')
+		_p(3,'buildActionMask = 2147483647;')
+		_p(3,'files = (')
+
+		-- write out library dependencies
+		tree.traverse(tr.frameworks, {
+			onleaf = function(node)
+				if node.buildid then
+					_p(4,'%s /* %s in Frameworks */,', node.buildid, node.name)
+				end
+			end
+		})
+
+		-- write out project dependencies
+		tree.traverse(tr.projects, {
+			onleaf = function(node)
+				if node.buildid then
+					_p(4,'%s /* %s in Frameworks */,', node.buildid, node.name)
+				end
+			end
+		})
+
+		_p(3,');')
+		_p(3,'runOnlyForDeploymentPostprocessing = 0;')
+		_p(2,'};')
+		_p('/* End PBXFrameworksBuildPhase section */')
+		_p('')
+	end
+
+
+	function xcode.PBXGroup(tr)
+		local settings = {}
+
+		tree.traverse(tr, {
+			onnode = function(node)
+				-- Skip over anything that isn't a proper group
+				if (node.path and #node.children == 0) or node.kind == "vgroup" then
+					return
+				end
+
+				settings[node.productgroupid or node.id] = function()
+					-- project references get special treatment
+					if node.parent == tr.projects then
+						_p(2,'%s /* Products */ = {', node.productgroupid)
+					else
+						_p(2,'%s /* %s */ = {', node.id, node.name)
+					end
+
+					_p(3,'isa = PBXGroup;')
+					_p(3,'children = (')
+					for _, childnode in ipairs(node.children) do
+						_p(4,'%s /* %s */,', childnode.id, childnode.name)
+					end
+					_p(3,');')
+
+					if node.parent == tr.projects then
+						_p(3,'name = Products;')
+					else
+						_p(3,'name = %s;', stringifySetting(node.name))
+
+						local vpath = project.getvpath(tr.project, node.name)
+
+						if node.path and node.name ~= vpath then
+							local p = node.path
+							if node.parent.path then
+								p = path.getrelative(node.parent.path, node.path)
+							end
+							_p(3,'path = %s;', stringifySetting(p))
+						end
+					end
+
+					_p(3,'sourceTree = "<group>";')
+					_p(2,'};')
+				end
+			end
+		}, true)
+
+		if not table.isempty(settings) then
+			_p('/* Begin PBXGroup section */')
+			printSettingsTable(2, settings)
+			_p('/* End PBXGroup section */')
+			_p('')
+		end
+	end
+
+
+	function xcode.PBXNativeTarget(tr)
+		_p('/* Begin PBXNativeTarget section */')
+		for _, node in ipairs(tr.products.children) do
+			local name = tr.project.name
+
+			-- This function checks whether there are build commands of a specific
+			-- type to be executed; they will be generated correctly, but the project
+			-- commands will not contain any per-configuration commands, so the logic
+			-- has to be extended a bit to account for that.
+			local function hasBuildCommands(which)
+				-- standard check...this is what existed before
+				if #tr.project[which] > 0 then
+					return true
+				end
+				-- what if there are no project-level commands? check configs...
+				for _, cfg in ipairs(tr.configs) do
+					if #cfg[which] > 0 then
+						return true
+					end
+				end
+			end
+
+			_p(2,'%s /* %s */ = {', node.targetid, name)
+			_p(3,'isa = PBXNativeTarget;')
+			_p(3,'buildConfigurationList = %s /* Build configuration list for PBXNativeTarget "%s" */;', node.cfgsection, escapeSetting(name))
+			_p(3,'buildPhases = (')
+			if hasBuildCommands('prebuildcommands') then
+				_p(4,'9607AE1010C857E500CD1376 /* Prebuild */,')
+			end
+			_p(4,'%s /* Resources */,', node.resstageid)
+			_p(4,'%s /* Sources */,', node.sourcesid)
+			if hasBuildCommands('prelinkcommands') then
+				_p(4,'9607AE3510C85E7E00CD1376 /* Prelink */,')
+			end
+			_p(4,'%s /* Frameworks */,', node.fxstageid)
+			if hasBuildCommands('postbuildcommands') then
+				_p(4,'9607AE3710C85E8F00CD1376 /* Postbuild */,')
+			end
+			_p(3,');')
+			_p(3,'buildRules = (')
+			_p(3,');')
+
+			_p(3,'dependencies = (')
+			for _, node in ipairs(tr.projects.children) do
+				_p(4,'%s /* PBXTargetDependency */,', node.targetdependid)
+			end
+			_p(3,');')
+
+			_p(3,'name = %s;', stringifySetting(name))
+
+			local p
+			if node.cfg.kind == "ConsoleApp" then
+				p = "$(HOME)/bin"
+			elseif node.cfg.kind == "WindowedApp" then
+				p = "$(HOME)/Applications"
+			end
+			if p then
+				_p(3,'productInstallPath = %s;', stringifySetting(p))
+			end
+
+			_p(3,'productName = %s;', stringifySetting(name))
+			_p(3,'productReference = %s /* %s */;', node.id, node.name)
+			_p(3,'productType = %s;', stringifySetting(xcode.getproducttype(node)))
+			_p(2,'};')
+		end
+		_p('/* End PBXNativeTarget section */')
+		_p('')
+	end
+
+
+	function xcode.PBXProject(tr)
+		_p('/* Begin PBXProject section */')
+		_p(2,'08FB7793FE84155DC02AAC07 /* Project object */ = {')
+		_p(3,'isa = PBXProject;')
+		_p(3,'buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "%s" */;', tr.name)
+		_p(3,'compatibilityVersion = "Xcode 3.2";')
+		_p(3,'hasScannedForEncodings = 1;')
+		_p(3,'mainGroup = %s /* %s */;', tr.id, tr.name)
+		_p(3,'projectDirPath = "";')
+
+		if #tr.projects.children > 0 then
+			_p(3,'projectReferences = (')
+			for _, node in ipairs(tr.projects.children) do
+				_p(4,'{')
+				_p(5,'ProductGroup = %s /* Products */;', node.productgroupid)
+				_p(5,'ProjectRef = %s /* %s */;', node.id, path.getname(node.path))
+				_p(4,'},')
+			end
+			_p(3,');')
+		end
+
+		_p(3,'projectRoot = "";')
+		_p(3,'targets = (')
+		for _, node in ipairs(tr.products.children) do
+			_p(4,'%s /* %s */,', node.targetid, node.name)
+		end
+		_p(3,');')
+		_p(2,'};')
+		_p('/* End PBXProject section */')
+		_p('')
+	end
+
+
+	function xcode.PBXReferenceProxy(tr)
+		local settings = {}
+
+		tree.traverse(tr.projects, {
+			onleaf = function(node)
+				settings[node.id] = function()
+					_p(2,'%s /* %s */ = {', node.id, node.name)
+					_p(3,'isa = PBXReferenceProxy;')
+					_p(3,'fileType = %s;', xcode.gettargettype(node))
+					_p(3,'path = %s;', stringifySetting(node.name))
+					_p(3,'remoteRef = %s /* PBXContainerItemProxy */;', node.parent.productproxyid)
+					_p(3,'sourceTree = BUILT_PRODUCTS_DIR;')
+					_p(2,'};')
+				end
+			end
+		})
+
+		if not table.isempty(settings) then
+			_p('/* Begin PBXReferenceProxy section */')
+			printSettingsTable(2, settings)
+			_p('/* End PBXReferenceProxy section */')
+			_p('')
+		end
+	end
+
+
+	function xcode.PBXResourcesBuildPhase(tr)
+		_p('/* Begin PBXResourcesBuildPhase section */')
+		for _, target in ipairs(tr.products.children) do
+			_p(2,'%s /* Resources */ = {', target.resstageid)
+			_p(3,'isa = PBXResourcesBuildPhase;')
+			_p(3,'buildActionMask = 2147483647;')
+			_p(3,'files = (')
+			tree.traverse(tr, {
+				onnode = function(node)
+					if xcode.getbuildcategory(node) == "Resources" then
+						_p(4,'%s /* %s in Resources */,', node.buildid, node.name)
+					end
+				end
+			})
+			_p(3,');')
+			_p(3,'runOnlyForDeploymentPostprocessing = 0;')
+			_p(2,'};')
+		end
+		_p('/* End PBXResourcesBuildPhase section */')
+		_p('')
+	end
+
+	function xcode.PBXShellScriptBuildPhase(tr)
+		local wrapperWritten = false
+
+		local function doblock(id, name, which)
+			-- start with the project-level commands (most common)
+			local prjcmds = tr.project[which]
+			local commands = table.join(prjcmds, {})
+
+			-- see if there are any config-specific commands to add
+			for _, cfg in ipairs(tr.configs) do
+				local cfgcmds = cfg[which]
+				if #cfgcmds > #prjcmds then
+					table.insert(commands, 'if [ "${CONFIGURATION}" = "' .. cfg.buildcfg .. '" ]; then')
+					for i = #prjcmds + 1, #cfgcmds do
+						table.insert(commands, cfgcmds[i])
+					end
+					table.insert(commands, 'fi')
+				end
+			end
+
+			if #commands > 0 then
+				commands = os.translateCommands(commands, p.MACOSX)
+				if not wrapperWritten then
+					_p('/* Begin PBXShellScriptBuildPhase section */')
+					wrapperWritten = true
+				end
+				_p(2,'%s /* %s */ = {', id, name)
+				_p(3,'isa = PBXShellScriptBuildPhase;')
+				_p(3,'buildActionMask = 2147483647;')
+				_p(3,'files = (')
+				_p(3,');')
+				_p(3,'inputPaths = (');
+				_p(3,');');
+				_p(3,'name = %s;', name);
+				_p(3,'outputPaths = (');
+				_p(3,');');
+				_p(3,'runOnlyForDeploymentPostprocessing = 0;');
+				_p(3,'shellPath = /bin/sh;');
+				_p(3,'shellScript = %s;', stringifySetting(table.concat(commands, '\n')))
+				_p(2,'};')
+			end
+		end
+
+		doblock("9607AE1010C857E500CD1376", "Prebuild", "prebuildcommands")
+		doblock("9607AE3510C85E7E00CD1376", "Prelink", "prelinkcommands")
+		doblock("9607AE3710C85E8F00CD1376", "Postbuild", "postbuildcommands")
+
+		if wrapperWritten then
+			_p('/* End PBXShellScriptBuildPhase section */')
+		end
+	end
+
+
+	function xcode.PBXSourcesBuildPhase(tr)
+		_p('/* Begin PBXSourcesBuildPhase section */')
+		for _, target in ipairs(tr.products.children) do
+			_p(2,'%s /* Sources */ = {', target.sourcesid)
+			_p(3,'isa = PBXSourcesBuildPhase;')
+			_p(3,'buildActionMask = 2147483647;')
+			_p(3,'files = (')
+			tree.traverse(tr, {
+				onleaf = function(node)
+					if xcode.getbuildcategory(node) == "Sources" then
+						_p(4,'%s /* %s in Sources */,', node.buildid, node.name)
+					end
+				end
+			})
+			_p(3,');')
+			_p(3,'runOnlyForDeploymentPostprocessing = 0;')
+			_p(2,'};')
+		end
+		_p('/* End PBXSourcesBuildPhase section */')
+		_p('')
+	end
+
+
+	function xcode.PBXVariantGroup(tr)
+		local settings = {}
+		tree.traverse(tr, {
+			onbranch = function(node)
+				settings[node.id] = function()
+					if node.kind == "vgroup" then
+						_p(2,'%s /* %s */ = {', node.id, node.name)
+						_p(3,'isa = PBXVariantGroup;')
+						_p(3,'children = (')
+						for _, lang in ipairs(node.children) do
+							_p(4,'%s /* %s */,', lang.id, lang.name)
+						end
+						_p(3,');')
+						_p(3,'name = %s;', node.name)
+						_p(3,'sourceTree = "<group>";')
+						_p(2,'};')
+					end
+				end
+			end
+		})
+
+		if not table.isempty(settings) then
+			_p('/* Begin PBXVariantGroup section */')
+			printSettingsTable(2, settings)
+			_p('/* End PBXVariantGroup section */')
+			_p('')
+		end
+	end
+
+
+	function xcode.PBXTargetDependency(tr)
+		local settings = {}
+		tree.traverse(tr.projects, {
+			onleaf = function(node)
+				settings[node.parent.targetdependid] = function()
+					_p(2,'%s /* PBXTargetDependency */ = {', node.parent.targetdependid)
+					_p(3,'isa = PBXTargetDependency;')
+					_p(3,'name = %s;', stringifySetting(node.name))
+					_p(3,'targetProxy = %s /* PBXContainerItemProxy */;', node.parent.targetproxyid)
+					_p(2,'};')
+				end
+			end
+		})
+
+		if not table.isempty(settings) then
+			_p('/* Begin PBXTargetDependency section */')
+			printSettingsTable(2, settings)
+			_p('/* End PBXTargetDependency section */')
+			_p('')
+		end
+	end
+
+
+	function xcode.XCBuildConfiguration_Target(tr, target, cfg)
+		local settings = {}
+
+		settings['ALWAYS_SEARCH_USER_PATHS'] = 'NO'
+
+		if not cfg.flags.Symbols then
+			settings['DEBUG_INFORMATION_FORMAT'] = 'dwarf-with-dsym'
+		end
+
+		if cfg.kind ~= "StaticLib" and cfg.buildtarget.prefix ~= '' then
+			settings['EXECUTABLE_PREFIX'] = cfg.buildtarget.prefix
+		end
+
+		--[[if cfg.targetextension then
+			local ext = cfg.targetextension
+			ext = iif(ext:startswith('.'), ext:sub(2), ext)
+			settings['EXECUTABLE_EXTENSION'] = ext
+		end]]
+
+		local outdir = path.getrelative(tr.project.location, path.getdirectory(cfg.buildtarget.relpath))
+		if outdir ~= "." then
+			settings['CONFIGURATION_BUILD_DIR'] = outdir
+		end
+
+		settings['GCC_DYNAMIC_NO_PIC'] = 'NO'
+
+		if tr.infoplist then
+			settings['INFOPLIST_FILE'] = config.findfile(cfg, path.getextension(tr.infoplist.name))
+		end
+
+		installpaths = {
+			ConsoleApp = '/usr/local/bin',
+			WindowedApp = '"$(HOME)/Applications"',
+			SharedLib = '/usr/local/lib',
+			StaticLib = '/usr/local/lib',
+		}
+		settings['INSTALL_PATH'] = installpaths[cfg.kind]
+
+		local fileNameList = {}
+		local file_tree = project.getsourcetree(tr.project)
+		tree.traverse(tr, {
+				onnode = function(node)
+					if node.buildid and not node.isResource and node.abspath then
+						-- ms this seems to work on visual studio !!!
+						-- why not in xcode ??
+						local filecfg = fileconfig.getconfig(node, cfg)
+						if filecfg and filecfg.flags.ExcludeFromBuild then
+						--fileNameList = fileNameList .. " " ..filecfg.name
+							table.insert(fileNameList, escapeArg(node.name))
+						end
+
+						--ms new way
+						-- if the file is not in this config file list excluded it from build !!!
+						--if not cfg.files[node.abspath] then
+						--	table.insert(fileNameList, escapeArg(node.name))
+						--end
+					end
+				end
+			})
+
+		if not table.isempty(fileNameList) then
+			settings['EXCLUDED_SOURCE_FILE_NAMES'] = fileNameList
+		end
+		settings['PRODUCT_NAME'] = cfg.buildtarget.basename
+
+		--ms not by default ...add it manually if you need it
+		--settings['COMBINE_HIDPI_IMAGES'] = 'YES'
+
+		overrideSettings(settings, cfg.xcodebuildsettings)
+
+		_p(2,'%s /* %s */ = {', cfg.xcode.targetid, cfg.buildcfg)
+		_p(3,'isa = XCBuildConfiguration;')
+		_p(3,'buildSettings = {')
+		printSettingsTable(4, settings)
+		_p(3,'};')
+		printSetting(3, 'name', cfg.buildcfg);
+		_p(2,'};')
+	end
+
+
+	function xcode.XCBuildConfiguration_Project(tr, cfg)
+		local settings = {}
+
+		local archs = {
+			Native = "$(NATIVE_ARCH_ACTUAL)",
+			x86    = "i386",
+			x86_64 = "x86_64",
+			Universal32 = "$(ARCHS_STANDARD_32_BIT)",
+			Universal64 = "$(ARCHS_STANDARD_64_BIT)",
+			Universal = "$(ARCHS_STANDARD_32_64_BIT)",
+		}
+
+		settings['ARCHS'] = archs[cfg.platform or "Native"]
+
+		--ms This is the default so don;t write it
+		--settings['SDKROOT'] = 'macosx'
+
+		local targetdir = path.getdirectory(cfg.buildtarget.relpath)
+		if targetdir ~= "." then
+			settings['CONFIGURATION_BUILD_DIR'] = '$(SYMROOT)'
+		end
+
+		settings['CONFIGURATION_TEMP_DIR'] = '$(OBJROOT)'
+
+		if cfg.flags.Symbols then
+			settings['COPY_PHASE_STRIP'] = 'NO'
+		end
+
+		settings['GCC_C_LANGUAGE_STANDARD'] = 'gnu99'
+
+		if cfg.exceptionhandling == p.OFF then
+			settings['GCC_ENABLE_CPP_EXCEPTIONS'] = 'NO'
+		end
+
+		if cfg.rtti == p.OFF then
+			settings['GCC_ENABLE_CPP_RTTI'] = 'NO'
+		end
+
+		if cfg.flags.Symbols and not cfg.flags.NoEditAndContinue then
+			settings['GCC_ENABLE_FIX_AND_CONTINUE'] = 'YES'
+		end
+
+		if cfg.exceptionhandling == p.OFF then
+			settings['GCC_ENABLE_OBJC_EXCEPTIONS'] = 'NO'
+		end
+
+		local optimizeMap = { On = 3, Size = 's', Speed = 3, Full = 'fast', Debug = 1 }
+		settings['GCC_OPTIMIZATION_LEVEL'] = optimizeMap[cfg.optimize] or 0
+
+		if cfg.pchheader and not cfg.flags.NoPCH then
+			settings['GCC_PRECOMPILE_PREFIX_HEADER'] = 'YES'
+			settings['GCC_PREFIX_HEADER'] = cfg.pchheader
+		end
+
+		settings['GCC_PREPROCESSOR_DEFINITIONS'] = cfg.defines
+
+		settings["GCC_SYMBOLS_PRIVATE_EXTERN"] = 'NO'
+
+		if cfg.flags.FatalWarnings then
+			settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'YES'
+		end
+
+		settings['GCC_WARN_ABOUT_RETURN_TYPE'] = 'YES'
+		settings['GCC_WARN_UNUSED_VARIABLE'] = 'YES'
+
+		local includedirs = project.getrelative(cfg.project, cfg.includedirs)
+		for i,v in ipairs(includedirs) do
+			cfg.includedirs[i] = premake.quoted(v)
+		end
+		settings['USER_HEADER_SEARCH_PATHS'] = cfg.includedirs
+
+		local sysincludedirs = project.getrelative(cfg.project, cfg.sysincludedirs)
+		for i,v in ipairs(sysincludedirs) do
+			cfg.sysincludedirs[i] = premake.quoted(v)
+		end
+		if not table.isempty(cfg.sysincludedirs) then
+			table.insert(cfg.sysincludedirs, "$(inherited)")
+		end
+		settings['HEADER_SEARCH_PATHS'] = cfg.sysincludedirs
+
+		for i,v in ipairs(cfg.libdirs) do
+			cfg.libdirs[i] = premake.project.getrelative(cfg.project, cfg.libdirs[i])
+		end
+		settings['LIBRARY_SEARCH_PATHS'] = cfg.libdirs
+		
+		for i,v in ipairs(cfg.frameworkdirs) do
+			cfg.frameworkdirs[i] = premake.project.getrelative(cfg.project, cfg.frameworkdirs[i])
+		end
+		settings['FRAMEWORK_SEARCH_PATHS'] = cfg.frameworkdirs
+
+		local objDir = path.getrelative(tr.project.location, cfg.objdir)
+		settings['OBJROOT'] = objDir
+
+		settings['ONLY_ACTIVE_ARCH'] = iif(premake.config.isDebugBuild(cfg), 'YES', 'NO')
+
+		-- build list of "other" C/C++ flags
+		local checks = {
+			["-ffast-math"]          = cfg.flags.FloatFast,
+			["-ffloat-store"]        = cfg.flags.FloatStrict,
+			["-fomit-frame-pointer"] = cfg.flags.NoFramePointer,
+		}
+
+		local flags = { }
+		for flag, check in pairs(checks) do
+			if check then
+				table.insert(flags, flag)
+			end
+		end
+
+
+		--[[if (type(cfg.buildoptions) == "table") then
+			for k,v in pairs(cfg.buildoptions) do
+				table.insertflat(flags, string.explode(v," -"))
+			end
+		end
+		]]
+
+		settings['OTHER_CFLAGS'] = table.join(flags, cfg.buildoptions)
+
+		-- build list of "other" linked flags. All libraries that aren't frameworks
+		-- are listed here, so I don't have to try and figure out if they are ".a"
+		-- or ".dylib", which Xcode requires to list in the Frameworks section
+		flags = { }
+		for _, lib in ipairs(config.getlinks(cfg, "system")) do
+			if not xcode.isframework(lib) then
+				table.insert(flags, "-l" .. lib)
+			end
+		end
+
+		--ms this step is for reference projects only
+		for _, lib in ipairs(config.getlinks(cfg, "dependencies", "object")) do
+			if (lib.external) then
+				if not xcode.isframework(lib.linktarget.basename) then
+					table.insert(flags, "-l" .. escapeArg(lib.linktarget.basename))
+				end
+			end
+		end
+
+		settings['OTHER_LDFLAGS'] = table.join(flags, cfg.linkoptions)
+
+		if cfg.flags.StaticRuntime then
+			settings['STANDARD_C_PLUS_PLUS_LIBRARY_TYPE'] = 'static'
+		end
+
+		if targetdir ~= "." then
+			settings['SYMROOT'] = path.getrelative(tr.project.location, targetdir)
+		end
+
+		if cfg.warnings == "Extra" then
+			settings['WARNING_CFLAGS'] = '-Wall -Wextra'
+		end
+
+		overrideSettings(settings, cfg.xcodebuildsettings)
+
+		_p(2,'%s /* %s */ = {', cfg.xcode.projectid, cfg.buildcfg)
+		_p(3,'isa = XCBuildConfiguration;')
+		_p(3,'buildSettings = {')
+		printSettingsTable(4, settings)
+		_p(3,'};')
+		printSetting(3, 'name', cfg.buildcfg);
+		_p(2,'};')
+	end
+
+
+	function xcode.XCBuildConfiguration(tr)
+		local settings = {}
+
+		for _, target in ipairs(tr.products.children) do
+			for _, cfg in ipairs(tr.configs) do
+				settings[cfg.xcode.targetid] = function()
+					xcode.XCBuildConfiguration_Target(tr, target, cfg)
+				end
+			end
+		end
+		for _, cfg in ipairs(tr.configs) do
+			settings[cfg.xcode.projectid] = function()
+				xcode.XCBuildConfiguration_Project(tr, cfg)
+			end
+		end
+
+		if not table.isempty(settings) then
+			_p('/* Begin XCBuildConfiguration section */')
+			printSettingsTable(0, settings)
+			_p('/* End XCBuildConfiguration section */')
+			_p('')
+		end
+	end
+
+
+	function xcode.XCBuildConfigurationList(tr)
+		local wks = tr.project.workspace
+		local defaultCfgName = stringifySetting(tr.configs[1].buildcfg)
+		local settings = {}
+
+		for _, target in ipairs(tr.products.children) do
+			settings[target.cfgsection] = function()
+				_p(2,'%s /* Build configuration list for PBXNativeTarget "%s" */ = {', target.cfgsection, target.name)
+				_p(3,'isa = XCConfigurationList;')
+				_p(3,'buildConfigurations = (')
+				for _, cfg in ipairs(tr.configs) do
+					_p(4,'%s /* %s */,', cfg.xcode.targetid, cfg.buildcfg)
+				end
+				_p(3,');')
+				_p(3,'defaultConfigurationIsVisible = 0;')
+				_p(3,'defaultConfigurationName = %s;', defaultCfgName)
+				_p(2,'};')
+			end
+		end
+		settings['1DEB928908733DD80010E9CD'] = function()
+			_p(2,'1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "%s" */ = {', tr.name)
+			_p(3,'isa = XCConfigurationList;')
+			_p(3,'buildConfigurations = (')
+			for _, cfg in ipairs(tr.configs) do
+				_p(4,'%s /* %s */,', cfg.xcode.projectid, cfg.buildcfg)
+			end
+			_p(3,');')
+			_p(3,'defaultConfigurationIsVisible = 0;')
+			_p(3,'defaultConfigurationName = %s;', defaultCfgName)
+			_p(2,'};')
+		end
+
+		_p('/* Begin XCConfigurationList section */')
+		printSettingsTable(2, settings)
+		_p('/* End XCConfigurationList section */')
+	end

--- a/modules/xcode/xcode_project.lua
+++ b/modules/xcode/xcode_project.lua
@@ -1,0 +1,200 @@
+---
+-- xcode/xcode4_project.lua
+-- Generate an Xcode project file.
+-- Author Jason Perkins
+-- Modified by Mihai Sebea
+-- Copyright (c) 2009-2015 Jason Perkins and the Premake project
+---
+
+	local p = premake
+	local m = p.modules.xcode
+
+	local xcode = p.modules.xcode
+	local project = p.project
+	local config = p.config
+	local fileconfig = p.fileconfig
+	local tree = p.tree
+
+--
+-- Create a tree corresponding to what is shown in the Xcode project browser
+-- pane, with nodes for files and folders, resources, frameworks, and products.
+--
+-- @param prj
+--    The project being generated.
+-- @returns
+--    A tree, loaded with metadata, which mirrors Xcode's view of the project.
+--
+
+	function xcode.buildprjtree(prj)
+		local tr = project.getsourcetree(prj, nil , false)
+		tr.project = prj
+
+		-- create a list of build configurations and assign IDs
+		tr.configs = {}
+
+		for cfg in project.eachconfig(prj) do
+			cfg.xcode = {}
+			cfg.xcode.targetid = xcode.newid(prj.xcode.projectnode.name, cfg.buildcfg, "target")
+			cfg.xcode.projectid = xcode.newid(tr.name, cfg.buildcfg)
+			table.insert(tr.configs, cfg)
+		end
+
+        -- convert localized resources from their filesystem layout (English.lproj/MainMenu.xib)
+		-- to Xcode's display layout (MainMenu.xib/English).
+		 tree.traverse(tr, {
+		 	onbranch = function(node)
+		 		if path.getextension(node.name) == ".lproj" then
+		 			local lang = path.getbasename(node.name)  -- "English", "French", etc.
+
+		 			-- create a new language group for each file it contains
+		 			for _, filenode in ipairs(node.children) do
+		 				local grpnode = node.parent.children[filenode.name]
+		 				if not grpnode then
+		 					grpnode = tree.insert(node.parent, tree.new(filenode.name))
+		 					grpnode.kind = "vgroup"
+		 				end
+
+		 				-- convert the file node to a language node and add to the group
+		 				filenode.name = path.getbasename(lang)
+		 				tree.insert(grpnode, filenode)
+		 			end
+
+					-- remove this directory from the tree
+		 			tree.remove(node)
+		 		end
+		 	end
+		 })
+
+        -- the special folder "Frameworks" lists all linked frameworks
+		tr.frameworks = tree.new("Frameworks")
+		for cfg in project.eachconfig(prj) do
+			for _, link in ipairs(config.getlinks(cfg, "system", "fullpath")) do
+				local name = path.getname(link)
+				if xcode.isframework(name) and not tr.frameworks.children[name] then
+					node = tree.insert(tr.frameworks, tree.new(name))
+					node.path = link
+		 		end
+		 	end
+		 end
+
+		-- only add it to the tree if there are frameworks to link
+		if #tr.frameworks.children > 0 then
+			tree.insert(tr, tr.frameworks)
+		end
+
+		-- the special folder "Products" holds the target produced by the project; this
+		-- is populated below
+		 tr.products = tree.insert(tr, tree.new("Products"))
+
+		-- the special folder "Projects" lists sibling project dependencies
+		 tr.projects = tree.new("Projects")
+		 for _, dep in ipairs(project.getdependencies(prj, "sibling", "object")) do
+		 	-- create a child node for the dependency's xcodeproj
+		 	local xcpath = xcode.getxcodeprojname(dep)
+		 	local xcnode = tree.insert(tr.projects, tree.new(path.getname(xcpath)))
+		 	xcnode.path = xcpath
+		 	xcnode.project = dep
+		 	xcnode.productgroupid = xcode.newid(xcnode.name, "prodgrp")
+		 	xcnode.productproxyid = xcode.newid(xcnode.name, "prodprox")
+		 	xcnode.targetproxyid  = xcode.newid(xcnode.name, "targprox")
+		 	xcnode.targetdependid = xcode.newid(xcnode.name, "targdep")
+
+			-- create a grandchild node for the dependency's link target
+		 	local lprj = premake.workspace.findproject(prj.workspace, dep.name)
+		 	local cfg = project.findClosestMatch(lprj, prj.configurations[1])
+		 	node = tree.insert(xcnode, tree.new(cfg.linktarget.name))
+		 	node.path = cfg.linktarget.fullpath
+		 	node.cfg = cfg
+		end
+
+		 if #tr.projects.children > 0 then
+		 	tree.insert(tr, tr.projects)
+		 end
+
+        -- Final setup
+		 tree.traverse(tr, {
+		 	onnode = function(node)
+		 		-- assign IDs to every node in the tree
+		 		node.id = xcode.newid(node.name, nil, node.path)
+
+		 		node.isResource = xcode.isItemResource(prj, node)
+
+		 		-- assign build IDs to buildable files
+		 		if xcode.getbuildcategory(node) then
+		 			node.buildid = xcode.newid(node.name, "build", node.path)
+		 		end
+
+		 		-- remember key files that are needed elsewhere
+		 		if string.endswith(node.name, "Info.plist") then
+		 			tr.infoplist = node
+		 		end
+		 	end
+		 }, true)
+
+        -- Plug in the product node into the Products folder in the tree. The node
+		-- was built in xcode.prepareWorkspace() in xcode_common.lua; it contains IDs
+		-- that are necessary for inter-project dependencies
+		node = tree.insert(tr.products, prj.xcode.projectnode)
+		node.kind = "product"
+		node.path = node.cfg.buildtarget.fullpath
+		node.cfgsection = xcode.newid(node.name, "cfg")
+		node.resstageid = xcode.newid(node.name, "rez")
+		node.sourcesid  = xcode.newid(node.name, "src")
+		node.fxstageid  = xcode.newid(node.name, "fxs")
+
+		return tr
+	end
+
+
+---
+-- Generate an Xcode .xcodeproj for a Premake project.
+---
+
+	m.elements.project = function(prj)
+		return {
+			m.header,
+		}
+	end
+
+	function m.generateProject(prj)
+		local tr = xcode.buildprjtree(prj)
+		p.callArray(m.elements.project, prj)
+		xcode.PBXBuildFile(tr)
+		xcode.PBXContainerItemProxy(tr)
+		xcode.PBXFileReference(tr)
+		xcode.PBXFrameworksBuildPhase(tr)
+		xcode.PBXGroup(tr)
+		xcode.PBXNativeTarget(tr)
+		xcode.PBXProject(tr)
+		xcode.PBXReferenceProxy(tr)
+		xcode.PBXResourcesBuildPhase(tr)
+		xcode.PBXShellScriptBuildPhase(tr)
+		xcode.PBXSourcesBuildPhase(tr)
+		xcode.PBXTargetDependency(tr)
+		xcode.PBXVariantGroup(tr)
+		xcode.XCBuildConfiguration(tr)
+		xcode.XCBuildConfigurationList(tr)
+		xcode.footer(prj)
+	end
+
+
+
+	function m.header(prj)
+		p.w('// !$*UTF8*$!')
+		p.push('{')
+		p.w('archiveVersion = 1;')
+		p.w('classes = {')
+		p.w('};')
+		p.w('objectVersion = 46;')
+		p.push('objects = {')
+		p.w()
+	end
+
+
+
+	function xcode.footer(prj)
+		p.pop('};')
+		p.w('rootObject = 08FB7793FE84155DC02AAC07 /* Project object */;')
+		p.pop('}')
+	end
+


### PR DESCRIPTION
This merges the submodules into the core repository, removing them as submodules, while maintaining their entire history...

One of the questions that came up as I was doing this however... If we're going to make it easier for modules to be 'fetched' from a remote server, or through some other means, wouldn't we want to keep these modules 'separate'... We can live with the sub-modules for now, since we've already lived with it for a while, and actually spend our time on that module registry system instead...

Once that works, we can just transition these modules into the registry and maintain their separate repositories. Or would we extract the history out of these folders again and apply them to their separate repositories when that time comes?