### PR TITLE
gmake2: fix cpp perfileflags

### DIFF
--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -545,7 +545,7 @@
 		_p('')
 	end
 
-	local function makeVarName(prj, value, saltValue)
+	function cpp.makeVarName(prj, value, saltValue)
 		prj._gmake = prj._gmake or {}
 		prj._gmake.varlist = prj._gmake.varlist or {}
 		prj._gmake.varlistlength = prj._gmake.varlistlength or 0
@@ -590,7 +590,7 @@
 
 		if #value > 0 then
 			local newPerFileFlag = false
-			fcfg.flagsVariable, newPerFileFlag = makeVarName(cfg.project, value, iif(isCFile, '_C', '_CPP'))
+			fcfg.flagsVariable, newPerFileFlag = cpp.makeVarName(cfg.project, value, iif(isCFile, '_C', '_CPP'))
 			if newPerFileFlag then
 				if isCFile then
 					_p('%s = $(ALL_CFLAGS)%s', fcfg.flagsVariable, value)

--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -569,7 +569,10 @@
 	function cpp.perFileFlags(cfg, fcfg)
 		local toolset = gmake2.getToolSet(cfg)
 
-		local value = gmake2.list(table.join(toolset.getcflags(fcfg), fcfg.buildoptions))
+		local isCFile = path.iscfile(fcfg.name)
+
+		local getflags = iif(isCFile, toolset.getcflags, toolset.getcxxflags)
+		local value = gmake2.list(table.join(getflags(fcfg), fcfg.buildoptions))
 
 		if fcfg.defines or fcfg.undefines then
 			local defs = table.join(toolset.getdefines(fcfg.defines, cfg), toolset.getundefines(fcfg.undefines))
@@ -587,9 +590,9 @@
 
 		if #value > 0 then
 			local newPerFileFlag = false
-			fcfg.flagsVariable, newPerFileFlag = makeVarName(cfg.project, value, iif(path.iscfile(fcfg.name), '_C', '_CPP'))
+			fcfg.flagsVariable, newPerFileFlag = makeVarName(cfg.project, value, iif(isCFile, '_C', '_CPP'))
 			if newPerFileFlag then
-				if path.iscfile(fcfg.name) then
+				if isCFile then
 					_p('%s = $(ALL_CFLAGS)%s', fcfg.flagsVariable, value)
 				else
 					_p('%s = $(ALL_CXXFLAGS)%s', fcfg.flagsVariable, value)

--- a/modules/gmake2/tests/test_gmake2_perfile_flags.lua
+++ b/modules/gmake2/tests/test_gmake2_perfile_flags.lua
@@ -73,3 +73,20 @@ PERFILE_FLAGS_1 = $(ALL_CXXFLAGS) -msse -msse2 -mfpmath=sse,387
 PERFILE_FLAGS_2 = $(ALL_CFLAGS) -msse -msse2 -mfpmath=sse,387 -msse3 -mssse3 -msse4.1 -maes
 		]]
 	end
+
+	function suite.perfile_cxxApi()
+		files { 'a.cpp', 'b.cpp', 'c.cpp' }
+
+		visibility "Hidden"
+
+		filter { 'files:b.cpp' }
+			visibility "Protected"
+
+		prepare()
+		test.capture [[
+# Per File Configurations
+# #############################################
+
+PERFILE_FLAGS_0 = $(ALL_CXXFLAGS) -fvisibility=protected
+		]]
+	end


### PR DESCRIPTION
ref: #1116 

Fix two of three issues mentioned:
- `perFileFlags` not using toolset `getcxxflags` on cpp files
- `makeVarName` was local and thus was a pain when overriding `perFileFlags`.