### PR TITLE
Add Support for Headless Actions

### DIFF
--- a/src/_premake_main.lua
+++ b/src/_premake_main.lua
@@ -230,7 +230,7 @@
 		-- script has run to allow for project-specific options
 		ok, err = p.option.validate(_OPTIONS)
 		if not ok then
-			print("Error: " .. err)
+			eprint("Error: " .. err)
 			os.exit(1)
 		end
 
@@ -243,12 +243,12 @@
 
 			local action = p.action.current()
 			if not action then
-				print("Error: no such action '" .. _ACTION .. "'")
+				eprint("Error: no such action '" .. _ACTION .. "'")
 				os.exit(1)
 			end
 
 			if p.action.isConfigurable() and not os.isfile(_MAIN_SCRIPT) then
-				print(string.format("No Premake script (%s) found!", path.getname(_MAIN_SCRIPT)))
+				eprint(string.format("No Premake script (%s) found!", path.getname(_MAIN_SCRIPT)))
 				os.exit(1)
 			end
 		end

--- a/src/_premake_main.lua
+++ b/src/_premake_main.lua
@@ -260,7 +260,7 @@
 ---
 
 	function m.preBake()
-		if p.action.isConfigurable() then
+		if p.action.isConfigurable() and not p.action.isHeadless() then
 			print("Building configurations...")
 		end
 	end
@@ -321,8 +321,10 @@
 ---
 
 	function m.preAction()
-		local action = p.action.current()
-		printf("Running action '%s'...", action.trigger)
+		if p.action.isHeadless() then
+			local action = p.action.current()
+			printf("Running action '%s'...", action.trigger)
+		end
 	end
 
 
@@ -341,7 +343,7 @@
 ---
 
 	function m.postAction()
-		if p.action.isConfigurable() then
+		if p.action.isConfigurable() and not p.action.isHeadless() then
 			local duration = math.floor((os.clock() - startTime) * 1000);
 			printf("Done (%dms).", duration)
 		end

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -404,6 +404,13 @@
 		end
 	end
 
+--
+-- A shortcut for printing formatted output to stderr
+--
+
+	function eprintf(msg, ...)
+		io.stderr:write(string.format(msg, ...))
+	end
 
 --
 -- make a string from debug.getinfo information.

--- a/src/base/action.lua
+++ b/src/base/action.lua
@@ -204,6 +204,21 @@
 	end
 
 
+---
+-- Determines if an action is headless or not.
+-- Headless actions prevent various built-in messages from printing.
+---
+
+	function action.isHeadless(self)
+		if not self then
+			self = action.current() or {}
+		end
+		if self.headless == true then
+			return true
+		end
+		return false
+	end
+
 
 ---
 -- Activates a particular action.

--- a/src/base/moduledownloader.lua
+++ b/src/base/moduledownloader.lua
@@ -60,7 +60,9 @@
 		end
 
 		-- Unzip the module, and delete the temporary zip file.
-		verbosef(' UNZIP   : %s', destination)
+		if not p.action.isHeadless() then
+			verbosef(' UNZIP   : %s', destination)
+		end
 		zip.extract(destination, location)
 		os.remove(destination)
 		return true;

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -189,7 +189,9 @@
 
 
 	function p.project.bake(self)
-		verbosef('    Baking %s...', self.name)
+		if not p.action.isHeadless() then
+			verbosef('    Baking %s...', self.name)
+		end
 
 		self.solution = self.workspace
 		self.global = self.workspace.global


### PR DESCRIPTION
+ Added eprintf() - a variant of printf() that writes to stderr instead of stdout.
+ Added support for "headless" actions which, when run, prevent Premake from printing various information (such as the "Building configurations..." notification, or the execution time summary). This can be used to allow Premake to function as a standalone Lua engine, as well as allows these "headless" actions to be used to pipe output to other programs.

An action can be made headless by setting the `headless` field of the action to true when calling `newaction`, if this field is not present or is not set to true, the action is not considered headless.

Example of a headless action:
```lua
newaction {
    trigger = "myaction",
    description = "Describe your action!",
    headless = true, -- Make this action headless
    onStart = function()
        print("START")
    end,
    onWorkspace = function(wks)
        printf("WORKSPACE:\t%s", wks.name)
    end,
    onProject = function(prj)
        printf("PROJECT:\t%s", prj.name)
    end,
    onRule = function(rule)
        print("RULE")
    end,
    execute = function()
        print("EXECUTE")
    end,
    onEnd = function()
        print("END")
    end
}
```