### PR TITLE
Fix VS mapping for `file.path` tokens

### DIFF
--- a/src/actions/vstudio/vs2010.lua
+++ b/src/actions/vstudio/vs2010.lua
@@ -31,7 +31,7 @@
 		["file.basename"]               = { absolute = false, token = "%(Filename)" },
 		["file.abspath"]                = { absolute = true,  token = "%(FullPath)" },
 		["file.relpath"]                = { absolute = false, token = "%(Identity)" },
-		["file.path"]                   = { absolute = true,  token = "%(RelativeDir)" },
+		["file.path"]                   = { absolute = true,  token = "%(Identity)" },
 	}
 
 


### PR DESCRIPTION
The `%{file.path}` token is an alias of `%{file.relpath}`, and should map to the same VS symbol. Specifically, it should be the relative path including the file name, and not just the path.