### PR TITLE
gmake2: Fix dependency for pch

### DIFF
--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -809,9 +809,6 @@
 		-- include the dependencies, built by GCC (with the -MMD flag)
 		_p('-include $(OBJECTS:%%.o=%%.d)')
 		_p('ifneq (,$(PCH))')
-			_p('  -include "$(PCH_PLACEHOLDER).d"')
+			_p('  -include $(PCH_PLACEHOLDER).d')
 		_p('endif')
 	end
-
-
-


### PR DESCRIPTION
PCH:
```
#include "myheader.h"
```

If `myheader.h` was changed but not the pch itself, Make would not detect it and cause gcc to fail.