### PR TITLE
fix switch/separator in rules_xml

### DIFF
--- a/src/actions/vstudio/vs2010_rules_xml.lua
+++ b/src/actions/vstudio/vs2010_rules_xml.lua
@@ -149,7 +149,7 @@
 		if def.switch then
 			p.w('Switch="%s"', def.switch)
 		end
-		p.w(' />')
+		p.w('/>')
 		p.pop()
 	end
 
@@ -173,9 +173,9 @@
 					p.w('Switch="%s"', switches[key])
 				end
 			else
-				p.w('DisplayName="%s" />', values[key])
+				p.w('DisplayName="%s"', values[key])
 			end
-			p.w(' />')
+			p.w('/>')
 			p.pop()
 		end
 
@@ -189,7 +189,7 @@
 		if def.switch then
 			p.w('Switch="%s"', def.switch)
 		end
-		p.w(' />')
+		p.w('/>')
 		p.pop()
 	end
 
@@ -203,7 +203,7 @@
 		if def.switch then
 			p.w('Switch="%s"', def.switch)
 		end
-		p.w(' />')
+		p.w('/>')
 		p.pop()
 	end
 

--- a/src/actions/vstudio/vs2010_rules_xml.lua
+++ b/src/actions/vstudio/vs2010_rules_xml.lua
@@ -146,7 +146,10 @@
 	function m.boolProperty(def)
 		p.push('<BoolProperty')
 		m.baseProperty(def)
-		p.w('Switch="%s" />', def.switch or "[value]")
+		if def.switch then
+			p.w('Switch="%s"', def.switch)
+		end
+		p.w(' />')
 		p.pop()
 	end
 
@@ -166,10 +169,13 @@
 			p.w('Name="%d"', key)
 			if switches[key] then
 				p.w('DisplayName="%s"', values[key])
-				p.w('Switch="%s" />', switches[key])
+				if switches[key] then
+					p.w('Switch="%s"', switches[key])
+				end
 			else
 				p.w('DisplayName="%s" />', values[key])
 			end
+			p.w(' />')
 			p.pop()
 		end
 
@@ -180,7 +186,10 @@
 	function m.stringProperty(def)
 		p.push('<StringProperty')
 		m.baseProperty(def)
-		p.w('Switch="%s" />', def.switch or "[value]")
+		if def.switch then
+			p.w('Switch="%s"', def.switch)
+		end
+		p.w(' />')
 		p.pop()
 	end
 
@@ -188,8 +197,13 @@
 	function m.stringListProperty(def)
 		p.push('<StringListProperty')
 		m.baseProperty(def)
-		p.w('Separator="%s"', def.separator or " ")
-		p.w('Switch="%s" />', def.switch or "[value]")
+		if def.separator then
+			p.w('Separator="%s"', def.separator)
+		end
+		if def.switch then
+			p.w('Switch="%s"', def.switch)
+		end
+		p.w(' />')
 		p.pop()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_rule_xml.lua
+++ b/tests/actions/vstudio/vc2010/test_rule_xml.lua
@@ -34,7 +34,7 @@
 -- Property definitions
 ---
 
-	function suite.properties_onString()
+	function suite.properties_onStringNoSwitch()
 		createVar { name="MyVar", kind="string" }
 		local r = test.getRule("MyRule")
 		m.properties(r)
@@ -43,7 +43,21 @@
 	Name="MyVar"
 	HelpContext="0"
 	DisplayName="MyVar"
-	Switch="[value]" />
+	/>
+		]]
+	end
+
+	function suite.properties_onString()
+		createVar { name="MyVar", kind="string", switch="[value]" }
+		local r = test.getRule("MyRule")
+		m.properties(r)
+		test.capture [[
+<StringProperty
+	Name="MyVar"
+	HelpContext="0"
+	DisplayName="MyVar"
+	Switch="[value]"
+	/>
 		]]
 	end
 
@@ -56,6 +70,112 @@
 	Name="MyVar"
 	HelpContext="0"
 	DisplayName="MyVar"
-	Switch="[value]" />
+	/>
+		]]
+	end
+
+
+	function suite.properties_onBooleanNoSwitch()
+		createVar { name="MyVar", kind="boolean" }
+		local r = test.getRule("MyRule")
+		m.properties(r)
+		test.capture [[
+<BoolProperty
+	Name="MyVar"
+	HelpContext="0"
+	DisplayName="MyVar"
+	/>
+		]]
+	end
+
+	function suite.properties_onBoolean()
+		createVar { name="MyVar", kind="boolean", switch="[value]" }
+		local r = test.getRule("MyRule")
+		m.properties(r)
+		test.capture [[
+<BoolProperty
+	Name="MyVar"
+	HelpContext="0"
+	DisplayName="MyVar"
+	Switch="[value]"
+	/>
+		]]
+	end
+
+	function suite.properties_onEnum()
+		createVar {
+			name = "OptimizationLevel",
+			display = "Optimization Level",
+			values = {
+				[0] = "None",
+				[1] = "Size",
+				[2] = "Speed",
+			},
+			switch = {
+				[0] = "-O0",
+				[1] = "-O1",
+				[2] = "-O3",
+			},
+			value = 2,
+		}
+
+		local r = test.getRule("MyRule")
+		m.properties(r)
+		test.capture [[
+<EnumProperty
+	Name="OptimizationLevel"
+	HelpContext="0"
+	DisplayName="Optimization Level">
+	<EnumValue
+		Name="0"
+		DisplayName="None"
+		Switch="-O0"
+		/>
+	<EnumValue
+		Name="1"
+		DisplayName="Size"
+		Switch="-O1"
+		/>
+	<EnumValue
+		Name="2"
+		DisplayName="Speed"
+		Switch="-O3"
+		/>
+</EnumProperty>
+		]]
+	end
+
+	function suite.properties_onEnumNoSwitches()
+		createVar {
+			name = "OptimizationLevel",
+			display = "Optimization Level",
+			values = {
+				[0] = "None",
+				[1] = "Size",
+				[2] = "Speed",
+			},
+			value = 2,
+		}
+
+		local r = test.getRule("MyRule")
+		m.properties(r)
+		test.capture [[
+<EnumProperty
+	Name="OptimizationLevel"
+	HelpContext="0"
+	DisplayName="Optimization Level">
+	<EnumValue
+		Name="0"
+		DisplayName="None"
+		/>
+	<EnumValue
+		Name="1"
+		DisplayName="Size"
+		/>
+	<EnumValue
+		Name="2"
+		DisplayName="Speed"
+		/>
+</EnumProperty>
 		]]
 	end


### PR DESCRIPTION
This is a workaround for a bug in msbuild, kind of hard to explain without the source for msbuild next to it.