### PR TITLE
use ';' as default separator for vs

### DIFF
--- a/modules/gmake2/tests/test_gmake2_file_rules.lua
+++ b/modules/gmake2/tests/test_gmake2_file_rules.lua
@@ -36,9 +36,20 @@
 			value = false,
 			switch = "-p2"
 		}
+	
+		propertydefinition {
+			name = "TestListProperty",
+			kind = "list"
+		}
+	
+		propertydefinition {
+			name = "TestListPropertySeparator",
+			kind = "list",
+			separator = ","
+		}
 
 		buildmessage 'Rule-ing %{file.name}'
-		buildcommands 'dorule %{TestProperty} %{TestProperty2} "%{file.path}"'
+		buildcommands 'dorule %{TestProperty} %{TestProperty2} %{TestListProperty} %{TestListPropertySeparator} "%{file.path}"'
 		buildoutputs { "%{file.basename}.obj" }
 
 		wks = test.createWorkspace()
@@ -278,9 +289,40 @@ endif
 
 test.obj: test.rule
 	@echo Rule-ing test.rule
-	$(SILENT) dorule -p  "test.rule"
+	$(SILENT) dorule -p    "test.rule"
 test2.obj: test2.rule
 	@echo Rule-ing test2.rule
-	$(SILENT) dorule -p -p2 "test2.rule"
+	$(SILENT) dorule -p -p2   "test2.rule"
 		]]
 	end
+
+	function suite.propertydefinitionSeparator()
+
+		rules { "TestRule" }
+
+		files { "test.rule", "test2.rule" }
+
+		filter "files:test.rule"
+			testRuleVars {
+				TestListProperty = { "testValue1", "testValue2" }
+			}
+
+		filter "files:test2.rule"
+			testRuleVars {
+				TestListPropertySeparator = { "testValue1", "testValue2" }
+			}
+
+		prepare()
+		test.capture [[
+# File Rules
+# #############################################
+
+test.obj: test.rule
+	@echo Rule-ing test.rule
+	$(SILENT) dorule   testValue1\ testValue2  "test.rule"
+test2.obj: test2.rule
+	@echo Rule-ing test2.rule
+	$(SILENT) dorule    testValue1,testValue2 "test2.rule"
+		]]
+	end
+

--- a/modules/vstudio/tests/vc2010/test_rule_vars.lua
+++ b/modules/vstudio/tests/vc2010/test_rule_vars.lua
@@ -92,7 +92,19 @@
 		prepare()
 		test.capture [[
 <MyRule>
-	<MyVar>a b c</MyVar>
+	<MyVar>a;b;c</MyVar>
+</MyRule>
+		]]
+	end
+
+
+	function suite.onCustomListSeparator()
+		createVar { name="MyVar", kind="list", separator="," }
+		myRuleVars { MyVar = { "a", "b", "c" } }
+		prepare()
+		test.capture [[
+<MyRule>
+	<MyVar>a,b,c</MyVar>
 </MyRule>
 		]]
 	end

--- a/src/base/rule.lua
+++ b/src/base/rule.lua
@@ -121,7 +121,7 @@
 		-- list?
 		if type(value) == "table" then
 			if #value > 0 then
-				local sep = prop.separator or " "
+				local sep = prop.separator or ";"
 				return table.concat(value, sep)
 			else
 				return nil
@@ -162,6 +162,7 @@
 
 	function rule.expandString(self, prop, value)
 		if not prop.switch then
+			prop.separator = prop.separator or " "
 			return rule.getPropertyString(self, prop, value)
 		end
 


### PR DESCRIPTION
This is a possible minimal workaround for #1157 .

Gmake2 keeps using " " as default list separator and VS201x gets the ";" it needs as default. It is still changeable in propertydefinitions. The field separator still does two different things at once but now it is at least possible to use list properties in VS201x projects.