### PR TITLE
Replace debuggerflavor with debugger

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -23,6 +23,11 @@
 
 	-- Initialize Specific API
 
+	p.api.addAllowed("debugger", "VisualStudioLocal")
+	p.api.addAllowed("debugger", "VisualStudioRemote")
+	p.api.addAllowed("debugger", "VisualStudioWebBrowser")
+	p.api.addAllowed("debugger", "VisualStudioWebService")
+
 	p.api.register {
 		name = "shaderoptions",
 		scope = "config",
@@ -114,18 +119,6 @@
 		scope = "config",
 		kind = "string",
 		tokens = true,
-	}
-
-	p.api.register {
-		name = "debuggerflavor",
-		scope = "config",
-		kind = "string",
-		allowed = {
-			"Local",
-			"Remote",
-			"WebBrowser",
-			"WebService"
-		}
 	}
 
 --

--- a/modules/vstudio/tests/vc2010/test_debug_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_debug_settings.lua
@@ -105,18 +105,44 @@ foo=bar</LocalDebuggerEnvironment>
 -- Test Debugger Flavor
 --
 
-	function suite.debuggerFlavor_OnWindowsLocal()
-		debuggerflavor "Local"
+	function suite.debuggerFlavor_OnWindowsDefault()
+		debugger "Default"
+		prepare()
+		test.capture [[
+
+		]]
+	end
+
+	function suite.debuggerFlavor_OnWindowsUnavailable()
+		debugger "GDB"
+		prepare()
+		test.capture [[
+
+		]]
+	end
+
+	function suite.debuggerFlavor_OnVisualStudioLocal()
+		debugger "VisualStudioLocal"
 		prepare()
 		test.capture [[
 <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
 		]]
 	end
 
-	function suite.debuggerFlavor_OnWindowsRemote()
-		debuggerflavor "Remote"
+	function suite.debuggerFlavor_OnVisualStudioRemote()
+		debugger "VisualStudioRemote"
 		prepare()
 		test.capture [[
+<DebuggerFlavor>WindowsRemoteDebugger</DebuggerFlavor>
+		]]
+	end
+
+	function suite.debuggerFlavor_OnDebugDirAndDebugger()
+		debugdir "bin/debug"
+		debugger "VisualStudioRemote"
+		prepare()
+		test.capture [[
+<LocalDebuggerWorkingDirectory>bin\debug</LocalDebuggerWorkingDirectory>
 <DebuggerFlavor>WindowsRemoteDebugger</DebuggerFlavor>
 		]]
 	end

--- a/modules/vstudio/vs2010_vcxproj_user.lua
+++ b/modules/vstudio/vs2010_vcxproj_user.lua
@@ -77,16 +77,15 @@
 	end
 
 
-
 	function m.debuggerFlavor(cfg)
 		local map = {
-			Local = "WindowsLocalDebugger",
-			Remote = "WindowsRemoteDebugger",
-			WebBrowser = "WebBrowserDebugger",
-			WebService = "WebServiceDebugger"
+			VisualStudioLocal		= "WindowsLocalDebugger",
+			VisualStudioRemote		= "WindowsRemoteDebugger",
+			VisualStudioWebBrowser	= "WebBrowserDebugger",
+			VisualStudioWebService	= "WebServiceDebugger"
 		}
 
-		local value = map[cfg.debuggerflavor]
+		local value = map[cfg.debugger]
 		if value then
 			p.w('<DebuggerFlavor>%s</DebuggerFlavor>', value)
 		elseif cfg.debugdir or cfg.debugcommand then


### PR DESCRIPTION
Ref: #1060 

Remove duplicate in APIs as `debugger` can be used to set `DebuggerFlavor` in Visual Studio.