### PR TITLE
Add support for wildcards in mapconfig.

### DIFF
--- a/src/base/project.lua
+++ b/src/base/project.lua
@@ -516,7 +516,8 @@
 		local testpattern = function(pattern, pairing, i)
 			local j = 1
 			while i <= #pairing and j <= #pattern do
-				if pairing[i] ~= pattern[j] then
+				local wd = path.wildcards(pattern[j])
+				if pairing[i]:match(wd) ~= pairing[i] then
 					return false
 				end
 				i = i + 1


### PR DESCRIPTION
allows you to write
```lua
workspace "MyWorkspace"
	configurations { "Debug", "DebugSlow", "Profile", "Release" }

project "MyProject"
	kind 'StaticLib'

	removeconfigurations { '*' }
	configurations { 'Codegen' }
	configmap { 
		["*"] = "Codegen",
	}

project "MyProject2"
	kind 'StaticLib'
```
