### PR TITLE
Treat *.inl files as headers

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -624,7 +624,7 @@
 ---
 	m.categories.ClInclude = {
 		name       = "ClInclude",
-		extensions = { ".h", ".hh", ".hpp", ".hxx" },
+		extensions = { ".h", ".hh", ".hpp", ".hxx", ".inl" },
 		priority   = 1,
 
 		emitFiles = function(prj, group)


### PR DESCRIPTION
This addresses issues with Visual Studio and Intellisense when using *.inl files. If they're not treated as headers or source files, Intellisense fails to parse them correctly.

I can't see this having undesirable side effects for existing projects. Ideally, the user should be able to specify how different files should be treated.