### PR TITLE
New Flag: WholeArchive

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -499,6 +499,7 @@
 			"UndefinedIdentifiers",
 			"Unicode",             -- DEPRECATED
 			"Unsafe",              -- DEPRECATED
+			"WholeArchive",
 			"WinMain",
 			"WPF",
 			"C++11",

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -499,7 +499,6 @@
 			"UndefinedIdentifiers",
 			"Unicode",             -- DEPRECATED
 			"Unsafe",              -- DEPRECATED
-			"WholeArchive",
 			"WinMain",
 			"WPF",
 			"C++11",
@@ -1149,6 +1148,12 @@
 			"Default",
 			"Extra",
 		}
+	}
+
+	api.register {
+		name = "wholearchive",
+		scope = "config",
+		kind = "boolean"
 	}
 
 	api.register {

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -417,8 +417,14 @@
 		if #static_syslibs > 1 then
 			table.insert(static_syslibs, "-Wl,-Bdynamic")
 			move(static_syslibs, result)
-	    end
+		end
 		move(shared_syslibs, result)
+
+		-- When WholeArchive is specified, it must be disabled following the final library
+		if cfg.flags.WholeArchive then
+			table.insert(result, 1, "-Wl,--whole-archive")
+			table.insert(result, "-Wl,--no-whole-archive")
+		end
 
 		return result
 	end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -421,7 +421,7 @@
 		move(shared_syslibs, result)
 
 		-- When WholeArchive is specified, it must be disabled following the final library
-		if cfg.flags.WholeArchive then
+		if cfg.wholearchive == true then
 			table.insert(result, 1, "-Wl,--whole-archive")
 			table.insert(result, "-Wl,--no-whole-archive")
 		end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -554,3 +554,15 @@
 		prepare()
 		test.excludes({ "-Wl,-Bstatic" }, gcc.getlinks(cfg))
 	end
+
+
+--
+-- Check whole archive linker flags
+--
+
+	function suite.linksWholeArchive()
+		links { "foo", "bar" }
+		flags "WholeArchive"
+		prepare()
+		test.contains({ "-Wl,--whole-archive", "-lfoo", "-lbar", "-Wl,--no-whole-archive" }, gcc.getlinks(cfg))
+	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -562,7 +562,7 @@
 
 	function suite.linksWholeArchive()
 		links { "foo", "bar" }
-		flags "WholeArchive"
+		wholearchive "On"
 		prepare()
 		test.contains({ "-Wl,--whole-archive", "-lfoo", "-lbar", "-Wl,--no-whole-archive" }, gcc.getlinks(cfg))
 	end


### PR DESCRIPTION
- Adds support for the GCC whole archive linker flags, which forces all symbols in libraries to be exported