### PR TITLE
Allow filters to be written as tables:

### DIFF
--- a/src/base/criteria.lua
+++ b/src/base/criteria.lua
@@ -37,6 +37,39 @@
 	}
 
 
+--
+-- Flattens a hierarchy of criteria terms into a single array containing all
+-- of the values as strings in the form of "term:value1 or value2" etc.
+--
+	function criteria.flatten(terms)
+		local result = {}
+
+		local function flatten(terms)
+			for key, value in pairs(terms) do
+				if type(key) == "number" then
+					if type(value) == "table" then
+						flatten(value)
+					elseif value then
+						table.insert(result, value)
+					end
+				elseif type(key) == "string" then
+					local word = key .. ":"
+					if type(value) == "table" then
+						local values = table.flatten(value)
+						word = word .. table.concat(values, " or ")
+					else
+						word = word .. value
+					end
+					table.insert(result, word)
+				else
+					error("Unknown key type in terms.")
+				end
+			end
+		end
+
+		flatten(terms)
+		return result
+	end
 
 ---
 -- Create a new criteria object.
@@ -51,7 +84,7 @@
 ---
 
 	function criteria.new(terms, unprefixed)
-		terms = table.flatten(terms)
+		terms = criteria.flatten(terms)
 
 		-- Preprocess the list of terms for better performance in matches().
 		-- Each term is replaced with a pattern, with an implied AND between

--- a/tests/base/test_criteria.lua
+++ b/tests/base/test_criteria.lua
@@ -172,6 +172,40 @@
 
 
 --
+-- Test criteria creation through a table.
+--
+
+	function suite.createCriteriaWithTable()
+		crit = criteria.new {
+			files  = { "**.c" },
+			system = "windows"
+		}
+		test.istrue(criteria.matches(crit, { system="windows", files="hello.c" }))
+	end
+
+	function suite.createCriteriaWithTable2()
+		crit = criteria.new {
+			system = "not windows"
+		}
+		test.isfalse(criteria.matches(crit, { system="windows" }))
+	end
+
+	function suite.createCriteriaWithTable3()
+		crit = criteria.new {
+			system = "not windows or linux"
+		}
+		test.istrue(criteria.matches(crit, { system="macosx" }))
+	end
+
+	function suite.createCriteriaWithTable4()
+		crit = criteria.new {
+			system = "windows or linux"
+		}
+		test.istrue(criteria.matches(crit, { system="windows" }))
+	end
+
+
+--
 -- "Not" modifiers can also be used on filenames.
 --
 


### PR DESCRIPTION
```lua
filter {
    files  = { "**.c" },
    system = "windows"
}
```