### PR TITLE
Adding 'symbolspath' API to allow specifying where the pdb file goes.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -957,6 +957,13 @@
 	}
 
 	api.register {
+		name = "symbolspath",
+		scope = "config",
+		kind = "path",
+		tokens = true,
+	}
+
+	api.register {
 		name = "sysincludedirs",
 		scope = "config",
 		kind = "list:directory",

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1827,8 +1827,9 @@
 
 
 	function m.programDataBaseFileName(cfg)
-		-- just a placeholder for overriding; will use the default VS name
-		-- for changes, see https://github.com/premake/premake-core/issues/151
+		if cfg.symbolspath and cfg.symbols == p.ON and cfg.debugformat ~= "c7" then
+			m.element("ProgramDataBaseFileName", nil, p.project.getrelative(cfg.project, cfg.symbolspath))
+		end
 	end
 
 


### PR DESCRIPTION
This 'finally' allows us to all eat the cake and have it...

if you specify:
```lua
symbolspath '$(OutDir)$(TargetName).pdb'
```
you get your pdb's right next to your exe/dll/lib with the same name.
if you don't specify it, it maintains the default behavior that we've gone back and forth between.

Fixes: 
https://github.com/premake/premake-core/issues/319
https://github.com/premake/premake-core/issues/314
https://github.com/premake/premake-core/issues/151
