### PR TITLE
Implemented 'debugenvs' for CodeLite

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -274,9 +274,10 @@
 	end
 
 	function m.environment(cfg)
+		local envs = table.concat(cfg.debugenvs, "\n")
+
 		_p(3, '<Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">')
-		local variables = ""
-		_x(4, '<![CDATA[%s]]>', variables)
+		_x(4, '<![CDATA[%s]]>', envs)
 		_p(3, '</Environment>')
 	end
 

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -142,11 +142,13 @@
 	end
 
 	function suite.OnProjectCfg_Environment()
+		debugenvs { "ENV_ONE=1", "ENV_TWO=2" }
 		prepare()
 		codelite.project.environment(cfg)
 		test.capture(
 '      <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">\n' ..
-'        <![CDATA[]]>\n' ..
+'        <![CDATA[ENV_ONE=1\n' ..
+'ENV_TWO=2]]>\n' ..
 '      </Environment>'
 		)
 	end


### PR DESCRIPTION
Here I go again. Another codelite patch. I'm suspecting that there was a good reason for this to not be implemented, but looking through the commits I couldn't find anything on it. I guess it must've fallen through the cracks. If not, let me know.