### PR TITLE
Table fix indexof

### DIFF
--- a/src/base/rule.lua
+++ b/src/base/rule.lua
@@ -130,7 +130,7 @@
 
 		-- enum?
 		if prop.values then
-			local i = table.indexof(prop.values, value)
+			local i = table.findKeyByValue(prop.values, value)
 			if i ~= nil then
 				return tostring(i)
 			else
@@ -185,7 +185,7 @@
 
 		-- enum?
 		if prop.values then
-			local i = table.indexof(prop.values, value)
+			local i = table.findKeyByValue(prop.values, value)
 			if i ~= nil then
 				return prop.switch .. tostring(i)
 			else

--- a/src/base/table.lua
+++ b/src/base/table.lua
@@ -197,13 +197,26 @@
 --
 
 	function table.indexof(tbl, obj)
-		for k, v in pairs(tbl) do
+		for k, v in ipairs(tbl) do
 			if v == obj then
 				return k
 			end
 		end
 	end
 
+
+--
+-- Looks for an object within a table. Returns the key if found,
+-- or nil if the object could not be found.
+--
+
+	function table.findKeyByValue(tbl, obj)
+		for k, v in pairs(tbl) do
+			if v == obj then
+				return k
+			end
+		end
+	end
 
 
 ---


### PR DESCRIPTION
Subtle, and this loop works as long as the table is a pure array...
but once you use the table.insertkeyed, or a mix of hashmap/array this can potentially return just a key of any type, not just the index to an element in the array part.

