### PR TITLE
do not clear _isIncludingExternal in nested calls

### DIFF
--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -82,10 +82,11 @@
 
 	function includeexternal(fname)
 		local fullPath = p.findProjectScript(fname)
+		local wasIncludingExternal = api._isIncludingExternal
 		api._isIncludingExternal = true
 		fname = fullPath or fname
 		dofile(fname)
-		api._isIncludingExternal = nil
+		api._isIncludingExternal = wasIncludingExternal
 	end
 
 	p.alias(_G, "includeexternal", "includeExternal")


### PR DESCRIPTION
nested includeexternal calls should not clear the state of their parent call

@Sairony's fix from #1001 