### PR TITLE
Fix subtle bug in table.translate

### DIFF
--- a/src/base/table.lua
+++ b/src/base/table.lua
@@ -401,12 +401,12 @@
 		if not translation then return {} end
 
 		local result = {}
-		for _, value in ipairs(arr) do
+		for i = 1, #arr do
 			local tvalue
 			if type(translation) == "function" then
-				tvalue = translation(value)
+				tvalue = translation(arr[i])
 			else
-				tvalue = translation[value]
+				tvalue = translation[arr[i]]
 			end
 			if (tvalue) then
 				table.insert(result, tvalue)


### PR DESCRIPTION
```
ipairs stops enumerating as soon as it cannot find the next index.
If you make a the following table:
	{'a', nil, 'b', 'c'}

ipairs will stop enumerating after 'a',
while #tbl will tell you there is 4 elements.
```