### PR TITLE
Adds shaderincludedirs to fxcompile configuration

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -39,6 +39,14 @@
 	}
 
 	p.api.register {
+		name = "shaderincludedirs",
+		scope = "config",
+		kind = "list:string",
+		tokens = true,
+		pathVars = true,
+	}
+
+	p.api.register {
 		name = "shadertype",
 		scope = "config",
 		kind = "string",

--- a/modules/vstudio/tests/vc2010/test_fxcompile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_fxcompile_settings.lua
@@ -78,6 +78,35 @@
 	end
 
 ---
+-- Test FxCompileAdditionalIncludeDirectories
+---
+
+	function suite.onFxCompileAdditionalIncludeDirectories()
+		files { "shader.hlsl" }
+		shaderincludedirs { "../includes" }
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<AdditionalIncludeDirectories>..\includes;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+</FxCompile>
+		]]
+	end
+
+
+	function suite.onFxCompileAdditionalIncludeDirectories_multipleDefines()
+		files { "shader.hlsl" }
+		shaderincludedirs { "../includes", "otherpath/embedded" }
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<AdditionalIncludeDirectories>..\includes;otherpath\embedded;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+</FxCompile>
+		]]
+	end
+
+---
 -- Test FxCompileShaderType
 ---
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -399,6 +399,7 @@
 	m.elements.fxCompile = function(cfg)
 		return {
 			m.fxCompilePreprocessorDefinition,
+			m.fxCompileAdditionalIncludeDirs,
 			m.fxCompileShaderType,
 			m.fxCompileShaderModel,
 			m.fxCompileShaderEntry,
@@ -802,6 +803,7 @@
 					return {
 						m.excludedFromBuild,
 						m.fxCompilePreprocessorDefinition,
+						m.fxCompileAdditionalIncludeDirs,
 						m.fxCompileShaderType,
 						m.fxCompileShaderModel,
 						m.fxCompileShaderEntry,
@@ -2648,6 +2650,12 @@
 		end
 	end
 
+	function m.fxCompileAdditionalIncludeDirs(cfg, condition)
+		if cfg.shaderincludedirs and #cfg.shaderincludedirs > 0 then
+			local dirs = vstudio.path(cfg, cfg.shaderincludedirs)
+			m.element('AdditionalIncludeDirectories', condition, "%s;%%(AdditionalIncludeDirectories)", table.concat(dirs, ";"))
+		end
+	end
 
 	function m.fxCompileShaderType(cfg, condition)
 		if cfg.shadertype then


### PR DESCRIPTION
Added shaderincludedirs to the visual studio configuration for fxcompile. Kept name inline with the premake includedirs