### PR TITLE
Add 'Default', 'Dwarf' and 'SplitDwarf' arguments to 'debugformat'

### DIFF
--- a/modules/gmake/tests/cpp/test_flags.lua
+++ b/modules/gmake/tests/cpp/test_flags.lua
@@ -53,6 +53,39 @@
 	end
 
 --
+-- symbols default to 'off'
+--
+	function suite.symbols_default()
+		symbols "default"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS)
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS)
+		]]
+	end
+
+--
+-- All other symbols flags also produce -g
+--
+	function suite.symbols_fastlink()
+		symbols "FastLink"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
+		]]
+	end
+
+	function suite.symbols_full()
+		symbols "full"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
+		]]
+	end
+
+--
 -- symbols "off" should not produce -g
 --
 	function suite.symbols_off()

--- a/modules/gmake/tests/cpp/test_flags.lua
+++ b/modules/gmake/tests/cpp/test_flags.lua
@@ -38,3 +38,74 @@
   INCLUDES += -Isrc/include -I../include
 		]]
 	end
+
+
+--
+-- symbols "on" should produce -g
+--
+	function suite.symbols_on()
+		symbols "on"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
+		]]
+	end
+
+--
+-- symbols "off" should not produce -g
+--
+	function suite.symbols_off()
+		symbols "off"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS)
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS)
+		]]
+	end
+
+--
+-- symbols "on" with a proper debugformat should produce a corresponding -g
+--
+	function suite.symbols_on_default()
+		symbols "on"
+		debugformat "Default"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
+		]]
+	end
+
+	function suite.symbols_on_dwarf()
+		symbols "on"
+		debugformat "Dwarf"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -gdwarf
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -gdwarf
+		]]
+	end
+
+	function suite.symbols_on_split_dwarf()
+		symbols "on"
+		debugformat "SplitDwarf"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -gsplit-dwarf
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -gsplit-dwarf
+		]]
+	end
+
+--
+-- symbols "off" with a proper debugformat should not produce -g
+--
+	function suite.symbols_off_dwarf()
+		symbols "off"
+		debugformat "Dwarf"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+  ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS)
+  ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS)
+		]]
+	end

--- a/modules/gmake2/tests/test_gmake2_flags.lua
+++ b/modules/gmake2/tests/test_gmake2_flags.lua
@@ -40,3 +40,73 @@
 INCLUDES += -Isrc/include -I../include
 		]]
 	end
+
+--
+-- symbols "on" should produce -g
+--
+	function suite.symbols_on()
+		symbols "on"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g
+ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
+		]]
+	end
+
+--
+-- symbols "off" should not produce -g
+--
+	function suite.symbols_off()
+		symbols "off"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS)
+ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS)
+		]]
+	end
+
+--
+-- symbols "on" with a proper debugformat should produce a corresponding -g
+--
+	function suite.symbols_on_default()
+		symbols "on"
+		debugformat "Default"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g
+ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
+		]]
+	end
+
+	function suite.symbols_on_dwarf()
+		symbols "on"
+		debugformat "Dwarf"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -gdwarf
+ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -gdwarf
+		]]
+	end
+
+	function suite.symbols_on_split_dwarf()
+		symbols "on"
+		debugformat "SplitDwarf"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -gsplit-dwarf
+ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -gsplit-dwarf
+		]]
+	end
+
+--
+-- symbols "off" with a proper debugformat should not produce -g
+--
+	function suite.symbols_off_dwarf()
+		symbols "off"
+		debugformat "Dwarf"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS)
+ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS)
+		]]
+	end

--- a/modules/gmake2/tests/test_gmake2_flags.lua
+++ b/modules/gmake2/tests/test_gmake2_flags.lua
@@ -54,6 +54,18 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 	end
 
 --
+-- symbols default to 'off'
+--
+	function suite.symbols_default()
+		symbols "default"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS)
+ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS)
+		]]
+	end
+
+--
 -- symbols "off" should not produce -g
 --
 	function suite.symbols_off()
@@ -62,6 +74,27 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 		test.capture [[
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS)
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS)
+		]]
+	end
+
+--
+-- All other symbols flags also produce -g
+--
+	function suite.symbols_fastlink()
+		symbols "FastLink"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g
+ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
+		]]
+	end
+
+	function suite.symbols_full()
+		symbols "full"
+		prepare { "cFlags", "cxxFlags" }
+		test.capture [[
+ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g
+ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 		]]
 	end
 

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -1209,6 +1209,69 @@
 	end
 
 
+	function suite.XCBuildConfigurationTarget_OnConsoleApp_dwarf()
+		debugformat "Dwarf"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnConsoleApp_split_dwarf()
+		debugformat "SplitDwarf"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationTarget_OnConsoleApp_default()
+		debugformat "Default"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
 	function suite.XCBuildConfigurationTarget_OnWindowedApp()
 		kind "WindowedApp"
 		prepare()

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -294,6 +294,27 @@
 		return types[iif(node.cfg.kind == "SharedLib" and node.cfg.sharedlibtype, node.cfg.sharedlibtype, node.cfg.kind)]
 	end
 
+--
+-- Return the Xcode debug information format for the current configuration
+--
+-- @param cfg
+--    The current configuration
+-- @returns
+--    The corresponding value of DEBUG_INFORMATION_FORMAT, or 'dwarf-with-dsym' if invalid
+--
+
+	function xcode.getdebugformat(cfg)
+		local formats = {
+			["Dwarf"]      = "dwarf",
+			["Default"]    = "dwarf-with-dsym",
+			["SplitDwarf"] = "dwarf-with-dsym",
+		}
+		local rval = "dwarf-with-dsym"
+		if cfg.debugformat then
+			rval = formats[cfg.debugformat] or rval
+		end
+		return rval
+	end
 
 --
 -- Return a unique file name for a project. Since Xcode uses .xcodeproj's to
@@ -1111,7 +1132,7 @@
 		settings['ALWAYS_SEARCH_USER_PATHS'] = 'NO'
 
 		if cfg.symbols ~= p.OFF then
-			settings['DEBUG_INFORMATION_FORMAT'] = 'dwarf-with-dsym'
+			settings['DEBUG_INFORMATION_FORMAT'] = xcode.getdebugformat(cfg)
 		end
 
 		if cfg.kind ~= "StaticLib" and cfg.buildtarget.prefix ~= '' then

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -255,7 +255,10 @@
 		scope = "config",
 		kind = "string",
 		allowed = {
+			"Default",
 			"c7",
+			"Dwarf",
+			"SplitDwarf",
 		},
 	}
 

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -492,6 +492,9 @@
 
 		for field in p.field.eachOrdered() do
 			local map = mappings[field.name]
+			if type(map) == "function" then
+				map = map(cfg, mappings)
+			end
 			if map then
 
 				-- Pass each cfg value in the list through the map and append the

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -32,6 +32,18 @@
 
 
 --
+-- Returns string to be appended to -g
+--
+	function gcc.getdebugformat(cfg)
+		local flags = {
+			Default = "",
+			Dwarf = "dwarf",
+			SplitDwarf = "split-dwarf",
+		}
+		return flags
+	end
+
+--
 -- Returns list of C compiler flags for a configuration.
 --
 	gcc.shared = {
@@ -93,9 +105,11 @@
 			High = "-Wall",
 			Off = "-w",
 		},
-		symbols = {
-			On = "-g"
-		},
+		symbols = function(cfg, mappings)
+			local values = gcc.getdebugformat(cfg)
+			local debugformat = values[cfg.debugformat] or ""
+			return { On = "-g" .. debugformat }
+		end,
 		unsignedchar = {
 			On = "-funsigned-char",
 			Off = "-fno-unsigned-char"

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -108,7 +108,11 @@
 		symbols = function(cfg, mappings)
 			local values = gcc.getdebugformat(cfg)
 			local debugformat = values[cfg.debugformat] or ""
-			return { On = "-g" .. debugformat }
+			return {
+				On       = "-g" .. debugformat,
+				FastLink = "-g" .. debugformat,
+				Full     = "-g" .. debugformat,
+			}
 		end,
 		unsignedchar = {
 			On = "-funsigned-char",


### PR DESCRIPTION
Adds 'Default', 'Dwarf' and 'SplitDwarf' options to 'debugformat' when using the xcode, gmake or gmake2 modules.

Wiki updates are at: https://github.com/ratzlaff/premake-core/wiki/debugformat
wiki repo URL: https://github.com/ratzlaff/premake-core.wiki.git (branch: xcode_debugformat)