### PR TITLE
add nil check to fileconfig.hasFileSetting (gmake)

### DIFF
--- a/src/base/fileconfig.lua
+++ b/src/base/fileconfig.lua
@@ -186,6 +186,9 @@
 --
 
 	function fileconfig.hasFileSettings(fcfg)
+		if not fcfg then
+			return false
+		end
 		for key, field in pairs(p.fields) do
 			if field.scopes[1] == "config" then
 				local value = fcfg[field.name]


### PR DESCRIPTION
fix for #1219 
`fileconfig.hasFileSettings` is as far as i see only used in gmake_cpp.lua so it should be safe