### PR TITLE
Fixed erroneous escape usages in VS2010+

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1797,7 +1797,7 @@
 	function m.nmakePreprocessorDefinitions(cfg)
 		if cfg.kind ~= p.NONE and #cfg.defines > 0 then
 			local defines = table.concat(cfg.defines, ";")
-			defines = p.esc(defines) .. ";$(NMakePreprocessorDefinitions)"
+			defines = defines .. ";$(NMakePreprocessorDefinitions)"
 			m.element('NMakePreprocessorDefinitions', nil, defines)
 		end
 	end
@@ -1912,7 +1912,7 @@
 			if escapeQuotes then
 				defines = defines:gsub('"', '\\"')
 			end
-			defines = p.esc(defines) .. ";%%(PreprocessorDefinitions)"
+			defines = defines .. ";%%(PreprocessorDefinitions)"
 			m.element('PreprocessorDefinitions', condition, defines)
 		end
 	end
@@ -1924,7 +1924,7 @@
 			if escapeQuotes then
 				undefines = undefines:gsub('"', '\\"')
 			end
-			undefines = p.esc(undefines) .. ";%%(UndefinePreprocessorDefinitions)"
+			undefines = undefines .. ";%%(UndefinePreprocessorDefinitions)"
 			m.element('UndefinePreprocessorDefinitions', condition, undefines)
 		end
 	end
@@ -2142,7 +2142,7 @@
 	function m.disableSpecificWarnings(cfg, condition)
 		if #cfg.disablewarnings > 0 then
 			local warnings = table.concat(cfg.disablewarnings, ";")
-			warnings = p.esc(warnings) .. ";%%(DisableSpecificWarnings)"
+			warnings = warnings .. ";%%(DisableSpecificWarnings)"
 			m.element('DisableSpecificWarnings', condition, warnings)
 		end
 	end
@@ -2151,7 +2151,7 @@
 	function m.treatSpecificWarningsAsErrors(cfg, condition)
 		if #cfg.fatalwarnings > 0 then
 			local fatal = table.concat(cfg.fatalwarnings, ";")
-			fatal = p.esc(fatal) .. ";%%(TreatSpecificWarningsAsErrors)"
+			fatal = fatal .. ";%%(TreatSpecificWarningsAsErrors)"
 			m.element('TreatSpecificWarningsAsErrors', condition, fatal)
 		end
 	end

--- a/tests/actions/vstudio/vc2010/test_compile_settings.lua
+++ b/tests/actions/vstudio/vc2010/test_compile_settings.lua
@@ -268,6 +268,24 @@
 
 
 --
+--	If defines are specified with escapable characters, they should be escaped.
+--
+
+	function suite.preprocessorDefinitions_onDefines()
+		premake.escaper(premake.vstudio.vs2010.esc)
+		defines { "&", "<", ">" }
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<PreprocessorDefinitions>&amp;;&lt;;&gt;;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+		]]
+		premake.escaper(nil)
+	end
+
+
+--
 -- If undefines are specified, the <UndefinePreprocessorDefinitions> element should be added.
 --
 

--- a/tests/actions/vstudio/vc2010/test_nmake_props.lua
+++ b/tests/actions/vstudio/vc2010/test_nmake_props.lua
@@ -126,6 +126,19 @@ command 2</NMakeBuildCommandLine>
 		]]
 	end
 
+	function suite.onEscapedDefines()
+		premake.escaper(premake.vstudio.vs2010.esc)
+		defines { "&", "<", ">" }
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
+	<NMakePreprocessorDefinitions>&amp;;&lt;;&gt;;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+</PropertyGroup>
+		]]
+		premake.escaper(nil)
+	end
+
 	function suite.onIncludeDirs()
 		includedirs { "include/lua", "include/zlib" }
 		prepare()


### PR DESCRIPTION
- Added tests for sensible escape usage locations (defines, not undefines or warnings)

Resolves #725