### PR TITLE
Fix missing CA certs on Windows

### DIFF
--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -53,7 +53,7 @@ mingw: $(SRC)
 
 osx: $(SRC)
 	mkdir -p build/bootstrap
-	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_MACOSX -I"$(LUA_DIR)" -framework CoreServices $?
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_MACOSX -I"$(LUA_DIR)" -framework CoreServices -framework Foundation -framework Security $?
 	./build/bootstrap/premake_bootstrap embed
 	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN`

--- a/contrib/curl/premake5.lua
+++ b/contrib/curl/premake5.lua
@@ -2,7 +2,7 @@ project "curl-lib"
 	language    "C"
 	kind        "StaticLib"
 	includedirs { "include", "lib", "../mbedtls/include/" }
-	defines     { "BUILDING_LIBCURL", "CURL_STATICLIB", "HTTP_ONLY", "USE_MBEDTLS" }
+	defines     { "BUILDING_LIBCURL", "CURL_STATICLIB", "HTTP_ONLY" }
 	warnings    "off"
 
 	if not _OPTIONS["no-zlib"] then
@@ -15,6 +15,12 @@ project "curl-lib"
 		"**.h",
 		"**.c"
 	}
+	
+	filter { "system:windows" }
+		defines { "USE_SCHANNEL", "USE_WINDOWS_SSPI" }
+	
+	filter { "system:not windows" }
+		defines { "USE_MBEDTLS" }
 
 	filter { "system:linux" }
 		defines { "CURL_HIDDEN_SYMBOLS" }

--- a/contrib/curl/premake5.lua
+++ b/contrib/curl/premake5.lua
@@ -18,8 +18,11 @@ project "curl-lib"
 	
 	filter { "system:windows" }
 		defines { "USE_SCHANNEL", "USE_WINDOWS_SSPI" }
-	
-	filter { "system:not windows" }
+
+	filter { "system:macosx" }
+		defines { "USE_DARWINSSL" }
+
+	filter { "system:not windows", "system:not macosx" }
 		defines { "USE_MBEDTLS" }
 
 	filter { "system:linux" }

--- a/contrib/mbedtls/premake5.lua
+++ b/contrib/mbedtls/premake5.lua
@@ -16,4 +16,5 @@ project "mbedtls-lib"
 		"library/*.c"
 	}
 
-
+	filter { "system:windows or macosx" }
+		flags { "ExcludeFromBuild" }

--- a/contrib/mbedtls/premake5.lua
+++ b/contrib/mbedtls/premake5.lua
@@ -16,5 +16,4 @@ project "mbedtls-lib"
 		"library/*.c"
 	}
 
-	filter { "system:windows or macosx" }
-		flags { "ExcludeFromBuild" }
+

--- a/premake5.lua
+++ b/premake5.lua
@@ -136,7 +136,7 @@
 		end
 		if not _OPTIONS["no-curl"] then
 			includedirs { "contrib/curl/include" }
-			links { "curl-lib", "mbedtls-lib" }
+			links { "curl-lib" }
 		end
 
 		files
@@ -168,6 +168,11 @@
 
 		filter "system:linux or hurd"
 			links       { "dl", "rt" }
+
+		filter { "system:not windows", "system:not macosx" }
+			if not _OPTIONS["no-curl"] then
+				links   { "mbedtls-lib" }
+			end
 
 		filter "system:macosx"
 			defines     { "LUA_USE_MACOSX" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -171,7 +171,7 @@
 
 		filter "system:macosx"
 			defines     { "LUA_USE_MACOSX" }
-			links       { "CoreServices.framework" }
+			links       { "CoreServices.framework", "Foundation.framework", "Security.framework" }
 
 		filter { "system:macosx", "action:gmake" }
 			toolset "clang"

--- a/tests/base/test_http.lua
+++ b/tests/base/test_http.lua
@@ -38,6 +38,18 @@
 		end
 	end
 
+	function suite.https_get_verify_peer()
+		local result, err = http.get("https://httpbin.org/user-agent")
+		if result then
+			p.out(result)
+			test.capture(
+				'{\n  "user-agent": "Premake/' .. _PREMAKE_VERSION .. '"\n}'
+			)
+		else
+			test.fail(err);
+		end
+	end
+
 	function suite.http_responsecode()
 		local result, err, responseCode = http.get("http://httpbin.org/status/418")
 		test.isequal(responseCode, 418)


### PR DESCRIPTION
This pull request fixes https://github.com/premake/premake-core/issues/706 (_http.* with SSL doesn't work on Windows_) and partially reverts the _mbedtls_ transition.

The main reason for using Microsoft's own TLS implementation (Schannel) is that it doesn't explicitly require us to bundle the CA certs, but uses the the OS' built-in certs instead (see the last section for details: https://curl.haxx.se/docs/sslcerts.html)