### PR TITLE
Write out build log element for VS utility projects

### DIFF
--- a/modules/vstudio/tests/vc2010/test_item_def_group.lua
+++ b/modules/vstudio/tests/vc2010/test_item_def_group.lua
@@ -79,3 +79,19 @@
 		prepare("Release")
 		test.isemptycapture()
 	end
+
+--
+-- Utility projects include buildlog
+--
+	function suite.utilityIncludesPath()
+		kind "Utility"
+		buildlog "MyCustomLogFile.log"
+		prepare()
+		test.capture [[
+<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<BuildLog>
+		<Path>MyCustomLogFile.log</Path>
+	</BuildLog>
+</ItemDefinitionGroup>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -268,6 +268,7 @@
 			return {
 				m.ruleVars,
 				m.buildEvents,
+				m.buildLog,
 			}
 		else
 			return {


### PR DESCRIPTION
In vs2017, utility projects were ignoring the value of buildlog
and defaulting the output to $(IntDir)$(MSBuildProjectName).log