### PR TITLE
Detect native source files.

### DIFF
--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -678,7 +678,7 @@
 
 			-- Only consider sources that actually generate object files
 
-			if not path.iscppfile(file.abspath) then
+			if not path.isnativefile(file.abspath) then
 				return
 			end
 

--- a/src/base/path.lua
+++ b/src/base/path.lua
@@ -142,23 +142,52 @@
 
 
 --
--- Returns true if the filename represents a C/C++ source code file. This check
--- is used to prevent passing non-code files to the compiler in makefiles. It is
--- not foolproof, but it has held up well. I'm open to better suggestions.
+-- Returns true if the filename represents various source languages.
 --
 
+	function path.isasmfile(fname)
+		return path.hasextension(fname, { ".s" })
+	end
+
 	function path.iscfile(fname)
-		return path.hasextension(fname, { ".c", ".s", ".m" })
+		return path.hasextension(fname, { ".c" })
+			or path.isasmfile(fname)	-- is this really right?
+			or path.isobjcfile(fname)	-- there is code that depends on this behaviour, which would need to change
 	end
 
 	function path.iscppfile(fname)
-		return path.hasextension(fname, { ".cc", ".cpp", ".cxx", ".c", ".s", ".m", ".mm" })
+		return path.hasextension(fname, { ".cc", ".cpp", ".cxx" })
+			or path.isobjcppfile(fname)	-- is this really right?
+			or path.iscfile(fname)
+	end
+
+	function path.isobjcfile(fname)
+		return path.hasextension(fname, { ".m" })
+	end
+
+	function path.isobjcppfile(fname)
+		return path.hasextension(fname, { ".mm" })
 	end
 
 	function path.iscppheader(fname)
 		return path.hasextension(fname, { ".h", ".hh", ".hpp", ".hxx" })
 	end
 
+
+--
+-- Returns true if the filename represents a native language source file.
+-- These checks are used to prevent passing non-code files to the compiler
+-- in makefiles. It is not foolproof, but it has held up well. I'm open to
+-- better suggestions.
+--
+
+	function path.isnativefile(fname)
+		return path.iscfile(fname)
+			or path.iscppfile(fname)
+			or path.isasmfile(fname)
+			or path.isobjcfile(fname)
+			or path.isobjcppfile(fname)
+	end
 
 
 --


### PR DESCRIPTION
Separated the concept of 'native' languages from language detection.
There is code that assumes native code == c/c++ code.
I also feel it's weird to conflate asm and obj-c... I can imagine myself writing code to detect those languages with the intent to do something language-specific that's probably not applicable to asm or whatever.