### PR TITLE
Added C90 and C99 flags to gcc

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -196,7 +196,7 @@
 		end
 
 		local toolset = m.getcompiler(cfg)
-		local cxxflags = table.concat(table.join(toolset.getcflags(cfg), toolset.getcxxflags(cfg), cfg.buildoptions), ";")
+		local cxxflags = table.concat(table.join(toolset.getcxxflags(cfg), cfg.buildoptions), ";")
 		local cflags   = table.concat(table.join(toolset.getcflags(cfg), cfg.buildoptions), ";")
 		local asmflags = ""
 		local pch      = ""

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -503,6 +503,8 @@
 			"WPF",
 			"C++11",
 			"C++14",
+			"C90",
+			"C99",
 		},
 		aliases = {
 			FatalWarnings = { "FatalWarnings", "FatalCompileWarnings", "FatalLinkWarnings" },

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -337,7 +337,7 @@
 
 
 	function make.cxxFlags(cfg, toolset)
-		_p('  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CFLAGS)%s', make.list(toolset.getcxxflags(cfg)))
+		_p('  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS)%s', make.list(table.join(toolset.getcxxflags(cfg), cfg.buildoptions)))
 	end
 
 

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -41,11 +41,11 @@
 --    An array of C compiler flags.
 --
 
-	clang.cflags = {
-		architecture = gcc.cflags.architecture,
-		flags = gcc.cflags.flags,
-		floatingpoint = gcc.cflags.floatingpoint,
-		strictaliasing = gcc.cflags.strictaliasing,
+	clang.shared = {
+		architecture = gcc.shared.architecture,
+		flags = gcc.shared.flags,
+		floatingpoint = gcc.shared.floatingpoint,
+		strictaliasing = gcc.shared.strictaliasing,
 		optimize = {
 			Off = "-O0",
 			On = "-O2",
@@ -54,18 +54,21 @@
 			Size = "-Os",
 			Speed = "-O3",
 		},
-		pic = gcc.cflags.pic,
-		vectorextensions = gcc.cflags.vectorextensions,
-		warnings = gcc.cflags.warnings,
-		symbols = gcc.cflags.symbols
+		pic = gcc.shared.pic,
+		vectorextensions = gcc.shared.vectorextensions,
+		warnings = gcc.shared.warnings,
+		symbols = gcc.shared.symbols
 	}
 
 	function clang.getcflags(cfg)
+		local shared_flags = config.mapFlags(cfg, clang.shared)
 
-		local flags = config.mapFlags(cfg, clang.cflags)
+		-- Just pass through to GCC for now
+		local cflags = config.mapFlags(cfg, gcc.cflags)
+
+		local flags = table.join(shared_flags, cflags)
 		flags = table.join(flags, clang.getwarnings(cfg))
 		return flags
-
 	end
 
 	function clang.getwarnings(cfg)
@@ -88,11 +91,14 @@
 --
 
 	function clang.getcxxflags(cfg)
+		local shared_flags = config.mapFlags(cfg, clang.shared)
 
 		-- Just pass through to GCC for now
-		local flags = gcc.getcxxflags(cfg)
-		return flags
+		local cxxflags = config.mapFlags(cfg, gcc.cxxflags)
 
+		local flags = table.join(shared_flags, cxxflags)
+		flags = table.join(flags, clang.getwarnings(cfg))
+		return flags
 	end
 
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -34,8 +34,7 @@
 --
 -- Returns list of C compiler flags for a configuration.
 --
-
-	gcc.cflags = {
+	gcc.shared = {
 		architecture = {
 			x86 = "-m32",
 			x86_64 = "-m64",
@@ -86,8 +85,17 @@
 		}
 	}
 
+	gcc.cflags = {
+		flags = {
+			["C90"] = "-std=gnu90",
+			["C99"] = "-std=gnu99",
+		},
+	}
+
 	function gcc.getcflags(cfg)
-		local flags = config.mapFlags(cfg, gcc.cflags)
+		local shared_flags = config.mapFlags(cfg, gcc.shared)
+		local cflags = config.mapFlags(cfg, gcc.cflags)
+		local flags = table.join(shared_flags, cflags)
 		flags = table.join(flags, gcc.getwarnings(cfg))
 		return flags
 	end
@@ -126,7 +134,10 @@
 	}
 
 	function gcc.getcxxflags(cfg)
-		local flags = config.mapFlags(cfg, gcc.cxxflags)
+		local shared_flags = config.mapFlags(cfg, gcc.shared)
+		local cxxflags = config.mapFlags(cfg, gcc.cxxflags)
+		local flags = table.join(shared_flags, cxxflags)
+		flags = table.join(flags, gcc.getwarnings(cfg))
 		return flags
 	end
 
@@ -192,7 +203,7 @@
 	end
 
 --
--- Return a list of decorated rpaths 
+-- Return a list of decorated rpaths
 --
 
 	function gcc.getrunpathdirs(cfg, dirs)
@@ -386,7 +397,7 @@
 					return ptrn == string.sub(s, -string.len(ptrn))
 				end
 				local name = path.getname(link)
-				-- Check whether link mode decorator is present 
+				-- Check whether link mode decorator is present
 				if endswith(name, ":static") then
 					name = string.sub(name, 0, -8)
 					table.insert(static_syslibs, "-l" .. name)


### PR DESCRIPTION
We needed to build our project for c99.
I saw that C++11 & C++14 was already addded as flags, so why not adding C90 & C99 as well..

Explanation about the other changes:
1. In make_cpp.lua: make.cxxFlags(cfg, toolset) which generates the ALL_CXXFLAGS makefile variable, $(ALL_CFLAGS) should not be there as these are specific flags for C files only. On the other hand $(ALL_CPPFLAGS) should be there and wasn't. In our case there could be a project with .c and .cpp files and -std=c99 can't co-exist with -std=c++14.
2. To support this split, in gcc.lua I split gcc.cflags to 2 tables: gcc.shared and gcc.cflags.
gcc.getcflags() will return shared flags, c flags and warnings.
gcc.getcxxflags() will return shared flags, c++ flags and warnings.

Currently only 1 test in the codelite module tests fails, would appreciate if anyone can help with that . :-)
@mindw
@alzix

