### PR TITLE
On OSX, convert systemversion to MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -1738,6 +1738,49 @@
 		]]
 	end
 
+    function suite.XCBuildConfigurationTarget_OnOSXMinVersion()
+		_TARGET_OS = "macosx"
+		systemversion "10.11"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+    function suite.XCBuildConfigurationTarget_OnOSXUnSpecificedVersion()
+		_TARGET_OS = "macosx"
+		-- systemversion "10.11"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
 
 	function suite.XCBuildConfigurationTarget_OnInfoPlist()
 		files { "./a/b/c/MyProject-Info.plist" }

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1233,6 +1233,11 @@
 			if family then
 				settings['TARGETED_DEVICE_FAMILY'] = family
 			end
+		else
+			local minOSVersion = project.systemversion(cfg)
+			if minOSVersion ~= nil then
+				settings['MACOSX_DEPLOYMENT_TARGET'] = minOSVersion
+			end
 		end
 
 		--ms not by default ...add it manually if you need it


### PR DESCRIPTION
Per the discussion in issue #1336, if systemversion is set
output MACOSX_DEPLOYMENT_TARGET into the resulting xcode project.
This borrows a diff from the (unmerged) PR #1003, applies it
in isolation, and adds a pair of unit tests to confirm that both
setting and not setting the systemversion results in correct
output 

There is one situation where this could break a user's premake. If they set a systemversion globally and built only on windows and mac, right now that global systemversion would be ignored on mac; but after this change that systemversion will need to be OS-scoped.

Since this is my first pull request, I am sure you'll have lots of feedback. I'm happy to change whatever you think is appropriate! I checked the contrib guidelines and I think I got everything but want to make sure this works for you all.

Thanks so much!

Closes #1336

- [ x ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ x ] Add unit tests showing fix or feature works; all tests pass
- [ x ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ x ] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [ x ] Minimize the number of commits
