### PR TITLE
Add 'tags' filter api.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1051,6 +1051,12 @@
 	}
 
 	api.register {
+		name = "tags",
+		scope = "config",
+		kind = "list:string",
+	}
+
+	api.register {
 		name = "targetdir",
 		scope = "config",
 		kind = "path",

--- a/src/base/criteria.lua
+++ b/src/base/criteria.lua
@@ -33,6 +33,7 @@
 		platforms = true,
 		system = true,
 		toolset = true,
+		tags = true,
 	}
 
 

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -207,6 +207,7 @@
 		self.system = self.system or p.action.current().targetos or os.target()
 		context.addFilter(self, "system", self.system)
 		context.addFilter(self, "architecture", self.architecture)
+		context.addFilter(self, "tags", self.tags)
 
 		-- The kind is a configuration level value, but if it has been set at the
 		-- project level allow that to influence the other project-level results.
@@ -592,6 +593,9 @@
 
 		-- if a kind is set, allow that to influence the configuration
 		context.addFilter(ctx, "kind", ctx.kind)
+
+		-- if tags are set, allow that to influence the configuration
+		context.addFilter(ctx, "tags", ctx.tags)
 
 		-- if any extra filters were specified, can include them now
 		if extraFilters then


### PR DESCRIPTION
This is just an API that can contain a arbitrary set of values, which you can then filter on.
for example:

```lua
workspace 'foobar'
    configurations { 'release-std', 'debug-std', 'release-blz', 'debug-blz' }

   filter { 'configuration:*-std' }
        tags { 'use-std' }
   filter { 'configuration:*-blz' }
        tags { 'use-blz' }

   project 'test'
        filter { 'tags:use-blz' }
            includedependencies { 'blz' }
            defines { 'USE_BLZ' }

        filter { 'tags:use-std' }
            defines { 'USE_STD' }
```

It allows authors to expose features in libraries through tags, and users to enable/disable said features.