### PR TITLE
Fix a bunch of compile warnings.

### DIFF
--- a/src/host/os_chmod.c
+++ b/src/host/os_chmod.c
@@ -10,6 +10,9 @@
 #include <string.h>
 #include <errno.h>
 
+#if PLATFORM_WINDOWS
+#include <io.h>
+#endif
 
 int os_chmod(lua_State* L)
 {

--- a/src/host/os_getcwd.c
+++ b/src/host/os_getcwd.c
@@ -24,7 +24,7 @@ int do_getcwd(char* buffer, size_t size)
 	int result;
 
 #if PLATFORM_WINDOWS
-	result = (GetCurrentDirectoryA(size, buffer) != 0);
+	result = (GetCurrentDirectoryA((DWORD)size, buffer) != 0);
 	if (result) {
 		do_translate(buffer, '/');
 	}

--- a/src/host/os_getpass.c
+++ b/src/host/os_getpass.c
@@ -18,14 +18,14 @@ int os_getpass(lua_State* L)
 		char buffer[1024];
 		const char* newline = "\n";
 
-		WriteConsoleA(hstdout, prompt, strlen(prompt), &written_chars, NULL);
+		WriteConsoleA(hstdout, prompt, (DWORD)strlen(prompt), &written_chars, NULL);
 
 		GetConsoleMode(hstdin, &mode);
 		SetConsoleMode(hstdin, ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
 		ReadConsoleA(hstdin, buffer, sizeof (buffer), &read_chars, NULL);
 		SetConsoleMode(hstdin, mode);
 
-		WriteConsoleA(hstdout, newline, strlen(newline), &written_chars, NULL);
+		WriteConsoleA(hstdout, newline, (DWORD)strlen(newline), &written_chars, NULL);
 
 		buffer[strcspn(buffer, "\r\n")] = '\0';
 

--- a/src/host/os_mkdir.c
+++ b/src/host/os_mkdir.c
@@ -26,7 +26,7 @@ int do_mkdir(const char* path)
 		return 1;
 
 	// find the parent folder name.
-	length = strlen(path);
+	length = (int)strlen(path);
 	for (i = length - 1; i >= 0; --i)
 	{
 		if (path[i] == '/' || path[i] == '\\')


### PR DESCRIPTION
This just takes care of some compiler warnings when compiling premake in 64-bit.

I think we should support and test both 32-bit and 64-bit versions of premake.