### PR TITLE
[core] Fix Visual Studio ExecutablePath settings.

### DIFF
--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -1875,6 +1875,12 @@
 	function m.executablePath(cfg)
 		local dirs = vstudio.path(cfg, cfg.bindirs)
 		if #dirs > 0 then
+			dirs = table.translate(dirs, function(dir)
+				if path.isabsolute(dir) then
+					return dir
+				end
+				return "$(ProjectDir)" .. dir
+			end)
 			m.element("ExecutablePath", nil, "%s;$(ExecutablePath)", table.concat(dirs, ";"))
 		end
 	end

--- a/tests/actions/vstudio/vc2010/test_output_props.lua
+++ b/tests/actions/vstudio/vc2010/test_output_props.lua
@@ -289,3 +289,37 @@
 </PropertyGroup>
 		]]
 	end
+
+--
+-- Check the handling of the VC++ ExecutablePath.
+--
+
+	function suite.onBinDirsRelative()
+		bindirs { "../Include" }
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+	<ExecutablePath>$(ProjectDir)..\Include;$(ExecutablePath)</ExecutablePath>
+</PropertyGroup>
+		]]
+	end
+
+	function suite.onBinDirsAbsolute()
+		bindirs { "C:\\Include" }
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+	<ExecutablePath>C:\Include;$(ExecutablePath)</ExecutablePath>
+</PropertyGroup>
+		]]
+	end


### PR DESCRIPTION
Turns out, the command line %PATH% variable is only resolved when you search for something, not at startup... so having relative paths in %PATH% breaks, as soon as you do a "cd <somefolder>" in your {pre/post}buildcommands..

This puts that %(ProjectDir) in front of all relative paths, so that the %PATH% variable only gets absolute paths during execution of the buildcommands.