### PR TITLE
Fix for #598

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -308,7 +308,6 @@
 			m.clCompileAdditionalUsingDirectories,
 			m.forceIncludes,
 			m.debugInformationFormat,
-			m.programDataBaseFileName,
 			m.optimization,
 			m.functionLevelLinking,
 			m.intrinsicFunctions,
@@ -409,6 +408,7 @@
 				m.largeAddressAware,
 				m.targetMachine,
 				m.additionalLinkOptions,
+				m.programDatabaseFile,
 			}
 		end
 	end
@@ -1793,9 +1793,9 @@
 	end
 
 
-	function m.programDataBaseFileName(cfg)
+	function m.programDatabaseFile(cfg)
 		if cfg.symbolspath and cfg.symbols == p.ON and cfg.debugformat ~= "c7" then
-			m.element("ProgramDataBaseFileName", nil, p.project.getrelative(cfg.project, cfg.symbolspath))
+			m.element("ProgramDatabaseFile", nil, p.project.getrelative(cfg.project, cfg.symbolspath))
 		end
 	end
 


### PR DESCRIPTION
ProgramDataBaseFileName (Compiler Option) describes the location of the debug information for the intermediate object files (.obj). 
ProgramDatabaseFile (Linker Option) instead sets the location of the debug information for the final binary (shared library or executable) which is the documented (and probably also intended) behavior.

Related MSDN Articles:
https://msdn.microsoft.com/en-us/library/9wst99a9.aspx (/Fd (ProgramDataBaseFileName))
https://msdn.microsoft.com/en-us/library/kwx19e36.aspx (/PDB (ProgramDatabaseFile))
