### PR TITLE
Fix VS'15 <GenerateDebugInformation> to match Update 3

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -391,12 +391,14 @@
 		if cfg.kind == p.STATICLIB then
 			return {
 				m.subSystem,
+				m.fullProgramDatabaseFile,
 				m.generateDebugInformation,
 				m.optimizeReferences,
 			}
 		else
 			return {
 				m.subSystem,
+				m.fullProgramDatabaseFile,
 				m.generateDebugInformation,
 				m.optimizeReferences,
 				m.additionalDependencies,
@@ -1294,6 +1296,7 @@
 		end
 	end
 
+
 	function m.inlineFunctionExpansion(cfg)
 		if cfg.inlining then
 			local types = {
@@ -1305,6 +1308,7 @@
 			m.element("InlineFunctionExpansion", nil, types[cfg.inlining])
 		end
 	end
+
 
 	function m.forceIncludes(cfg, condition)
 		if #cfg.forceincludes > 0 then
@@ -1322,6 +1326,13 @@
 	end
 
 
+	function m.fullProgramDatabaseFile(cfg)
+		if _ACTION >= "vs2015" and cfg.symbols == "FastLink" then
+			m.element("FullProgramDatabaseFile", nil, "true")
+		end
+	end
+
+
 	function m.functionLevelLinking(cfg)
 		if config.isOptimizedBuild(cfg) then
 			m.element("FunctionLevelLinking", nil, "true")
@@ -1332,13 +1343,9 @@
 	function m.generateDebugInformation(cfg)
 		local lookup = {}
 		if _ACTION >= "vs2015" then
-			lookup[p.ON]       = "Debug"
-			lookup[p.OFF]      = "No"
+			lookup[p.ON]       = "true"
+			lookup[p.OFF]      = "false"
 			lookup["FastLink"] = "DebugFastLink"
-
-			if cfg.symbols == "FastLink" then
-				m.element("FullProgramDatabaseFile", nil, "true")
-			end
 		else
 			lookup[p.ON]       = "true"
 			lookup[p.OFF]      = "false"

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -129,13 +129,48 @@
 -- Test the handling of the Symbols flag.
 --
 
-	function suite.generateDebugInfo_onSymbols()
+	function suite.generateDebugInfo_onSymbolsOn_on2010()
+		premake.action.set("vs2010")
 		symbols "On"
 		prepare()
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
 	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsFastLink_on2010()
+		premake.action.set("vs2010")
+		symbols "FastLink"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsOn_on2015()
+		premake.action.set("vs2015")
+		symbols "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsFastLink_on2015()
+		premake.action.set("vs2015")
+		symbols "FastLink"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<FullProgramDatabaseFile>true</FullProgramDatabaseFile>
+	<GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
 		]]
 	end
 


### PR DESCRIPTION
As of VS'15 Update 3, the correct values for <GenerateDebugInformation> are "true", "false", and "DebugFastLink". Previous of versions defaulted this element to "true", but would change it to "Debug" is set via the property page; that's been fixed in Update 3. The use of "true" and "false" is compatible with the earlier versions of VS'15.