### PR TITLE
Escape string literals passed to defines() for Xcode

### DIFF
--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1019,7 +1019,11 @@
 			settings['GCC_PREFIX_HEADER'] = cfg.pchheader
 		end
 
-		settings['GCC_PREPROCESSOR_DEFINITIONS'] = cfg.defines
+		local escapedDefines = { }
+		for i,v in ipairs(cfg.defines) do
+			escapedDefines[i] = escapeArg(v)
+		end
+		settings['GCC_PREPROCESSOR_DEFINITIONS'] = escapedDefines
 
 		settings["GCC_SYMBOLS_PRIVATE_EXTERN"] = 'NO'
 


### PR DESCRIPTION
This corrects an issue with `defines()` in Xcode. If you make a call such as `defines "MY_LITERAL=\"string literal\""`, you would expect the result to be `-DMY_LITERAL=\"string\ literal\"`. And indeed, that is the result in a makefile created by the gmake action. Furthermore, in the .xcodeproj, you will even see `GCC_PREPROCESSOR_DEFINITIONS = (  "MY_LITERAL=\"string literal\"", );`. However, when Xcode runs the compile command, it ends up being `-DMY_LITERAL=string\ literal` and compilation fails. With this change, values passed to `defines()` are escaped in Xcode and it will work equivalently to how it works in gmake.

It was possible before to pass a string literal to `defines()` for Xcode, but you had to escape it yourself (e.g., `defines "MY_LITERAL=\\\"value\\\""`). With this change, it eliminates the special platform check and handling you have to do because the behavior will be consistent. All types of arguments (string literals, numeric values, and names only) passed to `defines()` appear to function as expected after this change.