### PR TITLE
Removed deprecated APIs and flags older than two years

### DIFF
--- a/modules/d/tools/dmd.lua
+++ b/modules/d/tools/dmd.lua
@@ -218,7 +218,7 @@
 			CodeCoverage	= "-cov",
 			Deprecated		= "-d",
 			Documentation	= "-D",
-			FatalWarnings	= "-w",
+--			FatalWarnings	= "-w",
 			GenerateHeader	= "-H",
 			GenerateJSON	= "-X",
 			GenerateMap		= "-map",

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -1153,7 +1153,7 @@
 
 
 	function suite.XCBuildConfigurationProject_OnOptimizeSpeed()
-		flags { "OptimizeSpeed" }
+		optimize "speed"
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
@@ -1466,7 +1466,7 @@
 
 
 	function suite.XCBuildConfigurationProject_OnFloatFast()
-		flags { "FloatFast" }
+		floatingpoint "Fast"
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
@@ -1495,7 +1495,7 @@
 
 
 	function suite.XCBuildConfigurationProject_OnFloatStrict()
-		flags { "FloatStrict" }
+		floatingpoint "Strict"
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
@@ -1524,7 +1524,7 @@
 
 
 	function suite.XCBuildConfigurationProject_OnNoEditAndContinue()
-		flags { "NoEditAndContinue" }
+		editandcontinue "Off"
 		symbols "On"
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
@@ -2046,7 +2046,7 @@ function suite.defaultVisibilitySetting_setToNo()
 end
 
 function suite.releaseBuild_onlyDefaultArch_equalsNo()
-	flags { "Optimize" }
+	optimize "On"
 	prepare()
 	xcode.XCBuildConfiguration_Project(tr, tr.configs[2])
 	local str = premake.captured()

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1032,7 +1032,7 @@
 			settings['GCC_ENABLE_CPP_RTTI'] = 'NO'
 		end
 
-		if cfg.symbols == p.ON and not cfg.flags.NoEditAndContinue then
+		if cfg.symbols == p.ON and cfg.editandcontinue ~= "Off" then
 			settings['GCC_ENABLE_FIX_AND_CONTINUE'] = 'YES'
 		end
 
@@ -1095,8 +1095,8 @@
 
 		-- build list of "other" C/C++ flags
 		local checks = {
-			["-ffast-math"]          = cfg.flags.FloatFast,
-			["-ffloat-store"]        = cfg.flags.FloatStrict,
+			["-ffast-math"]          = cfg.floatingpoint == "Fast",
+			["-ffloat-store"]        = cfg.floatingpoint == "Strict",
 			["-fomit-frame-pointer"] = cfg.flags.NoFramePointer,
 		}
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -94,7 +94,8 @@
 		configurations { "Release", "Debug" }
 		location ( _OPTIONS["to"] )
 
-		flags { "No64BitChecks", "ExtraWarnings", "StaticRuntime", "MultiProcessorCompile" }
+		flags { "No64BitChecks", "StaticRuntime", "MultiProcessorCompile" }
+		warnings "Extra"
 
 		if not _OPTIONS["no-zlib"] then
 			defines { "PREMAKE_COMPRESSION" }

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -132,13 +132,6 @@
 	}
 
 	api.register {
-		name = "buildrule",     -- DEPRECATED
-		scope = "config",
-		kind = "table",
-		tokens = true,
-	}
-
-	api.register {
 		name = "characterset",
 		scope = "config",
 		kind = "string",
@@ -460,52 +453,33 @@
 		scope = "config",
 		kind  = "list:string",
 		allowed = {
-			"Component",           -- DEPRECATED
 			"DebugEnvsDontMerge",
 			"DebugEnvsInherit",
-			"EnableSSE",           -- DEPRECATED
-			"EnableSSE2",          -- DEPRECATED
 			"ExcludeFromBuild",
-			"ExtraWarnings",       -- DEPRECATED
 			"FatalCompileWarnings",
 			"FatalLinkWarnings",
-			"FloatFast",           -- DEPRECATED
-			"FloatStrict",         -- DEPRECATED
 			"LinkTimeOptimization",
-			"Managed",             -- DEPRECATED
 			"Maps",
 			"MFC",
 			"MultiProcessorCompile",
-			"NativeWChar",         -- DEPRECATED
 			"No64BitChecks",
 			"NoCopyLocal",
-			"NoEditAndContinue",   -- DEPRECATED
-			"NoExceptions",        -- DEPRECATED
 			"NoFramePointer",
 			"NoImplicitLink",
 			"NoImportLib",
 			"NoIncrementalLink",
 			"NoManifest",
 			"NoMinimalRebuild",
-			"NoNativeWChar",       -- DEPRECATED
 			"NoPCH",
 			"NoRuntimeChecks",
-			"NoRTTI",              -- DEPRECATED
 			"NoBufferSecurityCheck",
-			"NoWarnings",          -- DEPRECATED
 			"OmitDefaultLibrary",
-			"Optimize",            -- DEPRECATED
-			"OptimizeSize",        -- DEPRECATED
-			"OptimizeSpeed",       -- DEPRECATED
 			"RelativeLinks",
-			"ReleaseRuntime",      -- DEPRECATED
-			"SEH",                 -- DEPRECATED
 			"ShadowedVariables",
 			"StaticRuntime",
 			"Symbols",             -- DEPRECATED
 			"UndefinedIdentifiers",
 			"Unicode",             -- DEPRECATED
-			"Unsafe",              -- DEPRECATED
 			"WinMain",
 			"WPF",
 			"C++11",               -- DEPRECATED
@@ -516,9 +490,6 @@
 		},
 		aliases = {
 			FatalWarnings = { "FatalWarnings", "FatalCompileWarnings", "FatalLinkWarnings" },
-			Optimise = 'Optimize',
-			OptimiseSize = 'OptimizeSize',
-			OptimiseSpeed = 'OptimizeSpeed',
 		},
 	}
 
@@ -1209,145 +1180,6 @@
 -- Handlers for deprecated fields and values.
 --
 -----------------------------------------------------------------------------
-
-	-- 09 Apr 2013
-
-	api.deprecateField("buildrule", nil,
-	function(value)
-		if value.description then
-			buildmessage(value.description)
-		end
-		buildcommands(value.commands)
-		buildoutputs(value.outputs)
-	end)
-
-
-	-- 17 Jun 2013
-
-	api.deprecateValue("flags", "Component", nil,
-	function(value)
-		buildaction "Component"
-	end)
-
-
-	-- 26 Sep 2013
-
-	api.deprecateValue("flags", { "EnableSSE", "EnableSSE2" }, nil,
-	function(value)
-		vectorextensions(value:sub(7))
-	end,
-	function(value)
-		vectorextensions "Default"
-	end)
-
-
-	api.deprecateValue("flags", { "FloatFast", "FloatStrict" }, nil,
-	function(value)
-		floatingpoint(value:sub(6))
-	end,
-	function(value)
-		floatingpoint "Default"
-	end)
-
-
-	api.deprecateValue("flags", { "NativeWChar", "NoNativeWChar" }, nil,
-	function(value)
-		local map = { NativeWChar = "On", NoNativeWChar = "Off" }
-		nativewchar(map[value] or "Default")
-	end,
-	function(value)
-		nativewchar "Default"
-	end)
-
-
-	api.deprecateValue("flags", { "Optimize", "OptimizeSize", "OptimizeSpeed" }, nil,
-	function(value)
-		local map = { Optimize = "On", OptimizeSize = "Size", OptimizeSpeed = "Speed" }
-		optimize (map[value] or "Off")
-	end,
-	function(value)
-		optimize "Off"
-	end)
-
-	api.deprecateValue("flags", { "ReleaseRuntime" }, nil,
-	function(value)
-		runtime 'Release'
-	end,
-	function(value)
-	end)
-
-	api.deprecateValue("flags", { "Optimise", "OptimiseSize", "OptimiseSpeed" }, nil,
-	function(value)
-		local map = { Optimise = "On", OptimiseSize = "Size", OptimiseSpeed = "Speed" }
-		optimize (map[value] or "Off")
-	end,
-	function(value)
-		optimize "Off"
-	end)
-
-
-	api.deprecateValue("flags", { "ExtraWarnings", "NoWarnings" }, nil,
-	function(value)
-		local map = { ExtraWarnings = "Extra", NoWarnings = "Off" }
-		warnings (map[value] or "Default")
-	end,
-	function(value)
-		warnings "Default"
-	end)
-
-
-	-- 10 Nov 2014
-
-	api.deprecateValue("flags", "Managed", nil,
-	function(value)
-		clr "On"
-	end,
-	function(value)
-		clr "Off"
-	end)
-
-
-	api.deprecateValue("flags", "NoEditAndContinue", nil,
-	function(value)
-		editandcontinue "Off"
-	end,
-	function(value)
-		editandcontinue "On"
-	end)
-
-
-	api.deprecateValue("flags", "NoExceptions", 'Use `exceptionhandling "Off"` instead',
-	function(value)
-		exceptionhandling "Off"
-	end,
-	function(value)
-		exceptionhandling "On"
-	end)
-
-
-	api.deprecateValue("flags", "NoRTTI", 'Use `rtti "Off"` instead',
-	function(value)
-		rtti "Off"
-	end,
-	function(value)
-		rtti "On"
-	end)
-
-	api.deprecateValue("flags", "SEH", 'Use `exceptionhandling "SEH"` instead',
-	function(value)
-		exceptionhandling "SEH"
-	end,
-	function(value)
-		exceptionhandling "Default"
-	end)
-
-	api.deprecateValue("flags", "Unsafe", 'Use `clr "Unsafe"` instead',
-	function(value)
-		clr "Unsafe"
-	end,
-	function(value)
-		clr "On"
-	end)
 
 	-- 18 Dec 2015
 

--- a/tests/actions/vstudio/vc200x/test_compiler_block.lua
+++ b/tests/actions/vstudio/vc200x/test_compiler_block.lua
@@ -537,13 +537,13 @@
 
 
 --
--- Check handling of the ReleaseRuntime flag; should override the
+-- Check handling of the runtime API; should override the
 -- default behavior of linking the debug runtime when symbols are
 -- enabled with no optimizations.
 --
 
 	function suite.releaseRuntime_onFlag()
-		flags { "ReleaseRuntime" }
+		runtime "Release"
 		symbols "On"
 		prepare()
 		test.capture [[
@@ -557,7 +557,8 @@
 	end
 
 	function suite.releaseRuntime_onStaticAndReleaseRuntime()
-		flags { "ReleaseRuntime", "StaticRuntime" }
+		runtime "Release"
+		flags { "StaticRuntime" }
 		symbols "On"
 		prepare()
 		test.capture [[

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -494,7 +494,7 @@
 --
 
 	function suite.wchar_onNative()
-		flags "NativeWChar"
+		nativewchar "On"
 		prepare()
 		test.capture [[
 <ClCompile>
@@ -506,7 +506,7 @@
 	end
 
 	function suite.wchar_onNoNative()
-		flags "NoNativeWChar"
+		nativewchar "Off"
 		prepare()
 		test.capture [[
 <ClCompile>
@@ -751,13 +751,14 @@
 
 
 --
--- Check handling of the ReleaseRuntime flag; should override the
+-- Check handling of the runtime API; should override the
 -- default behavior of linking the debug runtime when symbols are
 -- enabled with no optimizations.
 --
 
 	function suite.releaseRuntime_onStaticAndReleaseRuntime()
-		flags { "ReleaseRuntime", "StaticRuntime" }
+		runtime "Release"
+		flags { "StaticRuntime" }
 		symbols "On"
 		prepare()
 		test.capture [[

--- a/tests/actions/vstudio/vc2010/test_config_props.lua
+++ b/tests/actions/vstudio/vc2010/test_config_props.lua
@@ -209,13 +209,13 @@
 	end
 
 --
--- Check handling of the ReleaseRuntime flag; should override the
+-- Check handling of the runtime API; should override the
 -- default behavior of linking the debug runtime when symbols are
 -- enabled with no optimizations.
 --
 
 	function suite.releaseRuntime_onFlag()
-		flags { "ReleaseRuntime" }
+		runtime "Release"
 		symbols "On"
 		prepare()
 		test.capture [[


### PR DESCRIPTION
Not sure if this is wanted or not, but I think two years is more than enough time to stop using those deprecated APIs and flags.