### PR TITLE
Fix objname collisions

### DIFF
--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -58,19 +58,19 @@
 	function cpp.initialize()
 		rule 'cpp'
 			fileExtension { ".cc", ".cpp", ".cxx", ".mm" }
-			buildoutputs  { "$(OBJDIR)/%{premake.modules.gmake2.cpp.makeUnique(cfg, file.objname)}.o" }
+			buildoutputs  { "$(OBJDIR)/%{file.objname}.o" }
 			buildmessage  '$(notdir $<)'
 			buildcommands {'$(CXX) %{premake.modules.gmake2.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"'}
 
 		rule 'cc'
 			fileExtension {".c", ".s", ".m"}
-			buildoutputs  { "$(OBJDIR)/%{premake.modules.gmake2.cpp.makeUnique(cfg, file.objname)}.o" }
+			buildoutputs  { "$(OBJDIR)/%{file.objname}.o" }
 			buildmessage  '$(notdir $<)'
 			buildcommands {'$(CC) %{premake.modules.gmake2.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"'}
 
 		rule 'resource'
 			fileExtension ".rc"
-			buildoutputs  { "$(OBJDIR)/%{premake.modules.gmake2.cpp.makeUnique(cfg, file.objname)}.res" }
+			buildoutputs  { "$(OBJDIR)/%{file.objname}.res" }
 			buildmessage  '$(notdir $<)'
 			buildcommands {'$(RESCOMP) $< -O coff -o "$@" $(ALL_RESFLAGS)'}
 
@@ -124,7 +124,6 @@
 			cfg._gmake = cfg._gmake or {}
 			cfg._gmake.filesets = {}
 			cfg._gmake.fileRules = {}
-			cfg._gmake.bases = {}
 
 			local files = table.shallowcopy(prj._.files)
 			table.foreachi(files, function(node)
@@ -767,18 +766,6 @@
 --
 -- Output the file compile targets.
 --
-
-	function cpp.makeUnique(cfg, f)
-		local cache = cfg._gmake.bases
-		local seq = cache[f]
-		if seq == nil then
-			cache[f] = 1
-			return f
-		else
-			cache[f] = seq + 1
-			return f .. tostring(seq)
-		end
-	end
 
 	cpp.elements.fileRules = function(cfg)
 		local funcs = {}

--- a/modules/gmake2/tests/test_gmake2_objects.lua
+++ b/modules/gmake2/tests/test_gmake2_objects.lua
@@ -117,6 +117,52 @@ OBJECTS += $(OBJDIR)/hello1.o
 		]]
 	end
 
+	function suite.uniqueObjNames_onBaseNameCollision2()
+		files { "a/hello.cpp", "b/hello.cpp", "c/hello1.cpp" }
+		prepare()
+		test.capture [[
+# File sets
+# #############################################
+
+OBJECTS :=
+
+OBJECTS += $(OBJDIR)/hello.o
+OBJECTS += $(OBJDIR)/hello1.o
+OBJECTS += $(OBJDIR)/hello11.o
+
+		]]
+	end
+
+	function suite.uniqueObjectNames_onBaseNameCollision_Release()
+		files { "a/hello.cpp", "b/hello.cpp", "c/hello1.cpp", "d/hello11.cpp" }
+		filter "configurations:Debug"
+			excludes {"b/hello.cpp"}
+		filter "configurations:Release"
+			excludes {"d/hello11.cpp"}
+
+		prepare()
+		test.capture [[
+# File sets
+# #############################################
+
+OBJECTS :=
+
+OBJECTS += $(OBJDIR)/hello.o
+OBJECTS += $(OBJDIR)/hello11.o
+
+ifeq ($(config),debug)
+OBJECTS += $(OBJDIR)/hello111.o
+
+else ifeq ($(config),release)
+OBJECTS += $(OBJDIR)/hello1.o
+
+else
+  $(error "invalid configuration $(config)")
+endif
+
+		]]
+	end
+
 
 --
 -- If there's a custom rule for a non-C++ file extension, make sure that those

--- a/modules/vstudio/tests/vc2010/test_files.lua
+++ b/modules/vstudio/tests/vc2010/test_files.lua
@@ -422,6 +422,64 @@
 	end
 
 
+	function suite.uniqueObjectNames_onBaseNameCollision1()
+		files { "a/hello.cpp", "b/hello.cpp", "c/hello1.cpp" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="a\hello.cpp" />
+	<ClCompile Include="b\hello.cpp">
+		<ObjectFileName>$(IntDir)\hello1.obj</ObjectFileName>
+	</ClCompile>
+	<ClCompile Include="c\hello1.cpp">
+		<ObjectFileName>$(IntDir)\hello11.obj</ObjectFileName>
+	</ClCompile>
+</ItemGroup>
+		]]
+	end
+
+
+	function suite.uniqueObjectNames_onBaseNameCollision2()
+		files { "a/hello1.cpp", "b/hello.cpp", "c/hello.cpp" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="a\hello1.cpp" />
+	<ClCompile Include="b\hello.cpp" />
+	<ClCompile Include="c\hello.cpp">
+		<ObjectFileName>$(IntDir)\hello2.obj</ObjectFileName>
+	</ClCompile>
+</ItemGroup>
+		]]
+	end
+
+
+	function suite.uniqueObjectNames_onBaseNameCollision_Release()
+		files { "a/hello.cpp", "b/hello.cpp", "c/hello1.cpp", "d/hello11.cpp" }
+		filter "configurations:Debug"
+			excludes {"b/hello.cpp"}
+		filter "configurations:Release"
+			excludes {"d/hello11.cpp"}
+
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="a\hello.cpp" />
+	<ClCompile Include="b\hello.cpp">
+		<ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+		<ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)\hello1.obj</ObjectFileName>
+	</ClCompile>
+	<ClCompile Include="c\hello1.cpp">
+		<ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)\hello11.obj</ObjectFileName>
+	</ClCompile>
+	<ClCompile Include="d\hello11.cpp">
+		<ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+	</ClCompile>
+</ItemGroup>
+		]]
+	end
+
+
 --
 -- Check handling of per-file forced includes.
 --

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -691,6 +691,29 @@
 -- conflicting object file names (i.e. src/hello.cpp and tests/hello.cpp both
 -- create hello.o).
 --
+-- a file list of: src/hello.cpp, tests/hello.cpp and src/hello1.cpp also generates
+-- conflicting object file names - hello1.o
+
+	function oven.uniqueSequence(f, cfg, seq, bases)
+		while true do
+			f.sequence = seq[cfg] or 0
+			seq[cfg] = f.sequence + 1
+
+			if seq[cfg] == 1 then
+				break
+			end
+
+			if not bases[f.objname] then
+				bases[f.objname] = {}
+			end
+
+			if not bases[f.objname][cfg] then
+				bases[f.objname][cfg] = 1
+				break
+			end
+		end
+	end
+
 
 	function oven.assignObjectSequences(prj)
 
@@ -719,8 +742,7 @@
 			for cfg in p.project.eachconfig(prj) do
 				local fcfg = p.fileconfig.getconfig(file, cfg)
 				if fcfg ~= nil and not fcfg.flags.ExcludeFromBuild then
-					fcfg.sequence = sequences[cfg] or 0
-					sequences[cfg] = fcfg.sequence + 1
+					oven.uniqueSequence(fcfg, cfg, sequences, bases)
 				end
 			end
 
@@ -728,8 +750,7 @@
 			-- this around until they do. At which point I might consider just
 			-- storing the sequence number instead of the whole object name
 
-			file.sequence = sequences[prj] or 0
-			sequences[prj] = file.sequence + 1
+			oven.uniqueSequence(file, prj, sequences, bases)
 
 		end)
 	end


### PR DESCRIPTION
Tweaks logic for setting the sequence number during baking so that objname's are unique on a per-configuration / project basis.

Should resolve #1187
Should resolve #1182 