### PR TITLE
Fix missing DebugInformationFormat when symbols are set to full

### DIFF
--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1579,7 +1579,7 @@
 	function m.debugInformationFormat(cfg)
 		local value
 		local tool, toolVersion = p.config.toolset(cfg)
-		if (cfg.symbols == p.ON) or (cfg.symbols == "FastLink") then
+		if (cfg.symbols == p.ON) or (cfg.symbols == "FastLink") or (cfg.symbols == "Full") then
 			if cfg.debugformat == "c7" then
 				value = "OldStyle"
 			elseif (cfg.architecture == "x86_64" and _ACTION < "vs2015") or


### PR DESCRIPTION
When symbols are set to "full" then the DebugInformationFormat attribute is not emitted no matter what the other settings are. For me, this manifested itself as the editandcontinue function appearing not to work.