### PR TITLE
Put back the old Symbols flag in premake5.lua

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -84,7 +84,10 @@
 -- default when folks build using the makefile. That way they don't have to
 -- worry about the /scripts argument and all that.
 --
--- TODO: defaultConfiguration "Release"
+-- TODO: Switch to these new APIs once they've had a chance to land everywhere
+--
+--    defaultConfiguration "Release"
+--    symbols "On"
 --
 
 	solution "Premake5"
@@ -102,7 +105,7 @@
 
 		filter "configurations:Debug"
 			defines     "_DEBUG"
-			symbols     "On"
+			flags       { "Symbols" }
 
 		filter "configurations:Release"
 			defines     "NDEBUG"


### PR DESCRIPTION
Using brand new APIs in the `premake5.lua` script prevents people from regenerating the project files while running an older version of Premake. We need to give everyone a chance to get caught up before we use these new APIs in the build scripts.

Roll back to the old `flags { "Symbols" }` approach while we let the new `symbols()` API settle.