### PR TITLE
Add generated files to vxcproj file.

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -30,6 +30,7 @@
 	m.elements.project = function(prj)
 		return {
 			m.xmlDeclaration,
+			m.updateFileTable,
 			m.project,
 			m.projectConfigurations,
 			m.globals,
@@ -56,6 +57,60 @@
 		p.out('</Project>')
 	end
 
+
+--
+-- Update the file table with generated files.
+--
+	function m.updateFileTable(prj)
+		local function addGeneratedFile(cfg, source, filename)
+			-- mark that we have generated files.
+			cfg.project.hasGeneratedFiles = true
+
+			-- add generated file to the project.
+			local files = cfg.project._.files
+			local node = files[filename]
+			if not node then
+				node = fileconfig.new(filename, cfg.project)
+				node.vpath = path.join("Generated", node.name)
+				node.dependsOn = source
+				node.generated = true
+
+				files[filename] = node
+				table.insert(files, node)
+			end
+			fileconfig.addconfig(node, cfg)
+		end
+
+		local function addFile(cfg, node)
+			local filecfg = fileconfig.getconfig(node, cfg)
+			if not filecfg or filecfg.flags.ExcludeFromBuild then
+				return
+			end
+
+			if fileconfig.hasCustomBuildRule(filecfg) then
+				local buildoutputs = p.project.getrelative(cfg.project, filecfg.buildoutputs)
+				if buildoutputs and #buildoutputs > 0 then
+					for _, output in ipairs(buildoutputs) do
+						addGeneratedFile(cfg, node, output)
+					end
+				end
+			else
+				--addRuleFile(cfg, node)
+			end
+		end
+
+		local files = table.shallowcopy(prj._.files)
+		for cfg in project.eachconfig(prj) do
+			table.foreachi(files, function(node)
+				addFile(cfg, node)
+			end)
+		end
+
+		-- we need to reassign object sequences if we generated any files.
+		if prj.hasGeneratedFiles and p.project.iscpp(prj) then
+			p.oven.assignObjectSequences(prj)
+		end
+	end
 
 
 --
@@ -575,6 +630,15 @@
 	end
 
 
+	function m.generatedFile(cfg, file)
+		if file.generated then
+			local path = path.translate(file.dependsOn.relpath)
+			m.element("AutoGen", nil, 'true')
+			m.element("DependentUpon", nil, path)
+		end
+	end
+
+
 ---
 -- Write out the list of source code files, and any associated configuration.
 ---
@@ -598,7 +662,7 @@
 		priority   = 1,
 
 		emitFiles = function(prj, group)
-			m.emitFiles(prj, group, "ClInclude")
+			m.emitFiles(prj, group, "ClInclude", {m.generatedFile})
 		end,
 
 		emitFilter = function(prj, group)
@@ -638,7 +702,7 @@
 				end
 			end
 
-			m.emitFiles(prj, group, "ClCompile", nil, fileCfgFunc)
+			m.emitFiles(prj, group, "ClCompile", {m.generatedFile}, fileCfgFunc)
 		end,
 
 		emitFilter = function(prj, group)
@@ -655,7 +719,7 @@
 		priority = 3,
 
 		emitFiles = function(prj, group)
-			m.emitFiles(prj, group, "None")
+			m.emitFiles(prj, group, "None", {m.generatedFile})
 		end,
 
 		emitFilter = function(prj, group)

--- a/src/base/project.lua
+++ b/src/base/project.lua
@@ -274,6 +274,11 @@
 		local tr = tree.new(prj.name)
 
 		table.foreachi(prj._.files, function(fcfg)
+			-- if the file is a generated file, we add those in a second pass.
+			if fcfg.generated then
+				return;
+			end
+
 			-- The tree represents the logical source code tree to be displayed
 			-- in the IDE, not the physical organization of the file system. So
 			-- virtual paths are used when adding nodes.
@@ -294,6 +299,20 @@
 			-- the parent folder node, creating it if necessary.
 
 			local parent = tree.add(tr, path.getdirectory(fcfg.vpath), flags)
+			local node = tree.insert(parent, tree.new(path.getname(fcfg.vpath)))
+
+			-- Pass through value fetches to the file configuration
+			setmetatable(node, { __index = fcfg })
+		end)
+
+
+		table.foreachi(prj._.files, function(fcfg)
+			-- if the file is not a generated file, we already added them
+			if not fcfg.generated then
+				return;
+			end
+
+			local parent = tree.add(tr, path.getdirectory(fcfg.dependsOn.vpath))
 			local node = tree.insert(parent, tree.new(path.getname(fcfg.vpath)))
 
 			-- Pass through value fetches to the file configuration


### PR DESCRIPTION
The fix we made for 'rules' where a .cpp file gets automatically compiled as part of the rule if the buildoutputs of a rule creates those files, needs to be applied to custom build steps as well.

Say for example in your project you write:
```lua
files { '*.example' }
   buildoutputs { '%{ file.basename}.cpp' }
   buildcommands { 'example-compiler %{file.relpath} %{file.basename}.cpp' }
```

then without this change, the %{file.basename}.cpp would not get compiled automatically.
And you can't do a 
```lua
files { '**.cpp' } 
```
on files that don't yet exists

This change add support in Visual Studio for those files to get added, and it makes it look pretty too:
![image](https://cloud.githubusercontent.com/assets/451515/16159192/2c590ab0-3476-11e6-8997-a673da8253e3.png)



