### PR TITLE
Account for filename collisions on systems with case-insensitive file…

### DIFF
--- a/modules/gmake2/tests/test_gmake2_objects.lua
+++ b/modules/gmake2/tests/test_gmake2_objects.lua
@@ -163,6 +163,71 @@ endif
 		]]
 	end
 
+--
+-- Test that changes in case are treated as if multiple files of the same name are being built
+--
+
+	function suite.uniqueObjNames_ignoreCase1()
+		files { "a/hello.cpp", "b/Hello.cpp" }
+		prepare()
+		test.capture [[
+# File sets
+# #############################################
+
+OBJECTS :=
+
+OBJECTS += $(OBJDIR)/Hello1.o
+OBJECTS += $(OBJDIR)/hello.o
+
+		]]
+	end
+
+	function suite.uniqueObjNames_ignoreCase2()
+		files { "a/hello.cpp", "b/hello.cpp", "c/Hello1.cpp" }
+		prepare()
+		test.capture [[
+# File sets
+# #############################################
+
+OBJECTS :=
+
+OBJECTS += $(OBJDIR)/Hello11.o
+OBJECTS += $(OBJDIR)/hello.o
+OBJECTS += $(OBJDIR)/hello1.o
+
+		]]
+	end
+
+	function suite.uniqueObjectNames_ignoreCase_Release()
+		files { "a/hello.cpp", "b/hello.cpp", "c/Hello1.cpp", "d/Hello11.cpp" }
+		filter "configurations:Debug"
+			excludes {"b/hello.cpp"}
+		filter "configurations:Release"
+			excludes {"d/Hello11.cpp"}
+
+		prepare()
+		test.capture [[
+# File sets
+# #############################################
+
+OBJECTS :=
+
+OBJECTS += $(OBJDIR)/Hello11.o
+OBJECTS += $(OBJDIR)/hello.o
+
+ifeq ($(config),debug)
+OBJECTS += $(OBJDIR)/Hello111.o
+
+else ifeq ($(config),release)
+OBJECTS += $(OBJDIR)/hello1.o
+
+else
+  $(error "invalid configuration $(config)")
+endif
+
+		]]
+	end
+
 
 --
 -- If there's a custom rule for a non-C++ file extension, make sure that those

--- a/modules/vstudio/tests/vc2010/test_files.lua
+++ b/modules/vstudio/tests/vc2010/test_files.lua
@@ -479,6 +479,82 @@
 		]]
 	end
 
+--
+-- Test that changes in case are treated as if multiple files of the same name are being built
+--
+
+	function suite.uniqueObjectNames_onSourceNameCollision_ignoreCase()
+		files { "hello.cpp", "greetings/Hello.cpp" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="greetings\Hello.cpp" />
+	<ClCompile Include="hello.cpp">
+		<ObjectFileName>$(IntDir)\hello1.obj</ObjectFileName>
+	</ClCompile>
+</ItemGroup>
+		]]
+	end
+
+
+	function suite.uniqueObjectNames_onBaseNameCollision_ignoreCase1()
+		files { "a/hello.cpp", "b/Hello.cpp", "c/hello1.cpp" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="a\hello.cpp" />
+	<ClCompile Include="b\Hello.cpp">
+		<ObjectFileName>$(IntDir)\Hello1.obj</ObjectFileName>
+	</ClCompile>
+	<ClCompile Include="c\hello1.cpp">
+		<ObjectFileName>$(IntDir)\hello11.obj</ObjectFileName>
+	</ClCompile>
+</ItemGroup>
+		]]
+	end
+
+
+	function suite.uniqueObjectNames_onBaseNameCollision_ignoreCase2()
+		files { "a/hello1.cpp", "b/Hello.cpp", "c/hello.cpp" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="a\hello1.cpp" />
+	<ClCompile Include="b\Hello.cpp" />
+	<ClCompile Include="c\hello.cpp">
+		<ObjectFileName>$(IntDir)\hello2.obj</ObjectFileName>
+	</ClCompile>
+</ItemGroup>
+		]]
+	end
+
+
+	function suite.uniqueObjectNames_onBaseNameCollision_Release_ignoreCase()
+		files { "a/Hello.cpp", "b/hello.cpp", "c/hello1.cpp", "d/hello11.cpp" }
+		filter "configurations:Debug"
+			excludes {"b/hello.cpp"}
+		filter "configurations:Release"
+			excludes {"d/hello11.cpp"}
+
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="a\Hello.cpp" />
+	<ClCompile Include="b\hello.cpp">
+		<ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+		<ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)\hello1.obj</ObjectFileName>
+	</ClCompile>
+	<ClCompile Include="c\hello1.cpp">
+		<ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)\hello11.obj</ObjectFileName>
+	</ClCompile>
+	<ClCompile Include="d\hello11.cpp">
+		<ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+	</ClCompile>
+</ItemGroup>
+		]]
+	end
+
+
 
 --
 -- Check handling of per-file forced includes.


### PR DESCRIPTION
**What does this PR do?**
Continues the work done in PR #1191 by accounting for case-insensitive filesystems

**How does this PR change Premake's behavior?**
when computing sequence numbers for a compiled object filename, use the lowercase version of the base file name

closes #1241 
