### PR TITLE
Sort categories in --help,

### DIFF
--- a/src/base/help.lua
+++ b/src/base/help.lua
@@ -31,22 +31,30 @@
 		end
 
 		-- display all options
-		for k, options in pairs(categories) do
+		for k, options in spairs(categories) do
 			printf(k)
 			printf("")
+
+			local length = 0
+			for _, option in ipairs(options) do
+				local trigger = option.trigger
+				if (option.value) then trigger = trigger .. "=" .. option.value end
+				if (#trigger > length) then length = #trigger end
+			end
+
 			for _, option in ipairs(options) do
 				local trigger = option.trigger
 				local description = option.description
 				if (option.value) then trigger = trigger .. "=" .. option.value end
 				if (option.allowed) then description = description .. "; one of:" end
 
-				printf(" --%-15s %s", trigger, description)
+				printf(" --%-" .. length .. "s %s", trigger, description)
 				if (option.allowed) then
 					for _, value in ipairs(option.allowed) do
-						printf("     %-14s %s", value[1], value[2])
+						printf("     %-" .. length-1 .. "s %s", value[1], value[2])
 					end
+					printf("")
 				end
-				printf("")
 			end
 			printf("")
 		end

--- a/src/base/table.lua
+++ b/src/base/table.lua
@@ -532,3 +532,25 @@
 		end
 		return true
 	end
+
+
+--
+-- Enumerate a table sorted by its keys.
+--
+	function spairs(t)
+		-- collect the keys
+		local keys = {}
+		for k in pairs(t) do
+			table.insert(keys, k)
+		end
+		table.sort(keys)
+
+		-- return the iterator function
+		local i = 0
+		return function()
+			i = i + 1
+			if keys[i] then
+				return keys[i], t[keys[i]]
+			end
+		end
+	end


### PR DESCRIPTION
better align options when they get longer then 15 characters.
Compact options if no 'allowed' table is there.