### PR TITLE
Makefile generation - Don't force serial compilation for all projects

### DIFF
--- a/src/actions/make/_make.lua
+++ b/src/actions/make/_make.lua
@@ -144,8 +144,19 @@
 		_p('')
 
 		if kind == "workspace" then
-			_p('.NOTPARALLEL:')
-			_p('')
+			local haspch = false
+			for _, prj in ipairs(target.projects) do
+				for cfg in project.eachconfig(prj) do
+					if cfg.pchheader then
+						haspch = true
+					end
+				end
+			end
+
+			if haspch then
+				_p('.NOTPARALLEL:')
+				_p('')
+			end
 		end
 
 		make.defaultconfig(target)


### PR DESCRIPTION
Only restrict parallel compilation when using precompiled
headers. Currently, the generated makefile has a `.NOTPARALLEL`
target, which means that make will ignore parallel builds, even
for projects which can build in parallel just fine.