### PR TITLE
Fix VS2019 solution icons

### DIFF
--- a/modules/vstudio/vs2019.lua
+++ b/modules/vstudio/vs2019.lua
@@ -60,7 +60,7 @@
 
 		vstudio = {
 			solutionVersion = "12",
-			versionName     = "16",
+			versionName     = "Version 16",
 			targetFramework = "4.7.2",
 			toolsVersion    = "15.0",
 			userToolsVersion = "Current",


### PR DESCRIPTION
VS2019 solutions save with this header (`# Visual Studio Version 16` rather than `# Visual Studio 16`), I figured this was why the icons were broken.