### PR TITLE
Undefine CURL_CA_BUNDLE on Linux builds

### DIFF
--- a/contrib/curl/lib/config-linux.h
+++ b/contrib/curl/lib/config-linux.h
@@ -4,7 +4,7 @@
 /* #undef BUILDING_LIBCURL */
 
 /* Location of default ca bundle */
-/* #undef CURL_CA_BUNDLE */
+#undef CURL_CA_BUNDLE
 
 /* Location of default ca path */
 /* #undef CURL_CA_PATH */


### PR DESCRIPTION
Not sure if this is the right solution, but I had to undefine this symbol in order to Premake to build on Ubuntu for the 5.0-alpha9 release. Can someone with more Linux smarts confirm or suggest a better fix?