### PR TITLE
change objdir to use more unique variant

### DIFF
--- a/contrib/luashim/luashim.c
+++ b/contrib/luashim/luashim.c
@@ -851,7 +851,7 @@ void shimInitialize(lua_State* L)
 
 	// Find the 'SHIM' entry in the registry.
 	const Table* reg = hvalue(&G(L)->l_registry);
-	const Node* n = findNode(reg, 'SHIM');
+	const Node* n = findNode(reg, 0x5348494D /* 'SHIM' */);
 	assert(n != NULL);
 
 	g_shimTable = (const LuaFunctionTable_t*)n->i_val.value_.p;

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -16,6 +16,8 @@
 	local wks, prj, cfg
 
 	function suite.setup()
+		_TARGET_OS="linux"
+
 		p.action.set("codelite")
 		p.indent("  ")
 		wks = test.createWorkspace()
@@ -135,7 +137,7 @@
 		prepare()
 		codelite.project.general(cfg)
 		test.capture [[
-      <General OutputFile="bin/Debug/MyProject.exe" IntermediateDirectory="obj/Debug" Command="bin/Debug/MyProject.exe" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+      <General OutputFile="bin/windows-clang-debug/MyProject.exe" IntermediateDirectory="obj/windows-clang-debug" Command="bin/windows-clang-debug/MyProject.exe" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
 		]]
 	end
 

--- a/modules/gmake/tests/cpp/test_clang.lua
+++ b/modules/gmake/tests/cpp/test_clang.lua
@@ -18,6 +18,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		wks = test.createWorkspace()
 		toolset "clang"
 		prj = p.workspace.getproject(wks, 1)

--- a/modules/gmake/tests/cpp/test_file_rules.lua
+++ b/modules/gmake/tests/cpp/test_file_rules.lua
@@ -17,6 +17,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		p.escaper(make.esc)
 		wks = test.createWorkspace()
 	end
@@ -101,16 +103,16 @@ endif
 		prepare()
 		test.capture [[
 ifeq ($(config),debug)
-obj/Debug/hello.obj: hello.x
+obj/linux-debug/hello.obj: hello.x
 	@echo "Compiling hello.x"
-	$(SILENT) cxc -c "hello.x" -o "obj/Debug/hello.xo"
-	$(SILENT) c2o -c "obj/Debug/hello.xo" -o "obj/Debug/hello.obj"
+	$(SILENT) cxc -c "hello.x" -o "obj/linux-debug/hello.xo"
+	$(SILENT) c2o -c "obj/linux-debug/hello.xo" -o "obj/linux-debug/hello.obj"
 endif
 ifeq ($(config),release)
-obj/Release/hello.obj: hello.x
+obj/linux-release/hello.obj: hello.x
 	@echo "Compiling hello.x"
-	$(SILENT) cxc -c "hello.x" -o "obj/Release/hello.xo"
-	$(SILENT) c2o -c "obj/Release/hello.xo" -o "obj/Release/hello.obj"
+	$(SILENT) cxc -c "hello.x" -o "obj/linux-release/hello.xo"
+	$(SILENT) c2o -c "obj/linux-release/hello.xo" -o "obj/linux-release/hello.obj"
 endif
 		]]
 	end
@@ -128,16 +130,16 @@ endif
 		prepare()
 		test.capture [[
 ifeq ($(config),debug)
-obj/Debug/hello.obj: hello.x hello.x.inc hello.x.inc2
+obj/linux-debug/hello.obj: hello.x hello.x.inc hello.x.inc2
 	@echo "Compiling hello.x"
-	$(SILENT) cxc -c "hello.x" -o "obj/Debug/hello.xo"
-	$(SILENT) c2o -c "obj/Debug/hello.xo" -o "obj/Debug/hello.obj"
+	$(SILENT) cxc -c "hello.x" -o "obj/linux-debug/hello.xo"
+	$(SILENT) c2o -c "obj/linux-debug/hello.xo" -o "obj/linux-debug/hello.obj"
 endif
 ifeq ($(config),release)
-obj/Release/hello.obj: hello.x hello.x.inc hello.x.inc2
+obj/linux-release/hello.obj: hello.x hello.x.inc hello.x.inc2
 	@echo "Compiling hello.x"
-	$(SILENT) cxc -c "hello.x" -o "obj/Release/hello.xo"
-	$(SILENT) c2o -c "obj/Release/hello.xo" -o "obj/Release/hello.obj"
+	$(SILENT) cxc -c "hello.x" -o "obj/linux-release/hello.xo"
+	$(SILENT) c2o -c "obj/linux-release/hello.xo" -o "obj/linux-release/hello.obj"
 endif
 		]]
 	end

--- a/modules/gmake/tests/cpp/test_flags.lua
+++ b/modules/gmake/tests/cpp/test_flags.lua
@@ -17,6 +17,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		wks, prj = test.createWorkspace()
 	end
 

--- a/modules/gmake/tests/cpp/test_ldflags.lua
+++ b/modules/gmake/tests/cpp/test_ldflags.lua
@@ -16,6 +16,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		wks, prj = test.createWorkspace()
 		symbols "On"
 	end

--- a/modules/gmake/tests/cpp/test_make_linking.lua
+++ b/modules/gmake/tests/cpp/test_make_linking.lua
@@ -124,8 +124,8 @@
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s
-  LIBS += build/bin/Debug/libMyProject2.a
-  LDDEPS += build/bin/Debug/libMyProject2.a
+  LIBS += build/lib/linux-debug/libMyProject2.a
+  LDDEPS += build/lib/linux-debug/libMyProject2.a
 		]]
 	end
 
@@ -145,7 +145,7 @@
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s
   LIBS += build/bin/Debug/libMyProject2.so
-  LDDEPS += build/bin/Debug/libMyProject2.so
+  LDDEPS += build/bin/linux-debug/libMyProject2.so
 		]]
 	end
 
@@ -163,9 +163,9 @@
 
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
-  ALL_LDFLAGS += $(LDFLAGS) -Lbuild/bin/Debug -Wl,-rpath,'$$ORIGIN/../../build/bin/Debug' -s
+  ALL_LDFLAGS += $(LDFLAGS) -Lbuild/bin/linux-debug -Wl,-rpath,'$$ORIGIN/../../build/bin/linux-debug' -s
   LIBS += -lMyProject2
-  LDDEPS += build/bin/Debug/libMyProject2.so
+  LDDEPS += build/bin/linux-debug/libMyProject2.so
 		]]
 	end
 
@@ -180,9 +180,9 @@
 
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
-  ALL_LDFLAGS += $(LDFLAGS) -Lbuild/bin/Debug -Wl,-rpath,'@loader_path/../../build/bin/Debug' -Wl,-x
+  ALL_LDFLAGS += $(LDFLAGS) -Lbuild/bin/macosx-clang-debug -Wl,-rpath,'@loader_path/../../build/bin/macosx-clang-debug' -Wl,-x
   LIBS += -lMyProject2
-  LDDEPS += build/bin/Debug/libMyProject2.dylib
+  LDDEPS += build/bin/macosx-clang-debug/libMyProject2.dylib
 		]]
 	end
 
@@ -205,8 +205,8 @@
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s
-  LIBS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
-  LDDEPS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
+  LIBS += build/lib/linux-debug/libMyProject2.a build/lib/linux-debug/libMyProject3.a
+  LDDEPS += build/lib/linux-debug/libMyProject2.a build/lib/linux-debug/libMyProject3.a
 		]]
 	end
 
@@ -230,8 +230,8 @@
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
   ALL_LDFLAGS += $(LDFLAGS) -s
-  LIBS += -Wl,--start-group build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a -Wl,--end-group
-  LDDEPS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
+  LIBS += -Wl,--start-group build/lib/linux-debug/libMyProject2.a build/lib/linux-debug/libMyProject3.a -Wl,--end-group
+  LDDEPS += build/lib/linux-debug/libMyProject2.a build/lib/linux-debug/libMyProject3.a
 		]]
 	end
 

--- a/modules/gmake/tests/cpp/test_make_pch.lua
+++ b/modules/gmake/tests/cpp/test_make_pch.lua
@@ -17,6 +17,8 @@
 
 	local wks, prj
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		os.chdir(_TESTS_DIR)
 		wks, prj = test.createWorkspace()
 	end

--- a/modules/gmake/tests/cpp/test_objects.lua
+++ b/modules/gmake/tests/cpp/test_objects.lua
@@ -16,6 +16,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		wks = test.createWorkspace()
 	end
 
@@ -129,10 +131,15 @@ CUSTOMFILES := \
 
 ifeq ($(config),debug)
   OBJECTS += \
-	obj/Debug/hello.obj \
+	obj/linux-debug/hello.obj \
 
 endif
 
+ifeq ($(config),release)
+  OBJECTS += \
+	obj/linux-release/hello.obj \
+
+endif
 		]]
 	end
 
@@ -162,10 +169,15 @@ CUSTOMFILES := \
 
 ifeq ($(config),debug)
   OBJECTS += \
-	obj/Debug/hello.obj \
+	obj/linux-debug/hello.obj \
 
 endif
 
+ifeq ($(config),release)
+  OBJECTS += \
+	obj/linux-release/hello.obj \
+
+endif
 		]]
 	end
 
@@ -195,10 +207,15 @@ CUSTOMFILES := \
 
 ifeq ($(config),debug)
   CUSTOMFILES += \
-	obj/Debug/hello.obj \
+	obj/linux-debug/hello.obj \
 
 endif
 
+ifeq ($(config),release)
+  CUSTOMFILES += \
+	obj/linux-release/hello.obj \
+
+endif
 		]]
 	end
 

--- a/modules/gmake/tests/cpp/test_target_rules.lua
+++ b/modules/gmake/tests/cpp/test_target_rules.lua
@@ -17,6 +17,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		wks, prj = test.createWorkspace()
 	end
 

--- a/modules/gmake/tests/cpp/test_tools.lua
+++ b/modules/gmake/tests/cpp/test_tools.lua
@@ -18,6 +18,8 @@
 	local cfg
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		local wks, prj = test.createWorkspace()
 		cfg = test.getconfig(prj, "Debug")
 	end

--- a/modules/gmake/tests/cs/test_links.lua
+++ b/modules/gmake/tests/cs/test_links.lua
@@ -17,6 +17,7 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = 'windows'
 		wks, prj = test.createWorkspace()
 	end
 
@@ -55,6 +56,7 @@
 
 		prepare ()
 		test.capture [[
-  DEPENDS = bin/Debug/MyProject2.dll bin/Debug/MyProject3.dll
+  DEPENDS = bin/windows-debug/MyProject2.dll bin/windows-debug/MyProject3.dll
+  REFERENCES = /r:bin/windows-debug/MyProject2.dll /r:bin/windows-debug/MyProject3.dll
 		]]
 	end

--- a/modules/gmake2/tests/test_gmake2_buildcmds.lua
+++ b/modules/gmake2/tests/test_gmake2_buildcmds.lua
@@ -15,6 +15,8 @@ premake.api.register {
 local wks, prj, cfg
 
 function suite.setup()
+	_TARGET_OS = "linux"
+
 	wks = workspace("MyWorkspace")
 	test_libdir   (path.join(_MAIN_SCRIPT_DIR, 'lib'))
 	configurations { "Debug", "Release" }

--- a/modules/gmake2/tests/test_gmake2_clang.lua
+++ b/modules/gmake2/tests/test_gmake2_clang.lua
@@ -16,6 +16,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		wks = test.createWorkspace()
 		toolset "clang"
 		prj = p.workspace.getproject(wks, 1)

--- a/modules/gmake2/tests/test_gmake2_file_rules.lua
+++ b/modules/gmake2/tests/test_gmake2_file_rules.lua
@@ -16,6 +16,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		p.escaper(gmake2.esc)
 		gmake2.cpp.initialize()
 
@@ -117,17 +119,17 @@ $(OBJDIR)/test.o: src/test.cpp
 # #############################################
 
 ifeq ($(config),debug)
-obj/Debug/hello.obj: hello.x
+obj/linux-debug/hello.obj: hello.x
 	@echo Compiling hello.x
-	$(SILENT) cxc -c "hello.x" -o "obj/Debug/hello.xo"
-	$(SILENT) c2o -c "obj/Debug/hello.xo" -o "obj/Debug/hello.obj"
+	$(SILENT) cxc -c "hello.x" -o "obj/linux-debug/hello.xo"
+	$(SILENT) c2o -c "obj/linux-debug/hello.xo" -o "obj/linux-debug/hello.obj"
 endif
 
 ifeq ($(config),release)
-obj/Release/hello.obj: hello.x
+obj/linux-release/hello.obj: hello.x
 	@echo Compiling hello.x
-	$(SILENT) cxc -c "hello.x" -o "obj/Release/hello.xo"
-	$(SILENT) c2o -c "obj/Release/hello.xo" -o "obj/Release/hello.obj"
+	$(SILENT) cxc -c "hello.x" -o "obj/linux-release/hello.xo"
+	$(SILENT) c2o -c "obj/linux-release/hello.xo" -o "obj/linux-release/hello.obj"
 endif
 		]]
 	end
@@ -148,17 +150,17 @@ endif
 # #############################################
 
 ifeq ($(config),debug)
-obj/Debug/hello.obj: hello.x hello.x.inc hello.x.inc2
+obj/linux-debug/hello.obj: hello.x hello.x.inc hello.x.inc2
 	@echo Compiling hello.x
-	$(SILENT) cxc -c "hello.x" -o "obj/Debug/hello.xo"
-	$(SILENT) c2o -c "obj/Debug/hello.xo" -o "obj/Debug/hello.obj"
+	$(SILENT) cxc -c "hello.x" -o "obj/linux-debug/hello.xo"
+	$(SILENT) c2o -c "obj/linux-debug/hello.xo" -o "obj/linux-debug/hello.obj"
 endif
 
 ifeq ($(config),release)
-obj/Release/hello.obj: hello.x hello.x.inc hello.x.inc2
+obj/linux-release/hello.obj: hello.x hello.x.inc hello.x.inc2
 	@echo Compiling hello.x
-	$(SILENT) cxc -c "hello.x" -o "obj/Release/hello.xo"
-	$(SILENT) c2o -c "obj/Release/hello.xo" -o "obj/Release/hello.obj"
+	$(SILENT) cxc -c "hello.x" -o "obj/linux-release/hello.xo"
+	$(SILENT) c2o -c "obj/linux-release/hello.xo" -o "obj/linux-release/hello.obj"
 endif
 		]]
 	end

--- a/modules/gmake2/tests/test_gmake2_flags.lua
+++ b/modules/gmake2/tests/test_gmake2_flags.lua
@@ -19,6 +19,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		wks, prj = test.createWorkspace()
 	end
 

--- a/modules/gmake2/tests/test_gmake2_ldflags.lua
+++ b/modules/gmake2/tests/test_gmake2_ldflags.lua
@@ -17,6 +17,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		wks, prj = test.createWorkspace()
 		symbols "On"
 	end

--- a/modules/gmake2/tests/test_gmake2_linking.lua
+++ b/modules/gmake2/tests/test_gmake2_linking.lua
@@ -19,7 +19,8 @@
 	local wks, prj
 
 	function suite.setup()
-		_OS = "linux"
+		_TARGET_OS = "linux"
+
 		wks, prj = test.createWorkspace()
 	end
 
@@ -126,8 +127,8 @@ LINKCMD = libtool -o "$@" $(OBJECTS)
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
 ALL_LDFLAGS += $(LDFLAGS) -s
-LIBS += build/bin/Debug/libMyProject2.a
-LDDEPS += build/bin/Debug/libMyProject2.a
+LIBS += build/lib/linux-debug/libMyProject2.a
+LDDEPS += build/lib/linux-debug/libMyProject2.a
 		]]
 	end
 
@@ -147,7 +148,7 @@ LDDEPS += build/bin/Debug/libMyProject2.a
 		test.capture [[
 ALL_LDFLAGS += $(LDFLAGS) -s
 LIBS += build/bin/Debug/libMyProject2.so
-LDDEPS += build/bin/Debug/libMyProject2.so
+LDDEPS += build/bin/linux-debug/libMyProject2.so
 		]]
 	end
 
@@ -165,16 +166,16 @@ LDDEPS += build/bin/Debug/libMyProject2.so
 
         prepare { "ldFlags", "libs", "ldDeps" }
         test.capture [[
-ALL_LDFLAGS += $(LDFLAGS) -Lbuild/bin/Debug -Wl,-rpath,'$$ORIGIN/../../build/bin/Debug' -s
+ALL_LDFLAGS += $(LDFLAGS) -Lbuild/bin/linux-debug -Wl,-rpath,'$$ORIGIN/../../build/bin/linux-debug' -s
 LIBS += -lMyProject2
-LDDEPS += build/bin/Debug/libMyProject2.so
+LDDEPS += build/bin/linux-debug/libMyProject2.so
         ]]
     end
 
     function suite.links_onMacOSXSiblingSharedLib()
-    	_OS = "macosx"
+        _OS = "macosx"
         links "MyProject2"
-		flags { "RelativeLinks" }
+        flags { "RelativeLinks" }
 
         test.createproject(wks)
         kind "SharedLib"
@@ -182,9 +183,9 @@ LDDEPS += build/bin/Debug/libMyProject2.so
 
         prepare { "ldFlags", "libs", "ldDeps" }
         test.capture [[
-ALL_LDFLAGS += $(LDFLAGS) -Lbuild/bin/Debug -Wl,-rpath,'@loader_path/../../build/bin/Debug' -Wl,-x
+ALL_LDFLAGS += $(LDFLAGS) -Lbuild/bin/macosx-clang-debug -Wl,-rpath,'@loader_path/../../build/bin/macosx-clang-debug' -Wl,-x
 LIBS += -lMyProject2
-LDDEPS += build/bin/Debug/libMyProject2.dylib
+LDDEPS += build/bin/macosx-clang-debug/libMyProject2.dylib
         ]]
     end
 
@@ -207,8 +208,8 @@ LDDEPS += build/bin/Debug/libMyProject2.dylib
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
 ALL_LDFLAGS += $(LDFLAGS) -s
-LIBS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
-LDDEPS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
+LIBS += build/lib/linux-debug/libMyProject2.a build/lib/linux-debug/libMyProject3.a
+LDDEPS += build/lib/linux-debug/libMyProject2.a build/lib/linux-debug/libMyProject3.a
 		]]
 	end
 
@@ -232,8 +233,8 @@ LDDEPS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
 		prepare { "ldFlags", "libs", "ldDeps" }
 		test.capture [[
 ALL_LDFLAGS += $(LDFLAGS) -s
-LIBS += -Wl,--start-group build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a -Wl,--end-group
-LDDEPS += build/bin/Debug/libMyProject2.a build/bin/Debug/libMyProject3.a
+LIBS += -Wl,--start-group build/lib/linux-debug/libMyProject2.a build/lib/linux-debug/libMyProject3.a -Wl,--end-group
+LDDEPS += build/lib/linux-debug/libMyProject2.a build/lib/linux-debug/libMyProject3.a
 		]]
 	end
 

--- a/modules/gmake2/tests/test_gmake2_objects.lua
+++ b/modules/gmake2/tests/test_gmake2_objects.lua
@@ -17,6 +17,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		gmake2.cpp.initialize()
 		wks = test.createWorkspace()
 	end
@@ -137,11 +139,11 @@ OBJECTS += $(OBJDIR)/hello1.o
 CUSTOM :=
 
 ifeq ($(config),debug)
-CUSTOM += obj/Debug/hello.luac
+CUSTOM += obj/linux-debug/hello.luac
 endif
 
 ifeq ($(config),release)
-CUSTOM += obj/Release/hello.luac
+CUSTOM += obj/linux-release/hello.luac
 endif
 		]]
 	end
@@ -169,11 +171,11 @@ endif
 OBJECTS :=
 
 ifeq ($(config),debug)
-OBJECTS += obj/Debug/hello.obj
+OBJECTS += obj/linux-debug/hello.obj
 endif
 
 ifeq ($(config),release)
-OBJECTS += obj/Release/hello.obj
+OBJECTS += obj/linux-release/hello.obj
 endif
 		]]
 	end
@@ -202,11 +204,11 @@ endif
 OBJECTS :=
 
 ifeq ($(config),debug)
-OBJECTS += obj/Debug/hello.obj
+OBJECTS += obj/linux-debug/hello.obj
 endif
 
 ifeq ($(config),release)
-OBJECTS += obj/Release/hello.obj
+OBJECTS += obj/linux-release/hello.obj
 endif
 		]]
 	end
@@ -235,11 +237,11 @@ endif
 CUSTOM :=
 
 ifeq ($(config),debug)
-CUSTOM += obj/Debug/hello.obj
+CUSTOM += obj/linux-debug/hello.obj
 endif
 
 ifeq ($(config),release)
-CUSTOM += obj/Release/hello.obj
+CUSTOM += obj/linux-release/hello.obj
 endif
 		]]
 	end

--- a/modules/gmake2/tests/test_gmake2_pch.lua
+++ b/modules/gmake2/tests/test_gmake2_pch.lua
@@ -20,6 +20,8 @@
 
 	local wks, prj
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		os.chdir(_TESTS_DIR)
 		wks, prj = test.createWorkspace()
 	end

--- a/modules/gmake2/tests/test_gmake2_perfile_flags.lua
+++ b/modules/gmake2/tests/test_gmake2_perfile_flags.lua
@@ -18,6 +18,8 @@
 	local wks
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		wks = test.createWorkspace()
 	end
 

--- a/modules/gmake2/tests/test_gmake2_target_rules.lua
+++ b/modules/gmake2/tests/test_gmake2_target_rules.lua
@@ -20,6 +20,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		wks, prj = test.createWorkspace()
 	end
 

--- a/modules/gmake2/tests/test_gmake2_tools.lua
+++ b/modules/gmake2/tests/test_gmake2_tools.lua
@@ -19,6 +19,8 @@
 	local cfg
 
 	function suite.setup()
+		_TARGET_OS = "linux"
+
 		local wks, prj = test.createWorkspace()
 		cfg = test.getconfig(prj, "Debug")
 	end

--- a/modules/vstudio/tests/cs2005/test_output_props.lua
+++ b/modules/vstudio/tests/cs2005/test_output_props.lua
@@ -49,8 +49,8 @@
 		p.action.set("vs2008")
 		prepare()
 		test.capture [[
-		<OutputPath>bin\Debug\</OutputPath>
-		<IntermediateOutputPath>obj\Debug\</IntermediateOutputPath>
+		<OutputPath>bin\windows-vc90-debug\</OutputPath>
+		<IntermediateOutputPath>obj\windows-vc90-debug\</IntermediateOutputPath>
 		]]
 	end
 
@@ -58,8 +58,8 @@
 		p.action.set("vs2010")
 		prepare()
 		test.capture [[
-		<OutputPath>bin\Debug\</OutputPath>
-		<BaseIntermediateOutputPath>obj\Debug\</BaseIntermediateOutputPath>
+		<OutputPath>bin\windows-vc100-debug\</OutputPath>
+		<BaseIntermediateOutputPath>obj\windows-vc100-debug\</BaseIntermediateOutputPath>
 		<IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
 		]]
 	end

--- a/modules/vstudio/tests/vc200x/test_configuration.lua
+++ b/modules/vstudio/tests/vc200x/test_configuration.lua
@@ -38,8 +38,8 @@
 		test.capture [[
 <Configuration
 	Name="Debug|Win32"
-	OutputDirectory="bin\Debug"
-	IntermediateDirectory="obj\Debug"
+	OutputDirectory="bin\windows-vc90-debug"
+	IntermediateDirectory="obj\windows-vc90-debug"
 	ConfigurationType="1"
 	CharacterSet="1"
 	>
@@ -102,8 +102,8 @@
 		test.capture [[
 <Configuration
 	Name="Debug|Win32"
-	OutputDirectory="bin\Debug"
-	IntermediateDirectory="obj\Debug"
+	OutputDirectory="bin\windows-vc90-debug"
+	IntermediateDirectory="obj\windows-vc90-debug"
 	ConfigurationType="0"
 	>
 		]]
@@ -115,8 +115,8 @@
 		test.capture [[
 <Configuration
 	Name="Debug|Win32"
-	OutputDirectory="bin\Debug"
-	IntermediateDirectory="obj\Debug"
+	OutputDirectory="bin\windows-vc90-debug"
+	IntermediateDirectory="obj\windows-vc90-debug"
 	ConfigurationType="0"
 	>
 		]]

--- a/modules/vstudio/tests/vc200x/test_excluded_configs.lua
+++ b/modules/vstudio/tests/vc200x/test_excluded_configs.lua
@@ -70,6 +70,6 @@
 <Tool
 	Name="VCLinkerTool"
 	AdditionalOptions="/NOLOGO"
-	AdditionalDependencies="bin\Ares\Debug\MyProject2.lib"
+	AdditionalDependencies="lib\windows-ares-vc90-debug\MyProject2.lib"
 		]]
 	end

--- a/modules/vstudio/tests/vc200x/test_linker_block.lua
+++ b/modules/vstudio/tests/vc200x/test_linker_block.lua
@@ -81,7 +81,7 @@
 	LinkIncremental="2"
 	GenerateDebugInformation="false"
 	SubSystem="2"
-	ImportLibrary="bin\Debug\MyProject.lib"
+	ImportLibrary="lib\windows-vc90-debug\MyProject.lib"
 	TargetMachine="1"
 />
 		]]
@@ -243,7 +243,7 @@
 <Tool
 	Name="VCLinkerTool"
 	LinkLibraryDependencies="false"
-	AdditionalDependencies="bin\Debug\MyProject2.lib"
+	AdditionalDependencies="lib\windows-vc90-debug\MyProject2.lib"
 		]]
 	end
 

--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -243,8 +243,8 @@
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
 	<ConfigurationType>Makefile</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 </PropertyGroup>
 		]]
 	end
@@ -256,8 +256,8 @@
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
 	<ConfigurationType>Makefile</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 </PropertyGroup>
 		]]
 	end

--- a/modules/vstudio/tests/vc2010/test_excluded_configs.lua
+++ b/modules/vstudio/tests/vc2010/test_excluded_configs.lua
@@ -69,7 +69,7 @@
 		test.capture [[
 <Link>
 	<SubSystem>Console</SubSystem>
-	<AdditionalDependencies>bin\Ares\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+	<AdditionalDependencies>lib\windows-ares-vc100-debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
 </Link>
 <ProjectReference>
 	<LinkLibraryDependencies>false</LinkLibraryDependencies>

--- a/modules/vstudio/tests/vc2010/test_link.lua
+++ b/modules/vstudio/tests/vc2010/test_link.lua
@@ -38,7 +38,7 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 </Link>
 		]]
 	end
@@ -56,7 +56,7 @@
 	<SubSystem>Windows</SubSystem>
 	<EnableCOMDATFolding>true</EnableCOMDATFolding>
 	<OptimizeReferences>true</OptimizeReferences>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 </Link>
 		]]
 	end
@@ -90,7 +90,7 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 </Link>
 		]]
 	end
@@ -132,7 +132,7 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 </Link>
 <ProjectReference>
 	<LinkLibraryDependencies>false</LinkLibraryDependencies>
@@ -340,7 +340,7 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 </Link>
 		]]
 	end
@@ -359,8 +359,8 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<AdditionalDependencies>bin\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<AdditionalDependencies>lib\windows-vc100-debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 </Link>
 <ProjectReference>
 	<LinkLibraryDependencies>false</LinkLibraryDependencies>
@@ -415,7 +415,7 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 	<AdditionalOptions>/kupo %(AdditionalOptions)</AdditionalOptions>
 		]]
 	end
@@ -461,7 +461,7 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 	<ModuleDefinitionFile>hello.def</ModuleDefinitionFile>
 </Link>
 		]]
@@ -551,7 +551,7 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 	<GenerateMapFile>true</GenerateMapFile>
 </Link>
 		]]
@@ -567,7 +567,7 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 	<IgnoreSpecificDefaultLibraries>lib1.lib;lib2.obj</IgnoreSpecificDefaultLibraries>
 </Link>
 		]]
@@ -583,7 +583,7 @@
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<ImportLibrary>lib\windows-vc100-debug\MyProject.lib</ImportLibrary>
 	<IgnoreSpecificDefaultLibraries>lib1.lib;lib2.obj</IgnoreSpecificDefaultLibraries>
 </Link>
 		]]

--- a/modules/vstudio/tests/vc2010/test_output_props.lua
+++ b/modules/vstudio/tests/vc2010/test_output_props.lua
@@ -35,8 +35,8 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 </PropertyGroup>
@@ -71,9 +71,9 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Xbox 360'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
+	<OutDir>bin\xbox360-vc100-debug\</OutDir>
 	<OutputFile>$(OutDir)MyProject.exe</OutputFile>
-	<IntDir>obj\Debug\</IntDir>
+	<IntDir>obj\xbox360-vc100-debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<ImageXexOutput>$(OutDir)$(TargetName).xex</ImageXexOutput>
@@ -87,9 +87,9 @@
 		prepare()
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Xbox 360'">
-	<OutDir>bin\Debug\</OutDir>
+	<OutDir>lib\xbox360-vc100-debug\</OutDir>
 	<OutputFile>$(OutDir)MyProject.lib</OutputFile>
-	<IntDir>obj\Debug\</IntDir>
+	<IntDir>obj\xbox360-vc100-debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.lib</TargetExt>
 	<ImageXexOutput>$(OutDir)$(TargetName).xex</ImageXexOutput>
@@ -107,7 +107,7 @@
 		prepare()
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-	<OutDir>bin\Debug\</OutDir>
+	<OutDir>lib\windows-vc100-debug\</OutDir>
 		]]
 	end
 
@@ -148,8 +148,8 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>..\tmp\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>..\tmp\windows-vc100-debug\</IntDir>
 		]]
 	end
 
@@ -163,8 +163,8 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 	<TargetName>MyTarget</TargetName>
 		]]
 	end
@@ -191,7 +191,7 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
 		]]
 	end
 
@@ -206,8 +206,8 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<GenerateManifest>false</GenerateManifest>
@@ -225,8 +225,8 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>
 	</TargetExt>
@@ -246,8 +246,8 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<ExtensionsToDeleteOnClean>*.temp1;*.temp2;$(ExtensionsToDeleteOnClean)</ExtensionsToDeleteOnClean>
@@ -266,8 +266,8 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<IncludePath>$(DXSDK_DIR)\Include;$(IncludePath)</IncludePath>
@@ -281,8 +281,8 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<LibraryPath>$(DXSDK_DIR)\lib\x86;$(LibraryPath)</LibraryPath>
@@ -300,8 +300,8 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<ExecutablePath>$(ProjectDir)..\Include;$(ExecutablePath)</ExecutablePath>
@@ -315,8 +315,8 @@
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>bin\windows-vc100-debug\</OutDir>
+	<IntDir>obj\windows-vc100-debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<ExecutablePath>C:\Include;$(ExecutablePath)</ExecutablePath>

--- a/modules/xcode/tests/test_xcode4_project.lua
+++ b/modules/xcode/tests/test_xcode4_project.lua
@@ -84,9 +84,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = YES;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -864,7 +864,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/macosx-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
@@ -885,7 +885,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/macosx-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = "\"$(HOME)/Applications\"";
@@ -906,7 +906,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "lib/macosx-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/lib;
@@ -927,7 +927,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/macosx-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				EXECUTABLE_PREFIX = lib;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -950,7 +950,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/macosx-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				EXECUTABLE_PREFIX = xyz;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -977,7 +977,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/macosx-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				EXECUTABLE_PREFIX = lib;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -999,7 +999,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/macosx-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INFOPLIST_FILE = "a/b/c/MyProject-Info.plist";
@@ -1021,7 +1021,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/macosx-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
@@ -1042,7 +1042,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/macosx-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
@@ -1063,7 +1063,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Universal32/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/macosx-universal32-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
@@ -1085,7 +1085,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = bin/Universal32/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/macosx-universal32-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
@@ -1106,7 +1106,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/ios-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
@@ -1129,7 +1129,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/ios-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
@@ -1153,7 +1153,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/ios-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
@@ -1177,7 +1177,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Premake Developers";
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/ios-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
@@ -1200,7 +1200,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CONFIGURATION_BUILD_DIR = bin/Debug;
+				CONFIGURATION_BUILD_DIR = "bin/ios-clang-debug";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
@@ -1232,9 +1232,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1257,9 +1257,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1282,9 +1282,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1307,10 +1307,10 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
 				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = static;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1333,7 +1333,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
 				SYMROOT = bin;
 			};
@@ -1362,9 +1362,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1387,9 +1387,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 				USER_HEADER_SEARCH_PATHS = (
 					../include,
 					../libs,
@@ -1422,9 +1422,9 @@
 					"\"../name with spaces\"",
 					"$(inherited)",
 				);
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1446,13 +1446,13 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
 					"build option 1",
 					"build option 2",
 				);
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1475,12 +1475,12 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lldap",
 				);
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1502,13 +1502,13 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"link option 1",
 					"link option 2",
 				);
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1531,9 +1531,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 				WARNING_CFLAGS = "-Wall -Wextra";
 			};
 			name = Debug;
@@ -1558,9 +1558,9 @@
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1583,12 +1583,12 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
 					"-ffast-math",
 				);
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1611,12 +1611,12 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
 					"-ffloat-store",
 				);
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1641,9 +1641,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = YES;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1668,9 +1668,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1693,12 +1693,12 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
 					"-fomit-frame-pointer",
 				);
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1722,9 +1722,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1748,9 +1748,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1775,9 +1775,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = YES;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1804,9 +1804,9 @@
 					mylibs1,
 					mylibs2,
 				);
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1831,9 +1831,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1857,9 +1857,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Universal/Debug;
+				OBJROOT = "obj/macosx-universal-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Universal/Debug;
+				SYMROOT = "bin/macosx-universal-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1883,9 +1883,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Universal32/Debug;
+				OBJROOT = "obj/macosx-universal32-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Universal32/Debug;
+				SYMROOT = "bin/macosx-universal32-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1909,9 +1909,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Universal64/Debug;
+				OBJROOT = "obj/macosx-universal64-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Universal64/Debug;
+				SYMROOT = "bin/macosx-universal64-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1935,9 +1935,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Native/Debug;
+				OBJROOT = "obj/macosx-native-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Native/Debug;
+				SYMROOT = "bin/macosx-native-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1961,9 +1961,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/x86/Debug;
+				OBJROOT = "obj/macosx-x86-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/x86/Debug;
+				SYMROOT = "bin/macosx-x86-clang-debug";
 			};
 			name = Debug;
 		};
@@ -1987,9 +1987,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/x86_64/Debug;
+				OBJROOT = "obj/macosx-x86_64-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/x86_64/Debug;
+				SYMROOT = "bin/macosx-x86_64-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2012,9 +2012,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Universal32/Debug;
+				OBJROOT = "obj/macosx-universal32-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Universal32/Debug;
+				SYMROOT = "bin/macosx-universal32-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2038,9 +2038,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2064,9 +2064,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2090,9 +2090,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2116,9 +2116,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2142,9 +2142,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2168,9 +2168,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2194,9 +2194,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2220,9 +2220,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2246,9 +2246,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2272,9 +2272,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2298,9 +2298,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2324,9 +2324,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2350,9 +2350,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2376,9 +2376,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2402,9 +2402,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2428,9 +2428,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2454,9 +2454,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};
@@ -2480,9 +2480,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
+				OBJROOT = "obj/macosx-clang-debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
+				SYMROOT = "bin/macosx-clang-debug";
 			};
 			name = Debug;
 		};

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -194,7 +194,7 @@ int premake_init(lua_State* L)
 #endif
 
 	lua_pushlightuserdata(L, &s_shimTable);
-	lua_rawseti(L, LUA_REGISTRYINDEX, 'SHIM');
+	lua_rawseti(L, LUA_REGISTRYINDEX, 0x5348494D /* 'SHIM' */);
 
 	/* push the application metadata */
 	lua_pushstring(L, LUA_COPYRIGHT);

--- a/tests/config/test_links.lua
+++ b/tests/config/test_links.lua
@@ -136,7 +136,7 @@
 		language "C++"
 
 		local r = prepare("all", "fullpath")
-		test.isequal({ "bin/Debug/MyProject2.lib" }, r)
+		test.isequal({ "lib/windows-debug/MyProject2.lib" }, r)
 	end
 
 	function suite.canLink_CsAndCs()
@@ -148,7 +148,7 @@
 		language "C#"
 
 		local r = prepare("all", "fullpath")
-		test.isequal({ "bin/Debug/MyProject2.dll" }, r)
+		test.isequal({ "bin/windows-debug/MyProject2.dll" }, r)
 	end
 
 	function suite.canLink_ManagedCppAndManagedCpp()
@@ -161,7 +161,7 @@
 		clr "On"
 
 		local r = prepare("all", "fullpath")
-		test.isequal({ "bin/Debug/MyProject2.lib" }, r)
+		test.isequal({ "lib/windows-debug/MyProject2.lib" }, r)
 	end
 
 	function suite.canLink_ManagedCppAndCs()
@@ -173,7 +173,7 @@
 		language "C#"
 
 		local r = prepare("all", "fullpath")
-		test.isequal({ "bin/Debug/MyProject2.dll" }, r)
+		test.isequal({ "bin/windows-debug/MyProject2.dll" }, r)
 	end
 
 

--- a/tests/config/test_targetinfo.lua
+++ b/tests/config/test_targetinfo.lua
@@ -233,7 +233,7 @@
 		kind "WindowedApp"
 		system "MacOSX"
 		i = prepare()
-		test.isequal("bin/Debug/MyProject.app/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
+		test.isequal("bin/macosx-clang-debug/MyProject.app/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
 	end
 
 

--- a/tests/oven/test_objdirs.lua
+++ b/tests/oven/test_objdirs.lua
@@ -15,6 +15,8 @@
 	local wks, prj
 
 	function suite.setup()
+		_TARGET_OS = 'windows'
+
 		wks = workspace("MyWorkspace")
 		configurations { "Debug", "Release" }
 		prj = project "MyProject"
@@ -26,10 +28,10 @@
 
 	function suite.singleProject_noPlatforms()
 		prepare("Debug")
-		test.isequal(path.getabsolute("obj/Debug"), cfg.objdir)
+		test.isequal(path.getabsolute("obj/windows-debug"), cfg.objdir)
 
 		prepare("Release")
-		test.isequal(path.getabsolute("obj/Release"), cfg.objdir)
+		test.isequal(path.getabsolute("obj/windows-release"), cfg.objdir)
 	end
 
 
@@ -38,7 +40,7 @@
 		prepare("Debug")
 
 		test.createproject(wks)
-		test.isequal(path.getabsolute("obj/Debug/MyProject"), cfg.objdir)
+		test.isequal(path.getabsolute("obj/windows-debug/MyProject"), cfg.objdir)
 	end
 
 
@@ -46,7 +48,7 @@
 		platforms { "x86", "x86_64" }
 		prepare("Debug", "x86")
 
-		test.isequal(path.getabsolute("obj/x86/Debug"), cfg.objdir)
+		test.isequal(path.getabsolute("obj/windows-x86-debug"), cfg.objdir)
 	end
 
 

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -303,7 +303,7 @@
 		system "Windows"
 		kind "SharedLib"
 		prepare()
-		test.contains({ "-shared", '-Wl,--out-implib="bin/Debug/MyProject.lib"' }, gcc.getldflags(cfg))
+		test.contains({ "-shared", '-Wl,--out-implib="lib/windows-debug/MyProject.lib"' }, gcc.getldflags(cfg))
 	end
 
 	function suite.ldflags_onWindowsApp()

--- a/tests/workspace/test_objdirs.lua
+++ b/tests/workspace/test_objdirs.lua
@@ -46,7 +46,7 @@
 	function suite.directoryIncludesPlatform_onPlatformConflict()
 		configurations { "Debug" }
 		platforms { "x86", "x86_64" }
-		test.isequal("obj/x86",  result())
+		test.isequal("obj/macosx-x86-clang-debug",  result())
 	end
 
 
@@ -57,7 +57,7 @@
 
 	function suite.directoryIncludesBuildCfg_onBuildCfgConflict()
 		configurations { "Debug", "Release" }
-		test.isequal("obj/Debug",  result())
+		test.isequal("obj/macosx-clang-debug",  result())
 	end
 
 
@@ -69,7 +69,7 @@
 	function suite.directoryIncludesBuildCfg_onPlatformAndBuildCfgConflict()
 		configurations { "Debug", "Release" }
 		platforms { "x86", "x86_64" }
-		test.isequal("obj/x86/Debug",  result())
+		test.isequal("obj/macosx-x86-clang-debug", result())
 	end
 
 
@@ -81,6 +81,6 @@
 	function suite.directoryIncludesBuildCfg_onProjectConflict()
 		configurations { "Debug", "Release" }
 		project "MyProject2"
-		test.isequal("obj/Debug/MyProject",  result())
+		test.isequal("obj/macosx-clang-debug/MyProject", result())
 	end
 


### PR DESCRIPTION
This change the objdir for each configuration to use a more consistent and more descriptive value.
It allows for multiple platforms, architectures, toolsets and configurations to all build concurrently.

We've ran into issues where two machines building to the same network share clobbered each others folders with .o & .obj files, because when running premake on linux it no longer considers the windows configurations, and so generates the same output folders.

By creating a more 'unique' variant name, we fixed that issue.