### PR TITLE
Fix bugs introduced by shared compiler flags

### DIFF
--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -822,7 +822,7 @@
 
 
 	function m.additionalExternalCompilerOptions(cfg, toolset)
-		local buildoptions = table.join(toolset.getcflags(cfg), toolset.getcxxflags(cfg), cfg.buildoptions)
+		local buildoptions = table.join(toolset.getcxxflags(cfg), cfg.buildoptions)
 		if not cfg.flags.NoPCH and cfg.pchheader then
 			table.insert(buildoptions, '--use_pch="$(IntDir)/$(TargetName).pch"')
 		end

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -60,22 +60,21 @@
 		symbols = gcc.shared.symbols
 	}
 
+	clang.cflags = table.merge(gcc.cflags, {
+	})
+
 	function clang.getcflags(cfg)
-		local shared_flags = config.mapFlags(cfg, clang.shared)
+		local shared = config.mapFlags(cfg, clang.shared)
+		local cflags = config.mapFlags(cfg, clang.cflags)
 
-		-- Just pass through to GCC for now
-		local cflags = config.mapFlags(cfg, gcc.cflags)
-
-		local flags = table.join(shared_flags, cflags)
+		local flags = table.join(shared, cflags)
 		flags = table.join(flags, clang.getwarnings(cfg))
+
 		return flags
 	end
 
 	function clang.getwarnings(cfg)
-
-		-- Just pass through to GCC for now
 		return gcc.getwarnings(cfg)
-
 	end
 
 
@@ -90,13 +89,13 @@
 --    An array of C++ compiler flags.
 --
 
+	clang.cxxflags = table.merge(gcc.cxxflags, {
+	})
+
 	function clang.getcxxflags(cfg)
-		local shared_flags = config.mapFlags(cfg, clang.shared)
-
-		-- Just pass through to GCC for now
-		local cxxflags = config.mapFlags(cfg, gcc.cxxflags)
-
-		local flags = table.join(shared_flags, cxxflags)
+		local shared = config.mapFlags(cfg, clang.shared)
+		local cxxflags = config.mapFlags(cfg, clang.cxxflags)
+		local flags = table.join(shared, cxxflags)
 		flags = table.join(flags, clang.getwarnings(cfg))
 		return flags
 	end

--- a/src/tools/snc.lua
+++ b/src/tools/snc.lua
@@ -1,20 +1,21 @@
 --
 -- snc.lua
 -- Provides Sony SNC-specific configuration strings.
--- Copyright (c) 2010-2012 Jason Perkins and the Premake project
+-- Copyright (c) 2010-2016 Jason Perkins and the Premake project
 --
 
-	premake.tools.snc = {}
-	local snc = premake.tools.snc
-	local gcc = premake.tools.gcc
-	local config = premake.config
+	local p = premake
+
+	p.tools.snc = {}
+	local snc = p.tools.snc
+	local gcc = p.tools.gcc
 
 
 --
 -- Retrieve the CFLAGS for a specific configuration.
 --
 
-	snc.cflags = {
+	snc.shared = {
 		flags = {
 			FatalCompileWarnings = "-Xquit=2",
 		},
@@ -31,8 +32,13 @@
 		}
 	}
 
+	snc.cflags = {
+	}
+
 	function snc.getcflags(cfg)
-		local flags = config.mapFlags(cfg, snc.cflags)
+		local shared = p.config.mapFlags(cfg, snc.shared)
+		local cflags = p.config.mapFlags(cfg, snc.cflags)
+		local flags = table.join(shared, cflags, snc.getwarnings(cfg))
 		return flags
 	end
 
@@ -41,22 +47,23 @@
 -- Retrieve the CXXFLAGS for a specific configuration.
 --
 
+	snc.cxxflags = {
+		exceptionhandling = {
+			Default = "-Xc+=exceptions",
+			On = "-Xc+=exceptions",
+			SEH = "-Xc-=exceptions",
+		},
+		rtti = {
+			Default = "-Xc+=rtti",
+			On = "-Xc+=rtti",
+			SEH = "-Xc-=rtti",
+		}
+	}
+
 	function snc.getcxxflags(cfg)
-		local flags = {}
-
-		-- turn on exceptions and RTTI by default, to match other toolsets
-		if cfg.exceptionhandling == p.ON then
-			table.insert(flags, "-Xc+=exceptions")
-		elseif cfg.exceptionhandling == p.OFF then
-			table.insert(flags, "-Xc-=exceptions")
-		end
-
-		if cfg.rtti == p.ON then
-			table.insert(flags, "-Xc+=rtti")
-		elseif cfg.rtti == p.OFF then
-			table.insert(flags, "-Xc-=rtti")
-		end
-
+		local shared = config.mapFlags(cfg, snc.shared)
+		local cxxflags = config.mapFlags(cfg, snc.cxxflags)
+		local flags = table.join(shared, cxxflags, snc.getwarnings(cfg))
 		return flags
 	end
 
@@ -72,11 +79,9 @@
 --
 
 	function snc.getforceincludes(cfg)
-
 		-- Just pass through to GCC for now
 		local flags = gcc.getforceincludes(cfg)
 		return flags
-
 	end
 
 


### PR DESCRIPTION
Fix a few spots where the shared compiler flag changes (PR #623) caused things to misbehave.

- Fixed duplicate flags in VC 200x external compiler options
- Added missing C and CXX flag maps to Clang adapter
- Reworked SNC adapter to follow same shared flags approach