### PR TITLE
do not add architecture-dependent library directories on macOS

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -236,8 +236,20 @@
 
 	gcc.libraryDirectories = {
 		architecture = {
-			x86 = "-L/usr/lib32",
-			x86_64 = "-L/usr/lib64",
+			x86 = function (cfg)
+				local r = {}
+				if cfg.system ~= premake.MACOSX then
+					table.insert (r, "-L/usr/lib32")
+				end
+				return r
+			end,
+			x86_64 = function (cfg)
+				local r = {}
+				if cfg.system ~= premake.MACOSX then
+					table.insert (r, "-L/usr/lib64")
+				end
+				return r
+			end,
 		},
 		system = {
 			wii = "-L$(LIBOGC_LIB)",

--- a/tests/actions/make/cpp/test_ldflags.lua
+++ b/tests/actions/make/cpp/test_ldflags.lua
@@ -48,3 +48,30 @@
   ALL_LDFLAGS += $(LDFLAGS) -L../libs -Llibs
 		]]
 	end
+	
+	function suite.checkLibDirs_X86_64()
+		architecture ("x86_64")
+		system (premake.LINUX)
+		prepare()
+		test.capture [[
+  ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib64 -m64
+		]]
+	end
+	
+	function suite.checkLibDirs_X86()
+		architecture ("x86")
+		system (premake.LINUX)
+		prepare()
+		test.capture [[
+  ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib32 -m32
+		]]
+	end
+	
+	function suite.checkLibDirs_X86_64_MacOSX()
+		architecture ("x86_64")
+		system (premake.MACOSX)
+		prepare()
+		test.capture [[
+  ALL_LDFLAGS += $(LDFLAGS) -m64
+		]]
+	end


### PR DESCRIPTION
fix issues #473 and #303