### PR TITLE
Fix out-of-date sources in the Xcode module

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -1021,6 +1021,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = MyProject;
@@ -1276,10 +1277,41 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+				USER_HEADER_SEARCH_PATHS = (
+					../include,
+					../libs,
+					"\"../name with spaces\"",
+				);
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationProject_OnSysIncludeDirs()
+		sysincludedirs { "../include", "../libs", "../name with spaces" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					../include,
 					../libs,
 					"\"../name with spaces\"",
+					"$(inherited)",
 				);
 				OBJROOT = obj/Debug;
 				ONLY_ACTIVE_ARCH = NO;
@@ -1289,7 +1321,6 @@
 		};
 		]]
 	end
-
 
 	function suite.XCBuildConfigurationProject_OnBuildOptions()
 		buildoptions { "build option 1", "build option 2" }

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -884,7 +884,7 @@
 
 		settings['ALWAYS_SEARCH_USER_PATHS'] = 'NO'
 
-		if not (cfg.symbols == p.ON) then
+		if cfg.symbols ~= p.OFF then
 			settings['DEBUG_INFORMATION_FORMAT'] = 'dwarf-with-dsym'
 		end
 
@@ -983,11 +983,17 @@
 
 		settings['CONFIGURATION_TEMP_DIR'] = '$(OBJROOT)'
 
-		if cfg.symbols == p.ON then
+		if config.isDebugBuild(cfg) then
 			settings['COPY_PHASE_STRIP'] = 'NO'
 		end
 
 		settings['GCC_C_LANGUAGE_STANDARD'] = 'gnu99'
+
+		if cfg.flags['C++14'] then
+			settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++14'
+		elseif cfg.flags['C++11'] then
+			settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++0x'
+		end
 
 		if cfg.exceptionhandling == p.OFF then
 			settings['GCC_ENABLE_CPP_EXCEPTIONS'] = 'NO'
@@ -1028,7 +1034,16 @@
 		for i,v in ipairs(includedirs) do
 			cfg.includedirs[i] = premake.quoted(v)
 		end
-		settings['HEADER_SEARCH_PATHS'] = table.join(cfg.includedirs, cfg.sysincludedirs)
+		settings['USER_HEADER_SEARCH_PATHS'] = cfg.includedirs
+
+		local sysincludedirs = project.getrelative(cfg.project, cfg.sysincludedirs)
+		for i,v in ipairs(sysincludedirs) do
+			cfg.sysincludedirs[i] = premake.quoted(v)
+		end
+		if not table.isempty(cfg.sysincludedirs) then
+			table.insert(cfg.sysincludedirs, "$(inherited)")
+		end
+		settings['HEADER_SEARCH_PATHS'] = cfg.sysincludedirs
 
 		for i,v in ipairs(cfg.libdirs) do
 			cfg.libdirs[i] = premake.project.getrelative(cfg.project, cfg.libdirs[i])


### PR DESCRIPTION
I must not have been on the latest revision when I merged the Xcode module into core. This catches things back up to the state of the submodule repository.