### PR TITLE
Fix httpbin useragent response format.

### DIFF
--- a/tests/base/test_http.lua
+++ b/tests/base/test_http.lua
@@ -17,7 +17,7 @@
 		if result then
 			p.out(result)
 			test.capture(
-				'{\n  "user-agent": "Premake/' .. _PREMAKE_VERSION .. '"\n}'
+				'{"user-agent": "Premake/' .. _PREMAKE_VERSION .. '"}'
 			)
 		else
 			test.fail(err);
@@ -31,7 +31,7 @@
 		if result then
 			p.out(result)
 			test.capture(
-				'{\n  "user-agent": "Premake/' .. _PREMAKE_VERSION .. '"\n}'
+				'{"user-agent": "Premake/' .. _PREMAKE_VERSION .. '"}'
 			)
 		else
 			test.fail(err);
@@ -43,7 +43,7 @@
 		if result then
 			p.out(result)
 			test.capture(
-				'{\n  "user-agent": "Premake/' .. _PREMAKE_VERSION .. '"\n}'
+				'{"user-agent": "Premake/' .. _PREMAKE_VERSION .. '"}'
 			)
 		else
 			test.fail(err);


### PR DESCRIPTION
Currently, the user-agent tests are failing. My assumption is that the `httpbin` response format of an user-agent request has been changed. 

I adjusted the format in the test to get it working again. The change fixes #1083.