### PR TITLE
Fix path normalization within os.execute

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -11,7 +11,6 @@
 --
 
 	premake.override(os, "execute", function(base, cmd)
-		cmd = path.normalize(cmd)
 		cmd = os.translateCommands(cmd)
 		return base(cmd)
 	end)
@@ -468,36 +467,36 @@
 	os.commandTokens = {
 		_ = {
 			chdir = function(v)
-				return "cd " .. v
+				return "cd " .. path.normalize(v)
 			end,
 			copy = function(v)
-				return "cp -rf " .. v
+				return "cp -rf " .. path.normalize(v)
 			end,
 			delete = function(v)
-				return "rm -f " .. v
+				return "rm -f " .. path.normalize(v)
 			end,
 			echo = function(v)
 				return "echo " .. v
 			end,
 			mkdir = function(v)
-				return "mkdir -p " .. v
+				return "mkdir -p " .. path.normalize(v)
 			end,
 			move = function(v)
-				return "mv -f " .. v
+				return "mv -f " .. path.normalize(v)
 			end,
 			rmdir = function(v)
-				return "rm -rf " .. v
+				return "rm -rf " .. path.normalize(v)
 			end,
 			touch = function(v)
-				return "touch " .. v
+				return "touch " .. path.normalize(v)
 			end,
 		},
 		windows = {
 			chdir = function(v)
-				return "chdir " .. path.translate(v)
+				return "chdir " .. path.translate(path.normalize(v))
 			end,
 			copy = function(v)
-				v = path.translate(v)
+				v = path.translate(path.normalize(v))
 
 				-- Detect if there's multiple parts to the input, if there is grab the first part else grab the whole thing
 				local src = string.match(v, '^".-"') or string.match(v, '^.- ') or v
@@ -508,22 +507,22 @@
 				return "IF EXIST " .. src .. "\\ (xcopy /Q /E /Y /I " .. v .. " > nul) ELSE (xcopy /Q /Y /I " .. v .. " > nul)"
 			end,
 			delete = function(v)
-				return "del " .. path.translate(v)
+				return "del " .. path.translate(path.normalize(v))
 			end,
 			echo = function(v)
 				return "echo " .. v
 			end,
 			mkdir = function(v)
-				return "mkdir " .. path.translate(v)
+				return "mkdir " .. path.translate(path.normalize(v))
 			end,
 			move = function(v)
-				return "move /Y " .. path.translate(v)
+				return "move /Y " .. path.translate(path.normalize(v))
 			end,
 			rmdir = function(v)
-				return "rmdir /S /Q " .. path.translate(v)
+				return "rmdir /S /Q " .. path.translate(path.normalize(v))
 			end,
 			touch = function(v)
-				v = path.translate(v)
+				v = path.translate(path.normalize(v))
 				return string.format("type nul >> %s && copy /b %s+,, %s", v, v, v)
 			end,
 		}

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -186,7 +186,7 @@
 	end
 
 	function suite.translateCommand_windowsCopyNoDst_ExtraSpace()
-		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a  > nul) ELSE (xcopy /Q /Y /I a  > nul)', os.translateCommands('{COPY} a ', "windows"))
+		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a > nul) ELSE (xcopy /Q /Y /I a > nul)', os.translateCommands('{COPY} a ', "windows"))
 	end
 
 	function suite.translateCommand_windowsCopyNoQuotes()
@@ -194,7 +194,7 @@
 	end
 
 	function suite.translateCommand_windowsCopyNoQuotes_ExtraSpace()
-		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a b  > nul) ELSE (xcopy /Q /Y /I a b  > nul)', os.translateCommands('{COPY} a b ', "windows"))
+		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a b > nul) ELSE (xcopy /Q /Y /I a b > nul)', os.translateCommands('{COPY} a b ', "windows"))
 	end
 
 	function suite.translateCommand_windowsCopyQuotes()
@@ -202,7 +202,7 @@
 	end
 
 	function suite.translateCommand_windowsCopyQuotes_ExtraSpace()
-		test.isequal('IF EXIST "a a"\\ (xcopy /Q /E /Y /I "a a" "b"  > nul) ELSE (xcopy /Q /Y /I "a a" "b"  > nul)', os.translateCommands('{COPY} "a a" "b" ', "windows"))
+		test.isequal('IF EXIST "a a"\\ (xcopy /Q /E /Y /I "a a" "b" > nul) ELSE (xcopy /Q /Y /I "a a" "b" > nul)', os.translateCommands('{COPY} "a a" "b" ', "windows"))
 	end
 
 	function suite.translateCommand_windowsCopyNoQuotesDst()
@@ -210,7 +210,7 @@
 	end
 
 	function suite.translateCommand_windowsCopyNoQuotesDst_ExtraSpace()
-		test.isequal('IF EXIST "a a"\\ (xcopy /Q /E /Y /I "a a" b  > nul) ELSE (xcopy /Q /Y /I "a a" b  > nul)', os.translateCommands('{COPY} "a a" b ', "windows"))
+		test.isequal('IF EXIST "a a"\\ (xcopy /Q /E /Y /I "a a" b > nul) ELSE (xcopy /Q /Y /I "a a" b > nul)', os.translateCommands('{COPY} "a a" b ', "windows"))
 	end
 
 	function suite.translateCommand_windowsCopyNoQuotesSrc()
@@ -218,5 +218,5 @@
 	end
 
 	function suite.translateCommand_windowsCopyNoQuotesSrc_ExtraSpace()
-		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a "b"  > nul) ELSE (xcopy /Q /Y /I a "b"  > nul)', os.translateCommands('{COPY} a "b" ', "windows"))
+		test.isequal('IF EXIST a\\ (xcopy /Q /E /Y /I a "b" > nul) ELSE (xcopy /Q /Y /I a "b" > nul)', os.translateCommands('{COPY} a "b" ', "windows"))
 	end


### PR DESCRIPTION
This is a merge of #320 and #538 which resolves the issues  #316 and #537 by normalizing only arguments that should be file system paths.