### PR TITLE
Fix sporadic failures when using make -j#

### DIFF
--- a/src/actions/make/_make.lua
+++ b/src/actions/make/_make.lua
@@ -173,17 +173,20 @@
 -- it screws up the escaping of spaces and parethesis (anyone know a fix?)
 --
 
-	function make.mkdirRules(dirname)
-		_p('%s:', dirname)
-		_p('\t@echo Creating %s', dirname)
+	function make.mkdir(dirname)
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) mkdir -p %s', dirname)
 		_p('else')
 		_p('\t$(SILENT) mkdir $(subst /,\\\\,%s)', dirname)
 		_p('endif')
-		_p('')
 	end
 
+	function make.mkdirRules(dirname)
+		_p('%s:', dirname)
+		_p('\t@echo Creating %s', dirname)
+		make.mkdir(dirname)
+		_p('')
+	end
 
 --
 -- Format a list of values to be safely written as part of a variable assignment.

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -34,8 +34,6 @@
 			make.cppObjects,
 			make.shellType,
 			make.cppTargetRules,
-			make.targetDirRules,
-			make.objDirRules,
 			make.cppCleanRules,
 			make.preBuildRules,
 			make.preLinkRules,

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -153,17 +153,14 @@
 		if path.iscppfile(node.abspath) then
 			_x('$(OBJDIR)/%s.o: %s', node.objname, node.relpath)
 			_p('\t@echo $(notdir $<)')
-			_p('ifeq (posix,$(SHELLTYPE))')
-			_p('\t$(SILENT) mkdir -p "$(OBJDIR)"')
-			_p('else')
-			_p('\t$(SILENT) mkdir "$(subst /,\\\\,$(OBJDIR))"')
-			_p('endif')
+			make.mkdir('$(OBJDIR)')
 			cpp.buildcommand(prj, "o", node)
 
 		-- resource file
 		elseif path.isresourcefile(node.abspath) then
 			_x('$(OBJDIR)/%s.res: %s', node.objname, node.relpath)
 			_p('\t@echo $(notdir $<)')
+			make.mkdir('$(OBJDIR)')
 			_p('\t$(SILENT) $(RESCOMP) $< -O coff -o "$@" $(ALL_RESFLAGS)')
 		end
 	end
@@ -370,11 +367,7 @@
 	function make.cppTargetRules(prj)
 		_p('$(TARGET): $(GCH) ${CUSTOMFILES} $(OBJECTS) $(LDDEPS) $(RESOURCES)')
 		_p('\t@echo Linking %s', prj.name)
-		_p('ifeq (posix,$(SHELLTYPE))')
-		_p('\t$(SILENT) mkdir -p "$(TARGETDIR)"')
-		_p('else')
-		_p('\t$(SILENT) mkdir "$(subst /,\\\\,$(TARGETDIR))"')
-		_p('endif')
+		make.mkdir('$(TARGETDIR)')
 		_p('\t$(SILENT) $(LINKCMD)')
 		_p('\t$(POSTBUILDCMDS)')
 		_p('')

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -153,6 +153,11 @@
 		if path.iscppfile(node.abspath) then
 			_x('$(OBJDIR)/%s.o: %s', node.objname, node.relpath)
 			_p('\t@echo $(notdir $<)')
+			_p('ifeq (posix,$(SHELLTYPE))')
+			_p('\t$(SILENT) mkdir -p "$(OBJDIR)"')
+			_p('else')
+			_p('\t$(SILENT) mkdir "$(subst /,\\\\,$(OBJDIR))"')
+			_p('endif')
 			cpp.buildcommand(prj, "o", node)
 
 		-- resource file
@@ -317,13 +322,13 @@
 
 	function make.cppAllRules(cfg, toolset)
 		if cfg.system == premake.MACOSX and cfg.kind == premake.WINDOWEDAPP then
-			_p('all: $(TARGETDIR) $(OBJDIR) prebuild prelink $(TARGET) $(dir $(TARGETDIR))PkgInfo $(dir $(TARGETDIR))Info.plist')
+			_p('all: prebuild prelink $(TARGET) $(dir $(TARGETDIR))PkgInfo $(dir $(TARGETDIR))Info.plist')
 			_p('\t@:')
 			_p('')
 			_p('$(dir $(TARGETDIR))PkgInfo:')
 			_p('$(dir $(TARGETDIR))Info.plist:')
 		else
-			_p('all: $(TARGETDIR) $(OBJDIR) prebuild prelink $(TARGET)')
+			_p('all: prebuild prelink $(TARGET)')
 			_p('\t@:')
 		end
 	end
@@ -365,6 +370,11 @@
 	function make.cppTargetRules(prj)
 		_p('$(TARGET): $(GCH) ${CUSTOMFILES} $(OBJECTS) $(LDDEPS) $(RESOURCES)')
 		_p('\t@echo Linking %s', prj.name)
+		_p('ifeq (posix,$(SHELLTYPE))')
+		_p('\t$(SILENT) mkdir -p "$(TARGETDIR)"')
+		_p('else')
+		_p('\t$(SILENT) mkdir "$(subst /,\\\\,$(TARGETDIR))"')
+		_p('endif')
 		_p('\t$(SILENT) $(LINKCMD)')
 		_p('\t$(POSTBUILDCMDS)')
 		_p('')

--- a/tests/actions/make/cpp/test_file_rules.lua
+++ b/tests/actions/make/cpp/test_file_rules.lua
@@ -36,9 +36,19 @@
 		test.capture [[
 $(OBJDIR)/hello.o: src/greetings/hello.cpp
 	@echo $(notdir $<)
+ifeq (posix,$(SHELLTYPE))
+	$(SILENT) mkdir -p $(OBJDIR)
+else
+	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
+endif
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/hello1.o: src/hello.cpp
 	@echo $(notdir $<)
+ifeq (posix,$(SHELLTYPE))
+	$(SILENT) mkdir -p $(OBJDIR)
+else
+	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
+endif
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 
   		]]
@@ -55,9 +65,19 @@ $(OBJDIR)/hello1.o: src/hello.cpp
 		test.capture [[
 $(OBJDIR)/hello.o: src/hello.c
 	@echo $(notdir $<)
+ifeq (posix,$(SHELLTYPE))
+	$(SILENT) mkdir -p $(OBJDIR)
+else
+	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
+endif
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/test.o: src/test.cpp
 	@echo $(notdir $<)
+ifeq (posix,$(SHELLTYPE))
+	$(SILENT) mkdir -p $(OBJDIR)
+else
+	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
+endif
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 
   		]]

--- a/tests/actions/make/cpp/test_target_rules.lua
+++ b/tests/actions/make/cpp/test_target_rules.lua
@@ -32,7 +32,7 @@
 	function suite.defaultRules()
 		prepare()
 		test.capture [[
-all: $(TARGETDIR) $(OBJDIR) prebuild prelink $(TARGET)
+all: prebuild prelink $(TARGET)
 	@:
   		]]
 	end
@@ -47,7 +47,7 @@ all: $(TARGETDIR) $(OBJDIR) prebuild prelink $(TARGET)
 		kind "WindowedApp"
 		prepare()
 		test.capture [[
-all: $(TARGETDIR) $(OBJDIR) prebuild prelink $(TARGET) $(dir $(TARGETDIR))PkgInfo $(dir $(TARGETDIR))Info.plist
+all: prebuild prelink $(TARGET) $(dir $(TARGETDIR))PkgInfo $(dir $(TARGETDIR))Info.plist
 	@:
 
 $(dir $(TARGETDIR))PkgInfo:


### PR DESCRIPTION
Hi,

We've been running into sporadic failures when running a premake5 Makefile with `make -j4`. We get errors like: `../../external/uuid/clear.c:42:1: fatal error: opening dependency file ../../intermediates/gmake/common/linux64/Debug/clear.d: No such file or directory`

Premake generates a target like `all: $(TARGETDIR) $(OBJDIR) prebuild prelink $(TARGET)`, which works fine for single threaded builds because the prerequisites are run left to right, but with -j4 the rule for `$(TARGET)` can get executed before the rule for `$(OBJDIR)`, causing the error.

Adding `$(OBJDIR)` as a prerequisite for each object file is not ideal because it causes `make; make` to build the project twice. The first time make will see that `$(OBJDIR)` doesn't exist and build everything that depends on it, the second time make will see that `$(OBJDIR)` has been modified and build everything that depends on it again.

The (slightly unsatisfactory) solution that I know of is to call `mkdir -p $(OBJDIR)` every time you build an object.

I've attached a patch which implements the unsatisfactory solution for C++ Makefiles. It's possible that there's a similar bug for C# projects too, but I don't have any C# projects and I didn't want to write "fixes" that I can't test. Similarly, I'm not familiar with the premake codebase so this patch isn't as clean as it could be, but hopefully it's a start!