### PR TITLE
linkgroups api.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -710,6 +710,16 @@
 	}
 
 	api.register {
+		name = "linkgroups",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Off",
+			"On",
+		}
+	}
+
+	api.register {
 		name = "locale",
 		scope = "config",
 		kind = "string",

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -239,11 +239,8 @@
 --    A list of libraries to link, decorated for the linker.
 --
 
-	function clang.getlinks(cfg, systemOnly)
-
-		-- Just pass through to GCC for now
-		return gcc.getlinksonly(cfg, systemOnly)
-
+	function clang.getlinks(cfg, systemonly)
+		return gcc.getlinks(cfg, systemonly)
 	end
 
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -314,10 +314,8 @@
 
 
 	function gcc.getlinks(cfg, systemonly)
-
-		-- we don't want libraries to be order dependent.
 		local result = gcc.getlinksonly(cfg, systemonly)
-		if #result > 1 then
+		if (#result > 1) and (cfg.linkgroups == p.ON) then
 			local res = {}
 			table.insert(res, '-Wl,--start-group')
 			table.insertflat(res, result)

--- a/tests/actions/make/cpp/test_make_linking.lua
+++ b/tests/actions/make/cpp/test_make_linking.lua
@@ -178,6 +178,31 @@
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s
+  LIBS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
+  LDDEPS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
+		]]
+	end
+
+--
+-- Check a linking multiple siblings with link groups enabled.
+--
+
+	function suite.links_onSiblingStaticLibWithLinkGroups()
+		links "MyProject2"
+		links "MyProject3"
+		linkgroups "On"
+
+		test.createproject(wks)
+		kind "StaticLib"
+		location "build"
+
+		test.createproject(wks)
+		kind "StaticLib"
+		location "build"
+
+		prepare { "ldFlags", "libs", "ldDeps" }
+		test.capture [[
+  ALL_LDFLAGS += $(LDFLAGS) -s
   LIBS += -Wl,--start-group build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a -Wl,--end-group
   LDDEPS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
 		]]


### PR DESCRIPTION
Turns out linkgroups can also be supported on clang, just not on the xcode version...
So instead of trying to figure it out, I just made turning it on/off a proper API, allowing the user to specify the behavior.

it defaults to disabled.