### PR TITLE
Add NoLinkObjects flag

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -478,7 +478,6 @@
 			"NoImplicitLink",
 			"NoImportLib",
 			"NoIncrementalLink",
-			"NoLinkObjects",
 			"NoManifest",
 			"NoMinimalRebuild",
 			"NoNativeWChar",       -- DEPRECATED
@@ -700,6 +699,12 @@
 		scope = "config",
 		kind = "list:directory",
 		tokens = true,
+	}
+
+	api.register {
+		name = "linkbuildoutputs",
+		scope = "config",
+		kind = "boolean"
 	}
 
 	api.register {

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -478,6 +478,7 @@
 			"NoImplicitLink",
 			"NoImportLib",
 			"NoIncrementalLink",
+			"NoLinkObjects",
 			"NoManifest",
 			"NoMinimalRebuild",
 			"NoNativeWChar",       -- DEPRECATED

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -257,12 +257,8 @@
 					for cfg in project.eachconfig(prj) do
 						local filecfg = incfg[cfg]
 						if filecfg then
-							-- If the custom build outputs an object file, we
-							-- add it to the link step automatically to match
-							-- Visual Studio. This behaviour can be turned off
-							-- by specifying the NoLinkObjects flag.
 							local output = project.getrelative(prj, filecfg.buildoutputs[1])
-							if path.isobjectfile(output) and not filecfg.flags.NoLinkObjects then
+							if path.isobjectfile(output) and (filecfg.linkbuildoutputs == true or filecfg.linkbuildoutputs == nil) then
 								table.insert(configs[cfg].objects, output)
 							else
 								table.insert(configs[cfg].customfiles, output)

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -257,10 +257,12 @@
 					for cfg in project.eachconfig(prj) do
 						local filecfg = incfg[cfg]
 						if filecfg then
-							-- if the custom build outputs an object file, add it to
-							-- the link step automatically to match Visual Studio
+							-- If the custom build outputs an object file, we
+							-- add it to the link step automatically to match
+							-- Visual Studio. This behaviour can be turned off
+							-- by specifying the NoLinkObjects flag.
 							local output = project.getrelative(prj, filecfg.buildoutputs[1])
-							if path.isobjectfile(output) then
+							if path.isobjectfile(output) and not filecfg.flags.NoLinkObjects then
 								table.insert(configs[cfg].objects, output)
 							else
 								table.insert(configs[cfg].customfiles, output)

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1106,8 +1106,8 @@
 
 
 	function m.linkObjects(fcfg, condition)
-		if fcfg.linkbuildoutputs == false then
-			m.element("LinkObjects", condition, "false")
+		if fcfg.linkbuildoutputs ~= nil then
+			m.element("LinkObjects", condition, tostring(fcfg.linkbuildoutputs))
 		end
 	end
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -719,6 +719,7 @@
 				m.excludedFromBuild,
 				m.buildCommands,
 				m.buildOutputs,
+				m.linkObjects,
 				m.buildMessage,
 				m.buildAdditionalInputs
 			}
@@ -1101,6 +1102,13 @@
 	function m.buildOutputs(fcfg, condition)
 		local outputs = project.getrelative(fcfg.project, fcfg.buildoutputs)
 		m.element("Outputs", condition, '%s', table.concat(outputs, ";"))
+	end
+
+
+	function m.linkObjects(fcfg, condition)
+		if fcfg.flags.NoLinkObjects then
+			m.element("LinkObjects", condition, 'false')
+		end
 	end
 
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1106,8 +1106,8 @@
 
 
 	function m.linkObjects(fcfg, condition)
-		if fcfg.flags.NoLinkObjects then
-			m.element("LinkObjects", condition, 'false')
+		if fcfg.linkbuildoutputs == false then
+			m.element("LinkObjects", condition, "false")
 		end
 	end
 

--- a/tests/actions/make/cpp/test_objects.lua
+++ b/tests/actions/make/cpp/test_objects.lua
@@ -110,7 +110,7 @@ OBJECTS := \
 -- link automatically to match the behavior of Visual Studio
 --
 
-	function suite.customBuildRule()
+	function suite.linkBuildOutputs_onNotSpecified()
 		files { "hello.x" }
 		filter "files:**.x"
 			buildmessage "Compiling %{file.name}"
@@ -129,6 +129,72 @@ CUSTOMFILES := \
 
 ifeq ($(config),debug)
   OBJECTS += \
+	obj/Debug/hello.obj \
+
+endif
+
+		]]
+	end
+
+
+--
+-- Also include it in the link step if we explicitly specified so with
+-- linkbuildoutputs.
+--
+
+	function suite.linkBuildOutputs_onOn()
+		files { "hello.x" }
+		filter "files:**.x"
+			buildmessage "Compiling %{file.name}"
+			buildcommands {
+				'cxc -c "%{file.path}" -o "%{cfg.objdir}/%{file.basename}.xo"',
+				'c2o -c "%{cfg.objdir}/%{file.basename}.xo" -o "%{cfg.objdir}/%{file.basename}.obj"'
+			}
+			buildoutputs { "%{cfg.objdir}/%{file.basename}.obj" }
+			linkbuildoutputs "On"
+		prepare()
+		test.capture [[
+OBJECTS := \
+
+RESOURCES := \
+
+CUSTOMFILES := \
+
+ifeq ($(config),debug)
+  OBJECTS += \
+	obj/Debug/hello.obj \
+
+endif
+
+		]]
+	end
+
+
+--
+-- If linkbuildoutputs says that we shouldn't include it in the link however,
+-- don't do it.
+--
+
+	function suite.linkBuildOutputs_onOff()
+		files { "hello.x" }
+		filter "files:**.x"
+			buildmessage "Compiling %{file.name}"
+			buildcommands {
+				'cxc -c "%{file.path}" -o "%{cfg.objdir}/%{file.basename}.xo"',
+				'c2o -c "%{cfg.objdir}/%{file.basename}.xo" -o "%{cfg.objdir}/%{file.basename}.obj"'
+			}
+			buildoutputs { "%{cfg.objdir}/%{file.basename}.obj" }
+			linkbuildoutputs "Off"
+		prepare()
+		test.capture [[
+OBJECTS := \
+
+RESOURCES := \
+
+CUSTOMFILES := \
+
+ifeq ($(config),debug)
+  CUSTOMFILES += \
 	obj/Debug/hello.obj \
 
 endif

--- a/tests/actions/vstudio/vc2010/test_files.lua
+++ b/tests/actions/vstudio/vc2010/test_files.lua
@@ -334,6 +334,75 @@
 
 
 --
+-- If a custom rule outputs an object file, it's automatically linked, unless
+-- we explicitly specify that it isn't with linkbuildoutputs.
+--
+
+	function suite.linkBuildOutputs_onNotSpecified()
+		files { "hello.x" }
+		filter "files:**.x"
+			buildcommands { "echo $(InputFile)" }
+			buildoutputs { "$(InputName).obj" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<CustomBuild Include="hello.x">
+		<FileType>Document</FileType>
+		<Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">echo $(InputFile)</Command>
+		<Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(InputName).obj</Outputs>
+		<Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo $(InputFile)</Command>
+		<Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(InputName).obj</Outputs>
+	</CustomBuild>
+</ItemGroup>
+		]]
+	end
+
+	function suite.linkBuildOutputs_onOff()
+		files { "hello.x" }
+		filter "files:**.x"
+			buildcommands { "echo $(InputFile)" }
+			buildoutputs { "$(InputName).obj" }
+			linkbuildoutputs "Off"
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<CustomBuild Include="hello.x">
+		<FileType>Document</FileType>
+		<Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">echo $(InputFile)</Command>
+		<Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(InputName).obj</Outputs>
+		<LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</LinkObjects>
+		<Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo $(InputFile)</Command>
+		<Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(InputName).obj</Outputs>
+		<LinkObjects Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkObjects>
+	</CustomBuild>
+</ItemGroup>
+		]]
+	end
+
+	function suite.linkBuildOutputs_onOn()
+		files { "hello.x" }
+		filter "files:**.x"
+			buildcommands { "echo $(InputFile)" }
+			buildoutputs { "$(InputName).obj" }
+			linkbuildoutputs "On"
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<CustomBuild Include="hello.x">
+		<FileType>Document</FileType>
+		<Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">echo $(InputFile)</Command>
+		<Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(InputName).obj</Outputs>
+		<LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkObjects>
+		<Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo $(InputFile)</Command>
+		<Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(InputName).obj</Outputs>
+		<LinkObjects Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</LinkObjects>
+	</CustomBuild>
+</ItemGroup>
+		]]
+	end
+
+
+--
 -- If two files at different folder levels have the same name, a different
 -- object file name should be used for each.
 --


### PR DESCRIPTION
The default behaviour for the Visual Studio and Makefile exporters is to link .obj files if a custom build command outputs them. There are some cases where we don't want this to happen, such as when dealing with Wavefront .obj model files.

I ran into this problem when trying to copy model files around with custom build commands:

```lua
filter "**/models/**.obj"

	-- Copy these files into the target directory while preserving the folder
	-- structure.

	buildcommands
	{
		os.translateCommands "{mkdir} \"%{ path.join(cfg.buildtarget.directory, path.getdirectory(file.relpath)) }\"",
		os.translateCommands "{copy} \"%{ file.relpath }\" \"%{ path.join(cfg.buildtarget.directory, path.getdirectory(file.relpath)) }\""
	}

	buildoutputs "%{ path.join(cfg.buildtarget.directory, file.relpath) }"
```

The linker would try to link these files, resulting in a build error. This can now be solved by specifying the new NoLinkObjects flag for these files:

```lua
filter "**/models/**.obj"

	flags "NoLinkObjects"
````

Please let me know if there's anything that I missed or anything that needs changing.