### PR TITLE
HLSL Shader compilation in Visual Studio

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -21,6 +21,102 @@
 	include("vs2015.lua")
 	include("vs2017.lua")
 
+	-- Initialize Specific API
+
+	p.api.register {
+		name = "shaderoptions",
+		scope = "config",
+		kind = "list:string",
+		tokens = true,
+		pathVars = true,
+	}
+
+	p.api.register {
+		name = "shaderdefines",
+		scope = "config",
+		kind = "list:string",
+		tokens = true,
+	}
+
+	p.api.register {
+		name = "shadertype",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Effect",
+			"Vertex",
+			"Pixel",
+			"Geometry",
+			"Hull",
+			"Domain",
+			"Compute",
+			"Texture",
+			"RootSignature",
+		}
+	}
+
+	p.api.register {
+		name = "shadermodel",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"2.0",
+			"3.0",
+			"4.0_level_9_1",
+			"4.0_level_9_3",
+			"4.0",
+			"4.1",
+			"5.0",
+		}
+	}
+
+	p.api.register {
+		name = "shaderentry",
+		scope = "config",
+		kind = "string",
+		tokens = true,
+	}
+
+	p.api.register {
+		name = "shadervariablename",
+		scope = "config",
+		kind = "string",
+		tokens = true,
+	}
+
+	p.api.register {
+		name = "shaderheaderfileoutput",
+		scope = "config",
+		kind = "string",
+		tokens = true,
+	}
+
+	p.api.register {
+		name = "shaderobjectfileoutput",
+		scope = "config",
+		kind = "string",
+		tokens = true,
+	}
+
+	p.api.register {
+		name = "shaderassembler",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"NoListing",
+			"AssemblyCode",
+			"AssemblyCodeAndHex",
+		}
+	}
+
+	p.api.register {
+		name = "shaderassembleroutput",
+		scope = "config",
+		kind = "string",
+		tokens = true,
+	}
+
+
 --
 -- Decide when the full module should be loaded.
 --

--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -63,6 +63,7 @@ return {
 	"vc2010/test_language_settings.lua",
 	"vc2010/test_language_targets.lua",
 	"vc2010/test_floatingpoint.lua",
+	"vc2010/test_fxcompile_settings.lua",
 	"vc2010/test_globals.lua",
 	"vc2010/test_header.lua",
 	"vc2010/test_files.lua",

--- a/modules/vstudio/tests/vc2010/test_fxcompile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_fxcompile_settings.lua
@@ -1,0 +1,229 @@
+--
+-- tests/actions/vstudio/vc2010/test_fxcompile_settings.lua
+-- Validate FxCompile settings in Visual Studio 2010 C/C++ projects.
+-- Copyright (c) 2014 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("vstudio_vs2010_fxcompile_settings")
+	local vc2010 = p.vstudio.vc2010
+	local project = p.project
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2010")
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare(platform)
+		local cfg = test.getconfig(prj, "Debug", platform)
+		vc2010.fxCompile(cfg)
+	end
+
+
+---
+-- Check the basic element structure with default settings.
+-- Project should not generate this block if no hlsl files or no shader settings sets.
+---
+
+	function suite.empty()
+		prepare()
+		test.capture [[
+
+		]]
+	end
+
+
+	function suite.defaultSettings()
+		files { "shader.hlsl" }
+		prepare()
+		test.capture [[
+
+		]]
+	end
+
+---
+-- Test FxCompilePreprocessorDefinition
+---
+
+	function suite.onFxCompilePreprocessorDefinition()
+		files { "shader.hlsl" }
+		shaderdefines { "DEFINED_VALUE" }
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<PreprocessorDefinitions>DEFINED_VALUE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+</FxCompile>
+		]]
+	end
+
+
+	function suite.onFxCompilePreprocessorDefinition_multipleDefines()
+		files { "shader.hlsl" }
+		shaderdefines { "DEFINED_VALUE", "OTHER_DEFINED_VALUE" }
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<PreprocessorDefinitions>DEFINED_VALUE;OTHER_DEFINED_VALUE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+</FxCompile>
+		]]
+	end
+
+---
+-- Test FxCompileShaderType
+---
+
+	function suite.onFxCompileShaderType()
+		files { "shader.hlsl" }
+		shadertype "Effect"
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<ShaderType>Effect</ShaderType>
+</FxCompile>
+		]]
+	end
+
+---
+-- Test FxCompileShaderModel
+---
+
+	function suite.onFxCompileShaderModel()
+		files { "shader.hlsl" }
+		shadermodel "5.0"
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<ShaderModel>5.0</ShaderModel>
+</FxCompile>
+		]]
+	end
+
+
+---
+-- Test FxCompileShaderEntry
+---
+
+	function suite.onFxCompileShaderEntry()
+		files { "shader.hlsl" }
+		shaderentry "NewEntry"
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<EntryPointName>NewEntry</EntryPointName>
+</FxCompile>
+		]]
+	end
+
+
+---
+-- Test FxCompileShaderVariableName
+---
+
+	function suite.onFxCompileShaderVariableName()
+		files { "shader.hlsl" }
+		shadervariablename "ShaderVar"
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<VariableName>ShaderVar</VariableName>
+</FxCompile>
+		]]
+	end
+
+
+---
+-- Test FxCompileShaderHeaderOutput
+---
+
+	function suite.onFxCompileShaderHeaderOutput()
+		files { "shader.hlsl" }
+		shaderheaderfileoutput "%%(filename).hlsl.h"
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<HeaderFileOutput>%(filename).hlsl.h</HeaderFileOutput>
+</FxCompile>
+		]]
+	end
+
+
+---
+-- Test FxCompileShaderObjectOutput
+---
+
+	function suite.onFxCompileShaderObjectOutput()
+		files { "shader.hlsl" }
+		shaderobjectfileoutput "%%(filename).hlsl.o"
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<ObjectFileOutput>%(filename).hlsl.o</ObjectFileOutput>
+</FxCompile>
+		]]
+	end
+
+
+---
+-- Test FxCompileShaderAssembler
+---
+
+	function suite.onFxCompileShaderAssembler()
+		files { "shader.hlsl" }
+		shaderassembler "AssemblyCode"
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<AssemblerOutput>AssemblyCode</AssemblerOutput>
+</FxCompile>
+		]]
+	end
+
+
+---
+-- Test FxCompileShaderAssemblerOutput
+---
+
+	function suite.onFxCompileShaderAssemblerOutput()
+		files { "shader.hlsl" }
+		shaderassembleroutput "%%(filename).hlsl.asm.o"
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<AssemblerOutputFile>%(filename).hlsl.asm.o</AssemblerOutputFile>
+</FxCompile>
+		]]
+	end
+
+
+---
+-- Test FxCompileShaderAdditionalOptions
+---
+
+	function suite.onFxCompileShaderAdditionalOptions()
+		files { "shader.hlsl" }
+		shaderoptions "-opt"
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<AdditionalOptions>-opt %(AdditionalOptions)</AdditionalOptions>
+</FxCompile>
+		]]
+	end

--- a/src/base/path.lua
+++ b/src/base/path.lua
@@ -252,6 +252,15 @@
 
 
 --
+-- Returns true if the filename represents a hlsl shader file.
+--
+
+	function path.ishlslfile(fname)
+		return path.hasextension(fname, ".hlsl")
+	end
+
+
+--
 -- Takes a path which is relative to one location and makes it relative
 -- to another location instead.
 --


### PR DESCRIPTION
Visual Studio can compile HLSL shaders with the FxCompile block.

As far as I know, this is available at least from vs2012. I did not test for earlier versions.

There is one thing bothering me with this implementation, I had to create shaderdefines and shaderoptions even though the resulting tag is the same as ClCompile.
This is to avoid doing something like
```
filter { "files:**.hlsl" }
   defines { "SOME_DEFINE" }
```
as it would be treated as a per-file config instead of a block one.

If you have any idea to improve this, I'm up to implement it.