### PR TITLE
Fix issue with msc.getlinks and vstudio.getLinks returning different results when 'explicit' is true.

### DIFF
--- a/src/actions/vstudio/_vstudio.lua
+++ b/src/actions/vstudio/_vstudio.lua
@@ -347,26 +347,7 @@
 ---
 
 	function vstudio.getLinks(cfg, explicit)
-		local links = {}
-
-		-- If we need sibling projects to be listed explicitly, grab them first
-		if explicit then
-			links = config.getlinks(cfg, "siblings", "fullpath")
-		end
-
-		-- Then the system libraries, which come undecorated
-		local system = config.getlinks(cfg, "system", "fullpath")
-		for i = 1, #system do
-			-- Add extension if required
-			local link = system[i]
-			if not p.tools.msc.getLibraryExtensions()[link:match("[^.]+$")] then
-				link = path.appendextension(link, ".lib")
-			end
-
-			table.insert(links, link)
-		end
-
-		return links
+		return p.tools.msc.getlinks(cfg, not explicit)
 	end
 
 

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -274,14 +274,26 @@
 -- Return the list of libraries to link, decorated with flags as needed.
 --
 
-	function msc.getlinks(cfg)
-		local links = config.getlinks(cfg, "system", "fullpath")
-		for i = 1, #links do
-			-- Add extension if required
-			if not msc.getLibraryExtensions()[links[i]:match("[^.]+$")] then
-				links[i] = path.appendextension(links[i], ".lib")
-			end
+	function msc.getlinks(cfg, systemonly, nogroups)
+		local links = {}
+
+		-- If we need sibling projects to be listed explicitly, grab them first
+		if not systemonly then
+			links = config.getlinks(cfg, "siblings", "fullpath")
 		end
+
+		-- Then the system libraries, which come undecorated
+		local system = config.getlinks(cfg, "system", "fullpath")
+		for i = 1, #system do
+			-- Add extension if required
+			local link = system[i]
+			if not p.tools.msc.getLibraryExtensions()[link:match("[^.]+$")] then
+				link = path.appendextension(link, ".lib")
+			end
+
+			table.insert(links, link)
+		end
+
 		return links
 	end
 


### PR DESCRIPTION
We have a project that works, as long as you don't specify a toolset...

So we just added "toolset 'v140_xp'" to one of our projects, and the project no longer links against any of our libraries in one of the configurations...