### PR TITLE
sometimes due to ordering of test, we're in a rule scope.

### DIFF
--- a/tests/base/test_configset.lua
+++ b/tests/base/test_configset.lua
@@ -17,6 +17,7 @@
 	local cset, parentset
 
 	function suite.setup()
+		local wks = test.createWorkspace()
 		parentset = configset.new()
 		cset = configset.new(parentset)
 	end


### PR DESCRIPTION
 which makes settings some of the values into configsets illegal.
So we must force ourselves into a project scope.