### PR TITLE
Rework binmodule example to silence unit test console output

### DIFF
--- a/binmodules/example/main.c
+++ b/binmodules/example/main.c
@@ -3,9 +3,9 @@
 
 static int example_test(lua_State* L)
 {
-	const char* text = luaL_checkstring(L, 1);
-	printf("%s\n", text);
-	lua_pushboolean(L, 1);
+	lua_pushstring(L, "hello ");
+	lua_pushvalue(L, 1);
+	lua_concat(L, 2);
 	return 1;
 }
 

--- a/tests/base/test_binmodules.lua
+++ b/tests/base/test_binmodules.lua
@@ -14,5 +14,6 @@
 
 
 	function suite.testExample()
-		test.istrue(example.test("hello world"));
+		local result = example.test("world")
+		test.isequal("hello world", result)
 	end


### PR DESCRIPTION
Trying to return from the dead…small fix to remove some spurious console output from Premake's own unit tests. Reworks the binmodule example function to concatenate two strings and return the result, rather than write to the console. Adjusts the corresponding unit test to verify the result.