### PR TITLE
Add additional tokens to fileconfig and vs2010+.

### DIFF
--- a/src/actions/vstudio/vs2010.lua
+++ b/src/actions/vstudio/vs2010.lua
@@ -31,7 +31,10 @@
 		["file.basename"]               = { absolute = false, token = "%(Filename)" },
 		["file.abspath"]                = { absolute = true,  token = "%(FullPath)" },
 		["file.relpath"]                = { absolute = false, token = "%(Identity)" },
-		["file.path"]                   = { absolute = true,  token = "%(Identity)" },
+		["file.path"]                   = { absolute = false, token = "%(Identity)" },
+		["file.directory"]              = { absolute = true,  token = "%(RootDir)%(Directory)" },
+		["file.reldirectory"]           = { absolute = false, token = "%(RelativeDir)" },
+		["file.extension"]              = { absolute = false, token = "%(Extension)" },
 	}
 
 

--- a/src/base/fileconfig.lua
+++ b/src/base/fileconfig.lua
@@ -243,7 +243,6 @@
 		return context.__mt.__index(fsub, key)
 	end
 
-
 --
 -- And here are the path building functions.
 --
@@ -257,6 +256,9 @@
 		return path.getdirectory(fcfg.abspath)
 	end
 
+	function fcfg_mt.reldirectory(fcfg)
+		return path.getdirectory(fcfg.relpath)
+	end
 
 	function fcfg_mt.name(fcfg)
 		return path.getname(fcfg.abspath)
@@ -285,4 +287,9 @@
 	function fcfg_mt.vpath(fcfg)
 		-- This only gets called if no explicit virtual path was set
 		return fcfg.relpath
+	end
+
+
+	function fcfg_mt.extension(fcfg)
+		return path.getextension(fcfg.abspath)
 	end


### PR DESCRIPTION
This provides us with a workaround for a fix that was made that broke our builds.

https://github.com/premake/premake-core/pull/643

we relied on "path" being the "%(RelativeDir)" token in visual studio... obviously wrong, but we relied on it, so we need another way to get there..