### PR TITLE
Fix gmake multiple-output rule issue.

### DIFF
--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -800,14 +800,12 @@
 
 
 	function cpp.outputFileRules(cfg, file)
-		local outputs = table.concat(file.buildoutputs, ' ')
-
 		local dependencies = p.esc(file.source)
 		if file.buildinputs and #file.buildinputs > 0 then
 			dependencies = dependencies .. " " .. table.concat(p.esc(file.buildinputs), " ")
 		end
 
-		_p('%s: %s', outputs, dependencies)
+		_p('%s: %s', file.buildoutputs[1], dependencies)
 
 		if file.buildmessage then
 			_p('\t@echo %s', file.buildmessage)
@@ -822,6 +820,13 @@
 					_p('\t$(SILENT) %s', cmd)
 				end
 			end
+		end
+
+		-- TODO: this is a hack with some imperfect side-effects.
+		--       better solution would be to emit a dummy file for the rule, and then outputs depend on it (must clean up dummy in 'clean')
+		--       better yet, is to use pattern rules, but we need to detect that all outputs have the same stem
+		if #file.buildoutputs > 1 then
+			_p('%s: %s', table.concat({ table.unpack(file.buildoutputs, 2) }, ' '), file.buildoutputs[1])
 		end
 	end
 

--- a/modules/gmake2/tests/test_gmake2_file_rules.lua
+++ b/modules/gmake2/tests/test_gmake2_file_rules.lua
@@ -222,6 +222,40 @@ endif
 		]]
 	end
 
+	function suite.customBuildRuleWithAdditionalOutputs()
+		files { "hello.x" }
+		filter "files:**.x"
+			buildmessage "Compiling %{file.name}"
+			buildcommands {
+				'cxc -c "%{file.path}" -o "%{cfg.objdir}/%{file.basename}.xo"',
+				'c2o -c "%{cfg.objdir}/%{file.basename}.xo" -o "%{cfg.objdir}/%{file.basename}.obj"'
+			}
+			buildoutputs { "%{cfg.objdir}/%{file.basename}.obj", "%{cfg.objdir}/%{file.basename}.other", "%{cfg.objdir}/%{file.basename}.another" }
+		prepare()
+		test.capture [[
+# File Rules
+# #############################################
+
+ifeq ($(config),debug)
+obj/Debug/hello.obj: hello.x
+	@echo Compiling hello.x
+	$(SILENT) cxc -c "hello.x" -o "obj/Debug/hello.xo"
+	$(SILENT) c2o -c "obj/Debug/hello.xo" -o "obj/Debug/hello.obj"
+obj/Debug/hello.other obj/Debug/hello.another: obj/Debug/hello.obj
+
+else ifeq ($(config),release)
+obj/Release/hello.obj: hello.x
+	@echo Compiling hello.x
+	$(SILENT) cxc -c "hello.x" -o "obj/Release/hello.xo"
+	$(SILENT) c2o -c "obj/Release/hello.xo" -o "obj/Release/hello.obj"
+obj/Release/hello.other obj/Release/hello.another: obj/Release/hello.obj
+
+else
+  $(error "invalid configuration $(config)")
+endif
+		]]
+	end
+
 	function suite.customRuleWithProps()
 
 		rules { "TestRule" }


### PR DESCRIPTION
Rules with multiple outputs were emitting rules in the form:
```make
a b c: src
  build src -o a b c
```
Which is incorrect, because it will execute the rule many times (once for each output).

I think it's intended to describe that a rule produces multiple outputs, and this patch improves the modelling of that relationship in make to read like:
```make
a: src
  build src -o a b c
b c: a
```
This isn't the best implementation, but it's not just plain broken, and others are much more complicated.

I left some TODO notes for future improvement.