### PR TITLE
Add color to failing test output

### DIFF
--- a/modules/self-test/test_runner.lua
+++ b/modules/self-test/test_runner.lua
@@ -103,7 +103,10 @@
 		if ok then
 			return 1, 0
 		else
-			m.print(string.format("%s.%s: %s", test.suiteName, test.testName, err))
+			term.pushColor(term.warningColor)
+			io.write(string.format("%s.%s", test.suiteName, test.testName))
+			term.popColor()
+			m.print(string.format(": %s", err))
 			return 0, 1
 		end
 	end

--- a/src/host/term_textColor.c
+++ b/src/host/term_textColor.c
@@ -54,10 +54,10 @@ void term_doSetTextColor(int color)
 	};
 	if (color >= 0 && color < 16)
 	{
-		puts(colorTable[color]);
+		fputs(colorTable[color], stdout);
 	} else
 	{
-		puts("\x1B[0m");
+		fputs("\x1B[0m", stdout);
 	}
 #endif
 }


### PR DESCRIPTION
1) use fptus in the implementation of term.setTextColor to have better newline control
2) change the color of the test name when tests fail so that they are easier to visually parse