### PR TITLE
Add --insecure option for SSL curl requests.

### DIFF
--- a/modules/self-test/test_runner.lua
+++ b/modules/self-test/test_runner.lua
@@ -120,7 +120,7 @@
 		_.builtin_write = mt.write
 		mt.write = _.stub_stderr_write
 
-		_OPTIONS = {}
+		_OPTIONS = table.shallowcopy(_OPTIONS) or {}
 		setmetatable(_OPTIONS, getmetatable(hooks.options))
 
 		io.open = _.stub_io_open

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1571,6 +1571,13 @@
 		description = "Display version information"
 	}
 
+	if http ~= nil then
+		newoption {
+			trigger = "insecure",
+			description = "forfit SSH certification checks."
+		}
+	end
+
 
 -----------------------------------------------------------------------------
 --

--- a/src/host/curl_utils.c
+++ b/src/host/curl_utils.c
@@ -88,6 +88,18 @@ CURL* curlRequest(lua_State* L, curl_state* state, int optionsIndex, int progres
 	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, state->errorBuffer);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, agent);
 
+	// check if the --insecure option was specified on the commandline.
+	lua_getglobal(L, "_OPTIONS");
+	lua_pushstring(L, "insecure");
+	lua_gettable(L, -2);
+	if (!lua_isnil(L, -1))
+	{
+		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+	}
+	lua_pop(L, 2);
+
+	// apply all other options.
 	if (optionsIndex && lua_istable(L, optionsIndex))
 	{
 		lua_pushnil(L);


### PR DESCRIPTION
We run into a lot of ssl errors when communicating with the outside world due to proxy settings.
This allows us to run some of the nuget tests without having to locally modify the code.