### PR TITLE
[core] Don't set default entrypoint, rely on visual studio default.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1545,7 +1545,4 @@
 	filter { "system:macosx" }
 		toolset "clang"
 
-	filter { "system:windows", "kind:WindowedApp or ConsoleApp" }
-		entrypoint "mainCRTStartup"
-
 	filter {}

--- a/tests/actions/vstudio/vc200x/test_linker_block.lua
+++ b/tests/actions/vstudio/vc200x/test_linker_block.lua
@@ -41,7 +41,6 @@
 	LinkIncremental="2"
 	GenerateDebugInformation="false"
 	SubSystem="1"
-	EntryPointSymbol="mainCRTStartup"
 	TargetMachine="1"
 />
 		]]
@@ -62,7 +61,6 @@
 	LinkIncremental="2"
 	GenerateDebugInformation="false"
 	SubSystem="2"
-	EntryPointSymbol="mainCRTStartup"
 	TargetMachine="1"
 />
 		]]
@@ -138,7 +136,6 @@
 	LinkIncremental="2"
 	GenerateDebugInformation="true"
 	SubSystem="1"
-	EntryPointSymbol="mainCRTStartup"
 	TargetMachine="1"
 />
 		]]

--- a/tests/actions/vstudio/vc2010/test_excluded_configs.lua
+++ b/tests/actions/vstudio/vc2010/test_excluded_configs.lua
@@ -52,7 +52,6 @@
 		test.capture [[
 <Link>
 	<SubSystem>Console</SubSystem>
-	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 </Link>
 		]]
 	end
@@ -71,7 +70,6 @@
 <Link>
 	<SubSystem>Console</SubSystem>
 	<AdditionalDependencies>bin\Ares\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
-	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 </Link>
 <ProjectReference>
 	<LinkLibraryDependencies>false</LinkLibraryDependencies>

--- a/tests/actions/vstudio/vc2010/test_link.lua
+++ b/tests/actions/vstudio/vc2010/test_link.lua
@@ -72,7 +72,6 @@
 		test.capture [[
 <Link>
 	<SubSystem>Console</SubSystem>
-	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 		]]
 	end
 
@@ -82,7 +81,6 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 		]]
 	end
 
@@ -103,6 +101,22 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
+</Link>
+		]]
+	end
+
+
+--
+-- Test the handling of the entrypoint API.
+--
+	function suite.onEntryPoint()
+		kind "ConsoleApp"
+		entrypoint "foobar"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Console</SubSystem>
+	<EntryPointSymbol>foobar</EntryPointSymbol>
 </Link>
 		]]
 	end
@@ -508,7 +522,6 @@
 		test.capture [[
 <Link>
 	<SubSystem>Console</SubSystem>
-	<EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
 	<TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
 		]]
 	end


### PR DESCRIPTION
We shouldn't set this default, since it's wrong and not setting the entrypoint API, will result in the wrong default for WindowedApps. While the Visual Studio default will just work...