### PR TITLE
Fixed a bug in gmake2 with clang and pch.

### DIFF
--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -405,7 +405,7 @@
 	function cpp.forceInclude(cfg, toolset)
 		local includes = toolset.getforceincludes(cfg)
 		if not cfg.flags.NoPCH and cfg.pchheader then
-			table.insert(includes, "-include $(PCH_PLACEHOLDER)")
+			table.insert(includes, 1, "-include $(PCH_PLACEHOLDER)")
 		end
 		p.outln('FORCE_INCLUDE +=' .. gmake2.list(includes))
 	end


### PR DESCRIPTION
Clang requires the pch file to be the first force-included item. This fix doesn't break pch usage in gcc.