### PR TITLE
Add bsd to the output of possible platforms

### DIFF
--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -46,7 +46,7 @@ none:
 	@echo "or"
 	@echo "   make -f Bootstrap.mak HOST_PLATFORM"
 	@echo "where HOST_PLATFORM is one of these:"
-	@echo "   osx linux"
+	@echo "   osx linux bsd"
 
 mingw: $(SRC)
 	$(SILENT) rm -rf ./bin


### PR DESCRIPTION
Adds bsd to the default output as a possible platform