### PR TITLE
Fix for issue https://github.com/premake/premake-core/issues/669

### DIFF
--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -587,7 +587,7 @@
 		context.addFilter(ctx, "architecture", ctx.architecture)
 
 		-- allow the project script to override the default toolset
-		ctx.toolset = ctx.toolset or toolset
+		ctx.toolset = _OPTIONS.cc or ctx.toolset or toolset
 		context.addFilter(ctx, "toolset", ctx.toolset)
 
 		-- if a kind is set, allow that to influence the configuration


### PR DESCRIPTION
when toolset is set through toolset ("clang"), the filter "toolset:clang" works, but when it's set through command line premake5 --cc=clang, it doesn't.