### PR TITLE
Added asmoptions [BUT WHY DOESN'T IT WORK???]

### DIFF
--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -794,6 +794,7 @@
 			local fileCfgFunc = function(fcfg, condition)
 				if fcfg then
 					return {
+						m.additionalASMOptions,
 						m.excludedFromBuild,
 						m.exceptionHandlingSEH,
 					}
@@ -1028,7 +1029,7 @@
 						if not checkFunc or checkFunc(cfg, fcfg) then
 							p.callArray(fileCfgFunc, fcfg, m.configPair(cfg))
 						end
-						end
+					end
 					if #m.conditionalElements > 0 then
 						m.emitConditionalElements(prj)
 					end
@@ -1218,6 +1219,18 @@
 			elseif (cfg.cppdialect == "C++17") then
 				m.element("LanguageStandard", nil, 'stdcpplatest')
 			end
+		end
+	end
+
+
+	function m.additionalASMOptions(cfg, condition)
+		print("Additional ASM Options")
+		print(tostring(#cfg.buildoptions).."/"..tostring(#cfg.asmoptions))
+		local opts = cfg.asmoptions
+		if #opts > 0 then
+			opts = table.concat(opts, " ")
+--			print("There are additional ASM options: "..opts)
+			m.element("AdditionalOptions", condition, '%s %%(AdditionalOptions)', opts)
 		end
 	end
 
@@ -2455,7 +2468,7 @@
 				else
 					element.setting = value .. table.concat(arg)
 				end
-		else
+			else
 				element.setting = element.value
 			end
 			table.insert(m.conditionalElements, element)

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -794,7 +794,6 @@
 			local fileCfgFunc = function(fcfg, condition)
 				if fcfg then
 					return {
-						m.additionalASMOptions,
 						m.excludedFromBuild,
 						m.exceptionHandlingSEH,
 					}
@@ -1029,7 +1028,7 @@
 						if not checkFunc or checkFunc(cfg, fcfg) then
 							p.callArray(fileCfgFunc, fcfg, m.configPair(cfg))
 						end
-					end
+						end
 					if #m.conditionalElements > 0 then
 						m.emitConditionalElements(prj)
 					end
@@ -1219,18 +1218,6 @@
 			elseif (cfg.cppdialect == "C++17") then
 				m.element("LanguageStandard", nil, 'stdcpplatest')
 			end
-		end
-	end
-
-
-	function m.additionalASMOptions(cfg, condition)
-		print("Additional ASM Options")
-		print(tostring(#cfg.buildoptions).."/"..tostring(#cfg.asmoptions))
-		local opts = cfg.asmoptions
-		if #opts > 0 then
-			opts = table.concat(opts, " ")
---			print("There are additional ASM options: "..opts)
-			m.element("AdditionalOptions", condition, '%s %%(AdditionalOptions)', opts)
 		end
 	end
 
@@ -2468,7 +2455,7 @@
 				else
 					element.setting = value .. table.concat(arg)
 				end
-			else
+		else
 				element.setting = element.value
 			end
 			table.insert(m.conditionalElements, element)

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -37,6 +37,14 @@
 	}
 
 	api.register {
+		name = "asmoptions",
+		scope = "config",
+		kind = "list:string",
+		tokens = true,
+		pathVars = true,
+	}
+
+	api.register {
 		name = "atl",
 		scope = "config",
 		kind  = "string",

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -37,14 +37,6 @@
 	}
 
 	api.register {
-		name = "asmoptions",
-		scope = "config",
-		kind = "list:string",
-		tokens = true,
-		pathVars = true,
-	}
-
-	api.register {
 		name = "atl",
 		scope = "config",
 		kind  = "string",


### PR DESCRIPTION
Just as you can add additional build options to the compile tool through buildoptions, so I want to be able to add additional options to the assembler tool. I registered an API called asmoptions added a function to vs2010_vcxproj.lua called m.additionalASMOptions and added it to the Masm category.

Now, when I make an asmoptions declaration at workspace scope, those declarations aren't forwarded through to the assembly files. I think I'[m missing something, and as I'm writing this I'm getting an idea that I may have missed the distinction between file specific and non-file specific declarations.

Any ideas from anyone?