### PR TITLE
Add vectorextensions "IA32" support for VS>=2012 on x86. (#560)

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1098,6 +1098,7 @@
 			"Default",
 			"AVX",
 			"AVX2",
+			"IA32",
 			"SSE",
 			"SSE2",
 			"SSE3",

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1213,6 +1213,8 @@
 				v = "StreamingSIMDExtensions2"
 			elseif x == "SSE" then
 				v = "StreamingSIMDExtensions"
+			elseif x == "IA32" and _ACTION > "vs2010" then
+				v = "NoExtensions"
 			end
 		end
 		if v then

--- a/tests/actions/vstudio/vc2010/test_vectorextensions.lua
+++ b/tests/actions/vstudio/vc2010/test_vectorextensions.lua
@@ -29,6 +29,12 @@
 	end
 
 
+	function suite.instructionSet_onIA32_onVS2010()
+		vectorextensions "IA32"
+		prepare()
+		test.isemptycapture()
+	end
+
 	function suite.instructionSet_onIA32()
 		premake.action.set("vs2012")
 		vectorextensions "IA32"

--- a/tests/actions/vstudio/vc2010/test_vectorextensions.lua
+++ b/tests/actions/vstudio/vc2010/test_vectorextensions.lua
@@ -29,6 +29,15 @@
 	end
 
 
+	function suite.instructionSet_onIA32()
+		premake.action.set("vs2012")
+		vectorextensions "IA32"
+		prepare()
+		test.capture [[
+<EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
+		]]
+	end
+
 	function suite.instructionSet_onSSE()
 		vectorextensions "SSE"
 		prepare()


### PR DESCRIPTION
Fixes #560 .