### PR TITLE
Removed "installer" kinds from vs2017.

### DIFF
--- a/modules/vstudio/vs2017.lua
+++ b/modules/vstudio/vs2017.lua
@@ -25,7 +25,7 @@
 
 		-- The capabilities of this action
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "Installer" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility" },
 		valid_languages = { "C", "C++", "C#" },
 		valid_tools     = {
 			cc     = { "msc"   },


### PR DESCRIPTION
Copy-Paste error from Blizzard, this is an internal extension we made to visual studio.