### PR TITLE
Remove defines and include directories "None" projects

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -216,30 +216,41 @@
 		end
 	end
 
-	function m.outputPropertiesGroup(prj)
-		for cfg in project.eachconfig(prj) do
-			m.outputProperties(cfg)
-			m.nmakeProperties(cfg)
-		end
-	end
-
-
 
 --
 -- Write the NMake property group for Makefile projects, which includes the custom
 -- build commands, output file location, etc.
 --
 
+	m.elements.nmakeProperties = function(cfg)
+		m.nmakeOutput(cfg)
+		m.nmakeCommandLine(cfg, cfg.buildcommands, "Build")
+		m.nmakeCommandLine(cfg, cfg.rebuildcommands, "ReBuild")
+		m.nmakeCommandLine(cfg, cfg.cleancommands, "Clean")
+		if cfg.kind ~= p.NONE then
+			m.nmakePreprocessorDefinitions(cfg, cfg.defines, false, nil)
+			m.nmakeIncludeDirs(cfg, cfg.includedirs)
+		end
+	end
+
 	function m.nmakeProperties(cfg)
 		if vstudio.isMakefile(cfg) then
 			m.propertyGroup(cfg)
-			m.nmakeOutput(cfg)
-			m.nmakeCommandLine(cfg, cfg.buildcommands, "Build")
-			m.nmakeCommandLine(cfg, cfg.rebuildcommands, "ReBuild")
-			m.nmakeCommandLine(cfg, cfg.cleancommands, "Clean")
-			m.nmakePreprocessorDefinitions(cfg, cfg.defines, false, nil)
-			m.nmakeIncludeDirs(cfg, cfg.includedirs)
+			p.callArray(m.elements.nmakeProperties, cfg)
 			p.pop('</PropertyGroup>')
+		end
+	end
+
+
+--
+-- The output and NMake properties should appear side-by-side, paired up
+-- for each configuration.
+--
+
+	function m.outputPropertiesGroup(prj)
+		for cfg in project.eachconfig(prj) do
+			m.outputProperties(cfg)
+			m.nmakeProperties(cfg)
 		end
 	end
 


### PR DESCRIPTION
Projects with a type of "None" do not build anything (are excluded from the build entirely, actually) and should not include these values.

I took the opportunity to also break the NMake elements out into a call array so they can be extended by modules a little more easily.