### PR TITLE
Suppress mkdir warning on Windows if the folder already exists

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -599,7 +599,8 @@
 				return "echo " .. v
 			end,
 			mkdir = function(v)
-				return "mkdir " .. path.translate(path.normalize(v))
+				v = path.translate(path.normalize(v))
+				return "IF NOT EXIST " .. v .. " (mkdir " .. v .. ")"
 			end,
 			move = function(v)
 				return "move /Y " .. path.translate(path.normalize(v))


### PR DESCRIPTION
Adds a check to see if the folder already exists to prevent the "A subdirectory or file X already exists" warning. I think this matches the behaviour on other platforms.