### PR TITLE
Add `softrequire()`

### DIFF
--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -95,10 +95,14 @@
 ---
 
 	function softrequire(modname, versions)
+		local loaded = table.shallowcopy(package.loaded)
+
 		local ok, mod = pcall(require, modname, versions)
+
 		if ok then
 			return mod
 		else
+			package.loaded = loaded
 			return nil
 		end
 	end

--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -4,6 +4,8 @@
 -- Copyright (c) 2002-2014 Jason Perkins and the Premake project
 --
 
+	local p = premake
+
 
 --
 -- Find and execute a Lua source file present on the filesystem, but
@@ -48,7 +50,7 @@
 	io._includedFiles = {}
 
 	function include(fname)
-		local fullPath = premake.findProjectScript(fname)
+		local fullPath = p.findProjectScript(fname)
 		fname = fullPath or fname
 		if not io._includedFiles[fname] then
 			io._includedFiles[fname] = true
@@ -73,14 +75,30 @@
 --    global package.loaded table.
 ---
 
-	premake.override(_G, "require", function(base, modname, versions)
-		local result, mod = pcall(base,modname)
-		if not result then
-			error( mod, 3 )
+	p.override(_G, "require", function(base, modname, versions)
+		local ok, mod = pcall(base, modname)
+		if not ok then
+			error(mod, 3)
 		end
-		if mod and versions and not premake.checkVersion(mod._VERSION, versions) then
+
+		if mod and versions and not p.checkVersion(mod._VERSION, versions) then
 			error(string.format("module %s %s does not meet version criteria %s",
 				modname, mod._VERSION or "(none)", versions), 3)
 		end
+
 		return mod
 	end)
+
+
+---
+-- Returns the specified module if it exists, or `nil` otherwise.
+---
+
+	function softrequire(modname, versions)
+		local ok, mod = pcall(require, modname, versions)
+		if ok then
+			return mod
+		else
+			return nil
+		end
+	end

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -13,6 +13,7 @@ return {
 	"base/test_override.lua",
 	"base/test_path.lua",
 	"base/test_premake_command.lua",
+	"base/test_softrequire.lua",
 	"base/test_table.lua",
 	"base/test_tree.lua",
 	"base/test_uuid.lua",

--- a/tests/base/test_softrequire.lua
+++ b/tests/base/test_softrequire.lua
@@ -6,13 +6,29 @@
 
 	local suite = test.declare("base_softrequire")
 
+	local TEST_MODULE = {
+		_VERSION = "5.0"
+	}
+
+
+	function suite.setup()
+		package.preload.TEST_MODULE = function()
+			return TEST_MODULE
+		end
+	end
+
+	function suite.teardown()
+		package.loaded.TEST_MODULE = nil
+		package.preload.TEST_MODULE = nil
+	end
+
 
 ---
 -- Soft require of existing module should return the module.
 ---
 
 	function suite.returnsModule_onExistingModule()
-		test.isnotnil(softrequire("self-test"))
+		test.isnotnil(softrequire("TEST_MODULE"))
 	end
 
 
@@ -22,4 +38,34 @@
 
 	function suite.returnsNil_onMissingModule()
 		test.isnil(softrequire("no-such-module"))
+	end
+
+
+---
+-- Soft require should be nil on a version mismatch.
+---
+
+	function suite.returnsNil_onVersionMismatch()
+		test.isnil(softrequire("TEST_MODULE", "^1.0"))
+	end
+
+
+---
+-- If module was not loaded, should still not be loaded after version mismatch.
+---
+
+	function suite.leavesModuleUnloaded_onVersionMismatch()
+		softrequire("TEST_MODULE", "^1.0")
+		test.isnil(package.loaded.TEST_MODULE)
+	end
+
+
+---
+-- If module was loaded, should still be loaded after version mismatch.
+---
+
+	function suite.leavesModuleLoaded_onVersionMismatch()
+		package.loaded.TEST_MODULE = TEST_MODULE
+		softrequire("self-test", "^1.0")
+		test.isequal(TEST_MODULE, package.loaded.TEST_MODULE)
 	end

--- a/tests/base/test_softrequire.lua
+++ b/tests/base/test_softrequire.lua
@@ -1,0 +1,25 @@
+---
+-- tests/base/test_softrequire.lua
+-- Test optional module loading.
+-- Copyright (c) 2016 Jason Perkins and the Premake project
+---
+
+	local suite = test.declare("base_softrequire")
+
+
+---
+-- Soft require of existing module should return the module.
+---
+
+	function suite.returnsModule_onExistingModule()
+		test.isnotnil(softrequire("self-test"))
+	end
+
+
+---
+-- Soft require of non-existent module should return nil.
+---
+
+	function suite.returnsNil_onMissingModule()
+		test.isnil(softrequire("no-such-module"))
+	end


### PR DESCRIPTION
Behaves just like the existing `require()` call, but returns `nil` if the module does not exist instead of raising an error.