### PR TITLE
Xcode 9.2 -std=c++17, MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -963,6 +963,11 @@
 			if family then
 				settings['TARGETED_DEVICE_FAMILY'] = family
 			end
+		else
+			local minOSVersion = project.systemversion(cfg)
+			if minOSVersion ~= nil then
+				settings['MACOSX_DEPLOYMENT_TARGET'] = minOSVersion
+			end
 		end
 
 		--ms not by default ...add it manually if you need it

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1011,7 +1011,7 @@
 		["C++98"] = "c++98",
 		["C++11"] = "c++0x",      -- Xcode project GUI uses c++0x, but c++11 also works
 		["C++14"] = "c++14",
-		["C++17"] = "c++1z",
+		["C++17"] = "c++17",
 		["gnu++98"] = "gnu++98",
 		["gnu++11"] = "gnu++0x",  -- Xcode project GUI uses gnu++0x, but gnu++11 also works
 		["gnu++14"] = "gnu++14",


### PR DESCRIPTION
Xcode 9.2 doesn't work correctly with premake5 generated projects when settings c++17. Also premake wasn't using systemversion() on macosx targets.