### PR TITLE
Add support Visual Studio 2017 DebugFull option

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1002,6 +1002,7 @@
 			"On",
 			"Off",
 			"FastLink",    -- Visual Studio 2015+ only, considered 'On' for all other cases.
+			"Full",        -- Visual Studio 2017+ only, considered 'On' for all other cases.
 		},
 	}
 

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1376,14 +1376,21 @@
 
 	function m.generateDebugInformation(cfg)
 		local lookup = {}
-		if _ACTION >= "vs2015" then
+		if _ACTION >= "vs2017" then
 			lookup[p.ON]       = "true"
 			lookup[p.OFF]      = "false"
 			lookup["FastLink"] = "DebugFastLink"
+			lookup["Full"]     = "DebugFull"
+		elseif _ACTION == "vs2015" then
+			lookup[p.ON]       = "true"
+			lookup[p.OFF]      = "false"
+			lookup["FastLink"] = "DebugFastLink"
+			lookup["Full"]     = "true"
 		else
 			lookup[p.ON]       = "true"
 			lookup[p.OFF]      = "false"
 			lookup["FastLink"] = "true"
+			lookup["Full"]     = "true"
 		end
 
 		local value = lookup[cfg.symbols]

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -151,6 +151,17 @@
 		]]
 	end
 
+	function suite.generateDebugInfo_onSymbolsFull_on2010()
+		premake.action.set("vs2010")
+		symbols "Full"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
 	function suite.generateDebugInfo_onSymbolsOn_on2015()
 		premake.action.set("vs2015")
 		symbols "On"
@@ -174,6 +185,27 @@
 		]]
 	end
 
+	function suite.generateDebugInfo_onSymbolsFull_on2015()
+		premake.action.set("vs2015")
+		symbols "Full"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsFull_on2017()
+		premake.action.set("vs2017")
+		symbols "Full"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+		]]
+	end
 
 --
 -- Any system libraries specified in links() should be listed as


### PR DESCRIPTION
In Visual Studio 2017, Microsoft changed the behavior of the default debug info flag to use fastlink rather than emitting a full PDB file. There is a new debug info flag /DEBUG:FULL that will work that same way that /DEBUG worked in Visual Studio 2015.

This change adds a new flag for symbols that will produce a full PDB. I think that this is the correct thing to do since symbols on should probably do whatever the current version of Visual Studio thinks is the default.

There's now the following logic for what to place in the GenerateDebugInformation attribute:

|          |        vs2017 |        vs2015 | vs20XX |
|----------|---------------|---------------|--------|
| On       |          true |          true |   true |
| Off      |         false |         false |  false |
| FastLink | DebugFastLink | DebugFastLink |   true |
| Full     |     DebugFull |          true |   true |

