### PR TITLE
Add table.combine()

### DIFF
--- a/src/base/table.lua
+++ b/src/base/table.lua
@@ -373,6 +373,25 @@
 	end
 
 
+--
+-- Combines multiple tables by adding the key-value associations from one table to another
+-- then adding indexed values (essentially a combined table.merge() & table.join()
+-- Returns the resulting merged table
+--
+
+	function table.combine(...)
+	    -- Merge the keyed values
+	    local result = table.merge(...)
+	    -- Append the indexed values
+	    local joined = table.join(...)
+	    for i, v in ipairs(joined) do
+	        result[i] = v
+	    end
+
+	    return result
+	end
+
+
 ---
 -- Replace all instances of `value` with `replacement` in an array. Array
 -- elements are modified in place.


### PR DESCRIPTION
Add table.combine(), a function which combines the behaviors of table.merge() and table.join() to combine multiple tables, but append indexed elements rather than overwrite them.