### PR TITLE
VStudio: Add additional deps & additional libdirs for static lib

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -431,6 +431,8 @@
 	m.elements.lib = function(cfg, explicit)
 		if cfg.kind == p.STATICLIB then
 			return {
+				m.additionalDependencies,
+				m.additionalLibraryDirectories,
 				m.treatLinkerWarningAsErrors,
 				m.targetMachine,
 				m.additionalLinkOptions,

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -155,6 +155,20 @@
 		]]
 	end
 
+	function suite.additionalDependencies_onSystemLinksStatic()
+		kind "StaticLib"
+		links { "lua", "zlib" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+</Link>
+<Lib>
+	<AdditionalDependencies>lua.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+</Lib>
+		]]
+	end
+
 
 --
 -- Any system libraries specified in links() with valid extensions should
@@ -171,6 +185,20 @@
 		]]
 	end
 
+	function suite.additionalDependencies_onSystemLinksExtensionsStatic()
+		kind "StaticLib"
+		links { "lua.obj", "zlib.lib" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+</Link>
+<Lib>
+	<AdditionalDependencies>lua.obj;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+</Lib>
+		]]
+	end
+
 
 --
 -- Any system libraries specified in links() with multiple dots should
@@ -184,6 +212,20 @@
 <Link>
 	<SubSystem>Windows</SubSystem>
 	<AdditionalDependencies>lua.5.3.lib;lua.5.4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+		]]
+	end
+
+	function suite.additionalDependencies_onSystemLinksExtensionsMultipleDotsStatic()
+		kind "StaticLib"
+		links { "lua.5.3.lib", "lua.5.4" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+</Link>
+<Lib>
+	<AdditionalDependencies>lua.5.3.lib;lua.5.4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+</Lib>
 		]]
 	end
 


### PR DESCRIPTION
Currently if static library links with another non-sibling library build fails.

For example: 
- If using the socket() API on windows in a static library, need to link with ws2_32.lib.
  In current premake, linking fails due to unresolved external symbol of the socket() symbol. @mindw
