### PR TITLE
Allow tokens to start with a ! to disable making paths relative.

### DIFF
--- a/tests/base/test_detoken.lua
+++ b/tests/base/test_detoken.lua
@@ -92,6 +92,17 @@
 		test.isequal("cd ..", x)
 	end
 
+--
+-- but not if it is prefixed with a !
+--
+
+	function suite.canExpandWithExclamationMark()
+		local cwd = os.getcwd()
+		environ.cfg = { basedir = path.getdirectory(cwd) }
+		x = detoken.expand("%{!cfg.basedir}", environ,  {}, cwd)
+		test.isequal(path.getdirectory(os.getcwd()), x)
+	end
+
 
 --
 -- If the value being expanded is a table, iterate over all of its values.


### PR DESCRIPTION
Allows you to write
```%{!file.abspath}``` in a buildcommand, and prevent it from getting turned into a relative path.


