### PR TITLE
Define _HAS_EXCEPTIONS=0 from vs2010 for exceptionhandling off

### DIFF
--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -574,20 +574,6 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
-	<Optimization>Disabled</Optimization>
-	<ExceptionHandling>false</ExceptionHandling>
-		]]
-	end
-
-
-	function suite.exceptions_onNoExceptionsVS2013()
-		exceptionhandling "Off"
-		p.action.set("vs2013")
-		prepare()
-		test.capture [[
-<ClCompile>
-	<PrecompiledHeader>NotUsing</PrecompiledHeader>
-	<WarningLevel>Level3</WarningLevel>
 	<PreprocessorDefinitions>_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 	<Optimization>Disabled</Optimization>
 	<ExceptionHandling>false</ExceptionHandling>

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1384,7 +1384,7 @@
 
 	function m.clCompilePreprocessorDefinitions(cfg, condition)
 		local defines = cfg.defines
-		if cfg.exceptionhandling == p.OFF and _ACTION >= "vs2013" then
+		if cfg.exceptionhandling == p.OFF then
 			defines = table.join(defines, "_HAS_EXCEPTIONS=0")
 		end
 		m.preprocessorDefinitions(cfg, defines, false, condition)
@@ -2261,7 +2261,7 @@
 
 	function m.resourcePreprocessorDefinitions(cfg)
 		local defines = table.join(cfg.defines, cfg.resdefines)
-		if cfg.exceptionhandling == p.OFF and _ACTION >= "vs2013" then
+		if cfg.exceptionhandling == p.OFF then
 			table.insert(defines, "_HAS_EXCEPTIONS=0")
 		end
 		m.preprocessorDefinitions(cfg, defines, true)


### PR DESCRIPTION
Not defining _HAS_EXCEPTIONS=0 when ExceptionHandling is off cause warning.
`warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc`

Ref: (VSINTALL)\VC\include\xstddef