### PR TITLE
Usage proof-of-concept.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1229,6 +1229,13 @@
 	}
 
 	api.register {
+		name = "using",
+		scope = "config",
+		kind = "list:string",
+		tokens = true,
+	}
+
+	api.register {
 		name = "usingdirs",
 		scope = "config",
 		kind = "list:directory",

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1232,7 +1232,6 @@
 		name = "using",
 		scope = "config",
 		kind = "list:string",
-		tokens = true,
 	}
 
 	api.register {

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -11,11 +11,15 @@
 	local api = p.api
 	local configset = p.configset
 
-
+---
+-- Create the public&interface namespaces for the api.register functions.
+---
+	public = {}
+	interface = {}
 
 ---
 -- Set up a place to store the current active objects in each configuration
--- scope (e.g. wprkspaces, projects, groups, and configurations). This likely
+-- scope (e.g. workspaces, projects, groups, and configurations). This likely
 -- ought to be internal scope, but it is useful for testing.
 ---
 
@@ -277,10 +281,19 @@
 		end
 
 		-- create a setter function for it
-		_G[name] = function(value, visibility)
-			return api.storeField(field, value, visibility)
+		_G[name] = function(value)
+			return api.storeField(field, value)
 		end
 
+		public[name] = function(value)
+			return api.storeField(field, value, 'public')
+		end
+
+		interface[name] = function(value)
+			return api.storeField(field, value, 'interface')
+		end
+
+		-- TODO, do we need the ability to remove things from public&interface?
 		if p.field.removes(field) then
 			_G["remove" .. name] = function(value)
 				return api.remove(field, value)

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -277,8 +277,8 @@
 		end
 
 		-- create a setter function for it
-		_G[name] = function(value)
-			return api.storeField(field, value)
+		_G[name] = function(value, visibility)
+			return api.storeField(field, value, visibility)
 		end
 
 		if p.field.removes(field) then
@@ -484,7 +484,7 @@
 -- gets parceled out to the individual set...() functions.
 --
 
-	function api.storeField(field, value)
+	function api.storeField(field, value, visibility)
 		if value == nil then
 			return
 		end
@@ -507,7 +507,7 @@
 			error(err, 3)
 		end
 
-		local status, err = configset.store(target, field, value)
+		local status, err = configset.store(target, field, value, visibility)
 		if err then
 			error(err, 3)
 		end

--- a/src/base/configset.lua
+++ b/src/base/configset.lua
@@ -556,7 +556,7 @@
 				newBlock._origin  = result
 
 				-- links don't propagate onto static libraries.
-				if kind ~= p.STATICLIB then
+				if kind == p.STATICLIB then
 					newBlock.links = nil
 				end
 

--- a/src/base/project.lua
+++ b/src/base/project.lua
@@ -36,6 +36,11 @@
 			prj.group = ""
 		end
 
+		-- projects using me, should link against me.
+		local f = p.field.get("links")
+		p.configset.store(prj, f, prj.name, 'interface')
+
+		-- return new project.
 		return prj
 	end
 

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -42,6 +42,7 @@ return {
 	-- Baking tests
 	"oven/test_filtering.lua",
 	"oven/test_objdirs.lua",
+	"oven/test_using.lua",
 
 	-- API tests
 	"api/test_boolean_kind.lua",

--- a/tests/oven/test_using.lua
+++ b/tests/oven/test_using.lua
@@ -12,31 +12,29 @@
 -- Setup
 ---
 
-	local wks, prj1, prj2
-
 	function suite.setup()
-		wks = workspace("MyWorkspace")
-		configurations { "Debug", "Release" }
+		workspace("MyWorkspace")
+			configurations { "Debug", "Release" }
 	end
 
 	function suite.testPublicProperty()
 		-- create two projects.
-
-		prj1 = project "MyProject1"
+		local prj1 = project "MyProject1"
 			kind 'StaticLib'
-
 			includedirs {"private"}
 			includedirs ({"public"}, "public")
 
-		prj2 = project "MyProject2"
+		local prj2 = project "MyProject2"
 			kind 'ConsoleApp'
-
 			using { "MyProject1" }
 
 		-- test if prj2 contains the public includedirs, but not the private ones.
-		cfg = test.getconfig(prj2, "Debug")
-		test.print(table.tostring(cfg.includedirs))
+		local cfg = test.getconfig(prj2, "Debug")
 		test.isequal(#cfg.includedirs, 1)
 		test.contains({ path.getabsolute("public") }, cfg.includedirs)
+
+		-- it must also link against it.
+		test.isequal(#cfg.links, 1)
+		test.contains({ "MyProject1" }, cfg.links)
 	end
 

--- a/tests/oven/test_using.lua
+++ b/tests/oven/test_using.lua
@@ -1,0 +1,42 @@
+---
+-- tests/oven/test_using.lua
+-- Test the using and import of exported values.
+-- Copyright (c) 2014-2015 Jason Perkins and the Premake project
+---
+
+	local p = premake
+	local suite = test.declare("oven_using")
+	local oven = p.oven
+
+---
+-- Setup
+---
+
+	local wks, prj1, prj2
+
+	function suite.setup()
+		wks = workspace("MyWorkspace")
+		configurations { "Debug", "Release" }
+	end
+
+	function suite.testPublicProperty()
+		-- create two projects.
+
+		prj1 = project "MyProject1"
+			kind 'StaticLib'
+
+			includedirs {"private"}
+			includedirs ({"public"}, "public")
+
+		prj2 = project "MyProject2"
+			kind 'ConsoleApp'
+
+			using { "MyProject1" }
+
+		-- test if prj2 contains the public includedirs, but not the private ones.
+		cfg = test.getconfig(prj2, "Debug")
+		test.print(table.tostring(cfg.includedirs))
+		test.isequal(#cfg.includedirs, 1)
+		test.contains({ path.getabsolute("public") }, cfg.includedirs)
+	end
+

--- a/tests/oven/test_using.lua
+++ b/tests/oven/test_using.lua
@@ -22,7 +22,7 @@
 		local prj1 = project "MyProject1"
 			kind 'StaticLib'
 			includedirs {"private"}
-			includedirs ({"public"}, "public")
+			public.includedirs {"public"}
 
 		local prj2 = project "MyProject2"
 			kind 'ConsoleApp'


### PR DESCRIPTION
This new 'using' API, and a slight addition to the storage of all properties, allows us to mark settings as either public, private or interface.

`using` then allows you to use import public & interface properties from other projects, effectively creating a way for a project to say... "if you use me, you need these settings".

This is currently in a proof of concept stage, and any feedback or additional unit-tests would be extremely helpful.
