### PR TITLE
Fix CodeLite / GCC project generation

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -213,7 +213,7 @@
 			SharedLib = function(cfg)
 				local r = { iif(cfg.system == premake.MACOSX, "-dynamiclib", "-shared") }
 				if cfg.system == "windows" and not cfg.flags.NoImportLib then
-					table.insert(r, '-Wl,--out-implib="' .. cfg.linktarget.relpath .. '"')
+					table.insert(r, '-Wl,--out-implib=\'' .. cfg.linktarget.relpath .. '\'')
 				end
 				return r
 			end,

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -281,7 +281,7 @@
 		system "Windows"
 		kind "SharedLib"
 		prepare()
-		test.contains({ "-shared", '-Wl,--out-implib="bin/Debug/MyProject.lib"' }, gcc.getldflags(cfg))
+		test.contains({ "-shared", '-Wl,--out-implib=\'bin/Debug/MyProject.lib\'' }, gcc.getldflags(cfg))
 	end
 
 	function suite.ldflags_onWindowsApp()


### PR DESCRIPTION
This is a fix for #565. It replaces the use of double quotes in "-Wl,--implib-" with single quotes. Also edited the test to reflect this.