### PR TITLE
Fix action override targetos

### DIFF
--- a/modules/self-test/test_runner.lua
+++ b/modules/self-test/test_runner.lua
@@ -82,6 +82,9 @@
 		_TESTS_DIR = test.suite._TESTS_DIR
 		_SCRIPT_DIR = test.suite._SCRIPT_DIR
 
+		m.suiteName = test.suiteName
+		m.testName = test.testName
+
 		local ok, err = _.setupTest(test)
 
 		if ok then
@@ -153,7 +156,7 @@
 
 
 	function _.removeTestingHooks(hooks)
-		_ACTION = hooks.action
+		p.action.set(hooks.action)
 		_OPTIONS = hooks.options
 		_TARGET_OS = hooks.targetOs
 

--- a/modules/vstudio/tests/cs2005/test_icon.lua
+++ b/modules/vstudio/tests/cs2005/test_icon.lua
@@ -16,6 +16,7 @@
 	local wks
 
 	function suite.setup()
+		p.action.set("vs2005")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/modules/vstudio/tests/vc200x/test_build_steps.lua
+++ b/modules/vstudio/tests/vc200x/test_build_steps.lua
@@ -16,6 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
+		p.action.set("vs2005")
 		p.escaper(p.vstudio.vs2005.esc)
 		wks, prj = test.createWorkspace()
 	end

--- a/modules/vstudio/tests/vc200x/test_nmake_settings.lua
+++ b/modules/vstudio/tests/vc200x/test_nmake_settings.lua
@@ -16,6 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
+		p.action.set("vs2005")
 		p.escaper(p.vstudio.vs2005.esc)
 		wks, prj = test.createWorkspace()
 		kind "Makefile"

--- a/modules/vstudio/tests/vc200x/test_project.lua
+++ b/modules/vstudio/tests/vc200x/test_project.lua
@@ -16,7 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = 'vs2008'
+		p.action.set("vs2008")
 		wks = test.createWorkspace()
 		uuid "AE61726D-187C-E440-BD07-2556188A6565"
 	end
@@ -32,7 +32,7 @@
 --
 
 	function suite.hasCorrectVersion_on2005()
-		_ACTION = 'vs2005'
+		p.action.set("vs2005")
 		prepare()
 		test.capture [[
 <VisualStudioProject
@@ -42,7 +42,7 @@
 	end
 
 	function suite.hasCorrectVersion_on2008()
-		_ACTION = 'vs2008'
+		p.action.set("vs2008")
 		prepare()
 		test.capture [[
 <VisualStudioProject

--- a/modules/vstudio/tests/vc2010/test_build_events.lua
+++ b/modules/vstudio/tests/vc2010/test_build_events.lua
@@ -16,6 +16,7 @@
 	local wks, prj, cfg
 
 	function suite.setup()
+		p.action.set("vs2010")
 		p.escaper(p.vstudio.vs2010.esc)
 		wks = test.createWorkspace()
 	end

--- a/modules/vstudio/tests/vc2010/test_character_set.lua
+++ b/modules/vstudio/tests/vc2010/test_character_set.lua
@@ -12,7 +12,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "vs2010"
+		p.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/modules/vstudio/tests/vc2010/test_globals.lua
+++ b/modules/vstudio/tests/vc2010/test_globals.lua
@@ -200,7 +200,7 @@
 --
 
 	function suite.windowsTargetPlatformVersionMissing_on2013Default()
-		_ACTION = "vs2013"
+		p.action.set("vs2013")
 		prepare()
 		test.capture [[
 <PropertyGroup Label="Globals">
@@ -213,7 +213,7 @@
 	end
 
 	function suite.windowsTargetPlatformVersionMissing_on2013()
-		_ACTION = "vs2013"
+		p.action.set("vs2013")
 		systemversion "10.0.10240.0"
 		prepare()
 		test.capture [[
@@ -227,7 +227,7 @@
 	end
 
 	function suite.windowsTargetPlatformVersionMissing_on2015Default()
-		_ACTION = "vs2015"
+		p.action.set("vs2015")
 		prepare()
 		test.capture [[
 <PropertyGroup Label="Globals">
@@ -240,7 +240,7 @@
 	end
 
 	function suite.windowsTargetPlatformVersion_on2015()
-		_ACTION = "vs2015"
+		p.action.set("vs2015")
 		systemversion "10.0.10240.0"
 		prepare()
 		test.capture [[

--- a/modules/vstudio/tests/vc2010/test_imagexex_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_imagexex_settings.lua
@@ -17,6 +17,7 @@
 	local wks, prj
 
 	function suite.setup()
+		p.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 		platforms "xbox360"
 	end

--- a/modules/vstudio/tests/vc2010/test_item_def_group.lua
+++ b/modules/vstudio/tests/vc2010/test_item_def_group.lua
@@ -17,6 +17,7 @@
 	local wks, prj
 
 	function suite.setup()
+		p.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/modules/vstudio/tests/vc2010/test_target_machine.lua
+++ b/modules/vstudio/tests/vc2010/test_target_machine.lua
@@ -16,6 +16,7 @@
 	local wks, prj
 
 	function suite.setup()
+		p.action.set("vs2010")
 		wks, prj = test.createWorkspace()
 	end
 

--- a/modules/xcode/tests/test_header_footer.lua
+++ b/modules/xcode/tests/test_header_footer.lua
@@ -17,6 +17,7 @@
 	local wks
 
 	function suite.setup()
+		p.action.set('xcode4')
 		wks = test.createWorkspace()
 	end
 

--- a/modules/xcode/tests/test_xcode4_project.lua
+++ b/modules/xcode/tests/test_xcode4_project.lua
@@ -49,8 +49,7 @@
 	end
 
 	function suite.setup()
-		_TARGET_OS = "macosx"
-		_ACTION = "xcode4"
+		p.action.set('xcode4')
 		io.eol = "\n"
 		xcode.used_ids = { } -- reset the list of generated IDs
 		wks = test.createWorkspace()

--- a/modules/xcode/tests/test_xcode4_workspace.lua
+++ b/modules/xcode/tests/test_xcode4_workspace.lua
@@ -18,7 +18,7 @@
 	local wks, prj
 
 	function suite.setup()
-		_ACTION = "xcode4"
+		p.action.set('xcode4')
 		wks = test.createWorkspace()
 	end
 

--- a/modules/xcode/tests/test_xcode_dependencies.lua
+++ b/modules/xcode/tests/test_xcode_dependencies.lua
@@ -23,7 +23,7 @@
 	end
 
 	function suite.setup()
-		_ACTION = "xcode4"
+		p.action.set('xcode4')
 		xcode.used_ids = { } -- reset the list of generated IDs
 
 		wks, prj = test.createWorkspace()

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -20,8 +20,7 @@
 	end
 
 	function suite.setup()
-		_TARGET_OS = "macosx"
-		_ACTION = "xcode4"
+		p.action.set('xcode4')
 		p.eol("\n")
 		xcode.used_ids = { } -- reset the list of generated IDs
 		wks = test.createWorkspace()

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -63,7 +63,7 @@
 		context.addFilter(self, "_ACTION", _ACTION)
 		context.addFilter(self, "action", _ACTION)
 
-		self.system = self.system or p.action.current().targetos or os.target()
+		self.system = self.system or os.target()
 		context.addFilter(self, "system", os.getSystemTags(self.system))
 
 		-- Add command line options to the filtering options
@@ -204,7 +204,7 @@
 		-- Now filter on the current system and architecture, allowing the
 		-- values that might already in the context to override my defaults.
 
-		self.system = self.system or p.action.current().targetos or os.target()
+		self.system = self.system or os.target()
 		context.addFilter(self, "system", os.getSystemTags(self.system))
 		context.addFilter(self, "architecture", self.architecture)
 		context.addFilter(self, "tags", self.tags)
@@ -529,7 +529,7 @@
 		-- More than a convenience; this is required to work properly with
 		-- external Visual Studio project files.
 
-		local system = p.action.current().targetos or os.target()
+		local system = os.target()
 		local architecture = nil
 		local toolset = p.action.current().toolset
 

--- a/tests/project/test_getconfig.lua
+++ b/tests/project/test_getconfig.lua
@@ -4,6 +4,7 @@
 -- Copyright (c) 2011-2014 Jason Perkins and the Premake project
 --
 
+	local p = premake
 	local suite = test.declare("project_getconfig")
 
 --
@@ -46,7 +47,7 @@
 
 	function suite.actionOverridesOS()
 		_TARGET_OS = "linux"
-		_ACTION = "vs2005"
+		p.action.set("vs2005")
 		project ("MyProject")
 		filter { "system:windows" }
 		defines { "correct" }
@@ -62,7 +63,7 @@
 
 	function suite.usesCfgSystem()
 		_TARGET_OS = "linux"
-		_ACTION = "vs2005"
+		p.action.set("vs2005")
 		project ("MyProject")
 		system "macosx"
 		filter { "system:macosx" }
@@ -77,7 +78,7 @@
 --
 
 	function suite.appliesActionToFilters()
-		_ACTION = "vs2005"
+		p.action.set("vs2005")
 		project ("MyProject")
 		filter { "action:vs2005" }
 		defines { "correct" }


### PR DESCRIPTION
Without this change, if the action has a targetos the "--os=" commandline option would be completely ignored, which is obviously a bug.