### PR TITLE
Default to Roslyn-based `csc` compiler on all platforms.

### DIFF
--- a/src/tools/dotnet.lua
+++ b/src/tools/dotnet.lua
@@ -247,7 +247,7 @@
 		}
 
 		if tool == "csc" then
-			local toolset = _OPTIONS.dotnet or iif(os.istarget("windows"), "msnet", "mono")
+			local toolset = _OPTIONS.dotnet or "msnet"
 			return compilers[toolset]
 		else
 			return "resgen"

--- a/tests/tools/test_dotnet.lua
+++ b/tests/tools/test_dotnet.lua
@@ -42,7 +42,7 @@
 	function suite.defaultCompiler_onMacOSX()
 		_TARGET_OS = "macosx"
 		prepare()
-		test.isequal("mcs", dotnet.gettoolname(cfg, "csc"))
+		test.isequal("csc", dotnet.gettoolname(cfg, "csc"))
 	end
 
 


### PR DESCRIPTION
Mono has switched to the Roslyn compiler in its latest releases, so default to it going forward.

Users can still set `mcs` compiler manually, but since it does not support newer language versions, it doesn't make as much sense to be the default.