### PR TITLE
Enable Edit and Continue for x64 builds on VS2015

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1180,7 +1180,7 @@
 		if cfg.symbols == p.ON then
 			if cfg.debugformat == "c7" then
 				value = "OldStyle"
-			elseif cfg.architecture == "x86_64" or
+			elseif (cfg.architecture == "x86_64" and _ACTION < "vs2015") or
 				   cfg.clr ~= p.OFF or
 				   config.isOptimizedBuild(cfg) or
 				   cfg.editandcontinue == p.OFF or


### PR DESCRIPTION
VS 2015 supports Edit and Continue for x64 builds! Let's enable it