### PR TITLE
Haiku fixes

### DIFF
--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -103,6 +103,16 @@ solaris: $(SRC)
 	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
 	$(MAKE) -C build/bootstrap -j`getconf NPROCESSORS_ONLN` config=$(CONFIG)
 
+haiku: $(SRC)
+	$(SILENT) rm -rf ./bin
+	$(SILENT) rm -rf ./build
+	$(SILENT) rm -rf ./obj
+	mkdir -p build/bootstrap
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -D_BSD_SOURCE -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $? -lbsd
+	./build/bootstrap/premake_bootstrap embed
+	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
+	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)
+
 windows-base: $(SRC)
 	$(SILENT) if exist .\bin rmdir /s /q .\bin
 	$(SILENT) if exist .\build rmdir /s /q .\build

--- a/contrib/curl/lib/curl_setup.h
+++ b/contrib/curl/lib/curl_setup.h
@@ -86,7 +86,7 @@
 #  include "config-linux.h"
 #endif
 
-#if defined(__sun__) && defined(__svr4__)
+#if defined(__sun__) && defined(__svr4__) || defined(__HAIKU__)
 #  include "config-linux.h"
 #  undef HAVE_IOCTL_SIOCGIFADDR
 #endif

--- a/contrib/libzip/premake5.lua
+++ b/contrib/libzip/premake5.lua
@@ -11,7 +11,7 @@ project "zip-lib"
 		"**.c"
 	}
 
-	filter "system:linux or bsd or solaris"
+	filter "system:linux or bsd or solaris or haiku"
 		defines { "HAVE_SSIZE_T_LIBZIP", "HAVE_CONFIG_H" }
 
 	filter "system:windows"

--- a/contrib/lua/premake5.lua
+++ b/contrib/lua/premake5.lua
@@ -21,7 +21,7 @@ project "lua-lib"
 		"etc/*.c"
 	}
 
-	filter "system:linux or bsd or hurd or aix or solaris"
+	filter "system:linux or bsd or hurd or aix or solaris or haiku"
 		defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }
 
 	filter "system:macosx"

--- a/contrib/luashim/premake5.lua
+++ b/contrib/luashim/premake5.lua
@@ -13,7 +13,7 @@ project "luashim-lib"
 		"*.lua"
 	}
 
-	filter "system:linux or bsd or hurd or aix"
+	filter "system:linux or bsd or hurd or aix or haiku"
 		defines      { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }
 
 	filter "system:macosx"

--- a/premake5.lua
+++ b/premake5.lua
@@ -197,6 +197,10 @@
 			defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }
 			links       { "m" }
 
+		filter "system:haiku"
+			defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN", "_BSD_SOURCE" }
+			links       { "network", "bsd" }
+
 
 	-- optional 3rd party libraries
 	group "contrib"

--- a/src/host/os_getversion.c
+++ b/src/host/os_getversion.c
@@ -193,7 +193,7 @@ int getversion(struct OsVersionInfo* info)
 
 /*************************************************************/
 
-#elif defined(PLATFORM_BSD) || defined(PLATFORM_LINUX) || defined(PLATFORM_SOLARIS) || defined(PLATFORM_HURD)
+#elif defined(PLATFORM_BSD) || defined(PLATFORM_LINUX) || defined(PLATFORM_SOLARIS) || defined(PLATFORM_HURD) || defined(PLATFORM_HAIKU)
 
 #include <string.h>
 #include <sys/utsname.h>

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -43,7 +43,7 @@
 #define PLATFORM_STRING   "windows"
 #endif
 
-#define PLATFORM_POSIX  (PLATFORM_LINUX || PLATFORM_BSD || PLATFORM_MACOSX || PLATFORM_SOLARIS)
+#define PLATFORM_POSIX  (PLATFORM_LINUX || PLATFORM_BSD || PLATFORM_MACOSX || PLATFORM_SOLARIS || PLATFORM_HAIKU)
 
 
 /* Pull in platform-specific headers required by built-in functions */


### PR DESCRIPTION
This fixes bootstrapping on Haiku.
I could probably squash this a bit.

Still some tests in error though.

Also the makefile in the tarball seems to have [hardcoded libs](https://github.com/haikuports/haikuports/blob/master/dev-util/premake/patches/premake-5.0.0%7Ealpha13.patchset#L54) and stuff, not sure how to fix this.