### PR TITLE
Fix MSC flags broken by PR #623

### DIFF
--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -387,3 +387,19 @@
 		test.contains('/NODEFAULTLIB:lib1.lib', msc.getldflags(cfg))
 	end
 
+
+--
+-- Check handling of shared C/C++ flags.
+--
+
+	function suite.mixedToolFlags_onCFlags()
+		flags { "FatalCompileWarnings" }
+		prepare()
+		test.isequal({ "/WX", "/MD" }, msc.getcflags(cfg))
+	end
+
+	function suite.mixedToolFlags_onCxxFlags()
+		flags { "FatalCompileWarnings" }
+		prepare()
+		test.isequal({ "/WX", "/MD", "/EHsc" }, msc.getcxxflags(cfg))
+	end


### PR DESCRIPTION
Adjust the MSC tool adapter to behave the same way as the latest GCC and Clang adapters. Now uses a separate table of shared C/C++ command flags.