### PR TITLE
Fix VS2015 sln file icon

### DIFF
--- a/src/actions/vstudio/vs2015.lua
+++ b/src/actions/vstudio/vs2015.lua
@@ -65,7 +65,7 @@
 
 		vstudio = {
 			solutionVersion = "12",
-			versionName     = "2015",
+			versionName     = "14",
 			targetFramework = "4.5",
 			toolsVersion    = "14.0",
 			filterToolsVersion = "4.0",


### PR DESCRIPTION
This is a minor fix to make the correct sln file icon appear in Windows.
The Icon Handler for sln files is apparently quite picky.

VS2015 sln files contain this:
`# Visual Studio 14`

Not this:
`# Visual Studio 2015`

Having 2015 instead of 14 does not appear to cause any major issues. But
you get the generic sln file icon in Explorer instead of the
VS2015-specific one.

Test results:
.\bin\release\premake5.exe test
Running action 'test'...
1435 tests passed, 0 failed in 1.76 seconds