### PR TITLE
Fix curl compilation on Debian PowerPC.

### DIFF
--- a/contrib/curl/include/curl/curlbuild.h
+++ b/contrib/curl/include/curl/curlbuild.h
@@ -528,7 +528,7 @@
 
 #elif defined(__GNUC__)
 #  if !defined(__LP64__) && (defined(__ILP32__) || \
-      defined(__i386__) || defined(__ppc__) || defined(__arm__) || \
+      defined(__i386__) || defined(__ppc__) || defined(__PPC__) || defined(__arm__) || \
       defined(__sparc__) || defined(__mips__) || defined(__sh__))
 #    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
@@ -539,7 +539,7 @@
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  elif defined(__LP64__) || \
-        defined(__x86_64__) || defined(__ppc64__) || defined(__sparc64__)
+        defined(__x86_64__) || defined(__ppc64__) || defined(__PPC64__) || defined(__sparc64__)
 #    define CURL_SIZEOF_LONG           8
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"


### PR DESCRIPTION
For some reason, __ppc__ is not defined by GCC, but __PPC__ is.