### PR TITLE
GameBoy build support

### DIFF
--- a/modules/gmake/_preload.lua
+++ b/modules/gmake/_preload.lua
@@ -20,7 +20,7 @@
 		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Utility", "Makefile", "GameBoyApp" },
 		valid_languages = { "C", "C++", "C#" },
 		valid_tools     = {
-			cc     = { "clang", "gcc" },
+			cc     = { "clang", "gcc", "lcc" },
 			dotnet = { "mono", "msnet", "pnet" }
 		},
 

--- a/modules/gmake/_preload.lua
+++ b/modules/gmake/_preload.lua
@@ -17,7 +17,7 @@
 		description     = "Generate GNU makefiles for POSIX, MinGW, and Cygwin",
 		toolset         = "gcc",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Utility", "Makefile" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Utility", "Makefile", "GameBoyApp" },
 		valid_languages = { "C", "C++", "C#" },
 		valid_tools     = {
 			cc     = { "clang", "gcc" },

--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -184,7 +184,14 @@
 			local iscfile = node and path.iscfile(node.abspath) or false
 			flags = iif(prj.language == "C" or iscfile, '$(CC) $(ALL_CFLAGS)', '$(CXX) $(ALL_CXXFLAGS)')
 		end
-		_p('\t$(SILENT) %s $(FORCE_INCLUDE) -o "$@" -MF "$(@:%%.%s=%%.d)" -c "$<"', flags, objext)
+
+		local buildCommand = '\t$(SILENT) %s $(FORCE_INCLUDE) -o "$@"'
+		if prj.kind ~= p.GAMEBOYAPP then
+			buildCommand = buildCommand .. ' -MF "$(@:%%.%s=%%.d)"'
+		end
+		buildCommand = buildCommand .. ' -c "$<"'
+
+		_p(buildCommand, flags, objext)
 	end
 
 
@@ -619,7 +626,14 @@ end
 		_p('\t@echo $(notdir $<)')
 
 		local cmd = iif(prj.language == "C", "$(CC) -x c-header $(ALL_CFLAGS)", "$(CXX) -x c++-header $(ALL_CXXFLAGS)")
-		_p('\t$(SILENT) %s -o "$@" -MF "$(@:%%.gch=%%.d)" -c "$<"', cmd)
+
+		pchBuildCommand = '\t$(SILENT) %s -o "$@"'
+		if prj.kind ~= p.GAMEBOYAPP then
+			pchBuildCommand = pchBuildCommand .. ' -MF "$(@:%%.gch=%%.d)"'
+		end
+		pchBuildCommand =  pchBuildCommand .. ' -c "$<"'
+
+		_p(pchBuildCommand, cmd)
 
 		_p('else')
 		_p('$(OBJECTS): | $(OBJDIR)')

--- a/src/_manifest.lua
+++ b/src/_manifest.lua
@@ -63,6 +63,7 @@
 		"tools/msc.lua",
 		"tools/snc.lua",
 		"tools/clang.lua",
+		"tools/lcc.lua",
 
 		-- Clean action
 		"actions/clean/_clean.lua",

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1639,6 +1639,7 @@
 		allowed = {
 			{ "clang", "Clang (clang)" },
 			{ "gcc", "GNU GCC (gcc/g++)" },
+			{ "lcc", "GNU GCC based GameBoy compiler"},
 		}
 	}
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -701,6 +701,7 @@
 			"StaticLib",
 			"WindowedApp",
 			"Utility",
+			"GameBoyApp"
 		},
 	}
 
@@ -1765,6 +1766,9 @@
 	filter { "kind:StaticLib" }
 		targetprefix "lib"
 		targetextension ".a"
+
+	filter { "kind:GameBoyApp"}
+		targetextension ".gb"
 
 	-- Add variations for other Posix-like systems.
 

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -32,6 +32,7 @@
 	premake.CONSOLEAPP  = "ConsoleApp"
 	premake.CPP         = "C++"
 	premake.CSHARP      = "C#"
+	premake.GAMEBOYAPP	= "GameBoyApp"
 	premake.GCC         = "gcc"
 	premake.HAIKU       = "haiku"
 	premake.IOS         = "ios"

--- a/src/tools/lcc.lua
+++ b/src/tools/lcc.lua
@@ -1,0 +1,313 @@
+--
+-- lcc.lua
+-- Clang toolset adapter for Premake
+-- Copyright (c) 2013 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	p.tools.lcc = {}
+	local lcc = p.tools.lcc
+	local gcc = p.tools.gcc
+	local config = p.config
+
+
+
+--
+-- Build a list of flags for the C preprocessor corresponding to the
+-- settings in a particular project configuration.
+--
+-- @param cfg
+--    The project configuration.
+-- @return
+--    An array of C preprocessor flags.
+--
+
+	function lcc.getcppflags(cfg)
+
+		-- Just pass through to GCC for now
+		local flags = gcc.getcppflags(cfg)
+		return flags
+
+	end
+
+
+--
+-- Build a list of C compiler flags corresponding to the settings in
+-- a particular project configuration. These flags are exclusive
+-- of the C++ compiler flags, there is no overlap.
+--
+-- @param cfg
+--    The project configuration.
+-- @return
+--    An array of C compiler flags.
+--
+
+	lcc.shared = {
+		architecture = gcc.shared.architecture,
+		flags = gcc.shared.flags,
+		floatingpoint = {
+			Fast = "-ffast-math",
+		},
+		strictaliasing = gcc.shared.strictaliasing,
+		optimize = {
+			Off = "-O0",
+			On = "-O2",
+			Debug = "-O0",
+			Full = "-O3",
+			Size = "-Os",
+			Speed = "-O3",
+		},
+		pic = gcc.shared.pic,
+		vectorextensions = gcc.shared.vectorextensions,
+		isaextensions = gcc.shared.isaextensions,
+		warnings = gcc.shared.warnings,
+		symbols = gcc.shared.symbols,
+		unsignedchar = gcc.shared.unsignedchar,
+		omitframepointer = gcc.shared.omitframepointer
+	}
+
+	lcc.cflags = table.merge(gcc.cflags, {
+	})
+
+	function lcc.getcflags(cfg)
+		local shared = config.mapFlags(cfg, lcc.shared)
+		local cflags = config.mapFlags(cfg, lcc.cflags)
+
+		local flags = table.join(shared, cflags)
+		flags = table.join(flags, lcc.getwarnings(cfg))
+
+		return flags
+	end
+
+	function lcc.getwarnings(cfg)
+		return gcc.getwarnings(cfg)
+	end
+
+
+--
+-- Build a list of C++ compiler flags corresponding to the settings
+-- in a particular project configuration. These flags are exclusive
+-- of the C compiler flags, there is no overlap.
+--
+-- @param cfg
+--    The project configuration.
+-- @return
+--    An array of C++ compiler flags.
+--
+
+	lcc.cxxflags = table.merge(gcc.cxxflags, {
+	})
+
+	function lcc.getcxxflags(cfg)
+		local shared = config.mapFlags(cfg, lcc.shared)
+		local cxxflags = config.mapFlags(cfg, lcc.cxxflags)
+		local flags = table.join(shared, cxxflags)
+		flags = table.join(flags, lcc.getwarnings(cfg))
+		return flags
+	end
+
+
+--
+-- Returns a list of defined preprocessor symbols, decorated for
+-- the compiler command line.
+--
+-- @param defines
+--    An array of preprocessor symbols to define; as an array of
+--    string values.
+-- @return
+--    An array of symbols with the appropriate flag decorations.
+--
+
+	function lcc.getdefines(defines)
+
+		-- Just pass through to GCC for now
+		local flags = gcc.getdefines(defines)
+		return flags
+
+	end
+
+	function lcc.getundefines(undefines)
+
+		-- Just pass through to GCC for now
+		local flags = gcc.getundefines(undefines)
+		return flags
+
+	end
+
+
+
+--
+-- Returns a list of forced include files, decorated for the compiler
+-- command line.
+--
+-- @param cfg
+--    The project configuration.
+-- @return
+--    An array of force include files with the appropriate flags.
+--
+
+	function lcc.getforceincludes(cfg)
+
+		-- Just pass through to GCC for now
+		local flags = gcc.getforceincludes(cfg)
+		return flags
+
+	end
+
+
+--
+-- Returns a list of include file search directories, decorated for
+-- the compiler command line.
+--
+-- @param cfg
+--    The project configuration.
+-- @param dirs
+--    An array of include file search directories; as an array of
+--    string values.
+-- @return
+--    An array of symbols with the appropriate flag decorations.
+--
+
+	function lcc.getincludedirs(cfg, dirs, sysdirs)
+
+		-- Just pass through to GCC for now
+		local flags = gcc.getincludedirs(cfg, dirs, sysdirs)
+		return flags
+
+	end
+
+	lcc.getrunpathdirs = gcc.getrunpathdirs
+
+--
+-- get the right output flag.
+--
+	function lcc.getsharedlibarg(cfg)
+		return gcc.getsharedlibarg(cfg)
+	end
+
+--
+-- Build a list of linker flags corresponding to the settings in
+-- a particular project configuration.
+--
+-- @param cfg
+--    The project configuration.
+-- @return
+--    An array of linker flags.
+--
+
+	lcc.ldflags = {
+		architecture = {
+			x86 = "-m32",
+			x86_64 = "-m64",
+		},
+		flags = {
+			LinkTimeOptimization = "-flto",
+		},
+		kind = {
+			SharedLib = function(cfg)
+				local r = { lcc.getsharedlibarg(cfg) }
+				if cfg.system == "windows" and not cfg.flags.NoImportLib then
+					table.insert(r, '-Wl,--out-implib="' .. cfg.linktarget.relpath .. '"')
+				elseif cfg.system == p.LINUX then
+					table.insert(r, '-Wl,-soname=' .. p.quoted(cfg.linktarget.name))
+				elseif table.contains(os.getSystemTags(cfg.system), "darwin") then
+					table.insert(r, '-Wl,-install_name,' .. p.quoted('@rpath/' .. cfg.linktarget.name))
+				end
+				return r
+			end,
+			WindowedApp = function(cfg)
+				if cfg.system == p.WINDOWS then return "-mwindows" end
+			end,
+		},
+		system = {
+			wii = "$(MACHDEP)",
+		}
+	}
+
+	function lcc.getldflags(cfg)
+		local flags = config.mapFlags(cfg, lcc.ldflags)
+		return flags
+	end
+
+
+
+--
+-- Build a list of additional library directories for a particular
+-- project configuration, decorated for the tool command line.
+--
+-- @param cfg
+--    The project configuration.
+-- @return
+--    An array of decorated additional library directories.
+--
+
+	function lcc.getLibraryDirectories(cfg)
+
+		-- Just pass through to GCC for now
+		local flags = gcc.getLibraryDirectories(cfg)
+		return flags
+
+	end
+
+
+--
+-- Build a list of libraries to be linked for a particular project
+-- configuration, decorated for the linker command line.
+--
+-- @param cfg
+--    The project configuration.
+-- @param systemOnly
+--    Boolean flag indicating whether to link only system libraries,
+--    or system libraries and sibling projects as well.
+-- @return
+--    A list of libraries to link, decorated for the linker.
+--
+
+	function lcc.getlinks(cfg, systemonly, nogroups)
+		return gcc.getlinks(cfg, systemonly, nogroups)
+	end
+
+
+--
+-- Return a list of makefile-specific configuration rules. This will
+-- be going away when I get a chance to overhaul these adapters.
+--
+-- @param cfg
+--    The project configuration.
+-- @return
+--    A list of additional makefile rules.
+--
+
+	function lcc.getmakesettings(cfg)
+
+		-- Just pass through to GCC for now
+		local flags = gcc.getmakesettings(cfg)
+		return flags
+
+	end
+
+
+--
+-- Retrieves the executable command name for a tool, based on the
+-- provided configuration and the operating environment. I will
+-- be moving these into global configuration blocks when I get
+-- the chance.
+--
+-- @param cfg
+--    The configuration to query.
+-- @param tool
+--    The tool to fetch, one of "cc" for the C compiler, "cxx" for
+--    the C++ compiler, or "ar" for the static linker.
+-- @return
+--    The executable command name for a tool, or nil if the system's
+--    default value should be used.
+--
+
+	lcc.tools = {
+		cc = "lcc",
+		ar = "ar"
+	}
+
+	function lcc.gettoolname(cfg, tool)
+		return lcc.tools[tool]
+	end

--- a/src/tools/lcc.lua
+++ b/src/tools/lcc.lua
@@ -42,32 +42,8 @@
 --    An array of C compiler flags.
 --
 
-	lcc.shared = {
-		architecture = gcc.shared.architecture,
-		flags = gcc.shared.flags,
-		floatingpoint = {
-			Fast = "-ffast-math",
-		},
-		strictaliasing = gcc.shared.strictaliasing,
-		optimize = {
-			Off = "-O0",
-			On = "-O2",
-			Debug = "-O0",
-			Full = "-O3",
-			Size = "-Os",
-			Speed = "-O3",
-		},
-		pic = gcc.shared.pic,
-		vectorextensions = gcc.shared.vectorextensions,
-		isaextensions = gcc.shared.isaextensions,
-		warnings = gcc.shared.warnings,
-		symbols = gcc.shared.symbols,
-		unsignedchar = gcc.shared.unsignedchar,
-		omitframepointer = gcc.shared.omitframepointer
-	}
-
-	lcc.cflags = table.merge(gcc.cflags, {
-	})
+	lcc.shared = table.merge(gcc.shared, {})
+	lcc.cflags = table.merge(gcc.cflags, {})
 
 	function lcc.getcflags(cfg)
 		local shared = config.mapFlags(cfg, lcc.shared)
@@ -95,8 +71,7 @@
 --    An array of C++ compiler flags.
 --
 
-	lcc.cxxflags = table.merge(gcc.cxxflags, {
-	})
+	lcc.cxxflags = table.merge(gcc.cxxflags, {})
 
 	function lcc.getcxxflags(cfg)
 		local shared = config.mapFlags(cfg, lcc.shared)
@@ -185,52 +160,12 @@
 		return gcc.getsharedlibarg(cfg)
 	end
 
---
--- Build a list of linker flags corresponding to the settings in
--- a particular project configuration.
---
--- @param cfg
---    The project configuration.
--- @return
---    An array of linker flags.
---
-
-	lcc.ldflags = {
-		architecture = {
-			x86 = "-m32",
-			x86_64 = "-m64",
-		},
-		flags = {
-			LinkTimeOptimization = "-flto",
-		},
-		kind = {
-			SharedLib = function(cfg)
-				local r = { lcc.getsharedlibarg(cfg) }
-				if cfg.system == "windows" and not cfg.flags.NoImportLib then
-					table.insert(r, '-Wl,--out-implib="' .. cfg.linktarget.relpath .. '"')
-				elseif cfg.system == p.LINUX then
-					table.insert(r, '-Wl,-soname=' .. p.quoted(cfg.linktarget.name))
-				elseif table.contains(os.getSystemTags(cfg.system), "darwin") then
-					table.insert(r, '-Wl,-install_name,' .. p.quoted('@rpath/' .. cfg.linktarget.name))
-				end
-				return r
-			end,
-			WindowedApp = function(cfg)
-				if cfg.system == p.WINDOWS then return "-mwindows" end
-			end,
-		},
-		system = {
-			wii = "$(MACHDEP)",
-		}
-	}
+	lcc.ldflags = table.merge(gcc.ldflags, {})
 
 	function lcc.getldflags(cfg)
 		local flags = config.mapFlags(cfg, lcc.ldflags)
 		return flags
 	end
-
-
-
 --
 -- Build a list of additional library directories for a particular
 -- project configuration, decorated for the tool command line.


### PR DESCRIPTION
Added new kind for `gmake` target which is `GameBoyApp`. It produces Makefile that outputs executable file with `.gb` extension and uses `lcc` compiler. For now you have to use `--cc` flag set to `lcc` during project generation in order to work properly. I'm pretty sure there is a way to set `lcc` compiler as default `cc` value when project kind is set to `GameBoyApp` same way target extension is set.

 I'm open to any suggestions and improvements.