### PR TITLE
Implement 'compileas' for vc2008

### DIFF
--- a/modules/vstudio/tests/vc200x/test_files.lua
+++ b/modules/vstudio/tests/vc200x/test_files.lua
@@ -181,6 +181,155 @@
 		]]
 	end
 
+--
+-- Check handling of per-file compileas options.
+--
+
+	function suite.onCompileAs_C_as_CPP()
+		language "C"
+		files { "hello.c" }
+		filter {"files:hello.c"}
+			compileas "C++"
+		prepare()
+		test.capture [[
+<Files>
+	<File
+		RelativePath="hello.c"
+		>
+		<FileConfiguration
+			Name="Debug|Win32"
+			>
+			<Tool
+				Name="VCCLCompilerTool"
+				CompileAs="2"
+			/>
+		</FileConfiguration>
+		<FileConfiguration
+			Name="Release|Win32"
+			>
+			<Tool
+				Name="VCCLCompilerTool"
+				CompileAs="2"
+			/>
+		</FileConfiguration>
+	</File>
+</Files>
+		]]
+	end
+
+	-- make sure compileas is still omitted when it matches the language.
+	function suite.onCompileAs_C_as_CPP_in_CPP()
+		language "C++"
+		files { "hello.c" }
+		filter {"files:hello.c"}
+			compileas "C++"
+		prepare()
+		test.capture [[
+<Files>
+	<File
+		RelativePath="hello.c"
+		>
+		<FileConfiguration
+			Name="Debug|Win32"
+			>
+			<Tool
+				Name="VCCLCompilerTool"
+				CompileAs="2"
+			/>
+		</FileConfiguration>
+		<FileConfiguration
+			Name="Release|Win32"
+			>
+			<Tool
+				Name="VCCLCompilerTool"
+				CompileAs="2"
+			/>
+		</FileConfiguration>
+	</File>
+</Files>
+		]]
+	end
+
+	function suite.onCompileAs_C_as_CPP_release()
+		language "C"
+		files { "hello.c" }
+		filter {"files:hello.c", "configurations:release"}
+			compileas "C++"
+		prepare()
+		test.capture [[
+<Files>
+	<File
+		RelativePath="hello.c"
+		>
+		<FileConfiguration
+			Name="Release|Win32"
+			>
+			<Tool
+				Name="VCCLCompilerTool"
+				CompileAs="2"
+			/>
+		</FileConfiguration>
+	</File>
+</Files>
+		]]
+	end
+
+	function suite.onCompileAs_CPP_as_C()
+		language "C++"
+		files { "hello.cpp" }
+		filter {"files:hello.cpp"}
+			compileas "C"
+		prepare()
+		test.capture [[
+<Files>
+	<File
+		RelativePath="hello.cpp"
+		>
+		<FileConfiguration
+			Name="Debug|Win32"
+			>
+			<Tool
+				Name="VCCLCompilerTool"
+				CompileAs="1"
+			/>
+		</FileConfiguration>
+		<FileConfiguration
+			Name="Release|Win32"
+			>
+			<Tool
+				Name="VCCLCompilerTool"
+				CompileAs="1"
+			/>
+		</FileConfiguration>
+	</File>
+</Files>
+		]]
+	end
+
+	function suite.onCompileAs_CPP_as_C_release()
+		language "C++"
+		files { "hello.cpp" }
+		filter {"files:hello.cpp", "configurations:release"}
+			compileas "C"
+		prepare()
+		test.capture [[
+<Files>
+	<File
+		RelativePath="hello.cpp"
+		>
+		<FileConfiguration
+			Name="Release|Win32"
+			>
+			<Tool
+				Name="VCCLCompilerTool"
+				CompileAs="1"
+			/>
+		</FileConfiguration>
+	</File>
+</Files>
+		]]
+	end
+
 
 --
 -- A PCH source file should be marked as such.

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -927,23 +927,24 @@
 	function m.compileAs(cfg, toolset)
 		local cfg, filecfg = config.normalize(cfg)
 		local c = p.languages.isc(cfg.language)
+		local compileAs
 		if filecfg then
-			if path.iscfile(filecfg.name) ~= c then
+			if filecfg.compileas then
+				compileAs = iif(p.languages.iscpp(filecfg.compileas), 2, 1)
+			elseif path.iscfile(filecfg.name) ~= c then
 				if path.iscppfile(filecfg.name) then
-					local value = iif(c, 2, 1)
-					p.w('CompileAs="%s"', value)
+					compileAs = iif(c, 2, 1)
 				end
 			end
 		else
-			local compileAs
 			if toolset then
 				compileAs = "0"
 			elseif c then
 				compileAs = "1"
 			end
-			if compileAs then
-				p.w('CompileAs="%s"', compileAs)
-			end
+		end
+		if compileAs then
+			p.w('CompileAs="%s"', compileAs)
 		end
 	end
 


### PR DESCRIPTION
**What does this PR do?**
Adds support for:

    filter {"files:..."}
        compileas "..."

to the `vs2008` action

**How does this PR change Premake's behavior?**
the vs2008 action gains new functionality

**Anything else we should know?**
closes #1255 
