### PR TITLE
Allow modules to register C code too.

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -144,6 +144,7 @@
 		{
 			"*.txt", "**.lua",
 			"src/**.h", "src/**.c",
+			"modules/**.h", "modules/**.c",
 		}
 
 		excludes

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -215,13 +215,18 @@ int premake_init(lua_State* L)
 	lua_newtable(L);
 	lua_setglobal(L, "premake");
 
+#if !defined(PREMAKE_NO_BUILTIN_SCRIPTS)
+	/* let native modules initialize themselves */
+	registerModules(L);
+#endif
+
 	return OKAY;
 }
 
 
 static int getErrorColor(lua_State* L)
 {
-	int color; 
+	int color;
 
 	lua_getglobal(L, "term");
 	lua_pushstring(L, "errorColor");
@@ -421,7 +426,7 @@ int premake_test_file(lua_State* L, const char* filename, int searchMask)
 		if (path && do_locate(L, filename, path)) return OKAY;
 	}
 
-	#if !defined(PREMAKE_NO_BUILTIN_SCRIPTS)
+#if !defined(PREMAKE_NO_BUILTIN_SCRIPTS)
 	if ((searchMask & TEST_EMBEDDED) != 0) {
 		/* Try to locate a record matching the filename */
 		if (premake_find_embedded_script(filename) != NULL) {
@@ -431,7 +436,7 @@ int premake_test_file(lua_State* L, const char* filename, int searchMask)
 			return OKAY;
 		}
 	}
-	#endif
+#endif
 
 	return !OKAY;
 }

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -181,7 +181,7 @@ typedef struct
 } buildin_mapping;
 
 extern const buildin_mapping builtin_scripts[];
-
+extern void  registerModules(lua_State* L);
 
 int premake_init(lua_State* L);
 int premake_execute(lua_State* L, int argc, const char** argv, const char* script);


### PR DESCRIPTION
This allows a module to include 'c' code as part of the module, although this only works for modules that are embedded at compile time through the _modules.lua file, and not for modules loaded at runtime.

The way you do this is to add a "modulename.c" file in the native folder... like so, 
![image](https://user-images.githubusercontent.com/451515/27361746-5bfec112-55de-11e7-8c10-a11f74be6782.png)



and then have a function in there that is called ```void register<ModuleName>(lua_State* L);``` where ModuleName is the name of the module starting with a capital... so for ```gmake2```, it becomes ```registerGmake2```.

