### PR TITLE
Replace last global state block in api.reset

### DIFF
--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -688,9 +688,11 @@
 		api.scope.current = api.scope.global
 
 		local currentGlobalBlockCount = #api.scope.global.blocks
-		for i = currentGlobalBlockCount, numBuiltInGlobalBlocks + 1, -1 do
+		for i = currentGlobalBlockCount, numBuiltInGlobalBlocks, -1 do
 			table.remove(api.scope.global.blocks, i)
 		end
+
+		configset.addFilter(api.scope.current, {}, os.getcwd())
 	end
 
 


### PR DESCRIPTION
Follow up to #1021: I removed the state blocks added by the tests, but neglected to put back a new, empty global state block for the next run.