### PR TITLE
Remove extra argument to os.match

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -274,7 +274,7 @@
 			while os.matchnext(m) do
 				if not os.matchisfile(m) then
 					local matchpath = path.join(before, os.matchname(m), mask:sub(starpos))
-					results = table.join(results, os.match(matchpath, after))
+					results = table.join(results, os.match(matchpath))
 				end
 			end
 			os.matchdone(m)


### PR DESCRIPTION
This value will always be ignored as os.match only takes a single
argument and is not needed to generate correct results.