### PR TITLE
Fix VS2013 and older always rebuilding when debug symbols explicitly …

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1262,7 +1262,14 @@
 
 			m.element("DebugInformationFormat", nil, value)
 		elseif cfg.symbols == p.OFF then
-			m.element("DebugInformationFormat", nil, "None")
+			-- leave field blank for vs2013 and older to workaround bug
+			if _ACTION < "vs2015" then
+				value = ""
+			else
+				value = "None"
+			end
+
+			m.element("DebugInformationFormat", nil, value)
 		end
 	end
 

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -790,9 +790,29 @@
 
 --
 -- Check handling of the explicitly disabling symbols.
+-- Note: VS2013 and older have a bug with setting
+-- DebugInformationFormat to None. The workaround
+-- is to leave the field blank.
 --
 	function suite.onNoSymbols()
 		symbols 'Off'
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<DebugInformationFormat></DebugInformationFormat>
+	<Optimization>Disabled</Optimization>
+		]]
+	end
+
+
+--
+-- VS2015 and newer can use DebugInformationFormat None.
+--
+	function suite.onNoSymbolsVS2015()
+		symbols 'Off'
+		premake.action.set("vs2015")
 		prepare()
 		test.capture [[
 <ClCompile>
@@ -802,7 +822,6 @@
 	<Optimization>Disabled</Optimization>
 		]]
 	end
-
 
 
 --


### PR DESCRIPTION
…disabled

Visual Studio versions 2013 and older have an issue with
DebugInformationFormat set to None. The project will always be out of
date and thus always rebuild. The workaround is to leave the
DebugInformationFormat field blank.

https://connect.microsoft.com/VisualStudio/feedback/details/833494/project-with-debug-information-disabled-always-rebuilds

VS2015 and newer do not have this issue.