### PR TITLE
We need to actually compile the context of the rule, so we can propely use the "filter {}" system.

### DIFF
--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -58,15 +58,8 @@
 
 	p.alias(oven, "bakeWorkspace", "bakeSolution")
 
----
--- Bakes a specific workspace object.
----
 
-	function p.workspace.bake(self)
-		-- Add filtering terms to the context and then compile the results. These
-		-- terms describe the "operating environment"; only results contained by
-		-- configuration blocks which match these terms will be returned.
-
+	local function addCommonContextFilters(self)
 		context.addFilter(self, "_ACTION", _ACTION)
 		context.addFilter(self, "action", _ACTION)
 
@@ -74,7 +67,6 @@
 		context.addFilter(self, "system", self.system)
 
 		-- Add command line options to the filtering options
-
 		local options = {}
 		for key, value in pairs(_OPTIONS) do
 			local term = key
@@ -85,6 +77,18 @@
 		end
 		context.addFilter(self, "_OPTIONS", options)
 		context.addFilter(self, "options", options)
+	end
+
+---
+-- Bakes a specific workspace object.
+---
+
+	function p.workspace.bake(self)
+		-- Add filtering terms to the context and then compile the results. These
+		-- terms describe the "operating environment"; only results contained by
+		-- configuration blocks which match these terms will be returned.
+
+		addCommonContextFilters(self)
 
 		-- Set up my token expansion environment
 
@@ -118,7 +122,6 @@
 
 		self.configs = oven.bakeConfigs(self)
 	end
-
 
 
 	function p.project.bake(self)
@@ -222,23 +225,7 @@
 		-- terms describe the "operating environment"; only results contained by
 		-- configuration blocks which match these terms will be returned.
 
-		context.addFilter(self, "_ACTION", _ACTION)
-		context.addFilter(self, "action", _ACTION)
-
-		self.system = self.system or p.action.current().os or os.get()
-		context.addFilter(self, "system", self.system)
-
-		-- Add command line options to the filtering options
-		local options = {}
-		for key, value in pairs(_OPTIONS) do
-			local term = key
-			if value ~= "" then
-				term = term .. "=" .. value
-			end
-			table.insert(options, term)
-		end
-		context.addFilter(self, "_OPTIONS", options)
-		context.addFilter(self, "options", options)
+		addCommonContextFilters(self)
 
 		-- Populate the token expansion environment
 
@@ -537,7 +524,7 @@
 
 		-- allow the project script to override the default toolset
 		ctx.toolset = ctx.toolset or toolset
-		context.addFilter(ctx, "toolset", ctx.toolset)		
+		context.addFilter(ctx, "toolset", ctx.toolset)
 
 		-- if a kind is set, allow that to influence the configuration
 		context.addFilter(ctx, "kind", ctx.kind)

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -233,7 +233,7 @@
 			rule = self,
 		}
 
-		-- Go ahead and distill all of that down now; this is my new project object
+		-- Go ahead and distill all of that down now; this is my new rule object
 
 		context.compile(self)
 
@@ -242,9 +242,9 @@
 			return a.name < b.name
 		end)
 
-		-- Set the context's base directory to the project's file system
+		-- Set the context's base directory to the rule's file system
 		-- location. Any path tokens which are expanded in non-path fields
-		-- are made relative to this, ensuring a portable generated project.
+		-- are made relative to this, ensuring a portable generated rule.
 
 		self.location = self.location or self.basedir
 		context.basedir(self, self.location)


### PR DESCRIPTION
I'm implementing the PBXBuildRule in our xcode backend, which is relatively simple, but due to differences in how the buildcommands etc are interpretted, I need the filter {}'s to work.

```lua
rule 'example'
    location(path.join('..', _OPTIONS.to))

    display 'Example compiler'
    fileExtension '.example'

    propertydefinition {
        name = "output_path",
        kind = "string",
        display = "Output Path",
        description = "",
        value = iif(_ACTION == 'xcode', "$DERIVED_FILE_DIR", "$(IntDir)")
    }

    filter { 'action:vs*' }
        buildmessage 'Compiling %(Filename) with example-compiler...'
        buildcommands {
            'package-example-compiler.exe [output_path] "%(Identity)"'
        }
        buildoutputs {
            '%(output_path)%(Filename).example.cc',
            '%(output_path)%(Filename).example.h'
        }

    filter { 'action:xcode' }
        buildcommands {
            'package-example-compiler "$DERIVED_FILE_DIR" "$INPUT_FILE_PATH"'
        }
        buildoutputs {
            '$DERIVED_FILE_DIR/$(INPUT_FILE_BASE).example.cc',
            '$DERIVED_FILE_DIR/$(INPUT_FILE_BASE).example.h'
        }
```

This PR allow the above to work.
