### PR TITLE
Fix premake4.lua bootstrap build script

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -17,24 +17,25 @@
 		targetname  "premake5"
 		language    "C"
 		kind        "ConsoleApp"
+		defines     { "PREMAKE_NO_BUILTIN_SCRIPTS" }
 		flags       { "No64BitChecks", "ExtraWarnings", "StaticRuntime" }
-		includedirs { "src/host/lua/src" }
+		includedirs { "contrib/lua/src" }
 
 		files
 		{
 			"*.txt", "**.lua",
-			"src/**.h", "src/**.c",
-			"src/host/scripts.c"
+			"contrib/lua/src/*.c", "contrib/lua/src/*.h",
+			"src/host/*.c"
 		}
 
 		excludes
 		{
-			"src/host/lua/src/lauxlib.c",
-			"src/host/lua/src/lua.c",
-			"src/host/lua/src/luac.c",
-			"src/host/lua/src/print.c",
-			"src/host/lua/**.lua",
-			"src/host/lua/etc/*.c"
+			"contrib/lua/src/lauxlib.c",
+			"contrib/lua/src/lua.c",
+			"contrib/lua/src/luac.c",
+			"contrib/lua/src/print.c",
+			"contrib/lua/**.lua",
+			"contrib/lua/etc/*.c"
 		}
 
 		configuration "Debug"


### PR DESCRIPTION
Fixes the premake4.lua build script with the new paths so it can be used for bootstrapping.