### PR TITLE
Swap order of applying project specific config

### DIFF
--- a/src/base/fileconfig.lua
+++ b/src/base/fileconfig.lua
@@ -100,8 +100,8 @@
 
 		local environ = {}
 		local fsub = context.new(prj, environ)
-		context.copyFilters(fsub, cfg)
-		context.mergeFilters(fsub, fcfg)
+		context.copyFilters(fsub, fcfg)
+		context.mergeFilters(fsub, cfg)
 
 		fcfg.configs[cfg] = fsub
 


### PR DESCRIPTION
the config needs to be resolved based on the isolated config|platform pair

The issue this is solving is that anything that changes "system" as part of the
config|platform pair would not be applied to resolve of per file config due to
prj.system being a table that contains the current os system and when the order
of application was in the original order the project pair settings would be
overriden by the generic prj settings which are set as defaults in other locations