### PR TITLE
Avoid impl dependent multi-char constants

### DIFF
--- a/contrib/luashim/luashim.c
+++ b/contrib/luashim/luashim.c
@@ -851,7 +851,7 @@ void shimInitialize(lua_State* L)
 
 	// Find the 'SHIM' entry in the registry.
 	const Table* reg = hvalue(&G(L)->l_registry);
-	const Node* n = findNode(reg, 'SHIM');
+	const Node* n = findNode(reg, 'S' + 'H' + 'I' + 'M');
 	assert(n != NULL);
 
 	g_shimTable = (const LuaFunctionTable_t*)n->i_val.value_.p;

--- a/contrib/luashim/luashim.c
+++ b/contrib/luashim/luashim.c
@@ -851,7 +851,7 @@ void shimInitialize(lua_State* L)
 
 	// Find the 'SHIM' entry in the registry.
 	const Table* reg = hvalue(&G(L)->l_registry);
-	const Node* n = findNode(reg, 'S' + 'H' + 'I' + 'M');
+	const Node* n = findNode(reg, 0x5348494D); // equal to 'SHIM'
 	assert(n != NULL);
 
 	g_shimTable = (const LuaFunctionTable_t*)n->i_val.value_.p;

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -194,7 +194,7 @@ int premake_init(lua_State* L)
 #endif
 
 	lua_pushlightuserdata(L, &s_shimTable);
-	lua_rawseti(L, LUA_REGISTRYINDEX, 'S' + 'H' + 'I' + 'M');
+	lua_rawseti(L, LUA_REGISTRYINDEX, 0x5348494D); // equal to 'SHIM'
 
 	/* push the application metadata */
 	lua_pushstring(L, LUA_COPYRIGHT);

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -194,7 +194,7 @@ int premake_init(lua_State* L)
 #endif
 
 	lua_pushlightuserdata(L, &s_shimTable);
-	lua_rawseti(L, LUA_REGISTRYINDEX, 'SHIM');
+	lua_rawseti(L, LUA_REGISTRYINDEX, 'S' + 'H' + 'I' + 'M');
 
 	/* push the application metadata */
 	lua_pushstring(L, LUA_COPYRIGHT);


### PR DESCRIPTION
Hello!

I was receiving this warning while compiling for linux:

```
src/host/premake.c: In function ‘premake_init’:
src/host/premake.c:197:36: warning: multi-character character constant [-Wmultichar]
  lua_rawseti(L, LUA_REGISTRYINDEX, 'SHIM');
                                    ^~~~~~
```

Instead of disabling the warning, I've decided to convert that array key to
an expression.

And I've tested with following compilers:

gcc version 7.3.0 (Ubuntu 7.3.0-27ubuntu1~18.04)
gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1)

Thank you