### PR TITLE
Implement the androidapilevel() API in Android packaging projects

### DIFF
--- a/modules/android/vsandroid_androidproj.lua
+++ b/modules/android/vsandroid_androidproj.lua
@@ -80,10 +80,18 @@
 	end
 
 
+	function android.androidAPILevel(cfg)
+		if cfg.androidapilevel ~= nil then
+			_p(2,'<AndroidAPILevel>android-%d</AndroidAPILevel>', cfg.androidapilevel)
+		end
+	end
+
+
 	premake.override(vc2010.elements, "configurationProperties", function(oldfn, cfg)
 		local elements = oldfn(cfg)
 		if cfg.kind == p.ANDROIDPROJ then
 			elements = {
+				android.androidAPILevel,
 				vc2010.useDebugLibraries,
 			}
 		end
@@ -156,7 +164,7 @@
 		-- below. Otherwise the function will use target seperator which
 		-- could be '\\' and result in failure to create links.
 		local fname = path.translate(file.relpath, '/')
-		
+
 		-- Files that live outside of the project tree need to be "linked"
 		-- and provided with a project relative pseudo-path. Check for any
 		-- leading "../" sequences and, if found, remove them and mark this

--- a/modules/android/vsandroid_androidproj.lua
+++ b/modules/android/vsandroid_androidproj.lua
@@ -80,13 +80,6 @@
 	end
 
 
-	function android.androidAPILevel(cfg)
-		if cfg.androidapilevel ~= nil then
-			_p(2,'<AndroidAPILevel>android-%d</AndroidAPILevel>', cfg.androidapilevel)
-		end
-	end
-
-
 	premake.override(vc2010.elements, "configurationProperties", function(oldfn, cfg)
 		local elements = oldfn(cfg)
 		if cfg.kind == p.ANDROIDPROJ then


### PR DESCRIPTION
The `androidapilevel` API is only implemented for shared library projects. Typically, one would want to change the SDK version for the APK project as well. When you don't specify it, VS picks `android-21` as the default `compileSdkVersion` for you. This PR adds support for `AndroidAPILevel` for APK projects (the code is simply taken from `vsandroid_vcxproj.lua`).