### PR TITLE
UTs fix: Use Windows registry locations that exist for built-in users

### DIFF
--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -246,22 +246,22 @@
 
 	function suite.getreg_namedValue()
 		if os.is("windows") then
-			local x = os.getWindowsRegistry("HKCU:Environment\\PATH")
+			local x = os.getWindowsRegistry("HKCU:Environment\\TEMP")
 			test.istrue(x ~= nil)
 		end
 	end
 
 	function suite.getreg_namedValueOptSeparator()
 		if os.is("windows") then
-			local x = os.getWindowsRegistry("HKCU:\\Environment\\PATH")
+			local x = os.getWindowsRegistry("HKCU:\\Environment\\TEMP")
 			test.istrue(x ~= nil)
 		end
 	end
 
 	function suite.getreg_defaultValue()
 		if os.is("windows") then
-			local x = os.getWindowsRegistry("HKCU:AppEvents\\EventLabels\\.Default\\")
-			test.isequal("Default Beep", x)
+			local x = os.getWindowsRegistry("HKLM:SYSTEM\\CurrentControlSet\\Control\\SafeBoot\\Minimal\\AppInfo\\")
+			test.isequal("Service", x)
 		end
 	end
 


### PR DESCRIPTION
I have some Jenkins jobs that run premake UTs and fail because the registry keys used to test os.getWindowsRegistry do not exist for the SYSTEM user (which Jenkins runs under). So I've tried to find the keys that are always present on the system. Tested only on Win7.