### PR TITLE
Clear additional global state between unit test runs

### DIFF
--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -674,9 +674,22 @@
 -- individual test runs.
 ---
 
+	local numBuiltInGlobalBlocks
+
 	function api.reset()
+		if numBuiltInGlobalBlocks == nil then
+			numBuiltInGlobalBlocks = #api.scope.global.blocks
+		end
+
 		for containerClass in p.container.eachChildClass(p.global) do
 			api.scope.global[containerClass.pluralName] = {}
+		end
+
+		api.scope.current = api.scope.global
+
+		local currentGlobalBlockCount = #api.scope.global.blocks
+		for i = currentGlobalBlockCount, numBuiltInGlobalBlocks + 1, -1 do
+			table.remove(api.scope.global.blocks, i)
 		end
 	end
 


### PR DESCRIPTION
Clears out some global state that was being left over between unit tests runs, causing indeterminate results when running multiple tests against data at the global scope.