### PR TITLE
Add support & tests for XCTest sharedlibtype

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -215,6 +215,30 @@
 		]]
 	end
 
+	function suite.PBXFileReference_ListsXCTestTarget()
+		kind "SharedLib"
+		sharedlibtype "XCTest"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[MyProject.xctest:product] /* MyProject.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.xctest; path = MyProject.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+	function suite.PBXFileReference_ListsIOSXCTestTarget()
+		_TARGET_OS = "ios"
+		kind "SharedLib"
+		sharedlibtype "XCTest"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		[MyProject.xctest:product] /* MyProject.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.xctest; path = MyProject.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
 
 	function suite.PBXFileReference_ListsOSXFrameworkTarget()
 		kind "SharedLib"
@@ -1287,6 +1311,26 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationTarget_OnXCTest()
+		kind "SharedLib"
+		sharedlibtype "XCTest"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		[MyProject.xctest:Debug] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
 				PRODUCT_NAME = MyProject;
 			};
 			name = Debug;

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -268,6 +268,7 @@
 			SharedLib    = "com.apple.product-type.library.dynamic",
 			OSXBundle    = "com.apple.product-type.bundle",
 			OSXFramework = "com.apple.product-type.framework",
+			XCTest       = "com.apple.product-type.bundle.unit-test",
 		}
 		return types[iif(node.cfg.kind == "SharedLib" and node.cfg.sharedlibtype, node.cfg.sharedlibtype, node.cfg.kind)]
 	end
@@ -290,6 +291,7 @@
 			SharedLib    = "\"compiled.mach-o.dylib\"",
 			OSXBundle    = "wrapper.cfbundle",
 			OSXFramework = "wrapper.framework",
+			XCTest       = "wrapper.cfbundle",
 		}
 		return types[iif(node.cfg.kind == "SharedLib" and node.cfg.sharedlibtype, node.cfg.sharedlibtype, node.cfg.kind)]
 	end
@@ -1125,6 +1127,7 @@
 				StaticLib    = "a",
 				OSXBundle    = "bundle",
 				OSXFramework = "framework",
+				XCTest       = "xctest",
 			}
 			local ext = cfg.buildtarget.extension:sub(2)
 			if ext ~= exts[iif(cfg.kind == "SharedLib" and cfg.sharedlibtype, cfg.sharedlibtype, cfg.kind)] then

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -708,6 +708,7 @@
 		allowed = {
 			"OSXBundle",
 			"OSXFramework",
+			"XCTest",
 		},
 	}
 
@@ -1777,6 +1778,10 @@
 	filter { "system:darwin", "kind:SharedLib", "sharedlibtype:OSXFramework" }
 		targetprefix ""
 		targetextension ".framework"
+
+	filter { "system:darwin", "kind:SharedLib", "sharedlibtype:XCTest" }
+		targetprefix ""
+		targetextension ".xctest"
 
 	-- Windows and friends.
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -306,6 +306,8 @@
 		if table.contains(os.getSystemTags(cfg.system), "darwin") then
 			if cfg.sharedlibtype == "OSXBundle" then
 				return "-bundle"
+			elseif cfg.sharedlibtype == "XCTest" then
+				return "-bundle"
 			elseif cfg.sharedlibtype == "OSXFramework" then
 				return "-framework"
 			else

--- a/tests/config/test_targetinfo.lua
+++ b/tests/config/test_targetinfo.lua
@@ -231,6 +231,18 @@
 		test.isequal("bin/Debug/MyProject.bundle/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
 	end
 
+--
+-- Bundle path should be set for macOS/iOS cocoa unit test bundle.
+--
+
+	function suite.bundlepathSet_onMacSharedLibXCTest()
+		kind "SharedLib"
+		sharedlibtype "XCTest"
+		system "macosx"
+		i = prepare()
+		test.isequal("bin/Debug/MyProject.xctest/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
+	end
+
 
 --
 -- Bundle path should be set for macOS/iOS framework.

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -353,6 +353,14 @@
 		test.contains({ "-Wl,-x", "-bundle" }, gcc.getldflags(cfg))
 	end
 
+	function suite.ldflags_onMacOSXXCTest()
+		system "MacOSX"
+		kind "SharedLib"
+		sharedlibtype "XCTest"
+		prepare()
+		test.contains({ "-Wl,-x", "-bundle" }, gcc.getldflags(cfg))
+	end
+
 	function suite.ldflags_onMacOSXFramework()
 		system "MacOSX"
 		kind "SharedLib"


### PR DESCRIPTION
.xctest files are OSXBundles that have executable code in them that Xcode uses to populate its integrated [unit testing UI](https://developer.apple.com/documentation/xctest). Since premake supports OSXBundles through the [sharedlibtype API](https://github.com/premake/premake-core/wiki/sharedlibtype) I extended that support to also include xctest. 

My use case was wanting to use premake rather than cmake with [CUTI](https://github.com/k-brac/CUTI) a C++ unit testing wrapper that integrates with XCode & Visual Studio, but others may find it helpful for swift or objective-c projects that include unit tests. 