### PR TITLE
Assure a default toolset is always set.

### DIFF
--- a/modules/codelite/_preload.lua
+++ b/modules/codelite/_preload.lua
@@ -18,6 +18,7 @@
 		trigger         = "codelite",
 		shortname       = "CodeLite",
 		description     = "Generate CodeLite project files",
+		toolset         = "clang",
 
 		-- The capabilities of this action
 

--- a/modules/gmake/_preload.lua
+++ b/modules/gmake/_preload.lua
@@ -15,6 +15,7 @@
 		trigger         = "gmake",
 		shortname       = "GNU Make",
 		description     = "Generate GNU makefiles for POSIX, MinGW, and Cygwin",
+		toolset         = "gcc",
 
 		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Utility", "Makefile" },
 		valid_languages = { "C", "C++", "C#" },

--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -38,6 +38,7 @@
 	<ConfigurationType>Application</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
 	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v100</PlatformToolset>
 </PropertyGroup>
 		]]
 	end
@@ -270,6 +271,7 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
 	<ConfigurationType>Utility</ConfigurationType>
+	<PlatformToolset>v100</PlatformToolset>
 </PropertyGroup>
 		]]
 	end
@@ -286,6 +288,7 @@
 	<ConfigurationType>Application</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
 	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v100</PlatformToolset>
 	<WholeProgramOptimization>true</WholeProgramOptimization>
 		]]
 	end

--- a/modules/vstudio/tests/vc2010/test_platform_toolset.lua
+++ b/modules/vstudio/tests/vc2010/test_platform_toolset.lua
@@ -35,7 +35,9 @@
 	function suite.correctDefault_onVS2010()
 		p.action.set("vs2010")
 		prepare()
-		test.isemptycapture()
+		test.capture [[
+<PlatformToolset>v100</PlatformToolset>
+		]]
 	end
 
 

--- a/modules/vstudio/vs2010.lua
+++ b/modules/vstudio/vs2010.lua
@@ -131,6 +131,7 @@
 		-- Visual Studio always uses Windows path and naming conventions
 
 		targetos = "windows",
+		toolset  = "msc-v100",
 
 		-- The capabilities of this action
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1929,8 +1929,8 @@
 	function m.platformToolset(cfg)
 		local tool, version = p.config.toolset(cfg)
 		if not version then
-			local action = p.action.current()
-			version = action.vstudio.platformToolset
+			local value = p.action.current().toolset
+			tool, version = p.tools.canonical(value)
 		end
 		if version then
 			if cfg.kind == p.NONE or cfg.kind == p.MAKEFILE then

--- a/modules/vstudio/vs2012.lua
+++ b/modules/vstudio/vs2012.lua
@@ -21,6 +21,7 @@
 		-- Visual Studio always uses Windows path and naming conventions
 
 		targetos = "windows",
+		toolset  = "msc-v110",
 
 		-- The capabilities of this action
 
@@ -62,6 +63,5 @@
 			versionName     = "2012",
 			targetFramework = "4.5",
 			toolsVersion    = "4.0",
-			platformToolset = "v110"
 		}
 	}

--- a/modules/vstudio/vs2013.lua
+++ b/modules/vstudio/vs2013.lua
@@ -21,6 +21,7 @@
 		-- Visual Studio always uses Windows path and naming conventions
 
 		targetos = "windows",
+		toolset  = "msc-v120",
 
 		-- The capabilities of this action
 
@@ -63,6 +64,5 @@
 			targetFramework = "4.5",
 			toolsVersion    = "12.0",
 			filterToolsVersion = "4.0",
-			platformToolset = "v120"
 		}
 	}

--- a/modules/vstudio/vs2015.lua
+++ b/modules/vstudio/vs2015.lua
@@ -21,6 +21,7 @@
 		-- Visual Studio always uses Windows path and naming conventions
 
 		targetos = "windows",
+		toolset  = "msc-v140",
 
 		-- The capabilities of this action
 
@@ -63,6 +64,5 @@
 			targetFramework = "4.5",
 			toolsVersion    = "14.0",
 			filterToolsVersion = "4.0",
-			platformToolset = "v140"
 		}
 	}

--- a/modules/vstudio/vs2017.lua
+++ b/modules/vstudio/vs2017.lua
@@ -21,6 +21,7 @@
 		-- Visual Studio always uses Windows path and naming conventions
 
 		targetos = "windows",
+		toolset  = "msc-v141",
 
 		-- The capabilities of this action
 
@@ -63,6 +64,5 @@
 			targetFramework = "4.5.2",
 			toolsVersion    = "15.0",
 			filterToolsVersion = "4.0",
-			platformToolset = "v141"
 		}
 	}

--- a/modules/xcode/_preload.lua
+++ b/modules/xcode/_preload.lua
@@ -36,6 +36,7 @@
 		-- Xcode always uses Mac OS X path and naming conventions
 
 		targetos = "macosx",
+		toolset  = "clang",
 
 		-- The capabilities of this action
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1149,7 +1149,9 @@
 			value = value:lower()
 			local tool, version = p.tools.canonical(value)
 			if tool then
-				return value
+				return p.tools.normalize(value)
+			else
+				return nil
 			end
 		end,
 	}

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -531,7 +531,7 @@
 
 		local system = p.action.current().targetos or os.target()
 		local architecture = nil
-		local toolset = nil
+		local toolset = p.action.current().toolset
 
 		if platform then
 			system = p.api.checkValue(p.fields.system, platform) or system

--- a/src/base/tools.lua
+++ b/src/base/tools.lua
@@ -29,25 +29,33 @@
 --    returns nil.
 ---
 
-	function p.tools.canonical(identifier)
-		local parts
+	function p.tools.normalize(identifier)
 		if identifier:startswith("v") then -- TODO: this should be deprecated?
-			parts = { "msc", identifier }
-		else
-			parts = identifier:explode("-", true, 1)
-
-			-- couple of little hacks here to fix up version names
-			if parts[2] ~= nil then
-				-- 'msc-100' is accepted, but the code expects 'v100'
-				if parts[1] == "msc" and tonumber(parts[2]:sub(1,3)) ~= nil then
-					parts[2] = "v" .. parts[2]
-				end
-
-				-- perform case-correction of the LLVM toolset
-				if parts[2]:startswith("llvm-vs") then
-					parts[2] = "LLVM-" .. parts[2]:sub(6)
-				end
-			end
+			identifier = 'msc-' .. identifier
 		end
+
+		local parts = identifier:explode("-", true, 1)
+		if parts[2] == nil then
+			return parts[1]
+		end
+
+		-- 'msc-100' is accepted, but the code expects 'v100'
+		if parts[1] == "msc" and tonumber(parts[2]:sub(1,3)) ~= nil then
+			parts[2] = "v" .. parts[2]
+		end
+
+		-- perform case-correction of the LLVM toolset
+		if parts[2]:startswith("llvm-vs") then
+			parts[2] = "LLVM-" .. parts[2]:sub(6)
+		end
+
+		return parts[1] .. '-' .. parts[2]
+	end
+
+
+	function p.tools.canonical(identifier)
+		identifier = p.tools.normalize(identifier)
+
+		local parts = identifier:explode("-", true, 1)
 		return p.tools[parts[1]], parts[2]
 	end

--- a/tests/oven/test_filtering.lua
+++ b/tests/oven/test_filtering.lua
@@ -108,6 +108,15 @@
 		test.isequal({}, cfg.defines)
 	end
 
+	function suite.onFilterToolsetNormalization()
+		toolset "v140"
+		filter { "toolset:msc-v140" }
+		defines { "USE_MSC" }
+		prepare()
+		test.isequal({ "USE_MSC" }, cfg.defines)
+	end
+
+
 --
 -- Test filtering on system.
 --


### PR DESCRIPTION
We're running into the issue where:
```
filter { 'toolset:msc-v140' }
```
doesn't work, because the majority of time, the toolset is not actually set. This change assures the filter always has a valid value in it, and not just 'nil' in the majority of cases.

We also normalize the toolset, so when you do
```
toolset 'v140'
```
it normalizes to ```msc-v140```, as well as the other rules implemented in the ```p.tool.canonical``` function.
We should realy deprecate the v140 naming however, and require explicit msc-v140 usage, so I added a p.warnOnce in there too.
