### PR TITLE
Refactor language flags to go through the language API.

### DIFF
--- a/modules/codelite/codelite.lua
+++ b/modules/codelite/codelite.lua
@@ -46,7 +46,7 @@
 		p.indent("  ")
 		p.escaper(codelite.esc)
 
-		if project.iscpp(prj) then
+		if project.isc(prj) or project.iscpp(prj) then
 			p.generate(prj, ".project", codelite.project.generate)
 		end
 	end

--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -51,9 +51,9 @@
 			error("Invalid toolset '" + (_OPTIONS.cc or cfg.toolset) + "'")
 		end
 
-		if cfg.language == "C" then
+		if p.languages.isc(cfg.language) then
 			return m.ctools[tool]
-		elseif cfg.language == "C++" then
+		elseif p.languages.iscpp(cfg.language) then
 			return m.cxxtools[tool]
 		end
 	end
@@ -354,8 +354,19 @@
 		_p(3, '</AdditionalRules>')
 	end
 
+	function m.isCpp11(cfg)
+		return (cfg.language == 'gnu++11') or (cfg.language == 'C++11') or cfg.flags["C++11"]
+	end
+
+	function m.isCpp14(cfg)
+		return (cfg.language == 'gnu++14') or (cfg.language == 'C++14') or cfg.flags["C++14"]
+	end
+
 	function m.completion(cfg)
-		_p(3, '<Completion EnableCpp11="%s" EnableCpp14="%s">', iif(cfg.flags["C++11"], "yes", "no"), iif(cfg.flags["C++14"], "yes", "no"))
+		_p(3, '<Completion EnableCpp11="%s" EnableCpp14="%s">',
+			iif(m.isCpp11(cfg), "yes", "no"),
+			iif(m.isCpp14(cfg), "yes", "no")
+		)
 		_p(4, '<ClangCmpFlagsC/>')
 		_p(4, '<ClangCmpFlags/>')
 		_p(4, '<ClangPP/>') -- TODO: we might want to set special code completion macros...?

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -40,7 +40,8 @@
 		rtti "Off"
 		pic "On"
 		symbols "On"
-		flags { "NoBufferSecurityCheck", "C++11" }
+		language "C++11"
+		flags { "NoBufferSecurityCheck" }
 		buildoptions { "-opt1", "-opt2" }
 		prepare()
 		codelite.project.compiler(cfg)
@@ -217,7 +218,7 @@ cmd2</StartupCommands>
 	end
 
 	function suite.OnProject_Completion()
-		flags { "C++11" }
+		language "C++11"
 		prepare()
 		codelite.project.completion(prj)
 		test.capture [[

--- a/modules/d/_preload.lua
+++ b/modules/d/_preload.lua
@@ -20,7 +20,9 @@
 
 	p.D = "D"
 
+	table.insert(p.languages.all, p.D)
 	api.addAllowed("language", p.D)
+
 	api.addAllowed("floatingpoint", "None")
 	api.addAllowed("flags", {
 		"CodeCoverage",

--- a/modules/d/actions/gmake.lua
+++ b/modules/d/actions/gmake.lua
@@ -239,7 +239,7 @@
 		if cfg.flags.SeparateCompilation then
 			_p('  LINKCMD = $(DC) ' .. toolset.gettarget("$(TARGET)") .. ' $(ALL_LDFLAGS) $(LIBS) $(OBJECTS)')
 
---			local cc = iif(cfg.language == "C", "CC", "CXX")
+--			local cc = iif(p.languages.isc(cfg.language), "CC", "CXX")
 --			_p('  LINKCMD = $(%s) -o $(TARGET) $(OBJECTS) $(RESOURCES) $(ARCH) $(ALL_LDFLAGS) $(LIBS)', cc)
 		else
 			_p('  BUILDCMD = $(DC) ' .. toolset.gettarget("$(TARGET)") .. ' $(ALL_DFLAGS) $(ALL_LDFLAGS) $(LIBS) $(SOURCEFILES)')

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -959,6 +959,40 @@
 	end
 
 
+	function xcode.XCBuildConfiguration_CLanguageStandard(settings, cfg)
+		if (p.languages.isc(cfg.language)) then
+			if cfg.language ~= "C" then
+				settings['GCC_C_LANGUAGE_STANDARD'] = cfg.language:lower()
+			else
+				if cfg.flags['C99'] then
+					settings['GCC_C_LANGUAGE_STANDARD'] = 'C99'
+				elseif cfg.flags['C11'] then
+					settings['GCC_C_LANGUAGE_STANDARD'] = 'C11'
+				else
+					settings['GCC_C_LANGUAGE_STANDARD'] = 'C90'
+				end
+			end
+		else
+			settings['GCC_C_LANGUAGE_STANDARD'] = 'gnu99'
+		end
+	end
+
+
+	function xcode.XCBuildConfiguration_CppLanguageStandard(settings, cfg)
+		if (p.languages.iscpp(cfg.language)) then
+			if cfg.language ~= "C++" then
+				settings['CLANG_CXX_LANGUAGE_STANDARD'] = cfg.language:lower()
+			else
+				if cfg.flags['C++11'] then
+					settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++11'
+				elseif cfg.flags['C++14'] then
+					settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++14'
+				end
+			end
+		end
+	end
+
+
 	function xcode.XCBuildConfiguration_Project(tr, cfg)
 		local settings = {}
 
@@ -987,13 +1021,8 @@
 			settings['COPY_PHASE_STRIP'] = 'NO'
 		end
 
-		settings['GCC_C_LANGUAGE_STANDARD'] = 'gnu99'
-
-		if cfg.flags['C++14'] then
-			settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++14'
-		elseif cfg.flags['C++11'] then
-			settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++0x'
-		end
+		xcode.XCBuildConfiguration_CLanguageStandard(settings, cfg)
+		xcode.XCBuildConfiguration_CppLanguageStandard(settings, cfg)
 
 		if cfg.exceptionhandling == p.OFF then
 			settings['GCC_ENABLE_CPP_EXCEPTIONS'] = 'NO'

--- a/src/_manifest.lua
+++ b/src/_manifest.lua
@@ -24,6 +24,7 @@
 		"base/http.lua",
 		"base/json.lua",
 		"base/jsonwrapper.lua",
+		"base/languages.lua",
 
 		-- configuration data
 		"base/field.lua",

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -508,11 +508,11 @@
 			"Unsafe",              -- DEPRECATED
 			"WinMain",
 			"WPF",
-			"C++11",
-			"C++14",
-			"C90",
-			"C99",
-			"C11",
+			"C++11",               -- DEPRECATED
+			"C++14",               -- DEPRECATED
+			"C90",                 -- DEPRECATED
+			"C99",                 -- DEPRECATED
+			"C11",                 -- DEPRECATED
 		},
 		aliases = {
 			FatalWarnings = { "FatalWarnings", "FatalCompileWarnings", "FatalLinkWarnings" },
@@ -700,13 +700,9 @@
 
 	api.register {
 		name = "language",
-		scope = "project",
+		scope = "config",
 		kind = "string",
-		allowed = {
-			"C",
-			"C++",
-			"C#",
-		},
+		allowed = p.languages.all
 	}
 
 	api.register {
@@ -1374,6 +1370,13 @@
 	end)
 
 
+	-- 31 January 2017
+
+	api.deprecateValue("flags", "C++11", 'Use `language "C++11"` instead', function(value) end, function(value) end)
+	api.deprecateValue("flags", "C++14", 'Use `language "C++14"` instead', function(value) end, function(value) end)
+	api.deprecateValue("flags", "C90",   'Use `language "C90"` instead',   function(value) end, function(value) end)
+	api.deprecateValue("flags", "C99",   'Use `language "C99"` instead',   function(value) end, function(value) end)
+	api.deprecateValue("flags", "C11",   'Use `language "C11"` instead',   function(value) end, function(value) end)
 
 -----------------------------------------------------------------------------
 --

--- a/src/actions/make/_make.lua
+++ b/src/actions/make/_make.lua
@@ -44,7 +44,7 @@
 			else
 				if project.isdotnet(prj) then
 					premake.generate(prj, makefile, make.cs.generate)
-				elseif project.iscpp(prj) then
+				elseif project.isc(prj) or project.iscpp(prj) then
 					premake.generate(prj, makefile, make.cpp.generate)
 				end
 			end

--- a/src/actions/make/make_cpp.lua
+++ b/src/actions/make/make_cpp.lua
@@ -455,7 +455,7 @@
 			-- $(LDFLAGS) moved to end (http://sourceforge.net/p/premake/patches/107/)
 			-- $(LIBS) moved to end (http://sourceforge.net/p/premake/bugs/279/)
 
-			local cc = iif(cfg.language == "C", "CC", "CXX")
+			local cc = iif(p.languages.isc(cfg.language), "CC", "CXX")
 			_p('  LINKCMD = $(%s) -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)', cc)
 		end
 	end

--- a/src/actions/vstudio/_vstudio.lua
+++ b/src/actions/vstudio/_vstudio.lua
@@ -456,7 +456,7 @@
 		local extension
 		if project.isdotnet(prj) then
 			extension = ".csproj"
-		elseif project.iscpp(prj) then
+		elseif project.isc(prj) or project.iscpp(prj) then
 			extension = iif(_ACTION > "vs2008", ".vcxproj", ".vcproj")
 		end
 
@@ -519,11 +519,8 @@
 		local hasnet = false
 		local slnarch
 		for prj in p.workspace.eachproject(cfg.workspace) do
-			if project.isnative(prj) then
-				hasnative = true
-			elseif project.isdotnet(prj) then
-				hasnet = true
-			end
+			hasnative = hasnative or project.isnative(prj)
+			hasnet    = hasnet    or project.isdotnet(prj)
 
 			-- get a VS architecture identifier for this project
 			local prjcfg = project.getconfig(prj, cfg.buildcfg, cfg.platform)
@@ -573,11 +570,8 @@
 		--
 
 		for prj in p.workspace.eachproject(cfg.workspace) do
-			if project.isnative(prj) then
-				hasnative = true
-			elseif project.isdotnet(prj) then
-				hasdotnet = true
-			end
+			hasnative = hasnative or project.isnative(prj)
+			hasnet    = hasnet    or project.isdotnet(prj)
 
 			if hasnative and hasdotnet then
 				return "Mixed Platforms"
@@ -632,7 +626,7 @@
 	function vstudio.tool(prj)
 		if project.isdotnet(prj) then
 			return "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC"
-		elseif project.iscpp(prj) then
+		elseif project.isc(prj) or project.iscpp(prj) then
 			return "8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942"
 		end
 	end

--- a/src/actions/vstudio/vs2005.lua
+++ b/src/actions/vstudio/vs2005.lua
@@ -51,8 +51,7 @@
 			if #user > 0 then
 				p.generate(prj, ".csproj.user", function() p.outln(user) end)
 			end
-
-		elseif premake.project.iscpp(prj) then
+		else
 			premake.generate(prj, ".vcproj", vstudio.vc200x.generate)
 
 			-- Skip generation of empty user files
@@ -60,7 +59,6 @@
 			if #user > 0 then
 				p.generate(prj, ".vcproj.user", function() p.outln(user) end)
 			end
-
 		end
 	end
 

--- a/src/actions/vstudio/vs200x_vcproj.lua
+++ b/src/actions/vstudio/vs200x_vcproj.lua
@@ -984,7 +984,7 @@
 
 	function m.compileAs(cfg, toolset)
 		local cfg, filecfg = config.normalize(cfg)
-		local c = project.isc(cfg)
+		local c = p.languages.isc(cfg.language)
 		if filecfg then
 			if path.iscfile(filecfg.name) ~= c then
 				if path.iscppfile(filecfg.name) then

--- a/src/actions/vstudio/vs2010.lua
+++ b/src/actions/vstudio/vs2010.lua
@@ -49,8 +49,8 @@
 		p.indent("  ")
 		p.escaper(vs2010.esc)
 
-		if premake.project.isdotnet(prj) then
-			premake.generate(prj, ".csproj", vstudio.cs2005.generate)
+		if p.project.isdotnet(prj) then
+			p.generate(prj, ".csproj", vstudio.cs2005.generate)
 
 			-- Skip generation of empty user files
 			local user = p.capture(function() vstudio.cs2005.generateUser(prj) end)
@@ -58,8 +58,8 @@
 				p.generate(prj, ".csproj.user", function() p.outln(user) end)
 			end
 
-		elseif premake.project.iscpp(prj) then
-			premake.generate(prj, ".vcxproj", vstudio.vc2010.generate)
+		elseif p.project.isc(prj) or p.project.iscpp(prj) then
+			p.generate(prj, ".vcxproj", vstudio.vc2010.generate)
 
 			-- Skip generation of empty user files
 			local user = p.capture(function() vstudio.vc2010.generateUser(prj) end)
@@ -71,7 +71,6 @@
 			if tree.hasbranches(project.getsourcetree(prj)) then
 				premake.generate(prj, ".vcxproj.filters", vstudio.vc2010.generateFilters)
 			end
-
 		end
 	end
 

--- a/src/actions/vstudio/vs2010_nuget.lua
+++ b/src/actions/vstudio/vs2010_nuget.lua
@@ -44,13 +44,13 @@
 	function nuget2010.packageFramework(wks, package)
 		local prj = packageProject(wks, package)
 
-		if p.project.iscpp(prj) then
-			return "native"
-		elseif p.project.isdotnet(prj) then
+		if p.project.isdotnet(prj) then
 			local cfg = p.project.getfirstconfig(prj)
 			local action = premake.action.current()
 			local framework = cfg.dotnetframework or action.vstudio.targetFramework
 			return cs2005.formatNuGetFrameworkVersion(framework)
+		else
+			return "native"
 		end
 	end
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1215,7 +1215,7 @@
 
 
 	function m.compileAs(cfg)
-		if cfg.project.language == "C" then
+		if p.languages.isc(cfg.language) then
 			m.element("CompileAs", nil, "CompileAsC")
 		end
 	end

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -192,7 +192,7 @@
 		-- if the configuration target is a DLL, and an import library
 		-- is provided, change the kind as import libraries are static.
 		local kind = cfg.kind
-		if project.iscpp(cfg.project) then
+		if project.isnative(cfg.project)  then
 			if cfg.system == premake.WINDOWS and kind == premake.SHAREDLIB and not cfg.flags.NoImportLib then
 				kind = premake.STATICLIB
 			end

--- a/src/base/languages.lua
+++ b/src/base/languages.lua
@@ -1,0 +1,68 @@
+---
+-- languages.lua
+-- Language helpers.
+-- Copyright (c) 2002-2015 Jason Perkins and the Premake project
+---
+
+	premake.languages = {}
+	local p = premake
+	local languages = p.languages
+
+
+---
+-- List of supported C languages.
+---
+	languages.c = {
+		"C",
+		"C89",
+		"C90",
+		"C99",
+		"C11",
+		"gnu89",
+		"gnu90",
+		"gnu99",
+		"gnu11",
+	}
+
+	function languages.isc(value)
+		return table.contains(languages.c, value)
+	end
+
+---
+-- List of supported C++ languages.
+---
+	languages.cpp = {
+		"C++",
+		"C++98",
+		"C++11",
+		"C++14",
+		"C++17",
+		"gnu++98",
+		"gnu++11",
+		"gnu++14",
+		"gnu++17",
+	}
+
+	function languages.iscpp(value)
+		return table.contains(languages.cpp, value)
+	end
+
+---
+-- List of supported dotnet languages.
+---
+	languages.dotnet = {
+		"C#"
+	}
+
+	function languages.isdotnet(value)
+		return table.contains(languages.dotnet, value)
+	end
+
+---
+-- Combined list of all supported languages.
+---
+	languages.all = table.join(
+		languages.c, 
+		languages.cpp, 
+		languages.dotnet
+	)

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -181,7 +181,7 @@
 			end
 
 			-- generated files might screw up the object sequences.
-			if prj.hasGeneratedFiles and p.project.iscpp(prj) then
+			if prj.hasGeneratedFiles and p.project.isnative(prj) then
 				oven.assignObjectSequences(prj)
 			end
 		end
@@ -278,7 +278,7 @@
 		-- to do this up front to make sure the sequence numbers are the same for
 		-- all the tools, even they reorder the source file list.
 
-		if p.project.iscpp(self) then
+		if p.project.isnative(self) then
 			oven.assignObjectSequences(self)
 		end
 	end

--- a/src/base/project.lua
+++ b/src/base/project.lua
@@ -441,39 +441,39 @@
 
 
 --
--- Returns true if the project uses the C (and not C++) language.
---
-
-	function project.isc(prj)
-		return prj.language == premake.C
-	end
-
-
-
---
--- Returns true if the project uses a C/C++ language.
---
-
-	function project.iscpp(prj)
-		return prj.language == premake.C or prj.language == premake.CPP
-	end
-
-
---
 -- Returns true if the project uses a .NET language.
 --
 
 	function project.isdotnet(prj)
-		return prj.language == premake.CSHARP
+		return p.languages.isdotnet(prj.language)
 	end
 
 
 --
--- Returns true if the project uses a native language.
+-- Returns true if the project uses a cpp language.
 --
 
+	function project.isc(prj)
+		return p.languages.isc(prj.language)
+	end
+
+
+--
+-- Returns true if the project uses a cpp language.
+--
+
+	function project.iscpp(prj)
+		return p.languages.iscpp(prj.language)
+	end
+
+
+--
+-- Returns true if the project has uses any 'native' languages.
+-- which is basically anything other then .net at this point.
+-- modules like the dlang should overload this to add 'project.isd(prj)' to it.
+--
 	function project.isnative(prj)
-		return project.iscpp(prj)
+		return project.isc(prj) or project.iscpp(prj)
 	end
 
 

--- a/src/base/validation.lua
+++ b/src/base/validation.lua
@@ -163,30 +163,34 @@
 
 	function m.actionSupportsKind(prj)
 		if not p.action.supports(prj.kind) then
-			p.warn("unsupported kind '%s' used for project '%s'", prj.kind, prj.name)
+			p.warn("Unsupported kind '%s' used for project '%s'", prj.kind, prj.name)
 		end
 	end
 
 
 	function m.actionSupportsLanguage(prj)
 		if not p.action.supports(prj.language) then
-			p.warn("unsupported language '%s' used for project '%s'", prj.language, prj.name)
+			p.warn("Unsupported language '%s' used for project '%s'", prj.language, prj.name)
 		end
 	end
 
 
 	function m.configHasKind(cfg)
 		if not cfg.kind then
-			p.error("project '%s' needs a kind in configuration '%s'", cfg.project.name, cfg.name)
+			p.error("Project '%s' needs a kind in configuration '%s'", cfg.project.name, cfg.name)
 		end
 	end
 
 
 	function m.configSupportsKind(cfg)
+		if not p.action.supports(cfg.kind) then
+			p.warn("Unsupported kind '%s' used in configuration '%s'", cfg.kind, cfg.name)
+		end
+
 		-- makefile configuration can only appear in C++ projects; this is the
 		-- default now, so should only be a problem if overridden.
-		if (cfg.kind == p.MAKEFILE or cfg.kind == p.NONE) and not p.project.iscpp(cfg.project) then
-			p.error("project '%s' uses %s kind in configuration '%s'; language must be C++", cfg.project.name, cfg.kind, cfg.name)
+		if (cfg.kind == p.MAKEFILE or cfg.kind == p.NONE) and p.project.isdotnet(cfg.project) then
+			p.error("Project '%s' uses '%s' kind in configuration '%s'; language must not be C#", cfg.project.name, cfg.kind, cfg.name)
 		end
 	end
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -91,6 +91,16 @@
 			["C99"] = "-std=gnu99",
 			["C11"] = "-std=gnu11",
 		},
+		language = {
+			["C89"] = "-std=c89",
+			["C90"] = "-std=c90",
+			["C99"] = "-std=c99",
+			["C11"] = "-std=c11",
+			["gnu89"] = "-std=gnu89",
+			["gnu90"] = "-std=gnu90",
+			["gnu99"] = "-std=gnu99",
+			["gnu11"] = "-std=gnu11",
+		}
 	}
 
 	function gcc.getcflags(cfg)
@@ -128,6 +138,16 @@
 			NoBufferSecurityCheck = "-fno-stack-protector",
 			["C++11"] = "-std=c++11",
 			["C++14"] = "-std=c++14",
+		},
+		language = {
+			["C++98"] = "-std=c++98",
+			["C++11"] = "-std=c++11",
+			["C++14"] = "-std=c++14",
+			["C++17"] = "-std=c++17",
+			["gnu++98"] = "-std=gnu++98",
+			["gnu++11"] = "-std=gnu++11",
+			["gnu++14"] = "-std=gnu++14",
+			["gnu++17"] = "-std=gnu++17",
 		},
 		rtti = {
 			Off = "-fno-rtti"


### PR DESCRIPTION
So you can use 'language "C++11"' instead of 'flags { "C++11" }'