### PR TITLE
Better detect debug build

### DIFF
--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -413,7 +413,10 @@
 --
 
 	function config.isDebugBuild(cfg)
-		return cfg.symbols == p.ON and not config.isOptimizedBuild(cfg)
+		return cfg.symbols ~= nil and
+				cfg.symbols ~= p.OFF and
+				cfg.symbols ~= "Default" and
+				not config.isOptimizedBuild(cfg)
 	end
 
 


### PR DESCRIPTION
Symbols changes from ages ago have broken this test... I'm not sure how much it's used, but it seems to be wrong.