### PR TITLE
CodeLite workspace folders (groups)

### DIFF
--- a/modules/codelite/codelite_workspace.lua
+++ b/modules/codelite/codelite_workspace.lua
@@ -26,11 +26,11 @@
 		--
 		-- Header
 		--
-		_p('<?xml version="1.0" encoding="UTF-8"?>')
+		p.w('<?xml version="1.0" encoding="UTF-8"?>')
 
 		local tagsdb = ""
 --		local tagsdb = "./" .. wks.name .. ".tags"
-		_p('<CodeLite_Workspace Name="%s" Database="%s" SWTLW="No">', wks.name, tagsdb)
+		p.push('<CodeLite_Workspace Name="%s" Database="%s" SWTLW="No">', wks.name, tagsdb)
 
 		--
 		-- Project list
@@ -45,15 +45,18 @@
 				prjpath = path.getrelative(prj.workspace.location, prjpath)
 
 				if (prj.name == wks.startproject) then
-					_x(1, '<Project Name="%s" Path="%s" Active="Yes"/>', prj.name, prjpath)
+					p.w('<Project Name="%s" Path="%s" Active="Yes"/>', prj.name, prjpath)
 				else
-					_x(1, '<Project Name="%s" Path="%s"/>', prj.name, prjpath)
+					p.w('<Project Name="%s" Path="%s"/>', prj.name, prjpath)
 				end
 			end,
 
-			onbranch = function(n)
-				-- TODO: not sure what situation this appears...?
-				-- premake5.lua emit's one of these for 'contrib', which is a top-level folder with the zip projects
+			onbranchenter = function(n)
+				p.push('<VirtualDirectory Name="%s">', n.name)
+			end,
+
+			onbranchexit = function(n)
+				p.pop('</VirtualDirectory>')
 			end,
 		})
 
@@ -78,23 +81,23 @@
 		end
 
 		-- for each workspace config
-		_p(1, '<BuildMatrix>')
+		p.push('<BuildMatrix>')
 		for cfg in workspace.eachconfig(wks) do
 
 			local cfgname = codelite.cfgname(cfg)
-			_p(2, '<WorkspaceConfiguration Name="%s" Selected="yes">', cfgname)
+			p.push('<WorkspaceConfiguration Name="%s" Selected="yes">', cfgname)
 
 			local tr = workspace.grouptree(wks)
 			tree.traverse(tr, {
 				onleaf = function(n)
 					local prj = n.project
-					_p(3, '<Project Name="%s" ConfigName="%s"/>', prj.name, cfgname)
+					p.w('<Project Name="%s" ConfigName="%s"/>', prj.name, cfgname)
 				end
 			})
-			_p(2, '</WorkspaceConfiguration>')
+			p.pop('</WorkspaceConfiguration>')
 
 		end
-		_p(1, '</BuildMatrix>')
+		p.pop('</BuildMatrix>')
 
-		_p('</CodeLite_Workspace>')
+		p.pop('</CodeLite_Workspace>')
 	end

--- a/modules/codelite/tests/test_codelite_workspace.lua
+++ b/modules/codelite/tests/test_codelite_workspace.lua
@@ -151,3 +151,42 @@
 </CodeLite_Workspace>
 		]])
 	end
+
+
+  function suite.onGroupedProjects()
+    wks.projects = {}
+    project "MyGrouplessProject"
+    group "MyGroup"
+    project "MyGroupedProject"
+    group "My/Nested/Group"
+    project "MyNestedGroupedProject"
+    prepare()
+    test.capture([[
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+  <VirtualDirectory Name="My">
+    <VirtualDirectory Name="Nested">
+      <VirtualDirectory Name="Group">
+        <Project Name="MyNestedGroupedProject" Path="MyNestedGroupedProject.project"/>
+      </VirtualDirectory>
+    </VirtualDirectory>
+  </VirtualDirectory>
+  <VirtualDirectory Name="MyGroup">
+    <Project Name="MyGroupedProject" Path="MyGroupedProject.project"/>
+  </VirtualDirectory>
+  <Project Name="MyGrouplessProject" Path="MyGrouplessProject.project"/>
+  <BuildMatrix>
+    <WorkspaceConfiguration Name="Debug" Selected="yes">
+      <Project Name="MyNestedGroupedProject" ConfigName="Debug"/>
+      <Project Name="MyGroupedProject" ConfigName="Debug"/>
+      <Project Name="MyGrouplessProject" ConfigName="Debug"/>
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="Release" Selected="yes">
+      <Project Name="MyNestedGroupedProject" ConfigName="Release"/>
+      <Project Name="MyGroupedProject" ConfigName="Release"/>
+      <Project Name="MyGrouplessProject" ConfigName="Release"/>
+    </WorkspaceConfiguration>
+  </BuildMatrix>
+</CodeLite_Workspace>
+    ]])
+  end


### PR DESCRIPTION
Didn't notice until today that groups for codelite wasn't working. The change was very small, but I had to update from the manual indenting ( `_x(1, ...)` ) to pushing/popping. Wrote a test as well. Feedback is much appreciated.

#### Example:
```lua
workspace "groups"
...

group "my/nested/samples"
project "nested_grouped_sample"
...
group ""
project "sample"
...
group "samples"
project "grouped_sample"
...
```
#### Result:
![](https://i.imgur.com/qDB4Tn4.png "Result")