### PR TITLE
Default rule variables to string when `kind` is not set

### DIFF
--- a/src/actions/vstudio/vs2010_rules_xml.lua
+++ b/src/actions/vstudio/vs2010_rules_xml.lua
@@ -119,7 +119,7 @@
 				m.stringListProperty(def)
 			elseif type(def.values) == "table" then
 				m.enumProperty(def)
-			elseif def.kind:startswith("list:") then
+			elseif def.kind and def.kind:startswith("list:") then
 				m.stringListProperty(def)
 			else
 				m.stringProperty(def)

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -136,6 +136,7 @@ return {
 	"actions/vstudio/vc2010/test_rule_props.lua",
 	"actions/vstudio/vc2010/test_rule_targets.lua",
 	"actions/vstudio/vc2010/test_rule_vars.lua",
+	"actions/vstudio/vc2010/test_rule_xml.lua",
 	"actions/vstudio/vc2010/test_target_machine.lua",
 	"actions/vstudio/vc2010/test_user_file.lua",
 	"actions/vstudio/vc2010/test_vectorextensions.lua",

--- a/tests/actions/vstudio/vc2010/test_rule_xml.lua
+++ b/tests/actions/vstudio/vc2010/test_rule_xml.lua
@@ -1,0 +1,61 @@
+--
+-- tests/actions/vstudio/vc2010/test_rule_xml.lua
+-- Validate generation of custom rules
+-- Author Jason Perkins
+-- Copyright (c) 2016 Jason Perkins and the Premake project
+--
+
+	local suite = test.declare("vstudio_vs2010_rule_xml")
+
+	local vc2010 = premake.vstudio.vc2010
+	local m = premake.vstudio.vs2010.rules.xml
+
+
+--
+-- Setup
+--
+
+	function suite.setup()
+		premake.action.set("vs2010")
+		rule "MyRule"
+		wks, prj = test.createWorkspace()
+		rules { "MyRule" }
+	end
+
+	local function createVar(def)
+		rule "MyRule"
+		propertydefinition(def)
+		project "MyProject"
+	end
+
+
+
+---
+-- Property definitions
+---
+
+	function suite.properties_onString()
+		createVar { name="MyVar", kind="string" }
+		local r = test.getRule("MyRule")
+		m.properties(r)
+		test.capture [[
+<StringProperty
+	Name="MyVar"
+	HelpContext="0"
+	DisplayName="MyVar"
+	Switch="[value]" />
+		]]
+	end
+
+	function suite.properties_onStringWithNoKind()
+		createVar { name="MyVar" }
+		local r = test.getRule("MyRule")
+		m.properties(r)
+		test.capture [[
+<StringProperty
+	Name="MyVar"
+	HelpContext="0"
+	DisplayName="MyVar"
+	Switch="[value]" />
+		]]
+	end


### PR DESCRIPTION
Because this is the most common case, we've been treating variables with no `kind` as an implicit string value. This maintains the previous behavior with the latest changes.