### PR TITLE
added a 'latest' systemversion for vs2017

### DIFF
--- a/modules/vstudio/tests/vc2010/test_globals.lua
+++ b/modules/vstudio/tests/vc2010/test_globals.lua
@@ -253,3 +253,48 @@
 </PropertyGroup>
 		]]
 	end
+
+--
+-- Check that the "latest" systemversion works.
+-- note: we override the os.getWindowsRegistry method for reliable tests.
+--
+
+	function suite.windowsTargetPlatformVersionLatest_on2017()
+		p.action.set("vs2017")
+		systemversion "latest"
+		prepare()
+		local oldRegistry = os.getWindowsRegistry
+		os.getWindowsRegistry = function (key)
+			return "10.0.11111"
+		end
+		test.capture [[
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
+	<Keyword>Win32Proj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+	<WindowsTargetPlatformVersion>10.0.11111.0</WindowsTargetPlatformVersion>
+</PropertyGroup>
+		]]
+		-- restore the registry function
+		os.getWindowsRegistry = oldRegistry
+	end
+
+--
+-- Check that the "latest" systemversion will not add <WindowsTargetPlatformVersion>
+-- when the action is less than 2017
+--
+
+	function suite.windowsTargetPlatformVersionLatest_on2015()
+		p.action.set("vs2015")
+		systemversion "10.0.10240.0"
+		prepare()
+		test.capture [[
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
+	<Keyword>Win32Proj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
+		]]
+	end

--- a/modules/vstudio/tests/vc2010/test_globals.lua
+++ b/modules/vstudio/tests/vc2010/test_globals.lua
@@ -262,11 +262,10 @@
 	function suite.windowsTargetPlatformVersionLatest_on2017()
 		p.action.set("vs2017")
 		systemversion "latest"
+		local oldRegistry = os["getWindowsRegistry"]
+		os["getWindowsRegistry"] = function (key) return "10.0.11111" end
 		prepare()
-		local oldRegistry = os.getWindowsRegistry
-		os.getWindowsRegistry = function (key)
-			return "10.0.11111"
-		end
+		os["getWindowsRegistry"] = oldRegistry
 		test.capture [[
 <PropertyGroup Label="Globals">
 	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
@@ -276,8 +275,6 @@
 	<WindowsTargetPlatformVersion>10.0.11111.0</WindowsTargetPlatformVersion>
 </PropertyGroup>
 		]]
-		-- restore the registry function
-		os.getWindowsRegistry = oldRegistry
 	end
 
 --

--- a/modules/vstudio/tests/vc2010/test_globals.lua
+++ b/modules/vstudio/tests/vc2010/test_globals.lua
@@ -287,7 +287,7 @@
 
 	function suite.windowsTargetPlatformVersionLatest_on2015()
 		p.action.set("vs2015")
-		systemversion "10.0.10240.0"
+		systemversion "latest"
 		prepare()
 		test.capture [[
 <PropertyGroup Label="Globals">

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2356,9 +2356,16 @@
 
 
 	function m.targetPlatformVersion(prj)
-		local min = project.systemversion(prj)
-		if min ~= nil and _ACTION >= "vs2015" then
-			m.element("WindowsTargetPlatformVersion", nil, min)
+		if _ACTION >= "vs2015" then
+			local min = project.systemversion(prj)
+			-- handle special "latest" version
+			if min == "latest" then
+				-- vs2015 and lower can't build against SDK 10
+				min = iif(_ACTION >= "vs2017", m.latestSDK10Version(), nil)
+			end
+			if min ~= nil then
+				m.element("WindowsTargetPlatformVersion", nil, min)
+			end
 		end
 	end
 
@@ -2484,6 +2491,15 @@
 		return m.conditionFromConfigText(vstudio.projectConfig(cfg))
 	end
 
+--
+-- Get the latest installed SDK 10 version from the registry.
+--
+
+	function m.latestSDK10Version()
+		local arch = iif(os.is64bit(), "\\WOW6432Node\\", "\\")
+		local version = os.getWindowsRegistry("HKLM:SOFTWARE" .. arch .."Microsoft\\Microsoft SDKs\\Windows\\v10.0\\ProductVersion")
+		return iif(version ~= nil, version .. ".0", nil)
+	end
 
 
 --

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2498,7 +2498,11 @@
 	function m.latestSDK10Version()
 		local arch = iif(os.is64bit(), "\\WOW6432Node\\", "\\")
 		local version = os.getWindowsRegistry("HKLM:SOFTWARE" .. arch .."Microsoft\\Microsoft SDKs\\Windows\\v10.0\\ProductVersion")
-		return iif(version ~= nil, version .. ".0", nil)
+		if version ~= nil then
+			return version .. ".0"
+		else
+			return nil
+		end
 	end
 
 


### PR DESCRIPTION
Sorry for the delay, but here is the pull request for issue #935 and the other related ones.

You can now specify `systemversion "latest"`. If the action is `vs2017`, it will query the registry to retrieve the latest SDK 10 version number. If anything's wrong (action less than vs2017, the registry does not exist, etc.) no system version will be written in the vcxproj.

There are 2 basic unit tests, but I couldn't run them, tests currently fail on `test_http.lua` on my setup...
I tested this on my personal project, and also to build Premake itself using vs2017, and it works fine (just needed to add `systemversion "latest"` on the various Premake scripts for the Windows config.