### PR TITLE
Fix path_getrelative for Windows

### DIFF
--- a/src/host/path_getrelative.c
+++ b/src/host/path_getrelative.c
@@ -6,6 +6,9 @@
 
 #include "premake.h"
 #include <string.h>
+#if PLATFORM_WINDOWS
+#include <ctype.h>
+#endif
 
 
 int path_getrelative(lua_State* L)
@@ -22,7 +25,11 @@ int path_getrelative(lua_State* L)
 	do_normalize(L, dst, p2);
 
 	/* same directory? */
+#if PLATFORM_WINDOWS
+	if (_stricmp(src, dst) == 0) {
+#else
 	if (strcmp(src, dst) == 0) {
+#endif
 		lua_pushstring(L, ".");
 		return 1;
 	}
@@ -41,7 +48,11 @@ int path_getrelative(lua_State* L)
 
 	last = -1;
 	i = 0;
+#if PLATFORM_WINDOWS
+	while (src[i] && dst[i] && tolower(src[i]) == tolower(dst[i])) {
+#else
 	while (src[i] && dst[i] && src[i] == dst[i]) {
+#endif
 		if (src[i] == '/') {
 			last = i;
 		}


### PR DESCRIPTION
Windows now performs case insensitive comparison for strings.