### PR TITLE
Move the Visual Studio symbols lookup table into the respective action files

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1002,6 +1002,7 @@
 			"On",
 			"Off",
 			"FastLink",    -- Visual Studio 2015+ only, considered 'On' for all other cases.
+			"Full",        -- Visual Studio 2017+ only, considered 'On' for all other cases.
 		},
 	}
 

--- a/src/actions/vstudio/vs2005.lua
+++ b/src/actions/vstudio/vs2005.lua
@@ -124,5 +124,12 @@
 			productVersion      = "8.0.50727",
 			solutionVersion     = "9",
 			versionName         = "2005",
+		},
+
+		symbols = {
+			[p.ON]       = "true",
+			[p.OFF]      = "false",
+			["FastLink"] = "true",
+			["Full"]     = "true"
 		}
 	}

--- a/src/actions/vstudio/vs2008.lua
+++ b/src/actions/vstudio/vs2008.lua
@@ -5,6 +5,8 @@
 --
 
 	premake.vstudio.vs2008 = {}
+
+	local p = premake
 	local vs2008 = premake.vstudio.vs2008
 	local vstudio = premake.vstudio
 
@@ -50,5 +52,12 @@
 			solutionVersion     = "10",
 			versionName         = "2008",
 			toolsVersion        = "3.5",
+		},
+
+		symbols = {
+			[p.ON]       = "true",
+			[p.OFF]      = "false",
+			["FastLink"] = "true",
+			["Full"]     = "true"
 		}
 	}

--- a/src/actions/vstudio/vs2010.lua
+++ b/src/actions/vstudio/vs2010.lua
@@ -163,5 +163,12 @@
 			versionName         = "2010",
 			targetFramework     = "4.0",
 			toolsVersion        = "4.0",
+		},
+
+		symbols = {
+			[p.ON]       = "true",
+			[p.OFF]      = "false",
+			["FastLink"] = "true",
+			["Full"]     = "true"
 		}
 	}

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1375,25 +1375,8 @@
 
 
 	function m.generateDebugInformation(cfg)
-		local lookup = {}
-		if _ACTION >= "vs2017" then
-			lookup[p.ON]       = "true"
-			lookup[p.OFF]      = "false"
-			lookup["FastLink"] = "DebugFastLink"
-			lookup["Full"]     = "DebugFull"
-		elseif _ACTION == "vs2015" then
-			lookup[p.ON]       = "true"
-			lookup[p.OFF]      = "false"
-			lookup["FastLink"] = "DebugFastLink"
-			lookup["Full"]     = "true"
-		else
-			lookup[p.ON]       = "true"
-			lookup[p.OFF]      = "false"
-			lookup["FastLink"] = "true"
-			lookup["Full"]     = "true"
-		end
-
-		local value = lookup[cfg.symbols]
+		local action = p.action.current()
+		local value = action.symbols[cfg.symbols]
 		if value then
 			m.element("GenerateDebugInformation", nil, value)
 		end

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1376,14 +1376,21 @@
 
 	function m.generateDebugInformation(cfg)
 		local lookup = {}
-		if _ACTION >= "vs2015" then
+		if _ACTION >= "vs2017" then
 			lookup[p.ON]       = "true"
 			lookup[p.OFF]      = "false"
 			lookup["FastLink"] = "DebugFastLink"
+			lookup["Full"]     = "DebugFull"
+		elseif _ACTION == "vs2015" then
+			lookup[p.ON]       = "true"
+			lookup[p.OFF]      = "false"
+			lookup["FastLink"] = "DebugFastLink"
+			lookup["Full"]     = "true"
 		else
 			lookup[p.ON]       = "true"
 			lookup[p.OFF]      = "false"
 			lookup["FastLink"] = "true"
+			lookup["Full"]     = "true"
 		end
 
 		local value = lookup[cfg.symbols]

--- a/src/actions/vstudio/vs2012.lua
+++ b/src/actions/vstudio/vs2012.lua
@@ -67,6 +67,13 @@
 			targetFramework = "4.5",
 			toolsVersion    = "4.0",
 			platformToolset = "v110"
+		},
+
+		symbols = {
+			[p.ON]       = "true",
+			[p.OFF]      = "false",
+			["FastLink"] = "true",
+			["Full"]     = "true"
 		}
 	}
 

--- a/src/actions/vstudio/vs2013.lua
+++ b/src/actions/vstudio/vs2013.lua
@@ -70,5 +70,12 @@
 			toolsVersion    = "12.0",
 			filterToolsVersion = "4.0",
 			platformToolset = "v120"
+		},
+
+		symbols = {
+			[p.ON]       = "true",
+			[p.OFF]      = "false",
+			["FastLink"] = "true",
+			["Full"]     = "true"
 		}
 	}

--- a/src/actions/vstudio/vs2015.lua
+++ b/src/actions/vstudio/vs2015.lua
@@ -70,5 +70,12 @@
 			toolsVersion    = "14.0",
 			filterToolsVersion = "4.0",
 			platformToolset = "v140"
+		},
+
+		symbols = {
+			[p.ON]       = "true",
+			[p.OFF]      = "false",
+			["FastLink"] = "DebugFastLink",
+			["Full"]     = "true"
 		}
 	}

--- a/src/actions/vstudio/vs2017.lua
+++ b/src/actions/vstudio/vs2017.lua
@@ -70,5 +70,12 @@
 			toolsVersion    = "15.0",
 			filterToolsVersion = "4.0",
 			platformToolset = "v141"
+		},
+
+		symbols = {
+			[p.ON]       = "true",
+			[p.OFF]      = "false",
+			["FastLink"] = "DebugFastLink",
+			["Full"]     = "DebugFull"
 		}
 	}

--- a/tests/actions/vstudio/vc2010/test_item_def_group.lua
+++ b/tests/actions/vstudio/vc2010/test_item_def_group.lua
@@ -16,6 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
+		premake.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -151,6 +151,17 @@
 		]]
 	end
 
+	function suite.generateDebugInfo_onSymbolsFull_on2010()
+		premake.action.set("vs2010")
+		symbols "Full"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
 	function suite.generateDebugInfo_onSymbolsOn_on2015()
 		premake.action.set("vs2015")
 		symbols "On"
@@ -174,6 +185,27 @@
 		]]
 	end
 
+	function suite.generateDebugInfo_onSymbolsFull_on2015()
+		premake.action.set("vs2015")
+		symbols "Full"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsFull_on2017()
+		premake.action.set("vs2017")
+		symbols "Full"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+		]]
+	end
 
 --
 -- Any system libraries specified in links() should be listed as

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -129,8 +129,74 @@
 -- Test the handling of the Symbols flag.
 --
 
+	function suite.generateDebugInfo_onSymbolsOn_on2005()
+		premake.action.set("vs2005")
+		symbols "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsOn_on2008()
+		premake.action.set("vs2008")
+		symbols "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
 	function suite.generateDebugInfo_onSymbolsOn_on2010()
 		premake.action.set("vs2010")
+		symbols "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsOn_on2012()
+		premake.action.set("vs2012")
+		symbols "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsOn_on2013()
+		premake.action.set("vs2013")
+		symbols "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsOn_on2015()
+		premake.action.set("vs2015")
+		symbols "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsOn_on2017()
+		premake.action.set("vs2017")
 		symbols "On"
 		prepare()
 		test.capture [[
@@ -151,28 +217,6 @@
 		]]
 	end
 
-	function suite.generateDebugInfo_onSymbolsFull_on2010()
-		premake.action.set("vs2010")
-		symbols "Full"
-		prepare()
-		test.capture [[
-<Link>
-	<SubSystem>Windows</SubSystem>
-	<GenerateDebugInformation>true</GenerateDebugInformation>
-		]]
-	end
-
-	function suite.generateDebugInfo_onSymbolsOn_on2015()
-		premake.action.set("vs2015")
-		symbols "On"
-		prepare()
-		test.capture [[
-<Link>
-	<SubSystem>Windows</SubSystem>
-	<GenerateDebugInformation>true</GenerateDebugInformation>
-		]]
-	end
-
 	function suite.generateDebugInfo_onSymbolsFastLink_on2015()
 		premake.action.set("vs2015")
 		symbols "FastLink"
@@ -182,6 +226,17 @@
 	<SubSystem>Windows</SubSystem>
 	<FullProgramDatabaseFile>true</FullProgramDatabaseFile>
 	<GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
+		]]
+	end
+
+	function suite.generateDebugInfo_onSymbolsFull_on2010()
+		premake.action.set("vs2010")
+		symbols "Full"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<GenerateDebugInformation>true</GenerateDebugInformation>
 		]]
 	end
 


### PR DESCRIPTION
I extracted the table information for the mapping between premake symbol flags and the various Visual Studio version flags. 

I duplicated the tables for vs2005-vs2013 since I wasn't sure if I should rather define them somewhere in the vs2005 file and then have each action reference them or not. It looks like some of the functions do this already, but I didn't find an example of a table doing this.

Also, I wasn't sure whether to put the new symbol lookup table inside the vstudio table that's part of the action. I decided not to in the end since that table looks more like it's for the general visual studio version configuration.

I added a few more tests just to verify that every current version of visual studio generates the correct value for symbols on.