### PR TITLE
Added support for generating .NET Core projects.

### DIFF
--- a/modules/vstudio/_manifest.lua
+++ b/modules/vstudio/_manifest.lua
@@ -23,4 +23,5 @@ return {
 	"vs2013.lua",
 	"vs2015.lua",
 	"vs2017.lua",
+	"netcore.lua",
 }

--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -20,6 +20,7 @@
 	include("vs2013.lua")
 	include("vs2015.lua")
 	include("vs2017.lua")
+	include("netcore.lua")
 
 	-- Initialize Specific API
 
@@ -140,5 +141,6 @@
 			_ACTION == "vs2012" or
 			_ACTION == "vs2013" or
 			_ACTION == "vs2015" or
-			_ACTION == "vs2017";
+			_ACTION == "vs2017" or
+			_ACTION == "netcore";
 	end

--- a/modules/vstudio/netcore.lua
+++ b/modules/vstudio/netcore.lua
@@ -1,0 +1,66 @@
+--
+-- netcore.lua
+-- Extend the existing exporters with support for .NET Core targets.
+-- Copyright (c) Jason Perkins and the Premake project
+--
+
+local p = premake
+local vstudio = p.vstudio
+
+---
+-- Define the .NET Core export action.
+---
+
+newaction {
+    -- Metadata for the command line and help system
+
+    trigger     = "netcore",
+    shortname   = ".NET Core (MSBuild)",
+    description = "Generate .NET Core MSBuild project files.",
+
+    -- Visual Studio always uses Windows path and naming conventions
+
+    targetos = "windows",
+    toolset  = "dotnet",
+
+    -- The capabilities of this action
+
+    valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility" },
+    valid_languages = { "C#", "F#" },
+    valid_tools     = {
+        dotnet = { "msnet" },
+    },
+
+    -- Workspace and project generation logic
+
+    onWorkspace = function(wks)
+        p.vstudio.vs2005.generateSolution(wks)
+    end,
+    onProject = function(prj)
+        p.vstudio.vs2010.generateProject(prj)
+    end,
+    onRule = function(rule)
+        p.vstudio.vs2010.generateRule(rule)
+    end,
+
+    onCleanWorkspace = function(wks)
+        p.vstudio.cleanSolution(wks)
+    end,
+    onCleanProject = function(prj)
+        p.vstudio.cleanProject(prj)
+    end,
+    onCleanTarget = function(prj)
+        p.vstudio.cleanTarget(prj)
+    end,
+
+    pathVars = vstudio.vs2010.pathVars,
+
+
+    -- This stuff is specific to the Visual Studio exporters
+
+    vstudio = {
+        solutionVersion = "12",
+        versionName     = "15",
+        targetFramework = "netstandard2.0",
+    }
+}

--- a/modules/vstudio/tests/cs2005/projectsettings.lua
+++ b/modules/vstudio/tests/cs2005/projectsettings.lua
@@ -7,8 +7,8 @@
 	local p = premake
 	local suite = test.declare("vstudio_dn2005_projectsettings")
 	local dn2005 = p.vstudio.dotnetbase
+	local netcore = p.vstudio.netcore
 	local cs2005 = p.vstudio.cs2005
-
 
 --
 -- Setup
@@ -26,7 +26,8 @@
 	local function prepare()
 		prj = test.getproject(wks, 1)
 
-		dn2005.prepare(cs2005)
+		local cs = _ACTION == "netcore" and netcore or cs2005
+		dn2005.prepare(cs)
 		dn2005.projectProperties(prj)
 	end
 
@@ -34,6 +35,20 @@
 --
 -- Version Tests
 --
+
+	function suite.OnNetCore()
+		p.action.set("netcore")
+		prepare()
+		test.capture [[
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<AssemblyName>MyProject</AssemblyName>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+	</PropertyGroup>
+		]]
+	end
+
 
 	function suite.OnVs2005()
 		prepare()

--- a/modules/vstudio/tests/cs2005/test_project_refs.lua
+++ b/modules/vstudio/tests/cs2005/test_project_refs.lua
@@ -35,8 +35,6 @@
 	function suite.emptyGroup_onNoDependencies()
 		prepare()
 		test.capture [[
-	<ItemGroup>
-	</ItemGroup>
 		]]
 	end
 
@@ -63,8 +61,6 @@
 		dependson { "MyProject" }
 		prepare()
 		test.capture [[
-	<ItemGroup>
-	</ItemGroup>
 		]]
 	end
 

--- a/modules/vstudio/tests/dotnet2005/projectelement.lua
+++ b/modules/vstudio/tests/dotnet2005/projectelement.lua
@@ -7,7 +7,7 @@
 	local p = premake
 	local suite = test.declare("vstudio_dn2005_projectelement")
 	local dn2005 = p.vstudio.dotnetbase
-
+	local netcore = p.vstudio.dotnetbase.netcore
 
 --
 -- Setup
@@ -23,7 +23,6 @@
 		dn2005.xmlDeclaration()
 		dn2005.projectElement(prj)
 	end
-
 
 --
 -- Tests
@@ -91,5 +90,21 @@
 		test.capture [[
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+		]]
+	end
+
+---
+--- .NET Core tests
+---
+
+	local function prepareNetcore()
+		netcore.projectElement(prj)
+	end
+
+	function suite.onNetcore()
+		p.action.set("netcore")
+		prepareNetcore()
+		test.capture [[
+<Project Sdk="Microsoft.NET.Sdk">
 		]]
 	end

--- a/modules/vstudio/vs2005_csproj.lua
+++ b/modules/vstudio/vs2005_csproj.lua
@@ -6,9 +6,11 @@
 
 	local p = premake
 	p.vstudio.cs2005 = {}
-
+	p.vstudio.netcore = {}
+	
 	local vstudio = p.vstudio
 	local cs2005 = p.vstudio.cs2005
+	local netcore = p.vstudio.netcore
 	local dotnetbase = p.vstudio.dotnetbase
 	local project = p.project
 	local config = p.config
@@ -60,7 +62,11 @@
 	end
 
 	function cs2005.generate(prj)
-		dotnetbase.prepare(cs2005)
+		if _ACTION == "netcore" then
+			dotnetbase.prepare(netcore)
+		else
+			dotnetbase.prepare(cs2005)
+		end
 		dotnetbase.generate(prj)
 	end
 
@@ -74,4 +80,41 @@
 		_p(1,'<Target Name="AfterBuild">')
 		_p(1,'</Target>')
 		_p(1,'-->')
+	end
+
+	---
+	--- .NET Core elements
+	---
+
+	netcore.elements = {}
+
+	netcore.elements.project = function ()
+		return {
+			dotnetbase.netcore.projectElement,
+			dotnetbase.projectProperties,
+			dotnetbase.configurations,
+			dotnetbase.applicationIcon,
+			dotnetbase.references
+		}
+	end
+
+	netcore.elements.projectProperties = function ()
+		return {
+			dotnetbase.outputType,
+			dotnetbase.assemblyName,
+			dotnetbase.netcore.targetFramework,
+			dotnetbase.targetFrameworkProfile,
+			dotnetbase.csversion,
+			dotnetbase.netcore.enableDefaultCompileItems
+		}
+	end
+
+	netcore.elements.configuration = function ()
+		return {
+			dotnetbase.propertyGroup,
+			dotnetbase.debugProps,
+			dotnetbase.outputProps,
+			dotnetbase.compilerProps,
+			dotnetbase.NoWarn
+		}
 	end

--- a/modules/vstudio/vs2010_nuget.lua
+++ b/modules/vstudio/vs2010_nuget.lua
@@ -39,7 +39,7 @@
 	end
 
 	function nuget2010.supportsPackageReferences(prj)
-		return _ACTION >= "vs2017" and p.project.isdotnet(prj)
+		return (_ACTION >= "vs2017" or _ACTION == "netcore") and p.project.isdotnet(prj)
 	end
 
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -28,6 +28,7 @@
 			p.X86_64,
 			p.ARM,
 			p.ARM64,
+			p.ANYCPU
 		},
 		aliases = {
 			i386  = p.X86,

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -56,7 +56,7 @@
 	premake.X86_64      = "x86_64"
 	premake.ARM         = "ARM"
 	premake.ARM64       = "ARM64"
-
+	premake.ANYCPU      = "AnyCPU"
 
 
 ---

--- a/src/tools/dotnet.lua
+++ b/src/tools/dotnet.lua
@@ -323,3 +323,28 @@
 	function dotnet.getmakesettings(cfg)
 		return nil
 	end
+
+---
+--- Returns if a project is a .NET Core target.
+---
+	function dotnet.isnetcoretarget(prj)
+		if prj == nil or prj.dotnetframework == nil then
+			return false
+		end
+		netcoretargets = {
+			["netstandard1.0"] = true,
+			["netstandard1.1"] = true,
+			["netstandard1.2"] = true,
+			["netstandard1.3"] = true,
+			["netstandard1.4"] = true,
+			["netstandard1.5"] = true,
+			["netstandard1.6"] = true,
+			["netstandard2.0"] = true,
+			["netcoreapp1.0"]= true,
+			["netcoreapp1.1"]= true,
+			["netcoreapp2.0"]= true,
+			["netcoreapp2.1"]= true,
+			["netcoreapp2.2"]= true
+		}
+		return netcoretargets[prj.dotnetframework] ~= nil
+	end


### PR DESCRIPTION
This adds a new action `netcore` that generates new style MSBuild `.csproj` projects for .NET Core.

This has been tested on CppSharp project, and it gets us far enough for a working build.

Also snuck in a fix to prevent us from generating empty property groups.

Related issue: https://github.com/premake/premake-core/issues/1010