### PR TITLE
Fix gmake dependencies

### DIFF
--- a/modules/gmake2/gmake2.lua
+++ b/modules/gmake2/gmake2.lua
@@ -267,7 +267,7 @@
 ---------------------------------------------------------------------------
 
 	function gmake2.phonyRules(prj)
-		_p('.PHONY: clean prebuild prelink')
+		_p('.PHONY: clean prebuild')
 		_p('')
 	end
 
@@ -349,15 +349,8 @@
 
 
 	function gmake2.preBuildRules(cfg, toolset)
-		_p('prebuild:')
+		_p('prebuild: | $(OBJDIR)')
 		_p('\t$(PREBUILDCMDS)')
-		_p('')
-	end
-
-
-	function gmake2.preLinkRules(cfg, toolset)
-		_p('prelink:')
-		_p('\t$(PRELINKCMDS)')
 		_p('')
 	end
 

--- a/modules/gmake2/gmake2_csharp.lua
+++ b/modules/gmake2/gmake2_csharp.lua
@@ -44,7 +44,6 @@
 			gmake2.objDirRules,
 			gmake2.csCleanRules,
 			gmake2.preBuildRules,
-			gmake2.preLinkRules,
 			gmake2.csFileRules,
 		}
 	end
@@ -135,7 +134,7 @@
 ---------------------------------------------------------------------------
 
 	function gmake2.csAllRules(prj, toolset)
-		_p('all: $(TARGETDIR) $(OBJDIR) prebuild $(EMBEDFILES) $(COPYFILES) prelink $(TARGET)')
+		_p('all: prebuild $(EMBEDFILES) $(COPYFILES) $(TARGET)')
 		_p('')
 	end
 
@@ -304,7 +303,8 @@
 
 
 	function gmake2.csTargetRules(prj, toolset)
-		_p('$(TARGET): $(SOURCES) $(EMBEDFILES) $(DEPENDS) $(RESPONSE)')
+		_p('$(TARGET): $(SOURCES) $(EMBEDFILES) $(DEPENDS) $(RESPONSE) | $(TARGETDIR)')
+		_p('\t$(PRELINKCMDS)')
 		_p('\t$(SILENT) $(CSC) /nologo /out:$@ $(FLAGS) $(REFERENCES) @$(RESPONSE) $(patsubst %%,/resource:%%,$(EMBEDFILES))')
 		_p('\t$(POSTBUILDCMDS)')
 		_p('')

--- a/modules/gmake2/gmake2_utility.lua
+++ b/modules/gmake2/gmake2_utility.lua
@@ -294,8 +294,6 @@
 			utility.targetRules,
 			gmake2.targetDirRules,
 			utility.cleanRules,
-			gmake2.preBuildRules,
-			gmake2.preLinkRules,
 		}
 	end
 
@@ -309,7 +307,7 @@
 
 
 	function utility.allRules(cfg, toolset)
-		local allTargets = 'all: $(TARGETDIR) prebuild prelink $(TARGET)'
+		local allTargets = 'all: $(TARGETDIR) $(TARGET)'
 		for _, kind in ipairs(cfg._gmake.kinds) do
 			allTargets = allTargets .. ' $(' .. kind .. ')'
 		end
@@ -327,6 +325,8 @@
 		end
 
 		_p('$(TARGET): %s', targets)
+		_p('\t$(PREBUILDCMDS)')
+		_p('\t$(PRELINKCMDS)')
 		_p('\t$(POSTBUILDCMDS)')
 		_p('')
 	end

--- a/modules/gmake2/tests/test_gmake2_pch.lua
+++ b/modules/gmake2/tests/test_gmake2_pch.lua
@@ -97,8 +97,8 @@ PCH = ../../../src/host/premake.h
 		prepareRules()
 		test.capture [[
 ifneq (,$(PCH))
-$(OBJECTS): $(GCH) $(PCH) | $(OBJDIR) $(PCH_PLACEHOLDER)
-$(GCH): $(PCH) | $(OBJDIR)
+$(OBJECTS): $(GCH) | $(PCH_PLACEHOLDER)
+$(GCH): $(PCH) | prebuild
 	@echo $(notdir $<)
 	$(SILENT) $(CXX) -x c++-header $(ALL_CXXFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
 $(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)
@@ -108,7 +108,7 @@ else
 	$(SILENT) echo $null >> "$@"
 endif
 else
-$(OBJECTS): | $(OBJDIR)
+$(OBJECTS): | prebuild
 endif
 		]]
 	end
@@ -124,8 +124,8 @@ endif
 		prepareRules()
 		test.capture [[
 ifneq (,$(PCH))
-$(OBJECTS): $(GCH) $(PCH) | $(OBJDIR) $(PCH_PLACEHOLDER)
-$(GCH): $(PCH) | $(OBJDIR)
+$(OBJECTS): $(GCH) | $(PCH_PLACEHOLDER)
+$(GCH): $(PCH) | prebuild
 	@echo $(notdir $<)
 	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
 $(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)
@@ -135,7 +135,7 @@ else
 	$(SILENT) echo $null >> "$@"
 endif
 else
-$(OBJECTS): | $(OBJDIR)
+$(OBJECTS): | prebuild
 endif
 		]]
 	end

--- a/modules/gmake2/tests/test_gmake2_target_rules.lua
+++ b/modules/gmake2/tests/test_gmake2_target_rules.lua
@@ -36,7 +36,7 @@
 	function suite.defaultRules()
 		prepare()
 		test.capture [[
-all: prebuild prelink $(TARGET) | $(TARGETDIR) $(OBJDIR)
+all: $(TARGET)
 	@:
 		]]
 	end
@@ -51,7 +51,7 @@ all: prebuild prelink $(TARGET) | $(TARGETDIR) $(OBJDIR)
 		kind "WindowedApp"
 		prepare()
 		test.capture [[
-all: prebuild prelink $(TARGET) $(dir $(TARGETDIR))PkgInfo $(dir $(TARGETDIR))Info.plist | $(TARGETDIR) $(OBJDIR)
+all: $(TARGET) $(dir $(TARGETDIR))PkgInfo $(dir $(TARGETDIR))Info.plist
 	@:
 
 $(dir $(TARGETDIR))PkgInfo:


### PR DESCRIPTION
Attempt to fix #981 

Note, this patch doesn't implement any logic to prevent execution of the prebuild step if the project is not dirty... it will ALWAYS run prebuild, just like gmake output always has, but the deps should now be structured that parallel builds work.