### PR TITLE
provide the parent to class.new

### DIFF
--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -153,7 +153,7 @@
 
 		-- otherwise, a new instance
 		if not instance then
-			instance = class.new(name)
+			instance = class.new(name, parent)
 			if parent then
 				p.container.addChild(parent, instance)
 			end


### PR DESCRIPTION
This is just a really minor change that allows an override, or implementation of a new container to actually know it's parent container before construction.

I needed this in a case where I was implementing an override for 'p.project.new'

