### PR TITLE
Define _HAS_EXCEPTIONS=0 when exceptionhandling is "off".

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1149,7 +1149,11 @@
 
 
 	function m.clCompilePreprocessorDefinitions(cfg, condition)
-		m.preprocessorDefinitions(cfg, cfg.defines, false, condition)
+		local defines = cfg.defines
+		if cfg.exceptionhandling == p.OFF then
+			defines = table.join(defines, "_HAS_EXCEPTIONS=0")
+		end
+		m.preprocessorDefinitions(cfg, defines, false, condition)
 	end
 
 
@@ -1942,7 +1946,11 @@
 
 
 	function m.resourcePreprocessorDefinitions(cfg)
-		m.preprocessorDefinitions(cfg, table.join(cfg.defines, cfg.resdefines), true)
+		local defines = table.join(cfg.defines, cfg.resdefines)
+		if cfg.exceptionhandling == p.OFF then
+			table.insert(defines, "_HAS_EXCEPTIONS=0")
+		end
+		m.preprocessorDefinitions(cfg, defines, true)
 	end
 
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1150,7 +1150,7 @@
 
 	function m.clCompilePreprocessorDefinitions(cfg, condition)
 		local defines = cfg.defines
-		if cfg.exceptionhandling == p.OFF then
+		if cfg.exceptionhandling == p.OFF and _ACTION >= "vs2013" then
 			defines = table.join(defines, "_HAS_EXCEPTIONS=0")
 		end
 		m.preprocessorDefinitions(cfg, defines, false, condition)
@@ -1947,7 +1947,7 @@
 
 	function m.resourcePreprocessorDefinitions(cfg)
 		local defines = table.join(cfg.defines, cfg.resdefines)
-		if cfg.exceptionhandling == p.OFF then
+		if cfg.exceptionhandling == p.OFF and _ACTION >= "vs2013" then
 			table.insert(defines, "_HAS_EXCEPTIONS=0")
 		end
 		m.preprocessorDefinitions(cfg, defines, true)

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -142,6 +142,11 @@
 		for _, define in ipairs(defines) do
 			table.insert(result, '/D"' .. define .. '"')
 		end
+
+		if cfg and cfg.exceptionhandling == p.OFF then
+			table.insert(result, "/D_HAS_EXCEPTIONS=0")
+		end
+
 		return result
 	end
 

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -529,11 +529,26 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<ExceptionHandling>false</ExceptionHandling>
+		]]
+	end
+
+
+	function suite.exceptions_onNoExceptionsVS2013()
+		exceptionhandling "Off"
+		premake.action.set("vs2013")
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
 	<PreprocessorDefinitions>_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 	<Optimization>Disabled</Optimization>
 	<ExceptionHandling>false</ExceptionHandling>
 		]]
 	end
+
 
 	function suite.exceptions_onSEH()
 		exceptionhandling "SEH"

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -529,6 +529,7 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
+	<PreprocessorDefinitions>_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 	<Optimization>Disabled</Optimization>
 	<ExceptionHandling>false</ExceptionHandling>
 		]]


### PR DESCRIPTION
When exceptionhandling "Off" is declared, "_HAS_EXCEPTIONS=0" should also be declared to avoid warnings about exception use in the standard library.