### PR TITLE
Fix bug in premake.filename(obj, ext)

### DIFF
--- a/src/base/premake.lua
+++ b/src/base/premake.lua
@@ -192,7 +192,7 @@ function premake.filename(obj, ext)
 		fname = path.join(fname, ext)
 	else
 		fname = path.join(fname, obj.filename)
-		if ext then
+		if ext and not fname:endswith(ext) then
 			fname = fname .. ext
 		end
 	end

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -18,6 +18,7 @@ return {
 	"base/test_uuid.lua",
 	"base/test_versions.lua",
 	"base/test_http.lua",
+	"base/test_filename.lua",
 
 	-- Workspace object tests
 	"workspace/test_eachconfig.lua",

--- a/tests/base/test_filename.lua
+++ b/tests/base/test_filename.lua
@@ -55,6 +55,11 @@
 		test.isequal("Howdy", path.getname(p.filename(prj)))
 	end
 
+	function suite.doesUseFilenameWithExtension()
+		filename "Howdy.xc"
+		prepare()
+		test.isequal("Howdy.xc", path.getname(p.filename(prj, ".xc")))
+	end
 
 --
 -- Appends file extension, if supplied.


### PR DESCRIPTION
- If "ext" is given and project was configured with filename which ends with "ext" than the returned filename will be "filename.ext.ext".
- It can be relevant in external projects where you want to give the filename of the project file explicitly.
  @mindw
