### PR TITLE
Allow rules to generate code that subsequently gets compiled.

### DIFF
--- a/src/actions/vstudio/vs2010_rules_targets.lua
+++ b/src/actions/vstudio/vs2010_rules_targets.lua
@@ -61,6 +61,7 @@
 
 	m.elements.computeInputsGroup = function(r)
 		return {
+			m.computeCompileInputsTargets,
 			m.computeLinkInputsTargets,
 			m.computeLibInputsTargets,
 		}
@@ -254,6 +255,15 @@
 
 
 
+	function m.computeCompileInputsTargets(r)
+		p.push('<ComputeCompileInputsTargets>')
+		p.w('$(ComputeCompileInputsTargets);')
+		p.w('Compute%sOutput;', r.name)
+		p.pop('</ComputeCompileInputsTargets>')
+	end
+
+
+
 	function m.dependsOnTargets(r)
 		p.w('DependsOnTargets="$(%sDependsOn);Compute%sOutput"', r.name, r.name)
 	end
@@ -267,10 +277,13 @@
 
 
 	function m.linkLib(r)
-		local linkable
+		local linkable, compileable
 		for i = 1, #r.buildoutputs do
 			if (path.islinkable(r.buildoutputs[i])) then
 				linkable = true
+			end
+			if (path.iscppfile(r.buildoutputs[i])) then
+				compileable = true
 			end
 		end
 		if linkable then
@@ -280,6 +293,12 @@
 				p.w('Condition="\'%%(Extension)\'==\'.obj\' or \'%%(Extension)\'==\'.res\' or \'%%(Extension)\'==\'.rsc\' or \'%%(Extension)\'==\'.lib\'" />')
 				p.pop()
 			end
+		end
+		if compileable then
+			p.push('<ClCompile', el)
+			p.w('Include="%%(%sOutputs.Identity)"', r.name)
+			p.w('Condition="\'%%(Extension)\'==\'.cc\' or \'%%(Extension)\'==\'.cpp\' or \'%%(Extension)\'==\'.cxx\' or \'%%(Extension)\'==\'.c\'" />')
+			p.pop()
 		end
 	end
 
@@ -302,7 +321,7 @@
 	function m.outputs(r)
 		p.w('<%sOutputs', r.name)
 		p.w('  Condition="\'@(%s)\' != \'\' and \'%%(%s.ExcludedFromBuild)\' != \'true\'"', r.name, r.name)
-        p.w('  Include="%%(%s.Outputs)" />', r.name)
+		p.w('  Include="%%(%s.Outputs)" />', r.name)
 	end
 
 

--- a/src/host/path_isabsolute.c
+++ b/src/host/path_isabsolute.c
@@ -29,8 +29,8 @@ int do_isabsolute(const char* path)
 	if (path[0] == '"')
 		return do_isabsolute(path + 1);
 
-	// $(foo)
-	if (path[0] == '$' && path[1] == '(')
+	// $(foo) and %(foo)
+	if ((path[0] == '%' || path[0] == '$') && path[1] == '(')
 	{
 		path += 2;
 		closing = strchr(path, ')');


### PR DESCRIPTION
So I made this rule:

```lua
rule 'example'
    location(path.join('..', _OPTIONS.to))

    display 'Example compiler'
    fileExtension '.example'

    propertydefinition {
        name = "output_path",
        kind = "string",
        display = "Output Path",
        description = "",
        value = "$(IntDir)",
    }

    buildmessage 'Compiling %(Filename) with example-compiler...'
    buildcommands {
        'package-example-compiler.exe [output_path] "%(Identity)"'
    }
    buildoutputs {
        '%(output_path)%(Filename).example.cc',
        '%(output_path)%(Filename).example.h'
    }
```

And wanted to get msbuild to compile the *.example.cc output files, and link them into my projects.

So two things I had to do:
- fix another bug in path.isabsolute (it would not recognize the %() tokens, and incorrectly expand)
- make the .target file generator recognize compilable files.


