### PR TITLE
Apply includedirs and defines for makefile projects in Visual Studio

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -237,6 +237,8 @@
 			m.nmakeCommandLine(cfg, cfg.buildcommands, "Build")
 			m.nmakeCommandLine(cfg, cfg.rebuildcommands, "ReBuild")
 			m.nmakeCommandLine(cfg, cfg.cleancommands, "Clean")
+			m.nmakePreprocessorDefinitions(cfg, cfg.defines, false, nil)
+			m.nmakeIncludeDirs(cfg, cfg.includedirs)
 			p.pop('</PropertyGroup>')
 		end
 	end
@@ -1669,7 +1671,25 @@
 		m.element("NMakeOutput", nil, "$(OutDir)%s", cfg.buildtarget.name)
 	end
 
+	function m.nmakePreprocessorDefinitions(cfg, defines, escapeQuotes, condition)
+		if #defines > 0 then
+			defines = table.concat(defines, ";")
+			if escapeQuotes then
+				defines = defines:gsub('"', '\\"')
+			end
+			defines = p.esc(defines) .. ";$(NMakePreprocessorDefinitions)"
+			m.element('NMakePreprocessorDefinitions', condition, defines)
+		end
+	end
 
+	function m.nmakeIncludeDirs(cfg, includedirs)
+		if #includedirs > 0 then
+			local dirs = vstudio.path(cfg, includedirs)
+			if #dirs > 0 then
+				m.element("NMakeIncludeSearchPath", nil, "%s", table.concat(dirs, ";"))
+			end
+		end
+	end
 
 	function m.objectFileName(fcfg)
 		if fcfg.objname ~= fcfg.basename then

--- a/tests/actions/vstudio/vc2010/test_nmake_props.lua
+++ b/tests/actions/vstudio/vc2010/test_nmake_props.lua
@@ -114,3 +114,25 @@ command 2</NMakeBuildCommandLine>
 </PropertyGroup>
 		]]
 	end
+
+	function suite.onDefines()
+		defines { "DEBUG", "_DEBUG" }
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
+	<NMakePreprocessorDefinitions>DEBUG;_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+</PropertyGroup>
+		]]
+	end
+
+	function suite.onIncludeDirs()
+		includedirs { "include/lua", "include/zlib" }
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
+	<NMakeIncludeSearchPath>include\lua;include\zlib</NMakeIncludeSearchPath>
+</PropertyGroup>
+		]]
+	end


### PR DESCRIPTION
This will help Intellisense when viewing makefile projects on Visual Studio.

For example:
You have a C project with an external makefile to build it.
When you open the project on Visual Studio you would like intellisense to know all the includedirs locations and show ifdefs code parts which their defines were defined in the premake5.lua.
@mindw
@Alex---
