### PR TITLE
Host/Posix: Fix os.copyfile with spaces in argument paths.

### DIFF
--- a/src/host/os_copyfile.c
+++ b/src/host/os_copyfile.c
@@ -16,7 +16,7 @@ int os_copyfile(lua_State* L)
 #if PLATFORM_WINDOWS
 	z = CopyFileA(src, dst, FALSE);
 #else
-	lua_pushfstring(L, "cp %s %s", src, dst);
+	lua_pushfstring(L, "cp \"%s\" \"%s\"", src, dst);
 	z = (system(lua_tostring(L, -1)) == 0);
 #endif
 


### PR DESCRIPTION
Hey,

I just encountered this bug, as Premake calls the cp utility without wrapping its argument by quotes, causing the copy to fail.

This is a simple fix, and my first contribution 😃 