### PR TITLE
Add tests for xcode id generator

### DIFF
--- a/modules/xcode/tests/test_xcode4_project.lua
+++ b/modules/xcode/tests/test_xcode4_project.lua
@@ -18,6 +18,7 @@
 
 	xcode.used_ids = {}
 
+	local old_idfn = xcode.newid
 	xcode.newid = function(node, usage)
 		local name = node
 		if usage then
@@ -61,6 +62,52 @@
 		xcode.prepareWorkspace(wks)
 		local prj = p.workspace.getproject(wks, 1)
 		tr = xcode.buildprjtree(prj)
+	end
+
+---------------------------------------------------------------------------
+-- xcode id generation tests
+---------------------------------------------------------------------------
+
+	local function print_id(...)
+		_p("%s - %s", xcode.newid(...), old_idfn(...))
+	end
+
+	function suite.IDGeneratorIsDeterministic()
+		print_id("project", "Debug")
+		print_id("project", "Release")
+		test.capture [[
+[project:Debug] - B266956655B21E987082EBA6
+[project:Release] - DAC961207F1BFED291544760
+		]]
+	end
+
+	function suite.IDGeneratorIsDifferent()
+		print_id("project", "Debug", "file")
+		print_id("project", "Debug", "hello")
+		test.capture [[
+[project:Debug] - 47C6E72E5ED982604EF57D6E
+[project:Debug(2)] - 8DCA12C2873014347ACB7102
+		]]
+	end
+
+	function suite.IDGeneratorSame3()
+		print_id("project", "Release", "file")
+		print_id("project", "Release", "file")
+		print_id("project", "Release", "file")
+		test.capture [[
+[project:Release] - 022ECCE82854FC9A8F5BF328
+[project:Release(2)] - 022ECCE82854FC9A8F5BF328
+[project:Release(3)] - 022ECCE82854FC9A8F5BF328
+		]]
+	end
+
+	function suite.IDGeneratorMoreThanNecessary()
+		print_id("a", "b", "c", "d", "e", "f")
+		print_id("abcdef")
+		test.capture [[
+[a:b] - 63AEF3DD89D5238FF0DC1A1D
+[abcdef] - 9F1AF6957CC5F947506A7CD5
+		]]
 	end
 
 ---------------------------------------------------------------------------

--- a/src/host/os_uuid.c
+++ b/src/host/os_uuid.c
@@ -16,7 +16,7 @@
  * without the help of the determinately sized C99 data types that
  * are not yet universally supported.
  */
-static void add(unsigned char* bytes, int offset, unsigned long value)
+static void add(unsigned char* bytes, int offset, uint32_t value)
 {
 	int i;
 	for (i = 0; i < 4; ++i)

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -53,6 +53,7 @@
 #else
 #include <unistd.h>
 #endif
+#include <stdint.h>
 
 /* not all platforms define this */
 #ifndef FALSE
@@ -85,7 +86,7 @@ extern const char* scripts_path;
 
 /* Bootstrapping helper functions */
 int do_chdir(lua_State* L, const char* path);
-unsigned long do_hash(const char* str, int seed);
+uint32_t do_hash(const char* str, int seed);
 void do_getabsolute(char* result, const char* value, const char* relative_to);
 int do_getcwd(char* buffer, size_t size);
 int do_isabsolute(const char* path);

--- a/src/host/string_hash.c
+++ b/src/host/string_hash.c
@@ -17,11 +17,11 @@ int string_hash(lua_State* L)
 }
 
 
-unsigned long do_hash(const char* str, int seed)
+uint32_t do_hash(const char* str, int seed)
 {
 	/* DJB2 hashing; see http://www.cse.yorku.ca/~oz/hash.html */
 
-	unsigned long hash = 5381;
+	uint32_t hash = 5381;
 
 	if (seed != 0) {
 		hash = hash * 33 + seed;


### PR DESCRIPTION
the 'long' type is not always of size four bytes - which is what the current code assumes. Changed to uint32_t and added tests for the xcode id-generator.