### PR TITLE
Fix for build failure in interop projects (/mt with /clr not supported)

### DIFF
--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2199,6 +2199,8 @@
 		local runtimes = {
 			StaticDebug   = "MultiThreadedDebug",
 			StaticRelease = "MultiThreaded",
+			StaticDLLDebug = "MultiThreadedDebugDLL",
+			StaticDLLRelease = "MultiThreadedDLL"
 		}
 		local runtime = runtimes[config.getruntime(cfg)]
 		if runtime then

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -327,6 +327,10 @@
 
 	function config.getruntime(cfg)
 		local linkage = iif(cfg.flags.StaticRuntime, "Static", "Shared")
+
+		if cfg.clr == "On" and cfg.flags.StaticRuntime then
+			linkage = linkage .. "DLL"
+		end
 		if not cfg.runtime then
 			return linkage .. iif(config.isDebugBuild(cfg), "Debug", "Release")
 		else


### PR DESCRIPTION
Fix for this compile error:
cl : Command line error D8016: '/clr' and '/MT' command-line options are incompatible [d:\p4\Prometheus\ReleaseBranches\1_13_0_0_Build\Projects\PC\DataBuildConverterInterop.vcxproj]

https://msdn.microsoft.com/en-us/library/ffkc918h.aspx

The combination of the _STATIC_CPPLIB preprocessor definition (/D_STATIC_CPPLIB) and the /clr or /clr:pure compiler option is not supported. This is so because the definition would cause your application to link with the static multithreaded Standard C++ Library, which is not supported. For more information, see the /MD, /MT, /LD (Use Run-Time Library) topic.