### PR TITLE
Fixes for various VS2005

### DIFF
--- a/modules/vstudio/vs2005.lua
+++ b/modules/vstudio/vs2005.lua
@@ -57,7 +57,7 @@
 
 	function vs2005.esc(value)
 		value = string.gsub(value, '&',  "&amp;")
-		value = value:gsub('"',  "&quot;")
+		value = value:gsub('"',  "\\&quot;")
 		value = value:gsub("'",  "&apos;")
 		value = value:gsub('<',  "&lt;")
 		value = value:gsub('>',  "&gt;")

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -819,10 +819,54 @@
 		end
 	end
 
-
+	function tablefindandremove(tab, el)
+		for index, value in pairs(tab) do
+			if value == el then
+				table.remove(tab, index)
+				return true
+			end
+		end
+		return false
+	end
 
 	function m.additionalExternalCompilerOptions(cfg, toolset)
 		local buildoptions = table.join(toolset.getcxxflags(cfg), cfg.buildoptions)
+		if tablefindandremove(buildoptions, "/MT") then
+			p.x('RuntimeLibrary="0"');
+		elseif tablefindandremove(buildoptions, "/MTd") then
+			p.x('RuntimeLibrary="1"');
+		elseif tablefindandremove(buildoptions, "/MD") then
+			p.x('RuntimeLibrary="2"');
+		elseif tablefindandremove(buildoptions, "/MDd") then
+			p.x('RuntimeLibrary="3"');
+		end
+		if tablefindandremove(buildoptions, "/Od") then
+			p.x('Optimization="0"');
+		elseif tablefindandremove(buildoptions, "/Os") or
+		       tablefindandremove(buildoptions, "/O1") then
+			p.x('Optimization="1"');
+		elseif tablefindandremove(buildoptions, "/Ot") or
+		       tablefindandremove(buildoptions, "/O2") then
+			p.x('Optimization="2"');
+		elseif tablefindandremove(buildoptions, "/Ox") then
+			p.x('Optimization="3"');
+		end
+		if tablefindandremove(buildoptions, "/Z7") then
+			p.x('DebugInformationFormat="1"');
+		elseif tablefindandremove(buildoptions, "/Zi") then
+			p.x('DebugInformationFormat="3"');
+		elseif tablefindandremove(buildoptions, "/ZI") then
+			p.x('DebugInformationFormat="4"');
+		else
+			p.x('DebugInformationFormat="0"');
+		end
+		if tablefindandremove(buildoptions, "/EHsc") then
+			p.x('ExceptionHandling="1"');
+		elseif tablefindandremove(buildoptions, "/EHa") then
+			p.x('ExceptionHandling="2"');
+		else
+			p.x('ExceptionHandling="0"');
+		end
 		if not cfg.flags.NoPCH and cfg.pchheader then
 			table.insert(buildoptions, '--use_pch="$(IntDir)/$(TargetName).pch"')
 		end

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -1063,8 +1063,8 @@
 	function m.debugInformationFormat(cfg, toolset)
 		local prjcfg, filecfg = config.normalize(cfg)
 		if not filecfg then
-			local fmt = iif(toolset, "0", m.symbols(cfg))
-			p.w('DebugInformationFormat="%s"', fmt)
+			--local fmt = iif(toolset, "0", m.symbols(cfg))
+			--p.w('DebugInformationFormat="%s"', fmt)
 		end
 	end
 

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -1428,7 +1428,7 @@
 
 	function m.programDataBaseFileName(cfg, toolset)
 		if toolset then
-			p.w('ProgramDataBaseFileName=""')
+			-- p.w('ProgramDataBaseFileName=""')
 		end
 	end
 

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -92,7 +92,8 @@
 			Off = "/GF-",
 		},
 		symbols = {
-			On = "/Z7"
+			Off = "",
+			On = "/Zi",
 		}
 	}
 


### PR DESCRIPTION
We are wanting to adopt premake5 within the mupdf project, but we've hit some problems with the VS2005 generation.

I have fixes (well, workarounds at least) implemented in the referenced commits. If the fixes can't be taken as-is, hopefully they'll a) illustrate the issues, and b) allow someone to point the way to fixing them properly.

The problems that this works around:

1) Normal generation of VS2005 C projects includes a 'ProgramDataBaseFileName=""' entry. This has the effect of confusing VS2005 into thinking that everything is always out of date. Any builds of the solution do a complete rebuild. Simply omitting this line solves it.

2) The standard debug information format these days (certainly for us) is to use /Zi, not /Z7. Also (if I'm reading the lua right), it is output at one point using the index within the list. Accordingly, I've introduced an empty 'Off' value.

3) DebugInformationFormat appears to always be being set to 0 (because toolset is never non-NULL in any of the cases in which I've hit the code that outputs it. This is the wrong value, so I've just disabled the code.

4) Finally, the approach taken by the code appears to be to just bung the flags for the different options in an "AdditionalOptions" entry.

The solution doesn't parse these flags, just passes them on, after setting the flags that it thinks should be used.

So, for instance, if you output a project that is to be a debug project, with the "/Od" option in the AdditionalOptions field, and load that into VS, the properties window will show the Optimisation field as being the default (which IIRC is "/Ot"). When built, both flags are passed to the compiler. The right one is used, but a warning is given. It's also very confusing for people to not see their options reflected in the project settings.

Accordingly, I've added code that spots the flags in the AdditionalOptions field, removes them and outputs the proper flags as appropriate.

It is quite possible that there is a neater solution to all of this, but I am not a lua speaker, so this is the best I could come up with on short notice.

