### PR TITLE
for vs2017 and up nuget is now handled by msbuild instead of premake

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,4 +6,3 @@ indent_size = 4
 tab_width = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
-charset = utf-8

--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -74,6 +74,7 @@ return {
 	"vc2010/test_manifest.lua",
 	"vc2010/test_nmake_props.lua",
 	"vc2010/test_nuget_packages_config.lua",
+	"vc2010/test_nuget_package_references.lua",
 	"vc2010/test_output_props.lua",
 	"vc2010/test_platform_toolset.lua",
 	"vc2010/test_project_configs.lua",

--- a/modules/vstudio/tests/vc2010/test_nuget_package_references.lua
+++ b/modules/vstudio/tests/vc2010/test_nuget_package_references.lua
@@ -1,0 +1,71 @@
+--
+-- tests/actions/vstudio/vs2010/test_nuget_package_references.lua
+-- Validate generation of NuGet packages references for Visual Studio 2017 and newer.
+-- Copyright (c) 2012-2015 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("vstudio_vs2010_nuget_package_references")
+	local cs2005 = p.vstudio.cs2005
+	local nuget2010 = p.vstudio.nuget2010
+	local dotnetbase = p.vstudio.dotnetbase
+
+--
+-- Setup and teardown
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2017")
+		wks = test.createWorkspace()
+		configurations {'Debug','Release'}
+		language "C#"
+	end
+
+	local function prepare(platform)
+		prj = test.getproject(wks, 1)
+		dotnetbase.packageReferences(prj)
+	end
+
+
+--
+-- Should not output anything if no packages have been set.
+--
+
+	function suite.noOutputIfNoPackages()
+		prepare()
+		test.isemptycapture()
+	end
+
+
+--
+-- Writes the packages.config file properly.
+--
+
+	function suite.structureIsCorrect()
+		nuget { "Newtonsoft.Json:10.0.2", "NUnit:3.6.1", "SSH.NET:2016.0.0" }
+		prepare()
+		test.capture [[
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="10.0.2"/>
+		<PackageReference Include="NUnit" Version="3.6.1"/>
+		<PackageReference Include="SSH.NET" Version="2016.0.0"/>
+	</ItemGroup>
+]]
+	end
+
+
+	function suite.configStructureIsCorrect()
+		nuget { "NUnit:3.6.1", "SSH.NET:2016.0.0" }
+		filter { "configurations:Debug" }
+			nuget { "Newtonsoft.Json:10.0.2" }
+		prepare()
+		test.capture [[
+	<ItemGroup>
+		<PackageReference Include="NUnit" Version="3.6.1"/>
+		<PackageReference Include="SSH.NET" Version="2016.0.0"/>
+		<PackageReference Include="Newtonsoft.Json" Version="10.0.2" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "/>
+	</ItemGroup>
+]]
+	end

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -4,63 +4,64 @@
 -- Copyright (c) Jason Perkins and the Premake project
 --
 
-    local p = premake
-    p.vstudio.dotnetbase = {}
+	local p = premake
+	p.vstudio.dotnetbase = {}
 
-    local vstudio = p.vstudio
-    local dotnetbase  = p.vstudio.dotnetbase
-    local project = p.project
-    local config = p.config
-    local fileconfig = p.fileconfig
-    local dotnet = p.tools.dotnet
+	local vstudio = p.vstudio
+	local dotnetbase  = p.vstudio.dotnetbase
+	local project = p.project
+	local config = p.config
+	local fileconfig = p.fileconfig
+	local dotnet = p.tools.dotnet
 
 
-    dotnetbase.elements = {}
-    dotnetbase.langObj = {}
+	dotnetbase.elements = {}
+	dotnetbase.langObj = {}
 
 
 --
 -- Generate a Visual Studio 200x dotnet project, with support for the new platforms API.
 --
 
-    function dotnetbase.prepare(langObj)
-        dotnetbase.elements.project = langObj.elements.project
-        dotnetbase.elements.projectProperties = langObj.elements.projectProperties
-        dotnetbase.elements.configuration = langObj.elements.configuration
+	function dotnetbase.prepare(langObj)
+		dotnetbase.elements.project = langObj.elements.project
+		dotnetbase.elements.projectProperties = langObj.elements.projectProperties
+		dotnetbase.elements.configuration = langObj.elements.configuration
 
-        dotnetbase.langObj = langObj
-    end
+		dotnetbase.langObj = langObj
+	end
 
 
-    function dotnetbase.generate(prj)
-        p.utf8()
+	function dotnetbase.generate(prj)
+		p.utf8()
 
-        p.callArray(dotnetbase.elements.project, prj)
+		p.callArray(dotnetbase.elements.project, prj)
 
-        _p(1,'<ItemGroup>')
-        dotnetbase.files(prj)
-        _p(1,'</ItemGroup>')
+		_p(1,'<ItemGroup>')
+		dotnetbase.files(prj)
+		_p(1,'</ItemGroup>')
 
-        dotnetbase.projectReferences(prj)
-        dotnetbase.langObj.targets(prj)
-        dotnetbase.buildEvents(prj)
+		dotnetbase.projectReferences(prj)
+		dotnetbase.packageReferences(prj)
+		dotnetbase.langObj.targets(prj)
+		dotnetbase.buildEvents(prj)
 
-        p.out('</Project>')
-    end
+		p.out('</Project>')
+	end
 
 
 --
 -- Write the opening <Project> element.
 --
 
-    function dotnetbase.projectElement(prj)
-        local ver = ''
-        local action = p.action.current()
-        if action.vstudio.toolsVersion then
-            ver = string.format(' ToolsVersion="%s"', action.vstudio.toolsVersion)
-        end
-        _p('<Project%s DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">', ver)
-    end
+	function dotnetbase.projectElement(prj)
+		local ver = ''
+		local action = p.action.current()
+		if action.vstudio.toolsVersion then
+			ver = string.format(' ToolsVersion="%s"', action.vstudio.toolsVersion)
+		end
+		_p('<Project%s DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">', ver)
+	end
 
 
 --
@@ -68,12 +69,12 @@
 --
 
 
-    function dotnetbase.projectProperties(prj)
-        _p(1,'<PropertyGroup>')
-        local cfg = project.getfirstconfig(prj)
-        p.callArray(dotnetbase.elements.projectProperties, cfg)
-        _p(1,'</PropertyGroup>')
-    end
+	function dotnetbase.projectProperties(prj)
+		_p(1,'<PropertyGroup>')
+		local cfg = project.getfirstconfig(prj)
+		p.callArray(dotnetbase.elements.projectProperties, cfg)
+		_p(1,'</PropertyGroup>')
+	end
 
 
 --
@@ -81,276 +82,276 @@
 --
 
 
-    function dotnetbase.configurations(prj)
-        for cfg in project.eachconfig(prj) do
-            dotnetbase.configuration(cfg)
-        end
-    end
+	function dotnetbase.configurations(prj)
+		for cfg in project.eachconfig(prj) do
+			dotnetbase.configuration(cfg)
+		end
+	end
 
-    function dotnetbase.configuration(cfg)
-        p.callArray(dotnetbase.elements.configuration, cfg)
-        _p(1,'</PropertyGroup>')
-    end
+	function dotnetbase.configuration(cfg)
+		p.callArray(dotnetbase.elements.configuration, cfg)
+		_p(1,'</PropertyGroup>')
+	end
 
 
-    function dotnetbase.dofile(node, cfg, condition)
-        local filecfg = fileconfig.getconfig(node, cfg)
-        if filecfg then
-            local fname = path.translate(node.relpath)
+	function dotnetbase.dofile(node, cfg, condition)
+		local filecfg = fileconfig.getconfig(node, cfg)
+		if filecfg then
+			local fname = path.translate(node.relpath)
 
-            -- Files that live outside of the project tree need to be "linked"
-            -- and provided with a project relative pseudo-path. Check for any
-            -- leading "../" sequences and, if found, remove them and mark this
-            -- path as external.
-            local link, count = node.relpath:gsub("%.%.%/", "")
-            local external = (count > 0)
+			-- Files that live outside of the project tree need to be "linked"
+			-- and provided with a project relative pseudo-path. Check for any
+			-- leading "../" sequences and, if found, remove them and mark this
+			-- path as external.
+			local link, count = node.relpath:gsub("%.%.%/", "")
+			local external = (count > 0)
 
-            -- Try to provide a little bit of flexibility by allowing virtual
-            -- paths for external files. Would be great to support them for all
-            -- files but Visual Studio chokes if file is already in project area.
-            if external and node.vpath ~= node.relpath then
-                link = node.vpath
-            end
+			-- Try to provide a little bit of flexibility by allowing virtual
+			-- paths for external files. Would be great to support them for all
+			-- files but Visual Studio chokes if file is already in project area.
+			if external and node.vpath ~= node.relpath then
+				link = node.vpath
+			end
 
-            -- Deduce what, if any, special attributes are required for this file.
-            -- For example, forms may have related source, designer, and resource
-            -- files which need to be associated.
+			-- Deduce what, if any, special attributes are required for this file.
+			-- For example, forms may have related source, designer, and resource
+			-- files which need to be associated.
 
-            local info = dotnet.fileinfo(filecfg)
+			local info = dotnet.fileinfo(filecfg)
 
-            -- Process any sub-elements required by this file; choose the write
-            -- element form to use based on the results.
+			-- Process any sub-elements required by this file; choose the write
+			-- element form to use based on the results.
 
-            local contents = p.capture(function ()
-                -- Try to write file-level elements in the same order as Visual Studio
-                local elements = {
-                    "AutoGen",
-                    "CopyToOutputDirectory",
-                    "DesignTime",
-                    "DependentUpon",
-                    "DesignTimeSharedInput",
-                    "Generator",
-                    "LastGenOutput",
-                    "SubType",
-                }
+			local contents = p.capture(function ()
+				-- Try to write file-level elements in the same order as Visual Studio
+				local elements = {
+					"AutoGen",
+					"CopyToOutputDirectory",
+					"DesignTime",
+					"DependentUpon",
+					"DesignTimeSharedInput",
+					"Generator",
+					"LastGenOutput",
+					"SubType",
+				}
 
-                for _, el in ipairs(elements) do
-                    local value = info[el]
-                    if value then
-                        _p(3,"<%s>%s</%s>", el, value, el)
-                    end
-                end
-                if info.action == "EmbeddedResource" and cfg.customtoolnamespace then
-                    _p(3,"<CustomToolNamespace>%s</CustomToolNamespace>", cfg.customtoolnamespace)
-                end
-            end)
+				for _, el in ipairs(elements) do
+					local value = info[el]
+					if value then
+						_p(3,"<%s>%s</%s>", el, value, el)
+					end
+				end
+				if info.action == "EmbeddedResource" and cfg.customtoolnamespace then
+					_p(3,"<CustomToolNamespace>%s</CustomToolNamespace>", cfg.customtoolnamespace)
+				end
+			end)
 
-            if #contents > 0 or external then
-                _p(2,'<%s%s Include="%s">', info.action, condition, fname)
-                if external then
-                    _p(3,'<Link>%s</Link>', path.translate(link))
-                end
-                if #contents > 0 then
-                    _p("%s", contents)
-                end
-                _p(2,'</%s>', info.action)
-            else
-                _p(2,'<%s%s Include="%s" />', info.action, condition, fname)
-            end
-        end
-    end
+			if #contents > 0 or external then
+				_p(2,'<%s%s Include="%s">', info.action, condition, fname)
+				if external then
+					_p(3,'<Link>%s</Link>', path.translate(link))
+				end
+				if #contents > 0 then
+					_p("%s", contents)
+				end
+				_p(2,'</%s>', info.action)
+			else
+				_p(2,'<%s%s Include="%s" />', info.action, condition, fname)
+			end
+		end
+	end
 
 
 --
 -- Write out the source files item group.
 --
 
-    function dotnetbase.files(prj)
-        local firstcfg = project.getfirstconfig(prj)
+	function dotnetbase.files(prj)
+		local firstcfg = project.getfirstconfig(prj)
 
-        local processfcfg = function(node)
-            -- test if all fileinfo's are going to be the same for each config.
-            local allsame = true
-            local first = nil
-            for cfg in project.eachconfig(prj) do
-                local filecfg = fileconfig.getconfig(node, cfg)
-                local info = dotnet.fileinfo(filecfg)
+		local processfcfg = function(node)
+			-- test if all fileinfo's are going to be the same for each config.
+			local allsame = true
+			local first = nil
+			for cfg in project.eachconfig(prj) do
+				local filecfg = fileconfig.getconfig(node, cfg)
+				local info = dotnet.fileinfo(filecfg)
 
-                if first == nil then
-                    first = info
-                elseif not table.equals(first, info) then
-                    allsame = false
-                end
-            end
+				if first == nil then
+					first = info
+				elseif not table.equals(first, info) then
+					allsame = false
+				end
+			end
 
-            -- output to proj file.
-            if allsame then
-                dotnetbase.dofile(node, firstcfg, '')
-            else
-                for cfg in project.eachconfig(prj) do
-                    dotnetbase.dofile(node, cfg, ' ' .. dotnetbase.condition(cfg))
-                end
-            end
-        end
+			-- output to proj file.
+			if allsame then
+				dotnetbase.dofile(node, firstcfg, '')
+			else
+				for cfg in project.eachconfig(prj) do
+					dotnetbase.dofile(node, cfg, ' ' .. dotnetbase.condition(cfg))
+				end
+			end
+		end
 
-        if project.isfsharp(prj) then
-            sorter = function(a,b)
-                verbosef('Sorting F# proj file (%s, %s), index %s < %s', a.name, b.name, a.order, b.order)
-                return a.order < b.order
-            end
+		if project.isfsharp(prj) then
+			sorter = function(a,b)
+				verbosef('Sorting F# proj file (%s, %s), index %s < %s', a.name, b.name, a.order, b.order)
+				return a.order < b.order
+			end
 
-            table.sort(prj._.files, sorter)
-            table.foreachi(prj._.files, processfcfg)
-        else
-            local tr = project.getsourcetree(prj)
-            p.tree.traverse(tr, {
-                onleaf = processfcfg
-            }, false)
-        end
-    end
+			table.sort(prj._.files, sorter)
+			table.foreachi(prj._.files, processfcfg)
+		else
+			local tr = project.getsourcetree(prj)
+			p.tree.traverse(tr, {
+				onleaf = processfcfg
+			}, false)
+		end
+	end
 
 
 --
 -- Write out pre- and post-build events, if provided.
 --
 
-    function dotnetbase.buildEvents(prj)
-        local function output(name, steps)
-            if #steps > 0 then
-                steps = os.translateCommandsAndPaths(steps, prj.basedir, prj.location)
-                steps = table.implode(steps, "", "", "\r\n")
-                _x(2,'<%sBuildEvent>%s</%sBuildEvent>', name, steps, name)
-            end
-        end
+	function dotnetbase.buildEvents(prj)
+		local function output(name, steps)
+			if #steps > 0 then
+				steps = os.translateCommandsAndPaths(steps, prj.basedir, prj.location)
+				steps = table.implode(steps, "", "", "\r\n")
+				_x(2,'<%sBuildEvent>%s</%sBuildEvent>', name, steps, name)
+			end
+		end
 
-        local cfg = project.getfirstconfig(prj)
-        if #cfg.prebuildcommands > 0 or #cfg.postbuildcommands > 0 then
-            _p(1,'<PropertyGroup>')
-            output("Pre", cfg.prebuildcommands)
-            output("Post", cfg.postbuildcommands)
-            _p(1,'</PropertyGroup>')
-        end
-    end
+		local cfg = project.getfirstconfig(prj)
+		if #cfg.prebuildcommands > 0 or #cfg.postbuildcommands > 0 then
+			_p(1,'<PropertyGroup>')
+			output("Pre", cfg.prebuildcommands)
+			output("Post", cfg.postbuildcommands)
+			_p(1,'</PropertyGroup>')
+		end
+	end
 
 
 --
 -- Write the compiler flags for a particular configuration.
 --
 
-    function dotnetbase.compilerProps(cfg)
-        _x(2,'<DefineConstants>%s</DefineConstants>', table.concat(cfg.defines, ";"))
+	function dotnetbase.compilerProps(cfg)
+		_x(2,'<DefineConstants>%s</DefineConstants>', table.concat(cfg.defines, ";"))
 
-        _p(2,'<ErrorReport>prompt</ErrorReport>')
-        _p(2,'<WarningLevel>4</WarningLevel>')
+		_p(2,'<ErrorReport>prompt</ErrorReport>')
+		_p(2,'<WarningLevel>4</WarningLevel>')
 
-        if cfg.clr == "Unsafe" then
-            _p(2,'<AllowUnsafeBlocks>true</AllowUnsafeBlocks>')
-        end
+		if cfg.clr == "Unsafe" then
+			_p(2,'<AllowUnsafeBlocks>true</AllowUnsafeBlocks>')
+		end
 
-        if cfg.flags.FatalCompileWarnings then
-            _p(2,'<TreatWarningsAsErrors>true</TreatWarningsAsErrors>')
-        end
+		if cfg.flags.FatalCompileWarnings then
+			_p(2,'<TreatWarningsAsErrors>true</TreatWarningsAsErrors>')
+		end
 
-        dotnetbase.debugCommandParameters(cfg)
-    end
+		dotnetbase.debugCommandParameters(cfg)
+	end
 
 --
 -- Write out the debug start parameters for MonoDevelop/Xamarin Studio.
 --
 
-    function dotnetbase.debugCommandParameters(cfg)
-        if #cfg.debugargs > 0 then
-            _x(2,'<Commandlineparameters>%s</Commandlineparameters>', table.concat(cfg.debugargs, " "))
-        end
-    end
+	function dotnetbase.debugCommandParameters(cfg)
+		if #cfg.debugargs > 0 then
+			_x(2,'<Commandlineparameters>%s</Commandlineparameters>', table.concat(cfg.debugargs, " "))
+		end
+	end
 
 --
 -- Write out the debugging and optimization flags for a configuration.
 --
 
-    function dotnetbase.debugProps(cfg)
-        if cfg.symbols == p.ON then
-            _p(2,'<DebugSymbols>true</DebugSymbols>')
-            _p(2,'<DebugType>full</DebugType>')
-        else
-            _p(2,'<DebugType>pdbonly</DebugType>')
-        end
-        _p(2,'<Optimize>%s</Optimize>', iif(config.isOptimizedBuild(cfg), "true", "false"))
-    end
+	function dotnetbase.debugProps(cfg)
+		if cfg.symbols == p.ON then
+			_p(2,'<DebugSymbols>true</DebugSymbols>')
+			_p(2,'<DebugType>full</DebugType>')
+		else
+			_p(2,'<DebugType>pdbonly</DebugType>')
+		end
+		_p(2,'<Optimize>%s</Optimize>', iif(config.isOptimizedBuild(cfg), "true", "false"))
+	end
 
 
 --
 -- Write out the target and intermediates settings for a configuration.
 --
 
-    function dotnetbase.outputProps(cfg)
-        local outdir = vstudio.path(cfg, cfg.buildtarget.directory)
-        _x(2,'<OutputPath>%s\\</OutputPath>', outdir)
+	function dotnetbase.outputProps(cfg)
+		local outdir = vstudio.path(cfg, cfg.buildtarget.directory)
+		_x(2,'<OutputPath>%s\\</OutputPath>', outdir)
 
-        -- Want to set BaseIntermediateOutputPath because otherwise VS will create obj/
-        -- anyway. But VS2008 throws up ominous warning if present.
-        local objdir = vstudio.path(cfg, cfg.objdir)
-        if _ACTION > "vs2008" then
-            _x(2,'<BaseIntermediateOutputPath>%s\\</BaseIntermediateOutputPath>', objdir)
-            _p(2,'<IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>')
-        else
-            _x(2,'<IntermediateOutputPath>%s\\</IntermediateOutputPath>', objdir)
-        end
-    end
+		-- Want to set BaseIntermediateOutputPath because otherwise VS will create obj/
+		-- anyway. But VS2008 throws up ominous warning if present.
+		local objdir = vstudio.path(cfg, cfg.objdir)
+		if _ACTION > "vs2008" then
+			_x(2,'<BaseIntermediateOutputPath>%s\\</BaseIntermediateOutputPath>', objdir)
+			_p(2,'<IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>')
+		else
+			_x(2,'<IntermediateOutputPath>%s\\</IntermediateOutputPath>', objdir)
+		end
+	end
 
 
 --
 -- Write out the references item group.
 --
 
-    dotnetbase.elements.references = function(prj)
-        return {
-            dotnetbase.assemblyReferences,
-            dotnetbase.nuGetReferences,
-        }
-    end
+	dotnetbase.elements.references = function(prj)
+		return {
+			dotnetbase.assemblyReferences,
+			dotnetbase.nuGetReferences,
+		}
+	end
 
-    function dotnetbase.references(prj)
-        _p(1,'<ItemGroup>')
-        p.callArray(dotnetbase.elements.references, prj)
-        _p(1,'</ItemGroup>')
-    end
+	function dotnetbase.references(prj)
+		_p(1,'<ItemGroup>')
+		p.callArray(dotnetbase.elements.references, prj)
+		_p(1,'</ItemGroup>')
+	end
 
 
 --
 -- Write the list of assembly (system, or non-sibling) references.
 --
 
-    function dotnetbase.assemblyReferences(prj)
-        -- C# doesn't support per-configuration links (does it?) so just use
-        -- the settings from the first available config instead
-        local cfg = project.getfirstconfig(prj)
+	function dotnetbase.assemblyReferences(prj)
+		-- C# doesn't support per-configuration links (does it?) so just use
+		-- the settings from the first available config instead
+		local cfg = project.getfirstconfig(prj)
 
-        config.getlinks(cfg, "system", function(original, decorated)
-            local name = path.getname(decorated)
-            if path.getextension(name) == ".dll" then
-                name = name.sub(name, 1, -5)
-            end
+		config.getlinks(cfg, "system", function(original, decorated)
+			local name = path.getname(decorated)
+			if path.getextension(name) == ".dll" then
+				name = name.sub(name, 1, -5)
+			end
 
-            if decorated:find("/", nil, true) then
-                _x(2,'<Reference Include="%s">', name)
-                local decPath, decVars = decorated:match("(.-),")
-                if not decPath then
-                    decPath = decorated
-                end
+			if decorated:find("/", nil, true) then
+				_x(2,'<Reference Include="%s">', name)
+				local decPath, decVars = decorated:match("(.-),")
+				if not decPath then
+					decPath = decorated
+				end
 
-                _x(3,'<HintPath>%s</HintPath>', path.appendextension(path.translate(decPath), ".dll"))
+				_x(3,'<HintPath>%s</HintPath>', path.appendextension(path.translate(decPath), ".dll"))
 
-                if not config.isCopyLocal(prj, original, true) then
-                    _p(3,"<Private>False</Private>")
-                end
+				if not config.isCopyLocal(prj, original, true) then
+					_p(3,"<Private>False</Private>")
+				end
 
-                _p(2,'</Reference>')
-            else
-                _x(2,'<Reference Include="%s" />', name)
-            end
-        end)
-    end
+				_p(2,'</Reference>')
+			else
+				_x(2,'<Reference Include="%s" />', name)
+			end
+		end)
+	end
 
 
 --
@@ -362,140 +363,171 @@
 -- with each other.
 --
 
-    function dotnetbase.makeVersionComparable(version)
-        local numbers = ""
+	function dotnetbase.makeVersionComparable(version)
+		local numbers = ""
 
-        for number in version:gmatch("%d") do
-            numbers = numbers .. number
-        end
+		for number in version:gmatch("%d") do
+			numbers = numbers .. number
+		end
 
-        return string.format("%-10d", numbers):gsub(" ", "0")
-    end
+		return string.format("%-10d", numbers):gsub(" ", "0")
+	end
 
 
 --
 -- https://github.com/NuGet/NuGet.Client/blob/dev/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
 --
 
-    function dotnetbase.frameworkVersionForFolder(folder)
-        -- If this exporter ever supports frameworks such as "netstandard1.3",
-        -- "sl4", "sl5", "uap10", "wp8" or "wp71", this code will need changing
-        -- to match the right folders, depending on the current framework.
+	function dotnetbase.frameworkVersionForFolder(folder)
+		-- If this exporter ever supports frameworks such as "netstandard1.3",
+		-- "sl4", "sl5", "uap10", "wp8" or "wp71", this code will need changing
+		-- to match the right folders, depending on the current framework.
 
-        -- Right now this only matches folders for the .NET Framework.
+		-- Right now this only matches folders for the .NET Framework.
 
-        if folder:match("^net%d+$") or folder:match("^[0-9%.]+$") then
-            return dotnetbase.makeVersionComparable(folder)
-        elseif folder == "net" then
-            return dotnetbase.makeVersionComparable("0")
-        end
-    end
+		if folder:match("^net%d+$") or folder:match("^[0-9%.]+$") then
+			return dotnetbase.makeVersionComparable(folder)
+		elseif folder == "net" then
+			return dotnetbase.makeVersionComparable("0")
+		end
+	end
 
 
 --
 -- Write the list of NuGet references.
 --
 
-    function dotnetbase.nuGetReferences(prj)
-        if _ACTION >= "vs2010" then
-            for _, package in ipairs(prj.nuget) do
-                local id = vstudio.nuget2010.packageId(package)
-                local packageAPIInfo = vstudio.nuget2010.packageAPIInfo(prj, package)
+	function dotnetbase.nuGetReferences(prj)
+		if _ACTION >= "vs2010" and _ACTION < "vs2017" then
+	  for _, package in ipairs(prj.nuget) do
+		local id = vstudio.nuget2010.packageId(package)
+		local packageAPIInfo = vstudio.nuget2010.packageAPIInfo(prj, package)
 
-                local cfg = p.project.getfirstconfig(prj)
-                local action = p.action.current()
-                local targetFramework = cfg.dotnetframework or action.vstudio.targetFramework
+		local cfg = p.project.getfirstconfig(prj)
+		local action = p.action.current()
+		local targetFramework = cfg.dotnetframework or action.vstudio.targetFramework
 
-                local targetVersion = dotnetbase.makeVersionComparable(targetFramework)
+		local targetVersion = dotnetbase.makeVersionComparable(targetFramework)
 
-                -- Figure out what folder contains the files for the nearest
-                -- supported .NET Framework version.
+		-- Figure out what folder contains the files for the nearest
+		-- supported .NET Framework version.
 
-                local files = {}
+		local files = {}
 
-                local bestVersion, bestFolder
+		local bestVersion, bestFolder
 
-                for _, file in ipairs(packageAPIInfo.packageEntries) do
-                    local folder = file:match("^lib[\\/](.+)[\\/]")
+		for _, file in ipairs(packageAPIInfo.packageEntries) do
+		  local folder = file:match("^lib[\\/](.+)[\\/]")
 
-                    if folder and path.hasextension(file, ".dll") then
-                        local version = dotnetbase.frameworkVersionForFolder(folder)
+		  if folder and path.hasextension(file, ".dll") then
+			local version = dotnetbase.frameworkVersionForFolder(folder)
 
-                        if version then
-                            files[folder] = files[folder] or {}
-                            table.insert(files[folder], file)
+			if version then
+			  files[folder] = files[folder] or {}
+			  table.insert(files[folder], file)
 
-                            if version <= targetVersion and (not bestVersion or version > bestVersion) then
-                                bestVersion = version
-                                bestFolder = folder
-                            end
-                        end
-                    end
-                end
+			  if version <= targetVersion and (not bestVersion or version > bestVersion) then
+				bestVersion = version
+				bestFolder = folder
+			  end
+			end
+		  end
+		end
 
-                if not bestVersion then
-                    p.error("NuGet package '%s' is not compatible with project '%s' .NET Framework version '%s'", id, prj.name, targetFramework)
-                end
+		if not bestVersion then
+		  p.error("NuGet package '%s' is not compatible with project '%s' .NET Framework version '%s'", id, prj.name, targetFramework)
+		end
 
-                -- Now, add references for all DLLs in that folder.
+		-- Now, add references for all DLLs in that folder.
 
-                for _, file in ipairs(files[bestFolder]) do
-                    -- There's some stuff missing from this include that we
-                    -- can't get from the API and would need to download and
-                    -- extract the package to figure out. It looks like we can
-                    -- just omit it though.
-                    --
-                    -- So, for example, instead of:
-                    --
-                    -- <Reference Include="nunit.framework, Version=3.6.1.0,
-                    -- <Culture=neutral, PublicKeyToken=2638cd05610744eb,
-                    -- <processorArchitecture=MSIL">
-                    --
-                    -- We're just outputting:
-                    --
-                    -- <Reference Include="nunit.framework">
+		for _, file in ipairs(files[bestFolder]) do
+		  -- There's some stuff missing from this include that we
+		  -- can't get from the API and would need to download and
+		  -- extract the package to figure out. It looks like we can
+		  -- just omit it though.
+		  --
+		  -- So, for example, instead of:
+		  --
+		  -- <Reference Include="nunit.framework, Version=3.6.1.0,
+		  -- <Culture=neutral, PublicKeyToken=2638cd05610744eb,
+		  -- <processorArchitecture=MSIL">
+		  --
+		  -- We're just outputting:
+		  --
+		  -- <Reference Include="nunit.framework">
 
-                    _x(2, '<Reference Include="%s">', path.getbasename(file))
-                    _x(3, '<HintPath>%s</HintPath>', vstudio.path(prj, p.filename(prj.workspace, string.format("packages\\%s.%s\\%s", id, packageAPIInfo.verbatimVersion or packageAPIInfo.version, file))))
+		  _x(2, '<Reference Include="%s">', path.getbasename(file))
+		  _x(3, '<HintPath>%s</HintPath>', vstudio.path(prj, p.filename(prj.workspace, string.format("packages\\%s.%s\\%s", id, packageAPIInfo.verbatimVersion or packageAPIInfo.version, file))))
 
-                    if config.isCopyLocal(prj, package, true) then
-                        _p(3, '<Private>True</Private>')
-                    else
-                        _p(3, '<Private>False</Private>')
-                    end
+		  if config.isCopyLocal(prj, package, true) then
+			_p(3, '<Private>True</Private>')
+		  else
+			_p(3, '<Private>False</Private>')
+		  end
 
-                    _p(2, '</Reference>')
-                end
-            end
-        end
-    end
+		  _p(2, '</Reference>')
+		end
+	  end
+		end
+	end
 
 
 --
 -- Write the list of project dependencies.
 --
-    function dotnetbase.projectReferences(prj)
-        _p(1,'<ItemGroup>')
+	function dotnetbase.projectReferences(prj)
+		_p(1,'<ItemGroup>')
 
-        local deps = project.getdependencies(prj, 'linkOnly')
-        if #deps > 0 then
-            for _, dep in ipairs(deps) do
-                local relpath = vstudio.path(prj, vstudio.projectfile(dep))
-                _x(2,'<ProjectReference Include="%s">', relpath)
-                _p(3,'<Project>{%s}</Project>', dep.uuid)
-                _x(3,'<Name>%s</Name>', dep.name)
+		local deps = project.getdependencies(prj, 'linkOnly')
+		if #deps > 0 then
+			for _, dep in ipairs(deps) do
+				local relpath = vstudio.path(prj, vstudio.projectfile(dep))
+				_x(2,'<ProjectReference Include="%s">', relpath)
+				_p(3,'<Project>{%s}</Project>', dep.uuid)
+				_x(3,'<Name>%s</Name>', dep.name)
 
-                if not config.isCopyLocal(prj, dep.name, true) then
-                    _p(3,"<Private>False</Private>")
-                end
+				if not config.isCopyLocal(prj, dep.name, true) then
+					_p(3,"<Private>False</Private>")
+				end
 
-                _p(2,'</ProjectReference>')
-            end
-        end
+				_p(2,'</ProjectReference>')
+			end
+		end
 
-        _p(1,'</ItemGroup>')
-    end
+		_p(1,'</ItemGroup>')
+	end
 
+--
+-- Write the list of package dependencies.
+--
+	function dotnetbase.packageReferences(prj)
+	if _ACTION >= "vs2017" then
+	  local hasNuget = prj.nuget and #prj.nuget>0
+	  for cfg in project.eachconfig(prj) do
+		if cfg.nuget and #cfg.nuget>0 then
+		  hasNuget = true
+		end
+	  end
+	  if hasNuget then
+		_p(1,'<ItemGroup>')
+		if prj.nuget and #prj.nuget>0 then
+		  for _, package in ipairs(prj.nuget) do
+			_p(2,'<PackageReference Include="%s" Version="%s"/>', vstudio.nuget2010.packageId(package), vstudio.nuget2010.packageVersion(package))
+		  end
+		end
+		for cfg in project.eachconfig(prj) do
+		  if cfg.nuget and #cfg.nuget>0 then
+			for _, package in ipairs(cfg.nuget) do
+			  if prj.nuget[package]==nil then
+				_p(2,'<PackageReference Include="%s" Version="%s" %s/>', vstudio.nuget2010.packageId(package), vstudio.nuget2010.packageVersion(package), dotnetbase.condition(cfg))
+			  end
+			end
+		  end
+		end
+		_p(1,'</ItemGroup>')
+	  end
+	end
+  end
 
 --
 -- Return the Visual Studio architecture identification string. The logic
@@ -503,41 +535,41 @@
 -- tackled all the permutations yet.
 --
 
-    function dotnetbase.arch(cfg)
-        local arch = vstudio.archFromConfig(cfg)
-        if arch == "Any CPU" then
-            arch = "AnyCPU"
-        end
-        return arch
-    end
+	function dotnetbase.arch(cfg)
+		local arch = vstudio.archFromConfig(cfg)
+		if arch == "Any CPU" then
+			arch = "AnyCPU"
+		end
+		return arch
+	end
 
 
 --
 -- Write the PropertyGroup element for a specific configuration block.
 --
 
-    function dotnetbase.propertyGroup(cfg)
-        p.push('<PropertyGroup %s>', dotnetbase.condition(cfg))
+	function dotnetbase.propertyGroup(cfg)
+		p.push('<PropertyGroup %s>', dotnetbase.condition(cfg))
 
-        local arch = dotnetbase.arch(cfg)
-        if arch ~= "AnyCPU" or _ACTION > "vs2008" then
-            p.x('<PlatformTarget>%s</PlatformTarget>', arch)
-        end
-    end
+		local arch = dotnetbase.arch(cfg)
+		if arch ~= "AnyCPU" or _ACTION > "vs2008" then
+			p.x('<PlatformTarget>%s</PlatformTarget>', arch)
+		end
+	end
 
 
 --
 -- Generators for individual project elements.
 --
 
-    function dotnetbase.applicationIcon(prj)
-        if prj.icon then
-            local icon = vstudio.path(prj, prj.icon)
-            _p(1,'<PropertyGroup>')
-            _x(2,'<ApplicationIcon>%s</ApplicationIcon>', icon)
-            _p(1,'</PropertyGroup>')
-        end
-    end
+	function dotnetbase.applicationIcon(prj)
+		if prj.icon then
+			local icon = vstudio.path(prj, prj.icon)
+			_p(1,'<PropertyGroup>')
+			_x(2,'<ApplicationIcon>%s</ApplicationIcon>', icon)
+			_p(1,'</PropertyGroup>')
+		end
+	end
 
 ---------------------------------------------------------------------------
 --
@@ -549,20 +581,20 @@
 -- Format and return a Visual Studio Condition attribute.
 --
 
-    function dotnetbase.condition(cfg)
-        local platform = vstudio.projectPlatform(cfg)
-        local arch = dotnetbase.arch(cfg)
-        return string.format('Condition=" \'$(Configuration)|$(Platform)\' == \'%s|%s\' "', platform, arch)
-    end
+	function dotnetbase.condition(cfg)
+		local platform = vstudio.projectPlatform(cfg)
+		local arch = dotnetbase.arch(cfg)
+		return string.format('Condition=" \'$(Configuration)|$(Platform)\' == \'%s|%s\' "', platform, arch)
+	end
 
 
 --
 -- When given a .NET Framework version, returns it formatted for NuGet.
 --
 
-    function dotnetbase.formatNuGetFrameworkVersion(framework)
-        return "net" .. framework:gsub("%.", "")
-    end
+	function dotnetbase.formatNuGetFrameworkVersion(framework)
+		return "net" .. framework:gsub("%.", "")
+	end
 
 ---------------------------------------------------------------------------
 --
@@ -570,112 +602,112 @@
 --
 ---------------------------------------------------------------------------
 
-    function dotnetbase.appDesignerFolder(cfg)
-        _p(2,'<AppDesignerFolder>Properties</AppDesignerFolder>')
-    end
+	function dotnetbase.appDesignerFolder(cfg)
+		_p(2,'<AppDesignerFolder>Properties</AppDesignerFolder>')
+	end
 
 
-    function dotnetbase.assemblyName(cfg)
-        _p(2,'<AssemblyName>%s</AssemblyName>', cfg.buildtarget.basename)
-    end
+	function dotnetbase.assemblyName(cfg)
+		_p(2,'<AssemblyName>%s</AssemblyName>', cfg.buildtarget.basename)
+	end
 
 
-    function dotnetbase.commonProperties(prj)
-        if _ACTION > "vs2010" then
-            _p(1,'<Import Project="$(MSBuildExtensionsPath)\\$(MSBuildToolsVersion)\\Microsoft.Common.props" Condition="Exists(\'$(MSBuildExtensionsPath)\\$(MSBuildToolsVersion)\\Microsoft.Common.props\')" />')
-        end
-    end
+	function dotnetbase.commonProperties(prj)
+		if _ACTION > "vs2010" then
+			_p(1,'<Import Project="$(MSBuildExtensionsPath)\\$(MSBuildToolsVersion)\\Microsoft.Common.props" Condition="Exists(\'$(MSBuildExtensionsPath)\\$(MSBuildToolsVersion)\\Microsoft.Common.props\')" />')
+		end
+	end
 
 
-    function dotnetbase.configurationCondition(cfg)
-        _x(2,'<Configuration Condition=" \'$(Configuration)\' == \'\' ">%s</Configuration>', cfg.buildcfg)
-    end
+	function dotnetbase.configurationCondition(cfg)
+		_x(2,'<Configuration Condition=" \'$(Configuration)\' == \'\' ">%s</Configuration>', cfg.buildcfg)
+	end
 
 
-    function dotnetbase.fileAlignment(cfg)
-        if _ACTION >= "vs2010" then
-            _p(2,'<FileAlignment>512</FileAlignment>')
-        end
-    end
+	function dotnetbase.fileAlignment(cfg)
+		if _ACTION >= "vs2010" then
+			_p(2,'<FileAlignment>512</FileAlignment>')
+		end
+	end
 
 
-    function dotnetbase.bindingRedirects(cfg)
-        if _ACTION >= "vs2015" then
-            _p(2, '<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>')
-        end
-    end
+	function dotnetbase.bindingRedirects(cfg)
+		if _ACTION >= "vs2015" then
+			_p(2, '<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>')
+		end
+	end
 
 
-    function dotnetbase.outputType(cfg)
-        _p(2,'<OutputType>%s</OutputType>', dotnet.getkind(cfg))
-    end
+	function dotnetbase.outputType(cfg)
+		_p(2,'<OutputType>%s</OutputType>', dotnet.getkind(cfg))
+	end
 
 
-    function dotnetbase.platformCondition(cfg)
-        _p(2,'<Platform Condition=" \'$(Platform)\' == \'\' ">%s</Platform>', dotnetbase.arch(cfg.project))
-    end
+	function dotnetbase.platformCondition(cfg)
+		_p(2,'<Platform Condition=" \'$(Platform)\' == \'\' ">%s</Platform>', dotnetbase.arch(cfg.project))
+	end
 
 
-    function dotnetbase.productVersion(cfg)
-        local action = p.action.current()
-        if action.vstudio.productVersion then
-            _p(2,'<ProductVersion>%s</ProductVersion>', action.vstudio.productVersion)
-        end
-    end
+	function dotnetbase.productVersion(cfg)
+		local action = p.action.current()
+		if action.vstudio.productVersion then
+			_p(2,'<ProductVersion>%s</ProductVersion>', action.vstudio.productVersion)
+		end
+	end
 
-    function dotnetbase.projectGuid(cfg)
-        _p(2,'<ProjectGuid>{%s}</ProjectGuid>', cfg.uuid)
-    end
-
-
-    function dotnetbase.projectTypeGuids(cfg)
-        if cfg.flags.WPF then
-            _p(2,'<ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>')
-        end
-    end
+	function dotnetbase.projectGuid(cfg)
+		_p(2,'<ProjectGuid>{%s}</ProjectGuid>', cfg.uuid)
+	end
 
 
-    function dotnetbase.rootNamespace(cfg)
-        _p(2,'<RootNamespace>%s</RootNamespace>', cfg.namespace or cfg.buildtarget.basename)
-    end
+	function dotnetbase.projectTypeGuids(cfg)
+		if cfg.flags.WPF then
+			_p(2,'<ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>')
+		end
+	end
 
 
-    function dotnetbase.schemaVersion(cfg)
-        local action = p.action.current()
-        if action.vstudio.csprojSchemaVersion then
-            _p(2,'<SchemaVersion>%s</SchemaVersion>', action.vstudio.csprojSchemaVersion)
-        end
-    end
+	function dotnetbase.rootNamespace(cfg)
+		_p(2,'<RootNamespace>%s</RootNamespace>', cfg.namespace or cfg.buildtarget.basename)
+	end
 
 
-    function dotnetbase.NoWarn(cfg)
-        if #cfg.disablewarnings > 0 then
-            local warnings = table.concat(cfg.disablewarnings, ";")
-            _p(2,'<NoWarn>%s</NoWarn>', warnings)
-        end
-    end
+	function dotnetbase.schemaVersion(cfg)
+		local action = p.action.current()
+		if action.vstudio.csprojSchemaVersion then
+			_p(2,'<SchemaVersion>%s</SchemaVersion>', action.vstudio.csprojSchemaVersion)
+		end
+	end
 
 
-    function dotnetbase.targetFrameworkVersion(cfg)
-        local action = p.action.current()
-        local framework = cfg.dotnetframework or action.vstudio.targetFramework
-        if framework then
-            _p(2,'<TargetFrameworkVersion>v%s</TargetFrameworkVersion>', framework)
-        end
-    end
+	function dotnetbase.NoWarn(cfg)
+		if #cfg.disablewarnings > 0 then
+			local warnings = table.concat(cfg.disablewarnings, ";")
+			_p(2,'<NoWarn>%s</NoWarn>', warnings)
+		end
+	end
 
 
-    function dotnetbase.targetFrameworkProfile(cfg)
-        if _ACTION == "vs2010" then
-            _p(2,'<TargetFrameworkProfile>')
-            _p(2,'</TargetFrameworkProfile>')
-        end
-    end
+	function dotnetbase.targetFrameworkVersion(cfg)
+		local action = p.action.current()
+		local framework = cfg.dotnetframework or action.vstudio.targetFramework
+		if framework then
+			_p(2,'<TargetFrameworkVersion>v%s</TargetFrameworkVersion>', framework)
+		end
+	end
 
 
-    function dotnetbase.xmlDeclaration()
-        if _ACTION > "vs2008" then
-            p.xmlUtf8()
-        end
-    end
+	function dotnetbase.targetFrameworkProfile(cfg)
+		if _ACTION == "vs2010" then
+			_p(2,'<TargetFrameworkProfile>')
+			_p(2,'</TargetFrameworkProfile>')
+		end
+	end
+
+
+	function dotnetbase.xmlDeclaration()
+		if _ACTION > "vs2008" then
+			p.xmlUtf8()
+		end
+	end
 

--- a/modules/vstudio/vs2010.lua
+++ b/modules/vstudio/vs2010.lua
@@ -85,16 +85,18 @@
 			end
 		end
 
-		-- Skip generation of empty packages.config files
-		local packages = p.capture(function() vstudio.nuget2010.generatePackagesConfig(prj) end)
-		if #packages > 0 then
-			p.generate(prj, "packages.config", function() p.outln(packages) end)
-		end
+		if not vstudio.nuget2010.supportsPackageReferences(prj) then
+			-- Skip generation of empty packages.config files
+			local packages = p.capture(function() vstudio.nuget2010.generatePackagesConfig(prj) end)
+			if #packages > 0 then
+				p.generate(prj, "packages.config", function() p.outln(packages) end)
+			end
 
-		-- Skip generation of empty NuGet.Config files
-		local config = p.capture(function() vstudio.nuget2010.generateNuGetConfig(prj) end)
-		if #config > 0 then
-			p.generate(prj, "NuGet.Config", function() p.outln(config) end)
+			-- Skip generation of empty NuGet.Config files
+			local config = p.capture(function() vstudio.nuget2010.generateNuGetConfig(prj) end)
+			if #config > 0 then
+				p.generate(prj, "NuGet.Config", function() p.outln(config) end)
+			end
 		end
 	end
 

--- a/modules/vstudio/vs2010_nuget.lua
+++ b/modules/vstudio/vs2010_nuget.lua
@@ -38,6 +38,10 @@
 		end
 	end
 
+	function nuget2010.supportsPackageReferences(prj)
+		return _ACTION >= "vs2017" and p.project.isdotnet(prj)
+	end
+
 
 --
 -- Given a package string, returns a table containing "verbatimVersion",
@@ -368,3 +372,66 @@
 		p.pop('</packageSources>')
 		p.pop('</configuration>')
 	end
+
+
+--
+-- nuget workspace validation
+--
+
+	function nuget2010.uniqueProjectLocationsWithNuGet(wks)
+		local locations = {}
+		for prj in p.workspace.eachproject(wks) do
+			if not nuget2010.supportsPackageReferences(prj) then
+				local function fail()
+					p.error("projects '%s' and '%s' cannot have the same location when using NuGet with different packages (packages.config conflict)", locations[prj.location].name, prj.name)
+				end
+
+				if locations[prj.location] and #locations[prj.location].nuget > 0 and #prj.nuget > 0 then
+					if #locations[prj.location].nuget ~= #prj.nuget then
+						fail()
+					end
+
+					for i, package in ipairs(locations[prj.location].nuget) do
+						if prj.nuget[i] ~= package then
+							fail()
+						end
+					end
+				end
+				locations[prj.location] = prj
+			end
+		end
+	end
+
+	p.override(p.validation.elements, "workspace", function (oldfn, wks)
+		local t = oldfn(wks)
+		table.insert(t, nuget2010.uniqueProjectLocationsWithNuGet)
+		return t
+	end)
+
+--
+-- nuget project validation
+--
+
+	function nuget2010.NuGetHasHTTP(prj)
+		if not http and #prj.nuget > 0 and not nuget2010.supportsPackageReferences(prj) then
+			p.error("Premake was compiled with --no-curl, but Curl is required for NuGet support (project '%s' is referencing NuGet packages)", prj.name)
+		end
+	end
+
+	function nuget2010.NuGetPackageStrings(prj)
+		for _, package in ipairs(prj.nuget) do
+			local components = package:explode(":")
+
+			if #components ~= 2 or #components[1] == 0 or #components[2] == 0 then
+				p.error("NuGet package '%s' in project '%s' is invalid - please give packages in the format 'id:version', e.g. 'NUnit:3.6.1'", package, prj.name)
+			end
+		end
+	end
+
+	p.override(p.validation.elements, "project", function (oldfn, prj)
+		local t = oldfn(prj)
+		table.insert(t, nuget2010.NuGetHasHTTP)
+		table.insert(t, nuget2010.NuGetPackageStrings)
+		return t
+	end)
+

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1711,9 +1711,11 @@
 	end
 
 	function m.importNuGetTargets(prj)
-		for i = 1, #prj.nuget do
-			local targetsFile = nuGetTargetsFile(prj, prj.nuget[i])
-			p.x('<Import Project="%s" Condition="Exists(\'%s\')" />', targetsFile, targetsFile)
+		if not vstudio.nuget2010.supportsPackageReferences(prj) then
+			for i = 1, #prj.nuget do
+				local targetsFile = nuGetTargetsFile(prj, prj.nuget[i])
+				p.x('<Import Project="%s" Condition="Exists(\'%s\')" />', targetsFile, targetsFile)
+			end
 		end
 	end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -847,7 +847,7 @@
 
 	api.register {
 		name = "nuget",
-		scope = "project",
+		scope = "config",
 		kind = "list:string",
 		tokens = true,
 	}

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -667,7 +667,7 @@
 			-- packages.config file to the project. Is there a better place to
 			-- do this?
 
-			if #prj.nuget > 0 then
+			if #prj.nuget > 0 and (_ACTION < "vs2017" or p.project.iscpp(prj)) then
 				addFile("packages.config")
 			end
 		end

--- a/src/base/validation.lua
+++ b/src/base/validation.lua
@@ -38,7 +38,6 @@
 		return {
 			m.workspaceHasConfigs,
 			m.uniqueProjectIds,
-			m.uniqueProjectLocationsWithNuGet,
 		}
 	end
 
@@ -60,8 +59,6 @@
 			m.actionSupportsKind,
 			m.projectRulesExist,
 			m.projectValuesInScope,
-			m.NuGetHasHTTP,
-			m.NuGetPackageStrings,
 		}
 	end
 
@@ -224,24 +221,6 @@
 	end
 
 
-	function m.NuGetHasHTTP(prj)
-		if not http and #prj.nuget > 0 then
-			p.error("Premake was compiled with --no-curl, but Curl is required for NuGet support (project '%s' is referencing NuGet packages)", prj.name)
-		end
-	end
-
-
-	function m.NuGetPackageStrings(prj)
-		for _, package in ipairs(prj.nuget) do
-			local components = package:explode(":")
-
-			if #components ~= 2 or #components[1] == 0 or #components[2] == 0 then
-				p.error("NuGet package '%s' in project '%s' is invalid - please give packages in the format 'id:version', e.g. 'NUnit:3.6.1'", package, prj.name)
-			end
-		end
-	end
-
-
 	function m.uniqueProjectIds(wks)
 		local uuids = {}
 		for prj in p.workspace.eachproject(wks) do
@@ -249,29 +228,6 @@
 				p.error("projects '%s' and '%s' have the same UUID", uuids[prj.uuid], prj.name)
 			end
 			uuids[prj.uuid] = prj.name
-		end
-	end
-
-
-	function m.uniqueProjectLocationsWithNuGet(wks)
-		local locations = {}
-		for prj in p.workspace.eachproject(wks) do
-			local function fail()
-				p.error("projects '%s' and '%s' cannot have the same location when using NuGet with different packages (packages.config conflict)", locations[prj.location].name, prj.name)
-			end
-
-			if locations[prj.location] and #locations[prj.location].nuget > 0 and #prj.nuget > 0 then
-				if #locations[prj.location].nuget ~= #prj.nuget then
-					fail()
-				end
-
-				for i, package in ipairs(locations[prj.location].nuget) do
-					if prj.nuget[i] ~= package then
-						fail()
-					end
-				end
-			end
-			locations[prj.location] = prj
 		end
 	end
 


### PR DESCRIPTION
via the new PackageReference nodes.

The upsides here are
1) the MS package downloading and validation is much faster than the premake version
2) since the config is in the project file instead of packages.config which means
   multiple nuget projects can sit in the same folder.