### PR TITLE
Enable property categories in VS projects

### DIFF
--- a/modules/vstudio/tests/vc2010/test_rule_xml.lua
+++ b/modules/vstudio/tests/vc2010/test_rule_xml.lua
@@ -179,3 +179,46 @@
 </EnumProperty>
 		]]
 	end
+
+	function suite.properties_onStringWithCategory()
+		createVar { name="MyVar", kind="string", category="Custom Category" }
+		local r = test.getRule("MyRule")
+		m.properties(r)
+		test.capture [[
+<StringProperty
+	Name="MyVar"
+	HelpContext="0"
+	DisplayName="MyVar"
+	Category="Custom Category"
+	/>
+		]]
+	end
+  
+  function suite.categories_onStringWithCategory()
+		createVar { name="MyVar", kind="string", category="Custom Category" }
+		local r = test.getRule("MyRule")
+		m.categories(r)
+		test.capture [[
+<Rule.Categories>
+	<Category
+		Name="General">
+		<Category.DisplayName>
+			<sys:String>General</sys:String>
+		</Category.DisplayName>
+	</Category>
+	<Category
+		Name="Custom Category">
+		<Category.DisplayName>
+			<sys:String>Custom Category</sys:String>
+		</Category.DisplayName>
+	</Category>
+	<Category
+		Name="Command Line"
+		Subtype="CommandLine">
+		<Category.DisplayName>
+			<sys:String>Command Line</sys:String>
+		</Category.DisplayName>
+	</Category>
+</Rule.Categories>
+    ]]
+  end

--- a/modules/vstudio/vs2010_rules_xml.lua
+++ b/modules/vstudio/vs2010_rules_xml.lua
@@ -72,8 +72,24 @@
 	function m.categories(r)
 		local categories = {
 			[1] = { name="General" },
-			[2] = { name="Command Line", subtype="CommandLine" },
 		}
+		local propCategory = {}
+		local defs = r.propertydefinition
+		for i = 1, #defs do
+			local def = defs[i]
+			local cat = def.category
+			if cat then
+				if type(cat) == "string" and cat ~= "Command Line" and cat ~= "General" then
+					if not propCategory[cat] then
+						table.insert(categories, { name=cat })
+						propCategory[cat] = true
+					end
+				else
+					def.category = nil
+				end
+			end
+		end
+		table.insert(categories, { name="Command Line", subtype="CommandLine" })
 		p.push('<Rule.Categories>')
 		for i = 1, #categories do
 			m.category(categories[i])
@@ -134,6 +150,9 @@
 			p.w('DisplayName="%s"', def.display or def.name)
 			if def.description then
 				p.w('Description="%s"', def.description)
+			end
+			if def.category then
+				p.w('Category="%s"', def.category)
 			end
 		end)
 		if suffix then


### PR DESCRIPTION
Allow the usage of Categories in VS to structure properties for big rules.

Items without Category go in "General", also the Category "Command Line" is invalid.

Usage:

```lua
propertydefinition {
  name = "O0",
  switch = "/O0",
  category = "Optimizations",
}
```