### PR TITLE
Fix C# buildaction

### DIFF
--- a/modules/vstudio/tests/cs2005/test_files.lua
+++ b/modules/vstudio/tests/cs2005/test_files.lua
@@ -200,6 +200,55 @@
 -- Test build actions.
 --
 
+	function suite.content()
+		files { "Hello.txt" }
+		filter "files:**.txt"
+		buildaction "Content"
+		prepare()
+		test.capture [[
+		<Content Include="Hello.txt" />
+		]]
+	end
+
+	function suite.content_PreserveNewest()
+		files { "Hello.txt" }
+		filter "files:**.txt"
+		buildaction "Content"
+		copytooutputdirectory "PreserveNewest"
+		prepare()
+		test.capture [[
+		<Content Include="Hello.txt">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		]]
+	end
+
+	function suite.content_Always()
+		files { "Hello.txt" }
+		filter "files:**.txt"
+		buildaction "Content"
+		copytooutputdirectory "Always"
+		prepare()
+		test.capture [[
+		<Content Include="Hello.txt">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		]]
+	end
+
+	function suite.content_Never()
+		files { "Hello.txt" }
+		filter "files:**.txt"
+		buildaction "Content"
+		copytooutputdirectory "Never"
+		prepare()
+		test.capture [[
+		<Content Include="Hello.txt">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</Content>
+		]]
+	end
+
 	function suite.copyAction()
 		files { "Hello.txt" }
 		filter "files:**.txt"
@@ -303,6 +352,48 @@
 		<Content Include="..\Resources\Hello.txt">
 			<Link>Resources\Hello.txt</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		]]
+	end
+
+	function suite.usesLinkInFolder_onExternalContentPreserveNewest()
+		files { "../Resources/Hello.txt" }
+		filter "files:**.txt"
+		buildaction "Content"
+		copytooutputdirectory "PreserveNewest"
+		prepare()
+		test.capture [[
+		<Content Include="..\Resources\Hello.txt">
+			<Link>Resources\Hello.txt</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		]]
+	end
+
+	function suite.usesLinkInFolder_onExternalContentAlwaysCopy()
+		files { "../Resources/Hello.txt" }
+		filter "files:**.txt"
+		buildaction "Content"
+		copytooutputdirectory "Always"
+		prepare()
+		test.capture [[
+		<Content Include="..\Resources\Hello.txt">
+			<Link>Resources\Hello.txt</Link>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		]]
+	end
+
+	function suite.usesLinkInFolder_onExternalContentNeverCopy()
+		files { "../Resources/Hello.txt" }
+		filter "files:**.txt"
+		buildaction "Content"
+		copytooutputdirectory "Never"
+		prepare()
+		test.capture [[
+		<Content Include="..\Resources\Hello.txt">
+			<Link>Resources\Hello.txt</Link>
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</Content>
 		]]
 	end

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -132,7 +132,11 @@
 					"DesignTimeSharedInput",
 					"Generator",
 					"LastGenOutput",
+					"ResourceName",
+					"MergeWithCTO",
+					"ManifestResourceName",
 					"SubType",
+					"IncludeInVSIX"
 				}
 
 				for _, el in ipairs(elements) do

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -205,6 +205,18 @@
 	}
 
 	api.register {
+		name = "copytooutputdirectory",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"Never",
+			"Always",
+			"PreserveNewest"
+		}
+	}
+
+	api.register {
 		name = "debugargs",
 		scope = "config",
 		kind = "list:string",
@@ -540,6 +552,17 @@
 	}
 
 	api.register {
+		name = "includeinvsix",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off"
+		}
+	}
+
+	api.register {
 		name = "inlining",
 		scope = "config",
 		kind = "string",
@@ -834,6 +857,23 @@
 	}
 
 	api.register {
+		name = "mergewithcto",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off"
+		}
+	}
+
+	api.register {
+		name = "manifestresourcename",
+		scope = "config",
+		kind = "string"
+	}
+
+	api.register {
 		name = "namespace",
 		scope = "project",
 		kind = "string",
@@ -884,6 +924,12 @@
 			"Speed",
 			"Full",
 		}
+	}
+
+	api.register {
+		name = "resourcename",
+		scope = "config",
+		kind = "string"
 	}
 
 	api.register {


### PR DESCRIPTION
`buildaction` should be able to override what the file extension says.
This also generalises support for `buildaction` to complement the recent change to support it in C/C++ projects.