### PR TITLE
gmake*: fix shell type identification

### DIFF
--- a/modules/gmake/gmake.lua
+++ b/modules/gmake/gmake.lua
@@ -274,12 +274,9 @@
 
 
 	function make.shellType()
-		_p('SHELLTYPE := msdos')
-		_p('ifeq (,$(ComSpec)$(COMSPEC))')
-		_p('  SHELLTYPE := posix')
-		_p('endif')
-		_p('ifeq (/bin,$(findstring /bin,$(SHELL)))')
-		_p('  SHELLTYPE := posix')
+		_p('SHELLTYPE := posix')
+		_p('ifeq (.exe,$(findstring .exe,$(ComSpec)))')
+		_p('\tSHELLTYPE := msdos')
 		_p('endif')
 		_p('')
 	end

--- a/modules/gmake2/gmake2.lua
+++ b/modules/gmake2/gmake2.lua
@@ -273,12 +273,9 @@
 
 
 	function gmake2.shellType()
-		_p('SHELLTYPE := msdos')
-		_p('ifeq (,$(ComSpec)$(COMSPEC))')
-		_p('  SHELLTYPE := posix')
-		_p('endif')
-		_p('ifeq (/bin,$(findstring /bin,$(SHELL)))')
-		_p('  SHELLTYPE := posix')
+		_p('SHELLTYPE := posix')
+		_p('ifeq (.exe,$(findstring .exe,$(ComSpec)))')
+		_p('\tSHELLTYPE := msdos')
 		_p('endif')
 		_p('')
 	end


### PR DESCRIPTION
I want to test it on Win7 and Osx before merging (should be able to do it tomorrow evening Western europe time).

So far, it works on cmd.exe, powershell, mingw (including git bash) and Cmder on Win10 + Debian.