### PR TITLE
Add an 'uncached' sub-context to the context.

### DIFF
--- a/modules/self-test/test_helpers.lua
+++ b/modules/self-test/test_helpers.lua
@@ -53,6 +53,11 @@
 	end
 
 
+	function m.getRule(name)
+		p.oven.bake()
+		return p.global.getRule(name)
+	end
+
 
 	function m.getProject(wks, i)
 		wks = m.getWorkspace(wks)

--- a/src/actions/vstudio/vs2010.lua
+++ b/src/actions/vstudio/vs2010.lua
@@ -31,6 +31,7 @@
 		["file.basename"]               = { absolute = false, token = "%(Filename)" },
 		["file.abspath"]                = { absolute = true,  token = "%(FullPath)" },
 		["file.relpath"]                = { absolute = false, token = "%(Identity)" },
+		["file.path"]                   = { absolute = true,  token = "%(RelativeDir)" },
 	}
 
 

--- a/src/actions/vstudio/vs2010_rules_props.lua
+++ b/src/actions/vstudio/vs2010_rules_props.lua
@@ -145,7 +145,15 @@
 
 	function m.commandLineTemplates(r)
 		if #r.buildcommands then
-			local cmds = os.translateCommands(r.buildcommands, p.WINDOWS)
+
+			-- create shadow context.
+			local env = p.rule.createEnvironment(r, "[%s]")
+			local ctx = p.context.extent(r, env)
+
+			-- now use the shadow context to detoken.
+			local cmds = os.translateCommands(ctx.buildcommands, p.WINDOWS)
+
+			-- write out the result.
 			cmds = table.concat(cmds, p.eol())
 			p.x('<CommandLineTemplate>%s</CommandLineTemplate>', cmds)
 		end
@@ -163,7 +171,12 @@
 
 	function m.executionDescription(r)
 		if r.buildmessage then
-			p.x('<ExecutionDescription>%s</ExecutionDescription>', r.buildmessage)
+			-- create shadow context.
+			local env = p.rule.createEnvironment(r, "[%s]")
+			local ctx = p.context.extent(r, env)
+
+			-- write out the result.
+			p.x('<ExecutionDescription>%s</ExecutionDescription>', ctx.buildmessage)
 		end
 	end
 
@@ -171,7 +184,14 @@
 
 	function m.outputs(r)
 		if #r.buildoutputs then
-			local outputs = table.concat(r.buildoutputs, ";")
+			-- create shadow context.
+			local pathVars = p.rule.createPathVars(r, "%%(%s)")
+			local ctx = p.context.extent(r, { pathVars = pathVars })
+
+			-- now use the shadow context to detoken.
+			local outputs = table.concat(ctx.buildoutputs, ";")
+
+			-- write out the result.
 			p.x('<Outputs>%s</Outputs>', path.translate(outputs))
 		end
 	end

--- a/src/base/detoken.lua
+++ b/src/base/detoken.lua
@@ -42,6 +42,9 @@
 			end
 		end
 
+		-- fetch the pathVars from the enviroment.
+		local envMap = environ.pathVars or {}
+
 		-- enable access to the global environment
 		setmetatable(environ, {__index = _G})
 
@@ -79,14 +82,14 @@
 				end
 			end
 
-			-- If this token is in my path variable mapping table, replace the
+			-- If this token is in my path variable mapping tables, replace the
 			-- value with the one from the map. This needs to go here because
 			-- I don't want to make the result relative, but I don't want the
 			-- absolute path handling below.
-
-			if varMap[token] then
+			local mapped = envMap[token] or varMap[token]
+			if mapped then
 				err    = nil
-				result = varMap[token]
+				result = mapped
 				if type(result) == "function" then
 					success, result = pcall(result, e)
 					if not success then

--- a/src/base/rule.lua
+++ b/src/base/rule.lua
@@ -159,3 +159,51 @@
 			p.api.storeField(fld, value)
 		end
 	end
+
+
+
+---
+-- prepare an environment with the rule properties as global tokens,
+-- according to the format specified.
+--
+-- @param environ
+--    The environment table to fill up
+-- @param format
+--    The formatting to be used, ie "[%s]".
+---
+
+	function rule.prepareEnvironment(self, environ, format)
+		for _, def in ipairs(self.propertydefinition) do
+			environ[def.name] = string.format(format, def.name)
+		end
+	end
+
+	function rule.createEnvironment(self, format)
+		local environ = {}
+		rule.prepareEnvironment(self, environ, format)
+		return environ
+	end
+
+
+
+---
+-- prepare an table of pathVars with the rule properties as global tokens,
+-- according to the format specified.
+--
+-- @param pathVars
+--    The pathVars table to fill up
+-- @param format
+--    The formatting to be used, ie "%%(%s)".
+---
+
+	function rule.preparePathVars(self, pathVars, format)
+		for _, def in ipairs(self.propertydefinition) do
+			pathVars[def.name] = { absolute = true,  token = string.format(format, def.name) }
+		end
+	end
+
+	function rule.createPathVars(self, format)
+		local pathVars = {}
+		rule.preparePathVars(self, pathVars, format)
+		return pathVars
+	end

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -131,6 +131,8 @@ return {
 	"actions/vstudio/vc2010/test_project_refs.lua",
 	"actions/vstudio/vc2010/test_prop_sheet.lua",
 	"actions/vstudio/vc2010/test_resource_compile.lua",
+	"actions/vstudio/vc2010/test_rule_props.lua",
+	"actions/vstudio/vc2010/test_rule_targets.lua",
 	"actions/vstudio/vc2010/test_rule_vars.lua",
 	"actions/vstudio/vc2010/test_target_machine.lua",
 	"actions/vstudio/vc2010/test_user_file.lua",

--- a/tests/actions/vstudio/vc2010/test_rule_props.lua
+++ b/tests/actions/vstudio/vc2010/test_rule_props.lua
@@ -1,0 +1,71 @@
+--
+-- tests/actions/vstudio/vc2010/vstudio_vs2010_rule_props.lua
+-- Validate generation of custom rules
+-- Author Tom van Dijck
+-- Copyright (c) 2016 Jason Perkins and the Premake project
+--
+
+	local suite = test.declare("vstudio_vs2010_rule_props")
+
+	local vc2010 = premake.vstudio.vc2010
+	local m = premake.vstudio.vs2010.rules.props
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		premake.action.set("vs2010")
+		rule 'example'
+			display 'Example compiler'
+			fileExtension '.example'
+
+			propertydefinition {
+				name = "output_path",
+				kind = "string",
+				display = "Output Path",
+				description = "",
+			}
+
+			buildmessage 'Compiling %{file.basename} with example-compiler...'
+			buildcommands {
+				'package-example-compiler.exe %{output_path} "%{file.relpath}"'
+			}
+			buildoutputs {
+				'%{output_path}%{file.basename}.example.cc',
+				'%{output_path}%{file.basename}.example.h'
+			}
+	end
+
+
+
+--
+-- commandLineTemplates
+--
+
+	function suite.commandLineTemplates()
+		local r = test.getRule("example")
+		m.commandLineTemplates(r)
+
+		test.capture [[
+<CommandLineTemplate>@echo off
+package-example-compiler.exe [output_path] "%(Identity)"</CommandLineTemplate>
+		]]
+	end
+
+--
+-- executionDescription
+--
+
+	function suite.executionDescription()
+		local r = test.getRule("example")
+		m.executionDescription(r)
+
+		test.capture [[
+<ExecutionDescription>Compiling %(Filename) with example-compiler...</ExecutionDescription>
+		]]
+	end
+

--- a/tests/actions/vstudio/vc2010/test_rule_targets.lua
+++ b/tests/actions/vstudio/vc2010/test_rule_targets.lua
@@ -1,0 +1,97 @@
+--
+-- tests/actions/vstudio/vc2010/vstudio_vs2010_rule_targets.lua
+-- Validate generation of custom rules
+-- Author Tom van Dijck
+-- Copyright (c) 2016 Jason Perkins and the Premake project
+--
+
+	local suite = test.declare("vstudio_vs2010_rule_targets")
+
+	local vc2010 = premake.vstudio.vc2010
+	local m = premake.vstudio.vs2010.rules.targets
+
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		premake.action.set("vs2010")
+		rule 'example'
+			display 'Example compiler'
+			fileExtension '.example'
+
+			propertydefinition {
+				name = "output_path",
+				kind = "string",
+				display = "Output Path",
+				description = "",
+			}
+
+			buildmessage 'Compiling %{file.basename} with example-compiler...'
+			buildcommands {
+				'package-example-compiler.exe %{output_path} "%{file.relpath}"'
+			}
+			buildoutputs {
+				'%{output_path}%{file.basename}.example.cc',
+				'%{output_path}%{file.basename}.example.h'
+			}
+	end
+
+
+
+--
+-- availableItemName
+--
+
+	function suite.availableItemName()
+		local r = test.getRule("example")
+		m.availableItemName(r)
+
+		test.capture [[
+<AvailableItemName Include="example">
+	<Targets>_example</Targets>
+</AvailableItemName>
+		]]
+	end
+
+
+--
+-- computedProperties
+--
+
+	function suite.computedProperties()
+		local r = test.getRule("example")
+		m.computedProperties(r)
+
+		test.capture [[
+<ItemDefinitionGroup>
+	<example>
+		<Outputs>%(output_path)%(Filename).example.cc;%(output_path)%(Filename).example.h</Outputs>
+	</example>
+</ItemDefinitionGroup>
+		]]
+	end
+
+
+
+--
+-- usingTask
+--
+
+	function suite.usingTask()
+		local r = test.getRule("example")
+		m.usingTask(r)
+
+		test.capture [[
+<UsingTask
+	TaskName="example"
+	TaskFactory="XamlTaskFactory"
+	AssemblyName="Microsoft.Build.Tasks.v4.0">
+	<Task>$(MSBuildThisFileDirectory)$(MSBuildThisFileName).xml</Task>
+</UsingTask>
+		]]
+	end

--- a/tests/base/test_context.lua
+++ b/tests/base/test_context.lua
@@ -51,3 +51,25 @@
 		configset.store(cset, field.get("targetname"), "MyProject%{1 + 1}")
 		test.isequal("MyProject2", ctx.targetname)
 	end
+
+
+--
+-- Token environment in extended context overrides context.
+--
+
+	function suite.extent()
+		-- set in toplevel context.
+		configset.store(cset, field.get("targetname"), "%{value}")
+
+		-- detoken in toplevel context should result in empty string.
+		test.isequal("", ctx.targetname)
+
+		-- create an extended context with a local environ.
+		local environ = {
+			value = "text"
+		}
+		local ext = context.extent(ctx, environ)
+
+		-- detoken in extended context should result in value set in that environ.
+		test.isequal("text", ext.targetname)
+	end


### PR DESCRIPTION
OK, so this is part one of a 2-part feature I'm working on...

What this does, is it allows you to access any property like normal, but uncached...
normally when you ask for a property, for example

```lua
local value = cfg.buildoutputs
```
The buildoutputs will be expanded, and stored in the table. The next time some piece of code asks for the buildoutputs from the same context (cfg in the above example), it'll just return the previously expanded value, without running the detokenizer again...

This PR, will allow you to write:
```lua
local ctx = p.context.uncached(cfg)
local value = ctx.buildoutputs
```
which will neither ask for the 'potentially' already expanded value, not store the result of the expansion. Essentially forcing a detoken anytime you access it this way.

So why do I want this?
Well, the 2nd part of what I'm working on, will allow you to 'add' custom behavior to the detokenizer. For example, in the [Custom Rules](https://github.com/premake/premake-core/wiki/Custom-Rules) feature, 'propertydefinitions' currently have no standard way of being references as tokens, and we can't just say

```lua
propertydefinition {
    name = "StripDebugInfo",
}
buildcommand 'MyCustomCC.exe -c "%(FullPath)" -o "%(IntDir)/%(Filename).obj" %{StripDebugInfo}'
```

Instead we've somewhat made this a Visual Studio only feature and use the [StripDebugInfo] token that is native to how visual studio treats props... I however, want to use the premake token syntax, and in this particular case it is context sensitive, for the '.xml' file of the rules it needs to expand to [StripDebugInfo], but in the '.props' file it needs to expand to %(StripDebugInfo). 

This means that the 'action.pathVars' needs to be changed depending on who asks the question.

Anyway, all that is for a 2nd PR after this one gets merged...







