### PR TITLE
Fix constructing executable path from argv[0]

### DIFF
--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -419,11 +419,12 @@ int premake_locate_executable(lua_State* L, const char* argv0)
 		lua_pushstring(L, "/");
 		lua_pushstring(L, argv0);
 
-		if (!path_isabsolute(L)) {
+		if (!do_isabsolute(argv0)) {
 			lua_concat(L, 3);
 		}
 		else {
-			lua_pop(L, 1);
+			lua_pop(L, 3);
+			lua_pushstring(L, argv0);
 		}
 
 		path = lua_tostring(L, -1);

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -409,6 +409,7 @@ int premake_locate_executable(lua_State* L, const char* argv0)
 			lua_concat(L, 3);
 			path = lua_tostring(L, -1);
 		}
+		lua_pop(L, 1);
 	}
 
 	/* If all else fails, use argv[0] as-is and hope for the best */
@@ -428,6 +429,7 @@ int premake_locate_executable(lua_State* L, const char* argv0)
 		}
 
 		path = lua_tostring(L, -1);
+		lua_pop(L, 1);
 	}
 
 	lua_pushstring(L, path);


### PR DESCRIPTION
The fallback code for constructing executable path from `argv[0]` does not work at all currently. (And possibly never worked?)

How to test:
Comment out e.g. the `#if PLATFORM_LINUX` block in `premake_locate_executable` in `premake.c` and witness the fallback code failing with the error:
`PANIC: unprotected error in call to Lua API (attemt to call a string value)`