### PR TITLE
Fix buildoutput pathvars

### DIFF
--- a/modules/vstudio/tests/vc2010/test_tokens.lua
+++ b/modules/vstudio/tests/vc2010/test_tokens.lua
@@ -42,7 +42,7 @@
 	<CustomBuild Include="..\hello.cg">
 		<FileType>Document</FileType>
 		<Command>cgc %(Identity)</Command>
-		<Outputs>../%(Filename).a;../%(Filename).b</Outputs>
+		<Outputs>../hello.a;../hello.b</Outputs>
 	</CustomBuild>
 </ItemGroup>
 		]]
@@ -61,7 +61,7 @@
 	<CustomBuild Include="..\hello.cg">
 		<FileType>Document</FileType>
 		<Command>cgc %(Identity)</Command>
-		<Outputs>../%(Filename).obj</Outputs>
+		<Outputs>../hello.obj</Outputs>
 		<Message>Compiling shader %(Identity)</Message>
 	</CustomBuild>
 </ItemGroup>
@@ -81,7 +81,7 @@
 	<CustomBuild Include="..\hello.cg">
 		<FileType>Document</FileType>
 		<Command>cgc %(Identity)</Command>
-		<Outputs>../%(Filename).obj</Outputs>
+		<Outputs>../hello.obj</Outputs>
 		<AdditionalInputs>../common.cg.inc;../common.cg.inc2</AdditionalInputs>
 	</CustomBuild>
 </ItemGroup>

--- a/modules/vstudio/vs2010_rules_targets.lua
+++ b/modules/vstudio/vs2010_rules_targets.lua
@@ -60,7 +60,7 @@
 	function m.computedProperties(r)
 		-- create shadow context.
 		local pathVars = p.rule.createPathVars(r, "%%(%s)")
-		local ctx = p.context.extent(r, { pathVars = pathVars })
+		local ctx = p.context.extent(r, { pathVars = pathVars, overridePathVars = true })
 
 		-- now use the shadow context to detoken.
 		local buildoutputs = ctx.buildoutputs
@@ -302,7 +302,7 @@
 	function m.linkLib(r)
 		-- create shadow context.
 		local pathVars = p.rule.createPathVars(r, "%%(%s)")
-		local ctx = p.context.extent(r, { pathVars = pathVars })
+		local ctx = p.context.extent(r, { pathVars = pathVars, overridePathVars=true })
 
 		-- now use the shadow context to detoken.
 		local buildoutputs = ctx.buildoutputs

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -122,7 +122,7 @@
 		scope = { "config", "rule" },
 		kind = "list:path",
 		tokens = true,
-		pathVars = true,
+		pathVars = false,
 	}
 
 	api.register {
@@ -130,7 +130,7 @@
 		scope = "config",
 		kind = "list:path",
 		tokens = true,
-		pathVars = true,
+		pathVars = false,
 	}
 
 	api.register {

--- a/src/base/detoken.lua
+++ b/src/base/detoken.lua
@@ -34,12 +34,13 @@
 		function expandtoken(token, e, f)
 			-- fetch the path variable from the action, if needed
 			local varMap = {}
-			if f.pathVars then
+			if f.pathVars or e.overridePathVars then
 				local action = p.action.current()
 				if action then
 					varMap = action.pathVars or {}
 				end
 			end
+
 			-- fetch the pathVars from the enviroment.
 			local envMap = e.pathVars or {}
 


### PR DESCRIPTION
It turns out, that Visual Studio really don't like having most of the pathVars in the `<Outputs>` property of a custom build command.... 

this just doesn't work. The command does the right thing, but the tracking of the outputs goes wrong, and visual studio manages to actually create a `$(SolutionDir)` folder on disk too.

```xml
    <CustomBuild Include="..\..\..\packages\tag_edit\include\tag_edit\tag_edit.tag">
      <FileType>Document</FileType>
      <Command>tagc --cpp --types --schema --out=$(SolutionDir)/generated_tag/tag_edit %(FullPath)</Command>
      <Outputs>$(SolutionDir)/generated_tag/tag_edit/tag_edit.h;$(SolutionDir)/generated_tag/tag_edit/tag_edit.cpp</Outputs>
      <Message>Compiling %(FullPath)</Message>
    </CustomBuild>
```

So instead of making pathVars the default for buildoutputs and buildinputs, we turn it off, and only turn it on through an override in the environment where appropriate.