### PR TITLE
Xcode newid determinism

### DIFF
--- a/modules/xcode/tests/test_xcode4_project.lua
+++ b/modules/xcode/tests/test_xcode4_project.lua
@@ -10,35 +10,6 @@
 	local xcode = p.modules.xcode
 
 
---
--- Replacement for xcode.newid(). Creates a synthetic ID based on the node name,
--- its intended usage (file ID, build ID, etc.) and its place in the tree. This
--- makes it easier to tell if the right ID is being used in the right places.
---
-
-	xcode.used_ids = {}
-
-	local old_idfn = xcode.newid
-	xcode.newid = function(node, usage)
-		local name = node
-		if usage then
-			name = name .. ":" .. usage
-		end
-
-		if xcode.used_ids[name] then
-			local count = xcode.used_ids[name] + 1
-			xcode.used_ids[name] = count
-			name = name .. "(" .. count .. ")"
-		else
-			xcode.used_ids[name] = 1
-		end
-
-		return "[" .. name .. "]"
-	end
-
-
-
-
 ---------------------------------------------------------------------------
 -- Setup/Teardown
 ---------------------------------------------------------------------------
@@ -53,7 +24,6 @@
 		_TARGET_OS = "macosx"
 		p.action.set('xcode4')
 		io.eol = "\n"
-		xcode.used_ids = { } -- reset the list of generated IDs
 		wks = test.createWorkspace()
 	end
 
@@ -69,15 +39,15 @@
 ---------------------------------------------------------------------------
 
 	local function print_id(...)
-		_p("%s - %s", xcode.newid(...), old_idfn(...))
+		_p("%s", xcode.newid(...))
 	end
 
 	function suite.IDGeneratorIsDeterministic()
 		print_id("project", "Debug")
 		print_id("project", "Release")
 		test.capture [[
-[project:Debug] - B266956655B21E987082EBA6
-[project:Release] - DAC961207F1BFED291544760
+B266956655B21E987082EBA6
+DAC961207F1BFED291544760
 		]]
 	end
 
@@ -85,8 +55,8 @@
 		print_id("project", "Debug", "file")
 		print_id("project", "Debug", "hello")
 		test.capture [[
-[project:Debug] - 47C6E72E5ED982604EF57D6E
-[project:Debug(2)] - 8DCA12C2873014347ACB7102
+47C6E72E5ED982604EF57D6E
+8DCA12C2873014347ACB7102
 		]]
 	end
 
@@ -95,9 +65,9 @@
 		print_id("project", "Release", "file")
 		print_id("project", "Release", "file")
 		test.capture [[
-[project:Release] - 022ECCE82854FC9A8F5BF328
-[project:Release(2)] - 022ECCE82854FC9A8F5BF328
-[project:Release(3)] - 022ECCE82854FC9A8F5BF328
+022ECCE82854FC9A8F5BF328
+022ECCE82854FC9A8F5BF328
+022ECCE82854FC9A8F5BF328
 		]]
 	end
 
@@ -105,8 +75,8 @@
 		print_id("a", "b", "c", "d", "e", "f")
 		print_id("abcdef")
 		test.capture [[
-[a:b] - 63AEF3DD89D5238FF0DC1A1D
-[abcdef] - 9F1AF6957CC5F947506A7CD5
+63AEF3DD89D5238FF0DC1A1D
+9F1AF6957CC5F947506A7CD5
 		]]
 	end
 
@@ -119,7 +89,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";

--- a/modules/xcode/tests/test_xcode_dependencies.lua
+++ b/modules/xcode/tests/test_xcode_dependencies.lua
@@ -25,7 +25,6 @@
 	function suite.setup()
 		_TARGET_OS = "macosx"
 		p.action.set('xcode4')
-		xcode.used_ids = { } -- reset the list of generated IDs
 
 		wks, prj = test.createWorkspace()
 		links { "MyProject2" }
@@ -54,7 +53,7 @@
 		xcode.PBXBuildFile(tr)
 		test.capture [[
 /* Begin PBXBuildFile section */
-		[libMyProject2-d.a:build] /* libMyProject2-d.a in Frameworks */ = {isa = PBXBuildFile; fileRef = [libMyProject2-d.a] /* libMyProject2-d.a */; };
+		5931FBCA4D31453CD21C5A0A /* libMyProject2-d.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CCB6C53210CA9664049C1B72 /* libMyProject2-d.a */; };
 /* End PBXBuildFile section */
 		]]
 	end
@@ -65,7 +64,7 @@
 		xcode.PBXBuildFile(tr)
 		test.capture [[
 /* Begin PBXBuildFile section */
-		[libMyProject2-d.dylib:build] /* libMyProject2-d.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = [libMyProject2-d.dylib] /* libMyProject2-d.dylib */; };
+		1BC538B0FA67D422AF49D6F0 /* libMyProject2-d.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 107168B810144BEA4A68FEF8 /* libMyProject2-d.dylib */; };
 /* End PBXBuildFile section */
 		]]
 	end
@@ -80,18 +79,18 @@
 		xcode.PBXContainerItemProxy(tr)
 		test.capture [[
 /* Begin PBXContainerItemProxy section */
-		[MyProject2.xcodeproj:prodprox] /* PBXContainerItemProxy */ = {
+		17DF877139AB34A376605DB1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = [MyProject2.xcodeproj] /* MyProject2.xcodeproj */;
+			containerPortal = CBD893DEB01F9C10340CCA1E /* MyProject2.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = [libMyProject2-d.a:product];
+			remoteGlobalIDString = E052136F28C2F7A16D61C9AF;
 			remoteInfo = "libMyProject2-d.a";
 		};
-		[MyProject2.xcodeproj:targprox] /* PBXContainerItemProxy */ = {
+		6A19FA0A8BE5A73CC89AD04A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = [MyProject2.xcodeproj] /* MyProject2.xcodeproj */;
+			containerPortal = CBD893DEB01F9C10340CCA1E /* MyProject2.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = [libMyProject2-d.a:target];
+			remoteGlobalIDString = DA5DB975C549DF670D2FA7B5;
 			remoteInfo = "libMyProject2-d.a";
 		};
 /* End PBXContainerItemProxy section */
@@ -108,8 +107,8 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject2.xcodeproj] /* libMyProject2-d.a */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "MyProject2.xcodeproj"; path = MyProject2.xcodeproj; sourceTree = SOURCE_ROOT; };
-		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		19A5C4E61D1697189E833B26 /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		CBD893DEB01F9C10340CCA1E /* libMyProject2-d.a */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "MyProject2.xcodeproj"; path = MyProject2.xcodeproj; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -121,8 +120,8 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject2.xcodeproj] /* libMyProject2-d.a */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "MyProject2.xcodeproj"; path = ../MyProject2.xcodeproj; sourceTree = SOURCE_ROOT; };
-		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		149CF6C96C0269BB1E108509 /* libMyProject2-d.a */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "MyProject2.xcodeproj"; path = ../MyProject2.xcodeproj; sourceTree = SOURCE_ROOT; };
+		19A5C4E61D1697189E833B26 /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -137,11 +136,11 @@
 		xcode.PBXFrameworksBuildPhase(tr)
 		test.capture [[
 /* Begin PBXFrameworksBuildPhase section */
-		[MyProject:fxs] /* Frameworks */ = {
+		9FDD37564328C0885DF98D96 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				[libMyProject2-d.a:build] /* libMyProject2-d.a in Frameworks */,
+				5931FBCA4D31453CD21C5A0A /* libMyProject2-d.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -155,11 +154,11 @@
 		xcode.PBXFrameworksBuildPhase(tr)
 		test.capture [[
 /* Begin PBXFrameworksBuildPhase section */
-		[MyProject:fxs] /* Frameworks */ = {
+		9FDD37564328C0885DF98D96 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				[libMyProject2-d.dylib:build] /* libMyProject2-d.dylib in Frameworks */,
+				1BC538B0FA67D422AF49D6F0 /* libMyProject2-d.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,37 +175,37 @@
 		xcode.PBXGroup(tr)
 		test.capture [[
 /* Begin PBXGroup section */
-		[MyProject2.xcodeproj:prodgrp] /* Products */ = {
+		12F5A37D963B00EFBF8281BD /* MyProject */ = {
 			isa = PBXGroup;
 			children = (
-				[libMyProject2-d.a] /* libMyProject2-d.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		[MyProject] /* MyProject */ = {
-			isa = PBXGroup;
-			children = (
-				[Products] /* Products */,
-				[Projects] /* Projects */,
+				A6C936B49B3FADE6EA134CF4 /* Products */,
+				9D968EAA920D05DCE0E0A4EA /* Projects */,
 			);
 			name = MyProject;
 			sourceTree = "<group>";
 		};
-		[Products] /* Products */ = {
+		9D968EAA920D05DCE0E0A4EA /* Projects */ = {
 			isa = PBXGroup;
 			children = (
-				[MyProject:product] /* MyProject */,
+				CBD893DEB01F9C10340CCA1E /* MyProject2.xcodeproj */,
+			);
+			name = Projects;
+			sourceTree = "<group>";
+		};
+		A6C936B49B3FADE6EA134CF4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				19A5C4E61D1697189E833B26 /* MyProject */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		[Projects] /* Projects */ = {
+		C7F36A91F7853983D29278D1 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				[MyProject2.xcodeproj] /* MyProject2.xcodeproj */,
+				CCB6C53210CA9664049C1B72 /* libMyProject2-d.a */,
 			);
-			name = Projects;
+			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -223,23 +222,23 @@
 		xcode.PBXNativeTarget(tr)
 		test.capture [[
 /* Begin PBXNativeTarget section */
-		[MyProject:target] /* MyProject */ = {
+		48B5980C775BEBFED09D464C /* MyProject */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = [MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildConfigurationList = 8E187FB5316408E74C34D5F5 /* Build configuration list for PBXNativeTarget "MyProject" */;
 			buildPhases = (
-				[MyProject:rez] /* Resources */,
-				[MyProject:src] /* Sources */,
-				[MyProject:fxs] /* Frameworks */,
+				0FC4B7F6B3104128CDE10E36 /* Resources */,
+				7971D14D1CBD5A7F378E278D /* Sources */,
+				9FDD37564328C0885DF98D96 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				[MyProject2.xcodeproj:targdep] /* PBXTargetDependency */,
+				B5ABA79AE53D768CC04AB5DA /* PBXTargetDependency */,
 			);
 			name = MyProject;
 			productInstallPath = "$(HOME)/bin";
 			productName = MyProject;
-			productReference = [MyProject:product] /* MyProject */;
+			productReference = 19A5C4E61D1697189E833B26 /* MyProject */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
@@ -261,17 +260,17 @@
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */;
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 1;
-			mainGroup = [MyProject] /* MyProject */;
+			mainGroup = 12F5A37D963B00EFBF8281BD /* MyProject */;
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = [MyProject2.xcodeproj:prodgrp] /* Products */;
-					ProjectRef = [MyProject2.xcodeproj] /* MyProject2.xcodeproj */;
+					ProductGroup = C7F36A91F7853983D29278D1 /* Products */;
+					ProjectRef = CBD893DEB01F9C10340CCA1E /* MyProject2.xcodeproj */;
 				},
 			);
 			projectRoot = "";
 			targets = (
-				[MyProject:target] /* MyProject */,
+				48B5980C775BEBFED09D464C /* MyProject */,
 			);
 		};
 /* End PBXProject section */
@@ -288,11 +287,11 @@
 		xcode.PBXReferenceProxy(tr)
 		test.capture [[
 /* Begin PBXReferenceProxy section */
-		[libMyProject2-d.a] /* libMyProject2-d.a */ = {
+		CCB6C53210CA9664049C1B72 /* libMyProject2-d.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = "libMyProject2-d.a";
-			remoteRef = [MyProject2.xcodeproj:prodprox] /* PBXContainerItemProxy */;
+			remoteRef = 17DF877139AB34A376605DB1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -309,10 +308,10 @@
 		xcode.PBXTargetDependency(tr)
 		test.capture [[
 /* Begin PBXTargetDependency section */
-		[MyProject2.xcodeproj:targdep] /* PBXTargetDependency */ = {
+		B5ABA79AE53D768CC04AB5DA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "libMyProject2-d.a";
-			targetProxy = [MyProject2.xcodeproj:targprox] /* PBXContainerItemProxy */;
+			targetProxy = 6A19FA0A8BE5A73CC89AD04A /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 		]]

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -23,7 +23,6 @@
 		_TARGET_OS = "macosx"
 		p.action.set('xcode4')
 		p.eol("\n")
-		xcode.used_ids = { } -- reset the list of generated IDs
 		wks = test.createWorkspace()
 	end
 
@@ -44,8 +43,8 @@
 		xcode.PBXBuildFile(tr)
 		test.capture [[
 /* Begin PBXBuildFile section */
-		[source.c:build] /* source.c in Sources */ = {isa = PBXBuildFile; fileRef = [source.c] /* source.c */; };
-		[source.cpp:build] /* source.cpp in Sources */ = {isa = PBXBuildFile; fileRef = [source.cpp] /* source.cpp */; };
+		7018C364CB5A16D69EB461A4 /* source.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B47484CB259E37EA275DE8C /* source.cpp */; };
+		F3989C244A260696229F1A64 /* source.c in Sources */ = {isa = PBXBuildFile; fileRef = 7DC6D30C8137A53E02A4494C /* source.c */; };
 /* End PBXBuildFile section */
 		]]
 	end
@@ -56,8 +55,8 @@
 		xcode.PBXBuildFile(tr)
 		test.capture [[
 /* Begin PBXBuildFile section */
-		[source.m:build] /* source.m in Sources */ = {isa = PBXBuildFile; fileRef = [source.m] /* source.m */; };
-		[source.mm:build] /* source.mm in Sources */ = {isa = PBXBuildFile; fileRef = [source.mm] /* source.mm */; };
+		8A01A092B9936F8494A0AED2 /* source.mm in Sources */ = {isa = PBXBuildFile; fileRef = CCAA329A6F98594CFEBE38DA /* source.mm */; };
+		CBA890782235FAEAFAAF0EB8 /* source.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AFE9C203E6F6E52BFDC1260 /* source.m */; };
 /* End PBXBuildFile section */
 		]]
 	end
@@ -68,7 +67,7 @@
 		xcode.PBXBuildFile(tr)
 		test.capture [[
 /* Begin PBXBuildFile section */
-		[MainMenu.xib:build] /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = [MainMenu.xib] /* MainMenu.xib */; };
+		6FE0F2A3E16C0B15906D30E3 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6CB8FB6B191BBB9DD7A431AB /* MainMenu.xib */; };
 /* End PBXBuildFile section */
 		]]
 	end
@@ -80,7 +79,7 @@
 		xcode.PBXBuildFile(tr)
 		test.capture [[
 /* Begin PBXBuildFile section */
-		[Cocoa.framework:build] /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = [Cocoa.framework] /* Cocoa.framework */; };
+		F8E8DBA28B76A594F44F49E2 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D6BC6AA50D7885C8F7B2CEA /* Cocoa.framework */; };
 /* End PBXBuildFile section */
 		]]
 	end
@@ -92,8 +91,8 @@
 		xcode.PBXBuildFile(tr)
 		test.capture [[
 /* Begin PBXBuildFile section */
-		[source.c:build] /* source.c in Sources */ = {isa = PBXBuildFile; fileRef = [source.c] /* source.c */; };
-		[source.cpp:build] /* source.cpp in Sources */ = {isa = PBXBuildFile; fileRef = [source.cpp] /* source.cpp */; };
+		7018C364CB5A16D69EB461A4 /* source.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B47484CB259E37EA275DE8C /* source.cpp */; };
+		F3989C244A260696229F1A64 /* source.c in Sources */ = {isa = PBXBuildFile; fileRef = 7DC6D30C8137A53E02A4494C /* source.c */; };
 /* End PBXBuildFile section */
 		]]
 	end
@@ -108,7 +107,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		19A5C4E61D1697189E833B26 /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -120,7 +119,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject.app:product] /* MyProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = MyProject.app; path = MyProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5FB9875FD0E33A7ED2A2EB5 /* MyProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = MyProject.app; path = MyProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -133,7 +132,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject.app:product] /* MyProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = MyProject.app; path = MyProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5FB9875FD0E33A7ED2A2EB5 /* MyProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = MyProject.app; path = MyProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -145,7 +144,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[libMyProject.a:product] /* libMyProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libMyProject.a; path = libMyProject.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		FDCF31ACF735331EEAD08FEC /* libMyProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libMyProject.a; path = libMyProject.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -158,7 +157,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[libMyProject.a:product] /* libMyProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libMyProject.a; path = libMyProject.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		FDCF31ACF735331EEAD08FEC /* libMyProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libMyProject.a; path = libMyProject.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -170,7 +169,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[libMyProject.dylib:product] /* libMyProject.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libMyProject.dylib; path = libMyProject.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		2781AF7F7E0F19F156882DBF /* libMyProject.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libMyProject.dylib; path = libMyProject.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -183,7 +182,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[libMyProject.dylib:product] /* libMyProject.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libMyProject.dylib; path = libMyProject.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		2781AF7F7E0F19F156882DBF /* libMyProject.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libMyProject.dylib; path = libMyProject.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -196,7 +195,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject.bundle:product] /* MyProject.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.bundle; path = MyProject.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		8AD066EE75BC8CE0BDA2552E /* MyProject.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.bundle; path = MyProject.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -210,7 +209,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject.bundle:product] /* MyProject.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.bundle; path = MyProject.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		8AD066EE75BC8CE0BDA2552E /* MyProject.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.bundle; path = MyProject.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -222,7 +221,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject.xctest:product] /* MyProject.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.xctest; path = MyProject.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F573990FE05FBF012845874F /* MyProject.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.xctest; path = MyProject.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -235,7 +234,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject.xctest:product] /* MyProject.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.xctest; path = MyProject.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F573990FE05FBF012845874F /* MyProject.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.xctest; path = MyProject.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -247,7 +246,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject.framework:product] /* MyProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = MyProject.framework; path = MyProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D914F2255CC07D43D679562 /* MyProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = MyProject.framework; path = MyProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -261,7 +260,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject.framework:product] /* MyProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = MyProject.framework; path = MyProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D914F2255CC07D43D679562 /* MyProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = MyProject.framework; path = MyProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -274,8 +273,8 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
-		[source.c] /* source.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = source.c; path = source.c; sourceTree = "<group>"; };
+		19A5C4E61D1697189E833B26 /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		7DC6D30C8137A53E02A4494C /* source.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = source.c; path = source.c; sourceTree = "<group>"; };
 		]]
 	end
 
@@ -287,8 +286,8 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
-		[source.c] /* source.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; name = source.c; path = source.c; sourceTree = "<group>"; };
+		19A5C4E61D1697189E833B26 /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		7DC6D30C8137A53E02A4494C /* source.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; name = source.c; path = source.c; sourceTree = "<group>"; };
 		]]
 	end
 
@@ -299,8 +298,9 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[English] /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/MainMenu.xib; sourceTree = "<group>"; };
-		[French] /* French */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = French; path = French.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		19A5C4E61D1697189E833B26 /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		31594983623D4175755577C3 /* French */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = French; path = French.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		625C7BEB5C1E385D961D3A2B /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		]]
 	end
 
@@ -311,8 +311,9 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[English] /* English */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		[French] /* French */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = French; path = French.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		19A5C4E61D1697189E833B26 /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		A329C1B0714D1562F85B67F0 /* English */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		C3BECE4859358D7AC7D1E488 /* French */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = French; path = French.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		]]
 	end
 
@@ -323,7 +324,9 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[Cocoa.framework] /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		19A5C4E61D1697189E833B26 /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		8D6BC6AA50D7885C8F7B2CEA /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
 		]]
 	end
 
@@ -362,7 +365,8 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[Icon.icns] /* Icon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = Icon.icns; path = Icon.icns; sourceTree = "<group>"; };
+		19A5C4E61D1697189E833B26 /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A07B4D0BCF5DB824C1BBB10 /* Icon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = Icon.icns; path = Icon.icns; sourceTree = "<group>"; };
 		]]
 	end
 
@@ -373,7 +377,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject.app:product] /* MyProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = MyProject.app; path = MyProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5FB9875FD0E33A7ED2A2EB5 /* MyProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = MyProject.app; path = MyProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -386,7 +390,7 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[libMyProject-d.dylib:product] /* libMyProject-d.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = "libMyProject-d.dylib"; path = "libMyProject-d.dylib"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9E361150CDC7E042A8D51F90 /* libMyProject-d.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = "libMyProject-d.dylib"; path = "libMyProject-d.dylib"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 		]]
 	end
@@ -399,8 +403,8 @@
 		xcode.PBXFileReference(tr)
 		test.capture [[
 /* Begin PBXFileReference section */
-		[MyProject:product] /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
-		[source.c] /* source.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = source.c; path = src/source.c; sourceTree = "<group>"; };
+		19A5C4E61D1697189E833B26 /* MyProject */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MyProject; path = MyProject; sourceTree = BUILT_PRODUCTS_DIR; };
+		721A4003892CDB357948D643 /* source.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = source.c; path = src/source.c; sourceTree = "<group>"; };
 		]]
 	end
 
@@ -414,7 +418,7 @@
 		xcode.PBXFrameworksBuildPhase(tr)
 		test.capture [[
 /* Begin PBXFrameworksBuildPhase section */
-		[MyProject:fxs] /* Frameworks */ = {
+		9FDD37564328C0885DF98D96 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -432,11 +436,11 @@
 		xcode.PBXFrameworksBuildPhase(tr)
 		test.capture [[
 /* Begin PBXFrameworksBuildPhase section */
-		[MyProject:fxs] /* Frameworks */ = {
+		9FDD37564328C0885DF98D96 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				[Cocoa.framework:build] /* Cocoa.framework in Frameworks */,
+				F8E8DBA28B76A594F44F49E2 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -454,18 +458,18 @@
 		xcode.PBXGroup(tr)
 		test.capture [[
 /* Begin PBXGroup section */
-		[MyProject] /* MyProject */ = {
+		12F5A37D963B00EFBF8281BD /* MyProject */ = {
 			isa = PBXGroup;
 			children = (
-				[Products] /* Products */,
+				A6C936B49B3FADE6EA134CF4 /* Products */,
 			);
 			name = MyProject;
 			sourceTree = "<group>";
 		};
-		[Products] /* Products */ = {
+		A6C936B49B3FADE6EA134CF4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				[MyProject:product] /* MyProject */,
+				19A5C4E61D1697189E833B26 /* MyProject */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -481,19 +485,19 @@
 		xcode.PBXGroup(tr)
 		test.capture [[
 /* Begin PBXGroup section */
-		[MyProject] /* MyProject */ = {
+		12F5A37D963B00EFBF8281BD /* MyProject */ = {
 			isa = PBXGroup;
 			children = (
-				[source.h] /* source.h */,
-				[Products] /* Products */,
+				5C62B7965FD389C8E1402DD6 /* source.h */,
+				A6C936B49B3FADE6EA134CF4 /* Products */,
 			);
 			name = MyProject;
 			sourceTree = "<group>";
 		};
-		[Products] /* Products */ = {
+		A6C936B49B3FADE6EA134CF4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				[MyProject:product] /* MyProject */,
+				19A5C4E61D1697189E833B26 /* MyProject */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -509,19 +513,19 @@
 		xcode.PBXGroup(tr)
 		test.capture [[
 /* Begin PBXGroup section */
-		[MyProject] /* MyProject */ = {
+		12F5A37D963B00EFBF8281BD /* MyProject */ = {
 			isa = PBXGroup;
 			children = (
-				[source.h] /* source.h */,
-				[Products] /* Products */,
+				5C62B7965FD389C8E1402DD6 /* source.h */,
+				A6C936B49B3FADE6EA134CF4 /* Products */,
 			);
 			name = MyProject;
 			sourceTree = "<group>";
 		};
-		[Products] /* Products */ = {
+		A6C936B49B3FADE6EA134CF4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				[MyProject:product] /* MyProject */,
+				19A5C4E61D1697189E833B26 /* MyProject */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -547,21 +551,21 @@
 		xcode.PBXGroup(tr)
 		test.capture [[
 /* Begin PBXGroup section */
-		[MyProject] /* MyProject */ = {
+		12F5A37D963B00EFBF8281BD /* MyProject */ = {
 			isa = PBXGroup;
 			children = (
-				[source.cpp] /* source.cpp */,
-				[source.h] /* source.h */,
-				[test.h] /* test.h */,
-				[Products] /* Products */,
+				9B47484CB259E37EA275DE8C /* source.cpp */,
+				5C62B7965FD389C8E1402DD6 /* source.h */,
+				ABEF15744F3A9EA66A0B6BB4 /* test.h */,
+				A6C936B49B3FADE6EA134CF4 /* Products */,
 			);
 			name = MyProject;
 			sourceTree = "<group>";
 		};
-		[Products] /* Products */ = {
+		A6C936B49B3FADE6EA134CF4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				[MyProject:product] /* MyProject */,
+				19A5C4E61D1697189E833B26 /* MyProject */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -577,20 +581,20 @@
 		xcode.PBXGroup(tr)
 		test.capture [[
 /* Begin PBXGroup section */
-		[MyProject] /* MyProject */ = {
+		12F5A37D963B00EFBF8281BD /* MyProject */ = {
 			isa = PBXGroup;
 			children = (
-				[Info.plist] /* Info.plist */,
-				[MainMenu.xib] /* MainMenu.xib */,
-				[Products] /* Products */,
+				ACC2AED4C3D54A06B3F14514 /* Info.plist */,
+				6CB8FB6B191BBB9DD7A431AB /* MainMenu.xib */,
+				A6C936B49B3FADE6EA134CF4 /* Products */,
 			);
 			name = MyProject;
 			sourceTree = "<group>";
 		};
-		[Products] /* Products */ = {
+		A6C936B49B3FADE6EA134CF4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				[MyProject:product] /* MyProject */,
+				19A5C4E61D1697189E833B26 /* MyProject */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -606,21 +610,29 @@
 		xcode.PBXGroup(tr)
 		test.capture [[
 /* Begin PBXGroup section */
-		[Frameworks] /* Frameworks */ = {
+		12F5A37D963B00EFBF8281BD /* MyProject */ = {
 			isa = PBXGroup;
 			children = (
-				[Cocoa.framework] /* Cocoa.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		[MyProject] /* MyProject */ = {
-			isa = PBXGroup;
-			children = (
-				[Frameworks] /* Frameworks */,
-				[Products] /* Products */,
+				BBF76781A7E87333FA200DC1 /* Frameworks */,
+				A6C936B49B3FADE6EA134CF4 /* Products */,
 			);
 			name = MyProject;
+			sourceTree = "<group>";
+		};
+		A6C936B49B3FADE6EA134CF4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				19A5C4E61D1697189E833B26 /* MyProject */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BBF76781A7E87333FA200DC1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				8D6BC6AA50D7885C8F7B2CEA /* Cocoa.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		]]
@@ -634,21 +646,21 @@
 		xcode.PBXGroup(tr)
 		test.capture [[
 /* Begin PBXGroup section */
-		[Headers] /* Headers */ = {
+		12F5A37D963B00EFBF8281BD /* MyProject */ = {
 			isa = PBXGroup;
 			children = (
-				[source.h] /* source.h */,
-			);
-			name = Headers;
-			sourceTree = "<group>";
-		};
-		[MyProject] /* MyProject */ = {
-			isa = PBXGroup;
-			children = (
-				[Headers] /* Headers */,
-				[Products] /* Products */,
+				20D885C0C52B2372D7636C00 /* Headers */,
+				A6C936B49B3FADE6EA134CF4 /* Products */,
 			);
 			name = MyProject;
+			sourceTree = "<group>";
+		};
+		20D885C0C52B2372D7636C00 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				E91A2DDD367D240FAC9C241D /* source.h */,
+			);
+			name = Headers;
 			sourceTree = "<group>";
 		};
 		]]
@@ -664,13 +676,13 @@
 		xcode.PBXNativeTarget(tr)
 		test.capture [[
 /* Begin PBXNativeTarget section */
-		[MyProject:target] /* MyProject */ = {
+		48B5980C775BEBFED09D464C /* MyProject */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = [MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildConfigurationList = 8E187FB5316408E74C34D5F5 /* Build configuration list for PBXNativeTarget "MyProject" */;
 			buildPhases = (
-				[MyProject:rez] /* Resources */,
-				[MyProject:src] /* Sources */,
-				[MyProject:fxs] /* Frameworks */,
+				0FC4B7F6B3104128CDE10E36 /* Resources */,
+				7971D14D1CBD5A7F378E278D /* Sources */,
+				9FDD37564328C0885DF98D96 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -679,7 +691,7 @@
 			name = MyProject;
 			productInstallPath = "$(HOME)/bin";
 			productName = MyProject;
-			productReference = [MyProject:product] /* MyProject */;
+			productReference = 19A5C4E61D1697189E833B26 /* MyProject */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
@@ -693,13 +705,13 @@
 		xcode.PBXNativeTarget(tr)
 		test.capture [[
 /* Begin PBXNativeTarget section */
-		[MyProject.app:target] /* MyProject */ = {
+		D2C7B5BBD37AB2AD475C83FB /* MyProject */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = [MyProject.app:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildConfigurationList = 8DCCE3C4913DB5F612AA5A04 /* Build configuration list for PBXNativeTarget "MyProject" */;
 			buildPhases = (
-				[MyProject.app:rez] /* Resources */,
-				[MyProject.app:src] /* Sources */,
-				[MyProject.app:fxs] /* Frameworks */,
+				0F791C0512E9EE3794569245 /* Resources */,
+				7926355C7C97078EFE03AB9C /* Sources */,
+				9F919B65A3026D97246F11A5 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -708,7 +720,7 @@
 			name = MyProject;
 			productInstallPath = "$(HOME)/Applications";
 			productName = MyProject;
-			productReference = [MyProject.app:product] /* MyProject.app */;
+			productReference = E5FB9875FD0E33A7ED2A2EB5 /* MyProject.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -722,13 +734,13 @@
 		xcode.PBXNativeTarget(tr)
 		test.capture [[
 /* Begin PBXNativeTarget section */
-		[libMyProject.dylib:target] /* MyProject */ = {
+		CD0213851572F7B75A11C9C5 /* MyProject */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = [libMyProject.dylib:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildConfigurationList = 1F5D05CE18C307400C5E640E /* Build configuration list for PBXNativeTarget "MyProject" */;
 			buildPhases = (
-				[libMyProject.dylib:rez] /* Resources */,
-				[libMyProject.dylib:src] /* Sources */,
-				[libMyProject.dylib:fxs] /* Frameworks */,
+				A1093E0F9A6F3F818E0A9C4F /* Resources */,
+				0AB65766041C58D8F7B7B5A6 /* Sources */,
+				3121BD6F2A87BEE11E231BAF /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -736,7 +748,7 @@
 			);
 			name = MyProject;
 			productName = MyProject;
-			productReference = [libMyProject.dylib:product] /* libMyProject.dylib */;
+			productReference = 2781AF7F7E0F19F156882DBF /* libMyProject.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
@@ -756,16 +768,16 @@
 		xcode.PBXNativeTarget(tr)
 		test.capture [[
 /* Begin PBXNativeTarget section */
-		[MyProject:target] /* MyProject */ = {
+		48B5980C775BEBFED09D464C /* MyProject */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = [MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildConfigurationList = 8E187FB5316408E74C34D5F5 /* Build configuration list for PBXNativeTarget "MyProject" */;
 			buildPhases = (
 				9607AE1010C857E500CD1376 /* Prebuild */,
-				[file.in:buildcommand] /* Build "file.in" */,
-				[MyProject:rez] /* Resources */,
-				[MyProject:src] /* Sources */,
+				C06220C983CDE27BC2718709 /* Build "file.in" */,
+				0FC4B7F6B3104128CDE10E36 /* Resources */,
+				7971D14D1CBD5A7F378E278D /* Sources */,
 				9607AE3510C85E7E00CD1376 /* Prelink */,
-				[MyProject:fxs] /* Frameworks */,
+				9FDD37564328C0885DF98D96 /* Frameworks */,
 				9607AE3710C85E8F00CD1376 /* Postbuild */,
 			);
 			buildRules = (
@@ -775,7 +787,7 @@
 			name = MyProject;
 			productInstallPath = "$(HOME)/bin";
 			productName = MyProject;
-			productReference = [MyProject:product] /* MyProject */;
+			productReference = 19A5C4E61D1697189E833B26 /* MyProject */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
@@ -798,16 +810,16 @@
 		xcode.PBXNativeTarget(tr)
 		test.capture [[
 /* Begin PBXNativeTarget section */
-		[MyProject:target] /* MyProject */ = {
+		48B5980C775BEBFED09D464C /* MyProject */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = [MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildConfigurationList = 8E187FB5316408E74C34D5F5 /* Build configuration list for PBXNativeTarget "MyProject" */;
 			buildPhases = (
-				[file.1:buildcommand] /* Build "file.1" */,
-				[file.2:buildcommand] /* Build "file.2" */,
-				[file.3:buildcommand] /* Build "file.3" */,
-				[MyProject:rez] /* Resources */,
-				[MyProject:src] /* Sources */,
-				[MyProject:fxs] /* Frameworks */,
+				A50DBDBDC6D96AEF038E93FD /* Build "file.1" */,
+				71E4A5FF93B05331D0657C3F /* Build "file.2" */,
+				3EBB8E4160873B739D3C6481 /* Build "file.3" */,
+				0FC4B7F6B3104128CDE10E36 /* Resources */,
+				7971D14D1CBD5A7F378E278D /* Sources */,
+				9FDD37564328C0885DF98D96 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -816,7 +828,7 @@
 			name = MyProject;
 			productInstallPath = "$(HOME)/bin";
 			productName = MyProject;
-			productReference = [MyProject:product] /* MyProject */;
+			productReference = 19A5C4E61D1697189E833B26 /* MyProject */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
@@ -841,16 +853,16 @@
 		xcode.PBXNativeTarget(tr)
 		test.capture [[
 /* Begin PBXNativeTarget section */
-		[MyProject:target] /* MyProject */ = {
+		48B5980C775BEBFED09D464C /* MyProject */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = [MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */;
+			buildConfigurationList = 8E187FB5316408E74C34D5F5 /* Build configuration list for PBXNativeTarget "MyProject" */;
 			buildPhases = (
-				[file.1:buildcommand] /* Build "file.1" */,
-				[file.2:buildcommand] /* Build "file.2" */,
-				[file.3:buildcommand] /* Build "file.3" */,
-				[MyProject:rez] /* Resources */,
-				[MyProject:src] /* Sources */,
-				[MyProject:fxs] /* Frameworks */,
+				A50DBDBDC6D96AEF038E93FD /* Build "file.1" */,
+				71E4A5FF93B05331D0657C3F /* Build "file.2" */,
+				3EBB8E4160873B739D3C6481 /* Build "file.3" */,
+				0FC4B7F6B3104128CDE10E36 /* Resources */,
+				7971D14D1CBD5A7F378E278D /* Sources */,
+				9FDD37564328C0885DF98D96 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -859,7 +871,7 @@
 			name = MyProject;
 			productInstallPath = "$(HOME)/bin";
 			productName = MyProject;
-			productReference = [MyProject:product] /* MyProject */;
+			productReference = 19A5C4E61D1697189E833B26 /* MyProject */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
@@ -877,9 +889,9 @@
 		xcode.PBXAggregateTarget(tr)
 		test.capture [[
 /* Begin PBXAggregateTarget section */
-		[MyProject:target] /* MyProject */ = {
+		48B5980C775BEBFED09D464C /* MyProject */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = [MyProject:cfg] /* Build configuration list for PBXAggregateTarget "MyProject" */;
+			buildConfigurationList = 8E187FB5316408E74C34D5F5 /* Build configuration list for PBXAggregateTarget "MyProject" */;
 			buildPhases = (
 			);
 			buildRules = (
@@ -907,12 +919,12 @@
 		xcode.PBXAggregateTarget(tr)
 		test.capture [[
 /* Begin PBXAggregateTarget section */
-		[MyProject:target] /* MyProject */ = {
+		48B5980C775BEBFED09D464C /* MyProject */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = [MyProject:cfg] /* Build configuration list for PBXAggregateTarget "MyProject" */;
+			buildConfigurationList = 8E187FB5316408E74C34D5F5 /* Build configuration list for PBXAggregateTarget "MyProject" */;
 			buildPhases = (
 				9607AE1010C857E500CD1376 /* Prebuild */,
-				[file.in:buildcommand] /* Build "file.in" */,
+				C06220C983CDE27BC2718709 /* Build "file.in" */,
 				9607AE3510C85E7E00CD1376 /* Prelink */,
 				9607AE3710C85E8F00CD1376 /* Postbuild */,
 			);
@@ -942,11 +954,11 @@
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */;
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 1;
-			mainGroup = [MyProject] /* MyProject */;
+			mainGroup = 12F5A37D963B00EFBF8281BD /* MyProject */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				[MyProject:target] /* MyProject */,
+				48B5980C775BEBFED09D464C /* MyProject */,
 			);
 		};
 /* End PBXProject section */
@@ -968,7 +980,7 @@
 			isa = PBXProject;
 			attributes = {
 				TargetAttributes = {
-					[MyProject:target] = {
+					48B5980C775BEBFED09D464C = {
 						SystemCapabilities = {
 							com.apple.GameCenter.iOS = {
 								enabled = 0;
@@ -986,11 +998,11 @@
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */;
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 1;
-			mainGroup = [MyProject] /* MyProject */;
+			mainGroup = 12F5A37D963B00EFBF8281BD /* MyProject */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				[MyProject:target] /* MyProject */,
+				48B5980C775BEBFED09D464C /* MyProject */,
 			);
 		};
 /* End PBXProject section */
@@ -1007,7 +1019,7 @@
 		xcode.PBXResourcesBuildPhase(tr)
 		test.capture [[
 /* Begin PBXResourcesBuildPhase section */
-		[MyProject:rez] /* Resources */ = {
+		0FC4B7F6B3104128CDE10E36 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1025,11 +1037,11 @@
 		xcode.PBXResourcesBuildPhase(tr)
 		test.capture [[
 /* Begin PBXResourcesBuildPhase section */
-		[MyProject:rez] /* Resources */ = {
+		0FC4B7F6B3104128CDE10E36 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				[MainMenu.xib:build] /* MainMenu.xib in Resources */,
+				6FE0F2A3E16C0B15906D30E3 /* MainMenu.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1085,7 +1097,7 @@
 		xcode.PBXShellScriptBuildPhase(tr)
 		test.capture [[
 /* Begin PBXShellScriptBuildPhase section */
-		[file.in1:buildcommand] /* Build "file.in1" */ = {
+		9AE2196BE8450F9D5E640FAB /* Build "file.in1" */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1143,7 +1155,7 @@
 		xcode.PBXSourcesBuildPhase(tr)
 		test.capture [[
 /* Begin PBXSourcesBuildPhase section */
-		[MyProject:src] /* Sources */ = {
+		7971D14D1CBD5A7F378E278D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1161,12 +1173,12 @@
 		xcode.PBXSourcesBuildPhase(tr)
 		test.capture [[
 /* Begin PBXSourcesBuildPhase section */
-		[MyProject:src] /* Sources */ = {
+		7971D14D1CBD5A7F378E278D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				[goodbye.cpp:build] /* goodbye.cpp in Sources */,
-				[hello.cpp:build] /* hello.cpp in Sources */,
+				D7426C94082664861B3E9AD4 /* goodbye.cpp in Sources */,
+				EF69EEEA1EFBBDDCFA08FD2A /* hello.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1195,11 +1207,11 @@
 		xcode.PBXVariantGroup(tr)
 		test.capture [[
 /* Begin PBXVariantGroup section */
-		[MainMenu.xib] /* MainMenu.xib */ = {
+		6CB8FB6B191BBB9DD7A431AB /* MainMenu.xib */ = {
 			isa = PBXVariantGroup;
 			children = (
-				[English] /* English */,
-				[French] /* French */,
+				625C7BEB5C1E385D961D3A2B /* English */,
+				31594983623D4175755577C3 /* French */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";
@@ -1217,7 +1229,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1238,7 +1250,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1259,7 +1271,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1280,7 +1292,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1301,7 +1313,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject.app:Debug] /* Debug */ = {
+		F1C0BE8A138C6BBC504194CA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1322,7 +1334,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[libMyProject.a:Debug] /* Debug */ = {
+		92D99EC1EE1AF233C1753D01 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1343,7 +1355,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[libMyProject.dylib:Debug] /* Debug */ = {
+		144A3F940E0BFC06480AFDD4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1366,7 +1378,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject.bundle:Debug] /* Debug */ = {
+		5C54F6038D38EDF5A0512443 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1387,7 +1399,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject.xctest:Debug] /* Debug */ = {
+		0C14B9243CF8B1165010E764 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1408,7 +1420,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject.framework:Debug] /* Debug */ = {
+		2EC4D23760BE1CE9DA9D5877 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1430,7 +1442,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[xyzMyProject.dylib:Debug] /* Debug */ = {
+		33365BC82CF8183A66F71A08 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1453,7 +1465,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject.xyz:Debug] /* Debug */ = {
+		4FD8665471A41386AE593C94 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1475,7 +1487,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1497,7 +1509,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[libMyProject.xyz:Debug] /* Debug */ = {
+		8FB8842BC09C7C1DD3B4B26B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1521,7 +1533,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[libMyProject:Debug] /* Debug */ = {
+		5E2996528DBB654468C8A492 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1545,7 +1557,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[libMyProject.xyz:Debug] /* Debug */ = {
+		8FB8842BC09C7C1DD3B4B26B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1568,7 +1580,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[libMyProject:Debug] /* Debug */ = {
+		5E2996528DBB654468C8A492 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1591,7 +1603,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject.xyz:Debug] /* Debug */ = {
+		4FD8665471A41386AE593C94 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1614,7 +1626,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1638,7 +1650,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject.xyz:Debug] /* Debug */ = {
+		4FD8665471A41386AE593C94 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1662,7 +1674,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1686,7 +1698,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject.xyz:Debug] /* Debug */ = {
+		4FD8665471A41386AE593C94 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1710,7 +1722,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1732,7 +1744,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1754,7 +1766,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1775,7 +1787,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject-d:Debug] /* Debug */ = {
+		46BCF44C6EF7ACFE56933A8C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1796,7 +1808,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1818,7 +1830,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1838,7 +1850,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1861,7 +1873,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1885,7 +1897,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1909,7 +1921,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1932,7 +1944,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
-		[MyProject:Debug] /* Debug */ = {
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1959,7 +1971,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -1984,7 +1996,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2009,7 +2021,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2034,7 +2046,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2060,7 +2072,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2085,7 +2097,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2114,7 +2126,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2143,7 +2155,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2173,7 +2185,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2202,7 +2214,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2229,7 +2241,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2258,7 +2270,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2284,7 +2296,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2310,7 +2322,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2338,7 +2350,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2364,7 +2376,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2390,7 +2402,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2417,7 +2429,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2445,7 +2457,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2473,7 +2485,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2502,7 +2514,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2527,7 +2539,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2553,7 +2565,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2580,7 +2592,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2609,7 +2621,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2637,7 +2649,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
@@ -2663,7 +2675,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
@@ -2689,7 +2701,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -2715,7 +2727,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2741,7 +2753,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = i386;
@@ -2767,7 +2779,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
@@ -2792,7 +2804,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
@@ -2817,7 +2829,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2843,7 +2855,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2869,7 +2881,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2895,7 +2907,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2921,7 +2933,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2947,7 +2959,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2973,7 +2985,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -2999,7 +3011,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3025,7 +3037,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3051,7 +3063,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3077,7 +3089,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3103,7 +3115,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3129,7 +3141,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3155,7 +3167,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3181,7 +3193,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3207,7 +3219,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3233,7 +3245,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3259,7 +3271,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3285,7 +3297,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3311,7 +3323,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
@@ -3338,7 +3350,7 @@
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
@@ -3369,17 +3381,17 @@
 		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				[MyProject:Debug(2)] /* Debug */,
-				[MyProject:Release(2)] /* Release */,
+				A14350AC4595EE5E57CE36EC /* Debug */,
+				F3C205E6F732D818789F7C26 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		[MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */ = {
+		8E187FB5316408E74C34D5F5 /* Build configuration list for PBXNativeTarget "MyProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				[MyProject:Debug] /* Debug */,
-				[MyProject:Release] /* Release */,
+				FDC4CBFB4635B02D8AD4823B /* Debug */,
+				C8EAD1B5F1258A67D8C117F5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -3398,17 +3410,17 @@
 		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				[MyProject:Debug(2)] /* Debug */,
-				[MyProject:Release(2)] /* Release */,
+				A14350AC4595EE5E57CE36EC /* Debug */,
+				F3C205E6F732D818789F7C26 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		[MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */ = {
+		8E187FB5316408E74C34D5F5 /* Build configuration list for PBXNativeTarget "MyProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				[MyProject:Debug] /* Debug */,
-				[MyProject:Release] /* Release */,
+				FDC4CBFB4635B02D8AD4823B /* Debug */,
+				C8EAD1B5F1258A67D8C117F5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -3428,21 +3440,21 @@
 		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				[MyProject:Debug(2)] /* Debug */,
-				[MyProject:Debug(4)] /* Debug */,
-				[MyProject:Release(2)] /* Release */,
-				[MyProject:Release(4)] /* Release */,
+				A14350AC4595EE5E57CE36EC /* Debug */,
+				A14350AC4595EE5E57CE36EC /* Debug */,
+				F3C205E6F732D818789F7C26 /* Release */,
+				F3C205E6F732D818789F7C26 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		[MyProject:cfg] /* Build configuration list for PBXNativeTarget "MyProject" */ = {
+		8E187FB5316408E74C34D5F5 /* Build configuration list for PBXNativeTarget "MyProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				[MyProject:Debug] /* Debug */,
-				[MyProject:Debug(3)] /* Debug */,
-				[MyProject:Release] /* Release */,
-				[MyProject:Release(3)] /* Release */,
+				FDC4CBFB4635B02D8AD4823B /* Debug */,
+				FDC4CBFB4635B02D8AD4823B /* Debug */,
+				C8EAD1B5F1258A67D8C117F5 /* Release */,
+				C8EAD1B5F1258A67D8C117F5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/modules/xcode/xcode_project.lua
+++ b/modules/xcode/xcode_project.lua
@@ -135,8 +135,12 @@
 		-- Final setup
 		tree.traverse(tr, {
 			onnode = function(node)
+				local nodePath
+				if node.path then
+					nodePath = path.getrelative(tr.project.location, node.path)
+				end
 				-- assign IDs to every node in the tree
-				node.id = xcode.newid(node.name, nil, node.path)
+				node.id = xcode.newid(node.name, nil, nodePath)
 
 				node.isResource = xcode.isItemResource(prj, node)
 
@@ -146,7 +150,7 @@
 						local filecfg = fileconfig.getconfig(node, cfg)
 						if fileconfig.hasCustomBuildRule(filecfg) then
 							if not node.buildcommandid then
-								node.buildcommandid = xcode.newid(node.name, "buildcommand", node.path)
+								node.buildcommandid = xcode.newid(node.name, "buildcommand", nodePath)
 							end
 						end
 					end
@@ -154,7 +158,7 @@
 
 				-- assign build IDs to buildable files
 				if xcode.getbuildcategory(node) and not node.excludefrombuild and not xcode.mustExcludeFromTarget(node, tr.project) then
-					node.buildid = xcode.newid(node.name, "build", node.path)
+					node.buildid = xcode.newid(node.name, "build", nodePath)
 				end
 
 				-- remember key files that are needed elsewhere


### PR DESCRIPTION
Enables the ability to generate the exact same xcodeproj from different environments

Prior to this change, the absolute path held in node.path passed into xcode.newid would create different id's depending on where the project was located on your filesystem (especially visible when creating projects on windows and comparing the same project generated from a mac)

Since this path was the third item passed into xcode.newid, it was not visible to the existing tests. Some tests have been updated to show the new relative path being used to generate the id. 