### PR TITLE
Provide access to  json implementation

### DIFF
--- a/src/base/jsonwrapper.lua
+++ b/src/base/jsonwrapper.lua
@@ -8,6 +8,7 @@
 
 	local implementation = dofile('json.lua')
 	local err
+	json.implementation = implementation
 
 	function implementation.assert(condition, message)
 		if not condition then


### PR DESCRIPTION
Allow configuring/overriding the base implementation

Specifically, I needed a way to set to set `strictTypes=true` so that I could override the `newArray` and `newObject` functions