### PR TITLE
Add MSBuild target to Bootstrap.mak

### DIFF
--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -65,10 +65,15 @@ linux: $(SRC)
 	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN`
 
-windows: $(SRC)
+windows-base: $(SRC)
 	if not exist build\bootstrap (mkdir build\bootstrap)
 	cl /Fo.\build\bootstrap\ /Fe.\build\bootstrap\premake_bootstrap.exe /DPREMAKE_NO_BUILTIN_SCRIPTS /I"$(LUA_DIR)" user32.lib ole32.lib $**
 	.\build\bootstrap\premake_bootstrap.exe embed
 	.\build\bootstrap\premake_bootstrap --to=build/bootstrap $(MSDEV)
+
+windows: windows-base
 	devenv .\build\bootstrap\Premake5.sln /Upgrade
 	devenv .\build\bootstrap\Premake5.sln /Build Release
+
+windows-msbuild: windows-base
+	msbuild /p:Configuration=Release .\build\bootstrap\Premake5.sln


### PR DESCRIPTION
As I [mentioned](https://github.com/premake/premake-core/issues/578) a while ago, Bootstrap.mak will not directly work when no full VS install is present.

This attempts to resolve said issue by adding a separate target (`windows-msbuild`) to the Makefile.

Another solution would be to handle upgrade behavior based on the MSDEV variable and use `msbuild` to build in all cases, but this would break (or require conditions, and I'm not too sure how well cross-platform Makefiles like those) for VS2008< which use VCBuild project files rather than the VS2010+ MSBuild .vcxproj w/ toolset configuration, and might potentially cause different behavior for build processes relying on the current `windows` target.

For VS2010+, there is no functional difference between binaries built by either method (except not specifying an explicit MSDEV argument will default to `v110` due to the vs2012 toolchain setting - and these will not be upgraded) as `devenv /Build` will dispatch to MSBuild for these projects anyway (though handling solution parsing internally, rather than using MSBuild compatibility behavior).