### PR TITLE
Add support for JavaCompile in vsandroid

### DIFF
--- a/modules/android/tests/_tests.lua
+++ b/modules/android/tests/_tests.lua
@@ -1,5 +1,6 @@
 require ("android")
 
 return {
-	"test_android_project.lua"
+	"test_android_files.lua",
+	"test_android_project.lua",
 }

--- a/modules/android/tests/test_android_files.lua
+++ b/modules/android/tests/test_android_files.lua
@@ -1,0 +1,47 @@
+local p = premake
+local suite = test.declare("test_android_files")
+local vc2010 = p.vstudio.vc2010
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2015")
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		prj = test.getproject(wks, 1)
+		system "android"
+		vc2010.files(prj)
+	end
+
+
+--
+-- Test filtering of source files into the correct categories.
+--
+
+	function suite.none_onJavaFile()
+		files { "hello.java" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<None Include="hello.java" />
+</ItemGroup>
+		]]
+	end
+
+	function suite.javaCompile_onJavaFile()
+		kind "androidproj"
+		files { "hello.java" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<JavaCompile Include="hello.java" />
+</ItemGroup>
+		]]
+	end

--- a/modules/android/vsandroid_androidproj.lua
+++ b/modules/android/vsandroid_androidproj.lua
@@ -220,6 +220,19 @@
 		end
 	}
 
+	vc2010.categories.JavaCompile = {
+		name = "JavaCompile",
+		priority = 99,
+
+		emitFiles = function(prj, group)
+			vc2010.emitFiles(prj, group, "JavaCompile", {vc2010.generatedFile, android.link})
+		end,
+
+		emitFilter = function(prj, group)
+			vc2010.filterGroup(prj, group, "JavaCompile")
+		end
+	}
+
 	vc2010.categories.Content = {
 		name = "Content",
 		priority = 99,
@@ -239,6 +252,7 @@
 		end
 
 		local filename = path.getname(file.name):lower()
+		local extension = path.getextension(filename)
 
 		if filename == "androidmanifest.xml" then
 			return vc2010.categories.AndroidManifest
@@ -246,6 +260,8 @@
 			return vc2010.categories.AntBuildXml
 		elseif filename == "project.properties" then
 			return vc2010.categories.AntProjectPropertiesFile
+		elseif extension == ".java" then
+			return vc2010.categories.JavaCompile
 		else
 			return vc2010.categories.Content
 		end


### PR DESCRIPTION
Set `ItemGroup` to`JavaCompile` when add ".java" files to ".androidproj".