### PR TITLE
Fixed a bug with gmake2 not generating compiler macros when using gcc.

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -502,5 +502,5 @@
 		if (cfg.gccprefix and gcc.tools[tool]) or tool == "rc" then
 			return (cfg.gccprefix or "") .. gcc.tools[tool]
 		end
-		return nil
+		return gcc.tools[tool]
 	end


### PR DESCRIPTION
gcc.gettoolname returns nil for gcc toolset. As a result gmake2 doesn't generate compiler macros (CC=gcc, CXX=g++, etc...).