### PR TITLE
Fix mkdir command on msdos if directory already exists

### DIFF
--- a/modules/gmake/gmake.lua
+++ b/modules/gmake/gmake.lua
@@ -145,7 +145,7 @@
 	function make.mkdir(dirname)
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) mkdir -p %s', dirname)
-		_p('else ifeq(msdos),$(SHELLTYPE))')
+		_p('else ifeq (msdos,$(SHELLTYPE))')
 		_p('\tif not exist "$(subst /,\\\\,%s)" $(SILENT) mkdir $(subst /,\\\\,%s)', dirname, dirname)
 		_p('else')
 		_p('\t$(SILENT) mkdir $(subst /,\\\\,%s)', dirname)

--- a/modules/gmake/gmake.lua
+++ b/modules/gmake/gmake.lua
@@ -146,7 +146,7 @@
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) mkdir -p %s', dirname)
 		_p('else ifeq(msdos),$(SHELLTYPE))')
-		_p('\tif not exist "$(subst /,\\\\,%s)" $(SILENT) mkdir $(subst /,\\\\,%s)')
+		_p('\tif not exist "$(subst /,\\\\,%s)" $(SILENT) mkdir $(subst /,\\\\,%s)', dirname, dirname)
 		_p('else')
 		_p('\t$(SILENT) mkdir $(subst /,\\\\,%s)', dirname)
 		_p('endif')

--- a/modules/gmake/gmake.lua
+++ b/modules/gmake/gmake.lua
@@ -145,6 +145,8 @@
 	function make.mkdir(dirname)
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) mkdir -p %s', dirname)
+		_p('else ifeq(msdos),$(SHELLTYPE))')
+		_p('\tif not exist "$(subst /,\\\\,%s)" $(SILENT) mkdir $(subst /,\\\\,%s)')
 		_p('else')
 		_p('\t$(SILENT) mkdir $(subst /,\\\\,%s)', dirname)
 		_p('endif')

--- a/modules/gmake/tests/cpp/test_file_rules.lua
+++ b/modules/gmake/tests/cpp/test_file_rules.lua
@@ -39,6 +39,8 @@ $(OBJDIR)/hello.o: src/greetings/hello.cpp
 	@echo $(notdir $<)
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) mkdir -p $(OBJDIR)
+else ifeq (msdos,$(SHELLTYPE))
+	if not exist "$(subst /,\\\\,$(OBJDIR))" $(SILENT) mkdir $(subst /,\\\\,$(OBJDIR))
 else
 	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
 endif
@@ -47,6 +49,8 @@ $(OBJDIR)/hello1.o: src/hello.cpp
 	@echo $(notdir $<)
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) mkdir -p $(OBJDIR)
+else ifeq (msdos,$(SHELLTYPE))
+	if not exist "$(subst /,\\\\,$(OBJDIR))" $(SILENT) mkdir $(subst /,\\\\,$(OBJDIR))
 else
 	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
 endif
@@ -68,6 +72,8 @@ $(OBJDIR)/hello.o: src/hello.c
 	@echo $(notdir $<)
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) mkdir -p $(OBJDIR)
+else ifeq (msdos,$(SHELLTYPE))
+	if not exist "$(subst /,\\\\,$(OBJDIR))" $(SILENT) mkdir $(subst /,\\\\,$(OBJDIR))
 else
 	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
 endif
@@ -76,6 +82,8 @@ $(OBJDIR)/test.o: src/test.cpp
 	@echo $(notdir $<)
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) mkdir -p $(OBJDIR)
+else ifeq (msdos,$(SHELLTYPE))
+	if not exist "$(subst /,\\\\,$(OBJDIR))" $(SILENT) mkdir $(subst /,\\\\,$(OBJDIR))
 else
 	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
 endif
@@ -98,6 +106,8 @@ $(OBJDIR)/hello.o: src/hello.c
 	@echo $(notdir $<)
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) mkdir -p $(OBJDIR)
+else ifeq (msdos,$(SHELLTYPE))
+	if not exist "$(subst /,\\\\,$(OBJDIR))" $(SILENT) mkdir $(subst /,\\\\,$(OBJDIR))
 else
 	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
 endif
@@ -111,6 +121,8 @@ $(OBJDIR)/test.o: src/test.c
 	@echo $(notdir $<)
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) mkdir -p $(OBJDIR)
+else ifeq (msdos,$(SHELLTYPE))
+	if not exist "$(subst /,\\\\,$(OBJDIR))" $(SILENT) mkdir $(subst /,\\\\,$(OBJDIR))
 else
 	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
 endif
@@ -132,6 +144,8 @@ $(OBJDIR)/hello.o: src/hello.c
 	@echo $(notdir $<)
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) mkdir -p $(OBJDIR)
+else ifeq (msdos,$(SHELLTYPE))
+	if not exist "$(subst /,\\\\,$(OBJDIR))" $(SILENT) mkdir $(subst /,\\\\,$(OBJDIR))
 else
 	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
 endif
@@ -145,6 +159,8 @@ $(OBJDIR)/test.o: src/test.c
 	@echo $(notdir $<)
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) mkdir -p $(OBJDIR)
+else ifeq (msdos,$(SHELLTYPE))
+	if not exist "$(subst /,\\\\,$(OBJDIR))" $(SILENT) mkdir $(subst /,\\\\,$(OBJDIR))
 else
 	$(SILENT) mkdir $(subst /,\\,$(OBJDIR))
 endif

--- a/modules/gmake2/gmake2.lua
+++ b/modules/gmake2/gmake2.lua
@@ -124,7 +124,7 @@
 	function gmake2.mkdir(dirname)
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) mkdir -p %s', dirname)
-		_p('else ifeq(msdos),$(SHELLTYPE))')
+		_p('else ifeq (msdos,$(SHELLTYPE))')
 		_p('\tif not exist "$(subst /,\\\\,%s)" $(SILENT) mkdir $(subst /,\\\\,%s)', dirname, dirname)
 		_p('else')
 		_p('\t$(SILENT) mkdir $(subst /,\\\\,%s)', dirname)

--- a/modules/gmake2/gmake2.lua
+++ b/modules/gmake2/gmake2.lua
@@ -125,7 +125,7 @@
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) mkdir -p %s', dirname)
 		_p('else ifeq(msdos),$(SHELLTYPE))')
-		_p('\tif not exist "$(subst /,\\\\,%s)" $(SILENT) mkdir $(subst /,\\\\,%s)')
+		_p('\tif not exist "$(subst /,\\\\,%s)" $(SILENT) mkdir $(subst /,\\\\,%s)', dirname, dirname)
 		_p('else')
 		_p('\t$(SILENT) mkdir $(subst /,\\\\,%s)', dirname)
 		_p('endif')

--- a/modules/gmake2/gmake2.lua
+++ b/modules/gmake2/gmake2.lua
@@ -124,6 +124,8 @@
 	function gmake2.mkdir(dirname)
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) mkdir -p %s', dirname)
+		_p('else ifeq(msdos),$(SHELLTYPE))')
+		_p('\tif not exist "$(subst /,\\\\,%s)" $(SILENT) mkdir $(subst /,\\\\,%s)')
 		_p('else')
 		_p('\t$(SILENT) mkdir $(subst /,\\\\,%s)', dirname)
 		_p('endif')


### PR DESCRIPTION
On windows `mkdir -p foo` creates two folders: -p and foo. When using mkdir to create a folder already existing, useless logs appear in the shell (even with the `@` before the command)