### PR TITLE
Support for Authenticated http requests

### DIFF
--- a/src/host/http.c
+++ b/src/host/http.c
@@ -157,7 +157,7 @@ static CURL* curl_request(lua_State* L, CurlCallbackState* state, FILE* fp, int 
 	curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1);
 	curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
 	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, state->errorBuffer);
-	curl_easy_setopt(curl, CURLOPT_USERAGENT, "premake/5.0");
+	curl_easy_setopt(curl, CURLOPT_USERAGENT, "Premake/" PREMAKE_VERSION);
 
 	if (lua_type(L, userpwdIndex) == LUA_TSTRING) {
 		curl_easy_setopt(curl, CURLOPT_USERPWD, luaL_checkstring(L, userpwdIndex));

--- a/src/host/http.c
+++ b/src/host/http.c
@@ -108,15 +108,12 @@ static void curl_init()
 
 static void get_headers(lua_State* L, int headersIndex, struct curl_slist** headers)
 {
-	if (lua_istable(L, headersIndex))
+	lua_pushnil(L);
+	while (lua_next(L, headersIndex) != 0)
 	{
-		lua_pushnil(L);
-		while (lua_next(L, headersIndex) != 0)
-		{
-			const char *item = luaL_checkstring(L, -1);
-			lua_pop(L, 1);
-			*headers = curl_slist_append(*headers, item);
-		}
+		const char *item = luaL_checkstring(L, -1);
+		lua_pop(L, 1);
+		*headers = curl_slist_append(*headers, item);
 	}
 }
 

--- a/src/host/http.c
+++ b/src/host/http.c
@@ -47,8 +47,7 @@ typedef struct
 	char errorBuffer[CURL_ERROR_SIZE];
 } CurlCallbackState;
 
-static int curl_progress_cb(void* userdata, double dltotal, double dlnow,
-	double ultotal, double ulnow)
+static int curl_progress_cb(void* userdata, double dltotal, double dlnow, double ultotal, double ulnow)
 {
 	CurlCallbackState* state = (CurlCallbackState*) userdata;
 	lua_State* L = state->L;
@@ -60,8 +59,8 @@ static int curl_progress_cb(void* userdata, double dltotal, double dlnow,
 
 	/* retrieve the lua progress callback we saved before */
 	lua_rawgeti(L, LUA_REGISTRYINDEX, state->RefIndex);
-	lua_pushnumber(L, (lua_Number)dltotal);
-	lua_pushnumber(L, (lua_Number)dlnow);
+	lua_pushnumber(L, (lua_Number) dltotal);
+	lua_pushnumber(L, (lua_Number) dlnow);
 	lua_pcall(L, 2, LUA_MULTRET, 0);
 
 	return 0;
@@ -107,43 +106,24 @@ static void curl_init()
 	initializedHTTP = 1;
 }
 
-
-static void get_headers(lua_State* L, struct curl_slist** headers)
+static void get_headers(lua_State* L, int headersIndex, struct curl_slist** headers)
 {
-	int i;
-	int argc = lua_gettop(L);
-	// Headers are optional so loop through them if they exist(also indexed 1 -> N instead of 0 -> N-1 in lua)
-	for (i = 3; i <= argc; ++i)
+	if (lua_istable(L, headersIndex))
 	{
-		if (lua_istable(L, -1))
+		lua_pushnil(L);
+		while (lua_next(L, headersIndex) != 0)
 		{
-			lua_pushnil(L);
-
-			while (lua_next(L, -2) != 0)
-			{
-				const char *item = luaL_checkstring(L, -1);
-				lua_pop(L, 1);
-				*headers = curl_slist_append(*headers, item);
-			}
-			// Only expect a single table as a parameter so break after reading it
-			break;
+			const char *item = luaL_checkstring(L, -1);
+			lua_pop(L, 1);
+			*headers = curl_slist_append(*headers, item);
 		}
 	}
 }
 
-static CURL* curl_request(lua_State* L, CurlCallbackState* state, FILE* fp, int progressFnIndex, int userpwdIndex)
+static CURL* curl_request(lua_State* L, CurlCallbackState* state, const char* url, FILE* fp, int optionsIndex, int progressFnIndex, int headersIndex)
 {
 	CURL* curl;
 	struct curl_slist* headers = NULL;
-	const char* url = luaL_checkstring(L, 1);
-
-	/* if the second argument is a lua function, then we save it
-		to call it later as the http progress callback */
-	if (lua_type(L, progressFnIndex) == LUA_TFUNCTION)
-	{
-		state->L = L;
-		state->RefIndex = luaL_ref(L, LUA_REGISTRYINDEX);
-	}
 
 	curl_init();
 	curl = curl_easy_init();
@@ -159,12 +139,56 @@ static CURL* curl_request(lua_State* L, CurlCallbackState* state, FILE* fp, int 
 	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, state->errorBuffer);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, "Premake/" PREMAKE_VERSION);
 
-	if (lua_type(L, userpwdIndex) == LUA_TSTRING) {
-		curl_easy_setopt(curl, CURLOPT_USERPWD, luaL_checkstring(L, userpwdIndex));
-	}
+	if (optionsIndex && lua_istable(L, optionsIndex))
+	{
+		lua_pushnil(L);
+		while (lua_next(L, optionsIndex) != 0)
+		{
+			const char* key = luaL_checkstring(L, -2);
 
-	get_headers(L, &headers);
-	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+			if (!strcmp(key, "headers") && lua_istable(L, -1))
+			{
+				get_headers(L, lua_gettop(L), &headers);
+				curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+			}
+			else if (!strcmp(key, "progress") && lua_isfunction(L, -1))
+			{
+				state->L = L;
+				lua_pushvalue(L, -1);
+				state->RefIndex = luaL_ref(L, LUA_REGISTRYINDEX);
+			}
+			else if (!strcmp(key, "userpwd") && lua_isstring(L, -1))
+			{
+				curl_easy_setopt(curl, CURLOPT_USERPWD, luaL_checkstring(L, -1));
+			}
+			else if (!strcmp(key, "username") && lua_isstring(L, -1))
+			{
+				curl_easy_setopt(curl, CURLOPT_USERNAME, luaL_checkstring(L, -1));
+			}
+			else if (!strcmp(key, "password") && lua_isstring(L, -1))
+			{
+				curl_easy_setopt(curl, CURLOPT_PASSWORD, luaL_checkstring(L, -1));
+			}
+
+			// pop the value, leave the key for lua_next
+			lua_pop(L, 1);
+		}
+	}
+	else
+	{
+		if (progressFnIndex && lua_type(L, progressFnIndex) == LUA_TFUNCTION)
+		{
+			state->L = L;
+			lua_pushvalue(L, progressFnIndex);
+			state->RefIndex = luaL_ref(L, LUA_REGISTRYINDEX);
+		}
+
+		if (headersIndex && lua_istable(L, headersIndex))
+		{
+			get_headers(L, headersIndex, &headers);
+			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+		}
+	}
 
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, state);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_cb);
@@ -192,17 +216,28 @@ static CURL* curl_request(lua_State* L, CurlCallbackState* state, FILE* fp, int 
 int http_get(lua_State* L)
 {
 	CurlCallbackState state = { 0, 0, {NULL, 0}, {0} };
-
-	CURL* curl = curl_request(L, &state, /*fp=*/NULL, /*progressFnIndex=*/2, /*userpwdIndex*/3);
+	CURL* curl;
 	CURLcode code;
 
-	string_init(&state.S);
+	if (lua_istable(L, 2))
+	{
+		// http.get(source, { options })
+		curl = curl_request(L, &state, luaL_checkstring(L, 1), /*fp=*/NULL, /*optionsIndex=*/2, /*progressFnIndex=*/0, /*headersIndex=*/0);
+	}
+	else
+	{
+		// backward compatible function signature
+		// http.get(source, progressFunction, { headers })
+		curl = curl_request(L, &state, luaL_checkstring(L, 1), /*fp=*/NULL, /*optionsIndex=*/0, /*progressFnIndex=*/2, /*headersIndex=*/3);
+	}
 
 	if (!curl)
 	{
 		lua_pushnil(L);
 		return 1;
 	}
+
+	string_init(&state.S);
 
 	code = curl_easy_perform(curl);
 	if (code != CURLE_OK)
@@ -243,7 +278,18 @@ int http_download(lua_State* L)
 		return 2;
 	}
 
-	curl = curl_request(L, &state, fp, /*progressFnIndex=*/3, /*userpwdIndex*/4);
+	if (lua_istable(L, 3))
+	{
+		// http.download(source, destination, { options })
+		curl = curl_request(L, &state, luaL_checkstring(L, 1), fp, /*optionsIndex=*/3, /*progressFnIndex=*/0, /*headersIndex=*/0);
+	}
+	else
+	{
+		// backward compatible function signature
+		// http.download(source, destination, progressFunction, { headers })
+		curl = curl_request(L, &state, luaL_checkstring(L, 1), fp, /*optionsIndex=*/0, /*progressFnIndex=*/3, /*headersIndex=*/4);
+	}
+
 	if (curl)
 	{
 		code = curl_easy_perform(curl);

--- a/src/host/http.c
+++ b/src/host/http.c
@@ -131,7 +131,7 @@ static void get_headers(lua_State* L, struct curl_slist** headers)
 	}
 }
 
-static CURL* curl_request(lua_State* L, CurlCallbackState* state, FILE* fp, int progressFnIndex, const char* userpwd)
+static CURL* curl_request(lua_State* L, CurlCallbackState* state, FILE* fp, int progressFnIndex, int userpwdIndex)
 {
 	CURL* curl;
 	struct curl_slist* headers = NULL;
@@ -157,9 +157,10 @@ static CURL* curl_request(lua_State* L, CurlCallbackState* state, FILE* fp, int 
 	curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1);
 	curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
 	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, state->errorBuffer);
+	curl_easy_setopt(curl, CURLOPT_USERAGENT, "premake/5.0");
 
-	if (userpwd) {
-		curl_easy_setopt(curl, CURLOPT_USERPWD, userpwd);
+	if (lua_type(L, userpwdIndex) == LUA_TSTRING) {
+		curl_easy_setopt(curl, CURLOPT_USERPWD, luaL_checkstring(L, userpwdIndex));
 	}
 
 	get_headers(L, &headers);
@@ -192,7 +193,7 @@ int http_get(lua_State* L)
 {
 	CurlCallbackState state = { 0, 0, {NULL, 0}, {0} };
 
-	CURL* curl = curl_request(L, &state, /*fp=*/NULL, /*progressFnIndex=*/2, luaL_checkstring(L, 3));
+	CURL* curl = curl_request(L, &state, /*fp=*/NULL, /*progressFnIndex=*/2, /*userpwdIndex*/3);
 	CURLcode code;
 
 	string_init(&state.S);
@@ -242,7 +243,7 @@ int http_download(lua_State* L)
 		return 2;
 	}
 
-	curl = curl_request(L, &state, fp, /*progressFnIndex=*/3, luaL_checkstring(L, 4));
+	curl = curl_request(L, &state, fp, /*progressFnIndex=*/3, /*userpwdIndex*/4);
 	if (curl)
 	{
 		code = curl_easy_perform(curl);

--- a/src/host/os_getpass.c
+++ b/src/host/os_getpass.c
@@ -1,0 +1,38 @@
+/**
+ * \file   os_getpass.c
+ * \brief  Prompt and retrieve a password from the user.
+ * \author Copyright (c) 2002-2008 Jason Perkins and the Premake project
+ */
+
+#include "premake.h"
+
+
+int os_getpass(lua_State* L)
+{
+	const char* prompt = luaL_checkstring(L, 1);
+
+	#if PLATFORM_WINDOWS
+		HANDLE hstdout = GetStdHandle(STD_OUTPUT_HANDLE);
+		HANDLE hstdin = GetStdHandle(STD_INPUT_HANDLE);
+		DWORD read_chars, mode, written_chars;
+		char buffer[1024];
+		const char* newline = "\n";
+
+		WriteConsoleA(hstdout, prompt, strlen(prompt), &written_chars, NULL);
+
+		GetConsoleMode(hstdin, &mode);
+		SetConsoleMode(hstdin, ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
+		ReadConsoleA(hstdin, buffer, sizeof (buffer), &read_chars, NULL);
+		SetConsoleMode(hstdin, mode);
+
+		WriteConsoleA(hstdout, newline, strlen(newline), &written_chars, NULL);
+
+		StrTrimA(buffer, "\r\n");
+
+		lua_pushstring(L, buffer);
+		return 1;
+	#else
+		lua_pushstring(L, getpass(prompt));
+		return 1;
+	#endif
+}

--- a/src/host/os_getpass.c
+++ b/src/host/os_getpass.c
@@ -27,7 +27,7 @@ int os_getpass(lua_State* L)
 
 		WriteConsoleA(hstdout, newline, strlen(newline), &written_chars, NULL);
 
-		StrTrimA(buffer, "\r\n");
+		buffer[strcspn(buffer, "\r\n")] = '\0';
 
 		lua_pushstring(L, buffer);
 		return 1;

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -57,6 +57,7 @@ static const luaL_Reg os_functions[] = {
 	{ "_is64bit",               os_is64bit              },
 	{ "isdir",                  os_isdir                },
 	{ "getcwd",                 os_getcwd               },
+	{ "getpass",                os_getpass              },
 	{ "getversion",             os_getversion           },
 	{ "isfile",                 os_isfile               },
 	{ "islink",                 os_islink               },

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -14,9 +14,6 @@
 #endif
 
 
-#define VERSION        "5.0.0-dev"
-#define COPYRIGHT      "Copyright (C) 2002-2016 Jason Perkins and the Premake Project"
-#define PROJECT_URL    "https://github.com/premake/premake-core/wiki"
 #define ERROR_MESSAGE  "Error: %s\n"
 
 
@@ -138,13 +135,13 @@ int premake_init(lua_State* L)
 	lua_pushstring(L, LUA_COPYRIGHT);
 	lua_setglobal(L, "_COPYRIGHT");
 
-	lua_pushstring(L, VERSION);
+	lua_pushstring(L, PREMAKE_VERSION);
 	lua_setglobal(L, "_PREMAKE_VERSION");
 
-	lua_pushstring(L, COPYRIGHT);
+	lua_pushstring(L, PREMAKE_COPYRIGHT);
 	lua_setglobal(L, "_PREMAKE_COPYRIGHT");
 
-	lua_pushstring(L, PROJECT_URL);
+	lua_pushstring(L, PREMAKE_PROJECT_URL);
 	lua_setglobal(L, "_PREMAKE_URL");
 
 	/* set the OS platform variable */

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -9,6 +9,10 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
+#define PREMAKE_VERSION        "5.0.0-dev"
+#define PREMAKE_COPYRIGHT      "Copyright (C) 2002-2016 Jason Perkins and the Premake Project"
+#define PREMAKE_PROJECT_URL    "https://github.com/premake/premake-core/wiki"
+
 /* Identify the current platform I'm not sure how to reliably detect
  * Windows but since it is the most common I use it as the default */
 #if defined(__linux__)

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -103,6 +103,7 @@ int os_chdir(lua_State* L);
 int os_chmod(lua_State* L);
 int os_copyfile(lua_State* L);
 int os_getcwd(lua_State* L);
+int os_getpass(lua_State* L);
 int os_getversion(lua_State* L);
 int os_is64bit(lua_State* L);
 int os_isdir(lua_State* L);

--- a/src/host/zip_extract.c
+++ b/src/host/zip_extract.c
@@ -75,6 +75,7 @@ static int is_directory(zip_uint8_t opsys, zip_uint32_t attrib)
 static int write_link(const char* filename, const char* bytes, size_t count)
 {
 #if PLATFORM_POSIX
+	(void)(count);
 	return symlink(bytes, filename);
 #else
 	FILE* fp = fopen(filename, "wb");


### PR DESCRIPTION
http.get and http.download have been extended to optionally accept username[:password] which is provided to the underlying curl library. 

User agent is now also being specified as "Premake/<version>" in the http requests.

This does not interfere with the optional parameter which contains headers which is a table type and the existing code scanned the arguments of the functions looking for that table.

Also added is os_getpass which allows lua scripts to prompt for a password from the user. If accepted the relevant documentation for http and os.getpass will be added to the premake wiki.

The purpose of these changes is to facilitate authentication support in [GitHub packages](https://github.com/mversluys/premake-ghp) which allows this module to work with private repositories and with GitHub Enterprise. The addition of user agent was required, the GitHub API refuses requests which don't supply it.

The changes have been tested on OS X (10.11.4) with LLVM 7.3, Windows with Visual Studio 2015 and Linux  (Ubuntu 14.04.1) with gcc 4.8.4.