### PR TITLE
symbols 'off' didn't work

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1247,6 +1247,8 @@
 			if value then
 				m.element("DebugInformationFormat", nil, value)
 			end
+		elseif cfg.symbols == p.OFF then
+			m.element("DebugInformationFormat", nil, "None")
 		end
 	end
 


### PR DESCRIPTION
It turns out that `symbols "off"` just left symbols in the default state, which in VS, is on.