### PR TITLE
Add FUNDING.yml for GitHub Sponsors

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: premake


### PR DESCRIPTION
Connect [Premake OpenCollective](https://opencollective.com/premake) using [GitHub's new sponsorship features](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository).