### PR TITLE
Add support for `targetextension` in xcode4

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -968,10 +968,6 @@
 		targetextension ".xyz"
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
-
-		--ms removed for now
-		--EXECUTABLE_EXTENSION = xyz;
-
 		test.capture [[
 		[libMyProject.xyz:Debug] /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -979,6 +975,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CONFIGURATION_BUILD_DIR = bin/Debug;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_EXTENSION = xyz;
 				EXECUTABLE_PREFIX = lib;
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/lib;

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -431,9 +431,10 @@
 
 				-- is this the product node, describing the output target?
 				if node.kind == "product" then
+					local name = iif(tr.project.kind ~= "ConsoleApp", node.name, node.cfg.buildtarget.prefix .. node.cfg.buildtarget.basename)
 					settings[node.id] = function(level)
 						_p(level,'%s /* %s */ = {isa = PBXFileReference; explicitFileType = %s; includeInIndex = 0; name = %s; path = %s; sourceTree = BUILT_PRODUCTS_DIR; };',
-							node.id, node.name, xcode.gettargettype(node), stringifySetting(node.name), stringifySetting(path.getname(node.cfg.buildtarget.bundlename ~= "" and node.cfg.buildtarget.bundlename or node.cfg.buildtarget.relpath)))
+							node.id, node.name, xcode.gettargettype(node), stringifySetting(name), stringifySetting(path.getname(node.cfg.buildtarget.bundlename ~= "" and node.cfg.buildtarget.bundlename or node.cfg.buildtarget.relpath)))
 					end
 				-- is this a project dependency?
 				elseif node.parent.parent == tr.projects then
@@ -892,11 +893,15 @@
 			settings['EXECUTABLE_PREFIX'] = cfg.buildtarget.prefix
 		end
 
-		--[[if cfg.targetextension then
+		if cfg.kind ~= "ConsoleApp" and cfg.targetextension then
 			local ext = cfg.targetextension
 			ext = iif(ext:startswith('.'), ext:sub(2), ext)
-			settings['EXECUTABLE_EXTENSION'] = ext
-		end]]
+			if cfg.kind == "WindowedApp" and ext ~= "app" then
+				settings['WRAPPER_EXTENSION'] = ext
+			elseif (cfg.kind == "StaticLib" and ext ~= "a") or (cfg.kind == "SharedLib" and ext ~= "dylib") then
+				settings['EXECUTABLE_EXTENSION'] = ext
+			end
+		end
 
 		local outdir = path.getrelative(tr.project.location, path.getdirectory(cfg.buildtarget.relpath))
 		if outdir ~= "." then

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1655,6 +1655,9 @@
 
 	-- Add variations for other Posix-like systems.
 
+	filter { "system:MacOSX", "kind:WindowedApp" }
+		targetextension ".app"
+
 	filter { "system:MacOSX", "kind:SharedLib" }
 		targetextension ".dylib"
 

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -49,7 +49,7 @@
 		local bundlepath = ""
 
 		if cfg.system == p.MACOSX and kind == p.WINDOWEDAPP then
-			bundlename = basename .. ".app"
+			bundlename = basename .. extension
 			bundlepath = path.join(bundlename, "Contents/MacOS")
 		end
 


### PR DESCRIPTION
I'm sorry I closed the last pull request, even though you commented.


> Is there any particular reason why a `ConsoleApp` can't specify a `targetextension`? `app.out` for example?

There is no way to add extensions to `ConsoleApp` in Xcode.
Even if you put values in `WRAPPER_EXTENSION` or `EXECUTABLE_EXTENSION`, the product has no extension.


> Could this also apply to `system:ios`?

I did not specifically think about `system:ios`.
This can also apply to `system:ios`.
