### PR TITLE
Upgrade Lua from 5.3.4 to 5.3.5

### DIFF
--- a/contrib/lua/README
+++ b/contrib/lua/README
@@ -1,5 +1,5 @@
 
-This is Lua 5.3.4, released on 12 Jan 2017.
+This is Lua 5.3.5, released on 26 Jun 2018.
 
 For installation instructions, license details, and
 further information about Lua, see doc/readme.html.

--- a/contrib/lua/doc/contents.html
+++ b/contrib/lua/doc/contents.html
@@ -32,7 +32,7 @@ For a complete introduction to Lua programming, see the book
 
 <P>
 <SMALL>
-Copyright &copy; 2015&ndash;2017 Lua.org, PUC-Rio.
+Copyright &copy; 2015&ndash;2018 Lua.org, PUC-Rio.
 Freely available under the terms of the
 <A HREF="http://www.lua.org/license.html">Lua license</A>.
 </SMALL>
@@ -609,10 +609,10 @@ Freely available under the terms of the
 
 <P CLASS="footer">
 Last update:
-Thu Dec 22 18:29:39 BRST 2016
+Mon Jun 18 22:56:06 -03 2018
 </P>
 <!--
-Last change: revised for Lua 5.3.4
+Last change: revised for Lua 5.3.5
 -->
 
 </BODY>

--- a/contrib/lua/doc/lua.css
+++ b/contrib/lua/doc/lua.css
@@ -10,7 +10,7 @@ body {
 	line-height: 1.25 ;
 	margin: 16px auto ;
 	padding: 32px ;
-	border: solid #a0a0a0 1px ;
+	border: solid #ccc 1px ;
 	border-radius: 20px ;
 	max-width: 70em ;
 	width: 90% ;
@@ -111,36 +111,29 @@ pre.session {
 	border-radius: 8px ;
 }
 
-td.gutter {
-	width: 4% ;
-}
-
-table.columns {
+table {
 	border: none ;
 	border-spacing: 0 ;
 	border-collapse: collapse ;
 }
 
+td {
+	padding: 0 ;
+	margin: 0 ;
+}
+
+td.gutter {
+	width: 4% ;
+}
+
 table.columns td {
 	vertical-align: top ;
-	padding: 0 ;
 	padding-bottom: 1em ;
 	text-align: justify ;
 	line-height: 1.25 ;
 }
 
-p.logos a:link:hover, p.logos a:visited:hover {
-	background-color: inherit ;
-}
-
-table.book {
-	border: none ;
-	border-spacing: 0 ;
-	border-collapse: collapse ;
-}
-
 table.book td {
-	padding: 0 ;
 	vertical-align: top ;
 }
 
@@ -157,6 +150,10 @@ table.book span {
 	text-align: left ;
 	display: block ;
 	margin-top: 0.25em ;
+}
+
+p.logos a:link:hover, p.logos a:visited:hover {
+	background-color: inherit ;
 }
 
 img {

--- a/contrib/lua/doc/manual.html
+++ b/contrib/lua/doc/manual.html
@@ -19,7 +19,7 @@ by Roberto Ierusalimschy, Luiz Henrique de Figueiredo, Waldemar Celes
 
 <P>
 <SMALL>
-Copyright &copy; 2015&ndash;2017 Lua.org, PUC-Rio.
+Copyright &copy; 2015&ndash;2018 Lua.org, PUC-Rio.
 Freely available under the terms of the
 <a href="http://www.lua.org/license.html">Lua license</a>.
 </SMALL>
@@ -35,7 +35,7 @@ Freely available under the terms of the
 <!-- ====================================================================== -->
 <p>
 
-<!-- $Id: manual.of,v 1.167 2017/01/09 15:18:11 roberto Exp $ -->
+<!-- $Id: manual.of,v 1.167.1.2 2018/06/26 15:49:07 roberto Exp $ -->
 
 
 
@@ -203,8 +203,8 @@ even those that do not support threads natively.
 
 <p>
 The type <em>table</em> implements associative arrays,
-that is, arrays that can be indexed not only with numbers,
-but with any Lua value except <b>nil</b> and NaN.
+that is, arrays that can have as indices not only numbers,
+but any Lua value except <b>nil</b> and NaN.
 (<em>Not a Number</em> is a special value used to represent
 undefined or unrepresentable numerical results, such as <code>0/0</code>.)
 Tables can be <em>heterogeneous</em>;
@@ -400,6 +400,8 @@ with the event name prefixed by two underscores;
 the corresponding values are called <em>metamethods</em>.
 In the previous example, the key is "<code>__add</code>"
 and the metamethod is the function that performs the addition.
+Unless stated otherwise,
+metamethods should be function values.
 
 
 <p>
@@ -597,7 +599,7 @@ it is also slower than a real <code>__le</code> metamethod.)
 </li>
 
 <li><b><code>__index</code>: </b>
-The indexing access <code>table[key]</code>.
+The indexing access operation <code>table[key]</code>.
 This event happens when <code>table</code> is not a table or
 when <code>key</code> is not present in <code>table</code>.
 The metamethod is looked up in <code>table</code>.
@@ -1276,13 +1278,8 @@ Square brackets are used to index a table:
 <pre>
 	var ::= prefixexp &lsquo;<b>[</b>&rsquo; exp &lsquo;<b>]</b>&rsquo;
 </pre><p>
-The meaning of accesses to table fields can be changed via metatables.
-An access to an indexed variable <code>t[i]</code> is equivalent to
-a call <code>gettable_event(t,i)</code>.
-(See <a href="#2.4">&sect;2.4</a> for a complete description of the
-<code>gettable_event</code> function.
-This function is not defined or callable in Lua.
-We use it here only for explanatory purposes.)
+The meaning of accesses to table fields can be changed via metatables
+(see <a href="#2.4">&sect;2.4</a>).
 
 
 <p>
@@ -1477,20 +1474,15 @@ cyclically permutes the values of <code>x</code>, <code>y</code>, and <code>z</c
 
 
 <p>
-The meaning of assignments to global variables
-and table fields can be changed via metatables.
-An assignment to an indexed variable <code>t[i] = val</code> is equivalent to
-<code>settable_event(t,i,val)</code>.
-(See <a href="#2.4">&sect;2.4</a> for a complete description of the
-<code>settable_event</code> function.
-This function is not defined or callable in Lua.
-We use it here only for explanatory purposes.)
-
-
-<p>
 An assignment to a global name <code>x = val</code>
 is equivalent to the assignment
 <code>_ENV.x = val</code> (see <a href="#2.2">&sect;2.2</a>).
+
+
+<p>
+The meaning of assignments to table fields and
+global variables (which are actually table fields, too)
+can be changed via metatables (see <a href="#2.4">&sect;2.4</a>).
 
 
 
@@ -1831,17 +1823,17 @@ Here are some examples:
      g(f(), x)          -- f() is adjusted to 1 result
      g(x, f())          -- g gets x plus all results from f()
      a,b,c = f(), x     -- f() is adjusted to 1 result (c gets nil)
-     a,b = ...          -- a gets the first vararg parameter, b gets
+     a,b = ...          -- a gets the first vararg argument, b gets
                         -- the second (both a and b can get nil if there
-                        -- is no corresponding vararg parameter)
+                        -- is no corresponding vararg argument)
      
      a,b,c = x, f()     -- f() is adjusted to 2 results
      a,b,c = f()        -- f() is adjusted to 3 results
      return f()         -- returns all results from f()
-     return ...         -- returns all received vararg parameters
+     return ...         -- returns all received vararg arguments
      return x,y,f()     -- returns x, y, and all results from f()
      {f()}              -- creates a list with all results from f()
-     {...}              -- creates a list with all vararg parameters
+     {...}              -- creates a list with all vararg arguments
      {f(), nil}         -- f() is adjusted to 1 result
 </pre>
 
@@ -2039,9 +2031,12 @@ two objects are considered equal only if they are the same object.
 Every time you create a new object
 (a table, userdata, or thread),
 this new object is different from any previously existing object.
-Closures with the same reference are always equal.
+A closure is always equal to itself.
 Closures with any detectable difference
 (different behavior, different definition) are always different.
+Closures created at different times but with no detectable differences
+may be classified as equal or not
+(depending on internal caching details).
 
 
 <p>
@@ -2303,7 +2298,7 @@ If the value of prefixexp has type <em>function</em>,
 then this function is called
 with the given arguments.
 Otherwise, the prefixexp "call" metamethod is called,
-having as first parameter the value of prefixexp,
+having as first argument the value of prefixexp,
 followed by the original call arguments
 (see <a href="#2.4">&sect;2.4</a>).
 
@@ -2881,7 +2876,7 @@ it can do whatever it wants on that Lua state,
 as it should be already protected.
 However,
 when C code operates on other Lua states
-(e.g., a Lua parameter to the function,
+(e.g., a Lua argument to the function,
 a Lua state stored in the registry, or
 the result of <a href="#lua_newthread"><code>lua_newthread</code></a>),
 it should use them only in API calls that cannot raise errors.
@@ -3370,7 +3365,7 @@ it is left unchanged.
 Destroys all objects in the given Lua state
 (calling the corresponding garbage-collection metamethods, if any)
 and frees all dynamic memory used by this state.
-On several platforms, you may not need to call this function,
+In several platforms, you may not need to call this function,
 because all resources are naturally released when the host program ends.
 On the other hand, long-running programs that create multiple states,
 such as daemons or web servers,
@@ -5584,7 +5579,7 @@ given as argument to a hook (see <a href="#lua_Hook"><code>lua_Hook</code></a>).
 
 
 <p>
-To get information about a function you push it onto the stack
+To get information about a function, you push it onto the stack
 and start the <code>what</code> string with the character '<code>&gt;</code>'.
 (In that case,
 <code>lua_getinfo</code> pops the function from the top of the stack.)
@@ -6462,7 +6457,7 @@ file-related functions in the standard library
 
 <p>
 Pushes onto the stack the field <code>e</code> from the metatable
-of the object at index <code>obj</code> and returns the type of pushed value.
+of the object at index <code>obj</code> and returns the type of the pushed value.
 If the object does not have a metatable,
 or if the metatable does not have this field,
 pushes nothing and returns <code>LUA_TNIL</code>.
@@ -6749,7 +6744,7 @@ In words, if the argument <code>arg</code> is nil or absent,
 the macro results in the default <code>dflt</code>.
 Otherwise, it results in the result of calling <code>func</code>
 with the state <code>L</code> and the argument index <code>arg</code> as
-parameters.
+arguments.
 Note that it evaluates the expression <code>dflt</code> only if needed.
 
 
@@ -8680,7 +8675,7 @@ the lowercase letters plus the '<code>-</code>' character.
 <p>
 You can put a closing square bracket in a set
 by positioning it as the first character in the set.
-You can put an hyphen in a set
+You can put a hyphen in a set
 by positioning it as the first or the last character in the set.
 (You can also use an escape for both cases.)
 
@@ -9082,8 +9077,8 @@ Returns the destination table <code>a2</code>.
 
 
 <p>
-Returns a new table with all parameters stored into keys 1, 2, etc.
-and with a field "<code>n</code>" with the total number of parameters.
+Returns a new table with all arguments stored into keys 1, 2, etc.
+and with a field "<code>n</code>" with the total number of arguments.
 Note that the resulting table may not be a sequence.
 
 
@@ -9215,7 +9210,7 @@ Returns the arc sine of <code>x</code> (in radians).
 <p>
 
 Returns the arc tangent of <code>y/x</code> (in radians),
-but uses the signs of both parameters to find the
+but uses the signs of both arguments to find the
 quadrant of the result.
 (It also handles correctly the case of <code>x</code> being zero.)
 
@@ -9516,7 +9511,7 @@ all I/O functions return <b>nil</b> on failure
 (plus an error message as a second result and
 a system-dependent error code as a third result)
 and some value different from <b>nil</b> on success.
-On non-POSIX systems,
+In non-POSIX systems,
 the computation of the error message and error code
 in case of errors
 may be not thread safe,
@@ -9553,7 +9548,7 @@ When called with a file name, it opens the named file (in text mode),
 and sets its handle as the default input file.
 When called with a file handle,
 it simply sets this file handle as the default input file.
-When called without parameters,
+When called without arguments,
 it returns the current default input file.
 
 
@@ -9580,7 +9575,7 @@ it returns no values (to finish the loop) and automatically closes the file.
 The call <code>io.lines()</code> (with no file name) is equivalent
 to <code>io.input():lines("*l")</code>;
 that is, it iterates over the lines of the default input file.
-In this case it does not close the file when the loop ends.
+In this case, the iterator does not close the file when the loop ends.
 
 
 <p>
@@ -9963,7 +9958,7 @@ the host system and on the current locale.
 
 
 <p>
-On non-POSIX systems,
+In non-POSIX systems,
 this function may be not thread safe
 because of its reliance on C&nbsp;function <code>gmtime</code> and C&nbsp;function <code>localtime</code>.
 
@@ -10163,7 +10158,7 @@ and explicitly removed when no longer needed.
 
 
 <p>
-On POSIX systems,
+In POSIX systems,
 this function also creates a file with that name,
 to avoid security risks.
 (Someone else might create the file with wrong permissions
@@ -10301,8 +10296,8 @@ The first parameter or local variable has index&nbsp;1, and so on,
 following the order that they are declared in the code,
 counting only the variables that are active
 in the current scope of the function.
-Negative indices refer to vararg parameters;
--1 is the first vararg parameter.
+Negative indices refer to vararg arguments;
+-1 is the first vararg argument.
 The function returns <b>nil</b> if there is no variable with the given index,
 and raises an error when called with a level out of range.
 (You can call <a href="#pdf-debug.getinfo"><code>debug.getinfo</code></a> to check whether the level is valid.)
@@ -10400,7 +10395,7 @@ When called without arguments,
 
 
 <p>
-When the hook is called, its first parameter is a string
+When the hook is called, its first argument is a string
 describing the event that has triggered its call:
 <code>"call"</code> (or <code>"tail call"</code>),
 <code>"return"</code>,
@@ -10551,7 +10546,8 @@ The options are:
 
 <ul>
 <li><b><code>-e <em>stat</em></code>: </b> executes string <em>stat</em>;</li>
-<li><b><code>-l <em>mod</em></code>: </b> "requires" <em>mod</em>;</li>
+<li><b><code>-l <em>mod</em></code>: </b> "requires" <em>mod</em> and assigns the
+  result to global @<em>mod</em>;</li>
 <li><b><code>-i</code>: </b> enters interactive mode after running <em>script</em>;</li>
 <li><b><code>-v</code>: </b> prints version information;</li>
 <li><b><code>-E</code>: </b> ignores environment variables;</li>
@@ -10629,7 +10625,7 @@ For instance, the call
 </pre><p>
 will print "<code>-e</code>".
 If there is a script,
-the script is called with parameters
+the script is called with arguments
 <code>arg[1]</code>, &middot;&middot;&middot;, <code>arg[#arg]</code>.
 (Like all chunks in Lua,
 the script is compiled as a vararg function.)
@@ -10815,7 +10811,7 @@ The following functions were deprecated in the mathematical library:
 <code>frexp</code>, and <code>ldexp</code>.
 You can replace <code>math.pow(x,y)</code> with <code>x^y</code>;
 you can replace <code>math.atan2</code> with <code>math.atan</code>,
-which now accepts one or two parameters;
+which now accepts one or two arguments;
 you can replace <code>math.ldexp(x,exp)</code> with <code>x * 2.0^exp</code>.
 For the other operations,
 you can either use an external library or
@@ -10850,7 +10846,7 @@ of the first result.)
 <ul>
 
 <li>
-Continuation functions now receive as parameters what they needed
+Continuation functions now receive as arguments what they needed
 to get through <code>lua_getctx</code>,
 so <code>lua_getctx</code> has been removed.
 Adapt your code accordingly.
@@ -10973,12 +10969,13 @@ and LiteralString, see <a href="#3.1">&sect;3.1</a>.)
 
 
 
+
 <P CLASS="footer">
 Last update:
-Mon Jan  9 13:30:53 BRST 2017
+Tue Jun 26 13:16:37 -03 2018
 </P>
 <!--
-Last change: revised for Lua 5.3.4
+Last change: revised for Lua 5.3.5
 -->
 
 </body></html>

--- a/contrib/lua/doc/readme.html
+++ b/contrib/lua/doc/readme.html
@@ -107,7 +107,7 @@ Here are the details.
 <OL>
 <LI>
 Open a terminal window and move to
-the top-level directory, which is named <TT>lua-5.3.x</TT>.
+the top-level directory, which is named <TT>lua-5.3.5</TT>.
 The <TT>Makefile</TT> there controls both the build process and the installation process.
 <P>
 <LI>
@@ -355,10 +355,10 @@ THE SOFTWARE.
 
 <P CLASS="footer">
 Last update:
-Thu Dec 22 18:22:57 BRST 2016
+Mon Jun 18 22:57:33 -03 2018
 </P>
 <!--
-Last change: revised for Lua 5.3.4
+Last change: revised for Lua 5.3.5
 -->
 
 </BODY>

--- a/contrib/lua/src/lapi.c
+++ b/contrib/lua/src/lapi.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lapi.c,v 2.259 2016/02/29 14:27:14 roberto Exp $
+** $Id: lapi.c,v 2.259.1.2 2017/12/06 18:35:12 roberto Exp $
 ** Lua API
 ** See Copyright Notice in lua.h
 */
@@ -533,6 +533,7 @@ LUA_API void lua_pushcclosure (lua_State *L, lua_CFunction fn, int n) {
   lua_lock(L);
   if (n == 0) {
     setfvalue(L->top, fn);
+    api_incr_top(L);
   }
   else {
     CClosure *cl;
@@ -546,9 +547,9 @@ LUA_API void lua_pushcclosure (lua_State *L, lua_CFunction fn, int n) {
       /* does not need barrier because closure is white */
     }
     setclCvalue(L, L->top, cl);
+    api_incr_top(L);
+    luaC_checkGC(L);
   }
-  api_incr_top(L);
-  luaC_checkGC(L);
   lua_unlock(L);
 }
 

--- a/contrib/lua/src/lapi.h
+++ b/contrib/lua/src/lapi.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lapi.h,v 2.9 2015/03/06 19:49:50 roberto Exp $
+** $Id: lapi.h,v 2.9.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Auxiliary functions from Lua API
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lauxlib.c
+++ b/contrib/lua/src/lauxlib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lauxlib.c,v 1.289 2016/12/20 18:37:00 roberto Exp $
+** $Id: lauxlib.c,v 1.289.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Auxiliary functions for building Lua libraries
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lauxlib.h
+++ b/contrib/lua/src/lauxlib.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lauxlib.h,v 1.131 2016/12/06 14:54:31 roberto Exp $
+** $Id: lauxlib.h,v 1.131.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Auxiliary functions for building Lua libraries
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lbaselib.c
+++ b/contrib/lua/src/lbaselib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lbaselib.c,v 1.314 2016/09/05 19:06:34 roberto Exp $
+** $Id: lbaselib.c,v 1.314.1.1 2017/04/19 17:39:34 roberto Exp $
 ** Basic library
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lbitlib.c
+++ b/contrib/lua/src/lbitlib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lbitlib.c,v 1.30 2015/11/11 19:08:09 roberto Exp $
+** $Id: lbitlib.c,v 1.30.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Standard library for bitwise operations
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lcode.c
+++ b/contrib/lua/src/lcode.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lcode.c,v 2.112 2016/12/22 13:08:50 roberto Exp $
+** $Id: lcode.c,v 2.112.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Code generator for Lua
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lcode.h
+++ b/contrib/lua/src/lcode.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lcode.h,v 1.64 2016/01/05 16:22:37 roberto Exp $
+** $Id: lcode.h,v 1.64.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Code generator for Lua
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lcorolib.c
+++ b/contrib/lua/src/lcorolib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lcorolib.c,v 1.10 2016/04/11 19:19:55 roberto Exp $
+** $Id: lcorolib.c,v 1.10.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Coroutine Library
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lctype.c
+++ b/contrib/lua/src/lctype.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lctype.c,v 1.12 2014/11/02 19:19:04 roberto Exp $
+** $Id: lctype.c,v 1.12.1.1 2017/04/19 17:20:42 roberto Exp $
 ** 'ctype' functions for Lua
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lctype.h
+++ b/contrib/lua/src/lctype.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lctype.h,v 1.12 2011/07/15 12:50:29 roberto Exp $
+** $Id: lctype.h,v 1.12.1.1 2013/04/12 18:48:47 roberto Exp $
 ** 'ctype' functions for Lua
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/ldblib.c
+++ b/contrib/lua/src/ldblib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: ldblib.c,v 1.151 2015/11/23 11:29:43 roberto Exp $
+** $Id: ldblib.c,v 1.151.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Interface from Lua to its debug API
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/ldebug.c
+++ b/contrib/lua/src/ldebug.c
@@ -1,5 +1,5 @@
 /*
-** $Id: ldebug.c,v 2.121 2016/10/19 12:32:10 roberto Exp $
+** $Id: ldebug.c,v 2.121.1.2 2017/07/10 17:21:50 roberto Exp $
 ** Debug Interface
 ** See Copyright Notice in lua.h
 */
@@ -653,6 +653,7 @@ l_noret luaG_runerror (lua_State *L, const char *fmt, ...) {
   CallInfo *ci = L->ci;
   const char *msg;
   va_list argp;
+  luaC_checkGC(L);  /* error message uses memory */
   va_start(argp, fmt);
   msg = luaO_pushvfstring(L, fmt, argp);  /* format message */
   va_end(argp);

--- a/contrib/lua/src/ldebug.h
+++ b/contrib/lua/src/ldebug.h
@@ -1,5 +1,5 @@
 /*
-** $Id: ldebug.h,v 2.14 2015/05/22 17:45:56 roberto Exp $
+** $Id: ldebug.h,v 2.14.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Auxiliary functions from Debug Interface module
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/ldo.c
+++ b/contrib/lua/src/ldo.c
@@ -1,5 +1,5 @@
 /*
-** $Id: ldo.c,v 2.157 2016/12/13 15:52:21 roberto Exp $
+** $Id: ldo.c,v 2.157.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Stack and Call structure of Lua
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/ldo.h
+++ b/contrib/lua/src/ldo.h
@@ -1,5 +1,5 @@
 /*
-** $Id: ldo.h,v 2.29 2015/12/21 13:02:14 roberto Exp $
+** $Id: ldo.h,v 2.29.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Stack and Call structure of Lua
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/ldump.c
+++ b/contrib/lua/src/ldump.c
@@ -1,5 +1,5 @@
 /*
-** $Id: ldump.c,v 2.37 2015/10/08 15:53:49 roberto Exp $
+** $Id: ldump.c,v 2.37.1.1 2017/04/19 17:20:42 roberto Exp $
 ** save precompiled Lua chunks
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lfunc.c
+++ b/contrib/lua/src/lfunc.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lfunc.c,v 2.45 2014/11/02 19:19:04 roberto Exp $
+** $Id: lfunc.c,v 2.45.1.1 2017/04/19 17:39:34 roberto Exp $
 ** Auxiliary functions to manipulate prototypes and closures
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lfunc.h
+++ b/contrib/lua/src/lfunc.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lfunc.h,v 2.15 2015/01/13 15:49:11 roberto Exp $
+** $Id: lfunc.h,v 2.15.1.1 2017/04/19 17:39:34 roberto Exp $
 ** Auxiliary functions to manipulate prototypes and closures
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lgc.c
+++ b/contrib/lua/src/lgc.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lgc.c,v 2.215 2016/12/22 13:08:50 roberto Exp $
+** $Id: lgc.c,v 2.215.1.2 2017/08/31 16:15:27 roberto Exp $
 ** Garbage Collector
 ** See Copyright Notice in lua.h
 */
@@ -643,8 +643,9 @@ static void clearkeys (global_State *g, GCObject *l, GCObject *f) {
     for (n = gnode(h, 0); n < limit; n++) {
       if (!ttisnil(gval(n)) && (iscleared(g, gkey(n)))) {
         setnilvalue(gval(n));  /* remove value ... */
-        removeentry(n);  /* and remove entry from table */
       }
+      if (ttisnil(gval(n)))  /* is entry empty? */
+        removeentry(n);  /* remove entry from table */
     }
   }
 }

--- a/contrib/lua/src/lgc.h
+++ b/contrib/lua/src/lgc.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lgc.h,v 2.91 2015/12/21 13:02:14 roberto Exp $
+** $Id: lgc.h,v 2.91.1.1 2017/04/19 17:39:34 roberto Exp $
 ** Garbage Collector
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/linit.c
+++ b/contrib/lua/src/linit.c
@@ -1,5 +1,5 @@
 /*
-** $Id: linit.c,v 1.39 2016/12/04 20:17:24 roberto Exp $
+** $Id: linit.c,v 1.39.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Initialization of libraries for lua.c and other clients
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/liolib.c
+++ b/contrib/lua/src/liolib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: liolib.c,v 2.151 2016/12/20 18:37:00 roberto Exp $
+** $Id: liolib.c,v 2.151.1.1 2017/04/19 17:29:57 roberto Exp $
 ** Standard I/O (and system) library
 ** See Copyright Notice in lua.h
 */
@@ -212,11 +212,16 @@ static int aux_close (lua_State *L) {
 }
 
 
+static int f_close (lua_State *L) {
+  tofile(L);  /* make sure argument is an open stream */
+  return aux_close(L);
+}
+
+
 static int io_close (lua_State *L) {
   if (lua_isnone(L, 1))  /* no argument? */
     lua_getfield(L, LUA_REGISTRYINDEX, IO_OUTPUT);  /* use standard output */
-  tofile(L);  /* make sure argument is an open stream */
-  return aux_close(L);
+  return f_close(L);
 }
 
 
@@ -741,7 +746,7 @@ static const luaL_Reg iolib[] = {
 ** methods for file handles
 */
 static const luaL_Reg flib[] = {
-  {"close", io_close},
+  {"close", f_close},
   {"flush", f_flush},
   {"lines", f_lines},
   {"read", f_read},

--- a/contrib/lua/src/llex.c
+++ b/contrib/lua/src/llex.c
@@ -1,5 +1,5 @@
 /*
-** $Id: llex.c,v 2.96 2016/05/02 14:02:12 roberto Exp $
+** $Id: llex.c,v 2.96.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Lexical Analyzer
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/llex.h
+++ b/contrib/lua/src/llex.h
@@ -1,5 +1,5 @@
 /*
-** $Id: llex.h,v 1.79 2016/05/02 14:02:12 roberto Exp $
+** $Id: llex.h,v 1.79.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Lexical Analyzer
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/llimits.h
+++ b/contrib/lua/src/llimits.h
@@ -1,5 +1,5 @@
 /*
-** $Id: llimits.h,v 1.141 2015/11/19 19:16:22 roberto Exp $
+** $Id: llimits.h,v 1.141.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Limits, basic types, and some other 'installation-dependent' definitions
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lmathlib.c
+++ b/contrib/lua/src/lmathlib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lmathlib.c,v 1.119 2016/12/22 13:08:50 roberto Exp $
+** $Id: lmathlib.c,v 1.119.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Standard mathematical library
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lmem.c
+++ b/contrib/lua/src/lmem.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lmem.c,v 1.91 2015/03/06 19:45:54 roberto Exp $
+** $Id: lmem.c,v 1.91.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Interface to Memory Manager
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lmem.h
+++ b/contrib/lua/src/lmem.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lmem.h,v 1.43 2014/12/19 17:26:14 roberto Exp $
+** $Id: lmem.h,v 1.43.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Interface to Memory Manager
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/loadlib.c
+++ b/contrib/lua/src/loadlib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: loadlib.c,v 1.130 2017/01/12 17:14:26 roberto Exp $
+** $Id: loadlib.c,v 1.130.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Dynamic library loader for Lua
 ** See Copyright Notice in lua.h
 **

--- a/contrib/lua/src/lobject.c
+++ b/contrib/lua/src/lobject.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lobject.c,v 2.113 2016/12/22 13:08:50 roberto Exp $
+** $Id: lobject.c,v 2.113.1.1 2017/04/19 17:29:57 roberto Exp $
 ** Some generic functions over Lua objects
 ** See Copyright Notice in lua.h
 */
@@ -435,7 +435,8 @@ const char *luaO_pushvfstring (lua_State *L, const char *fmt, va_list argp) {
       }
       case 'p': {  /* a pointer */
         char buff[4*sizeof(void *) + 8]; /* should be enough space for a '%p' */
-        int l = l_sprintf(buff, sizeof(buff), "%p", va_arg(argp, void *));
+        void *p = va_arg(argp, void *);
+        int l = lua_pointer2str(buff, sizeof(buff), p);
         pushstr(L, buff, l);
         break;
       }

--- a/contrib/lua/src/lobject.h
+++ b/contrib/lua/src/lobject.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lobject.h,v 2.117 2016/08/01 19:51:24 roberto Exp $
+** $Id: lobject.h,v 2.117.1.1 2017/04/19 17:39:34 roberto Exp $
 ** Type definitions for Lua objects
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lopcodes.c
+++ b/contrib/lua/src/lopcodes.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lopcodes.c,v 1.55 2015/01/05 13:48:33 roberto Exp $
+** $Id: lopcodes.c,v 1.55.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Opcodes for Lua virtual machine
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lopcodes.h
+++ b/contrib/lua/src/lopcodes.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lopcodes.h,v 1.149 2016/07/19 17:12:21 roberto Exp $
+** $Id: lopcodes.h,v 1.149.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Opcodes for Lua virtual machine
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/loslib.c
+++ b/contrib/lua/src/loslib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: loslib.c,v 1.65 2016/07/18 17:58:58 roberto Exp $
+** $Id: loslib.c,v 1.65.1.1 2017/04/19 17:29:57 roberto Exp $
 ** Standard Operating System library
 ** See Copyright Notice in lua.h
 */
@@ -293,7 +293,8 @@ static int os_date (lua_State *L) {
   else
     stm = l_localtime(&t, &tmr);
   if (stm == NULL)  /* invalid date? */
-    luaL_error(L, "time result cannot be represented in this installation");
+    return luaL_error(L,
+                 "time result cannot be represented in this installation");
   if (strcmp(s, "*t") == 0) {
     lua_createtable(L, 0, 9);  /* 9 = number of fields */
     setallfields(L, stm);
@@ -340,7 +341,8 @@ static int os_time (lua_State *L) {
     setallfields(L, &ts);  /* update fields with normalized values */
   }
   if (t != (time_t)(l_timet)t || t == (time_t)(-1))
-    luaL_error(L, "time result cannot be represented in this installation");
+    return luaL_error(L,
+                  "time result cannot be represented in this installation");
   l_pushtime(L, t);
   return 1;
 }

--- a/contrib/lua/src/lparser.c
+++ b/contrib/lua/src/lparser.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lparser.c,v 2.155 2016/08/01 19:51:24 roberto Exp $
+** $Id: lparser.c,v 2.155.1.2 2017/04/29 18:11:40 roberto Exp $
 ** Lua Parser
 ** See Copyright Notice in lua.h
 */
@@ -1392,7 +1392,7 @@ static void test_then_block (LexState *ls, int *escapelist) {
     luaK_goiffalse(ls->fs, &v);  /* will jump to label if condition is true */
     enterblock(fs, &bl, 0);  /* must enter block before 'goto' */
     gotostat(ls, v.t);  /* handle goto/break */
-    skipnoopstat(ls);  /* skip other no-op statements */
+    while (testnext(ls, ';')) {}  /* skip colons */
     if (block_follow(ls, 0)) {  /* 'goto' is the entire block? */
       leaveblock(fs);
       return;  /* and that is it */

--- a/contrib/lua/src/lparser.h
+++ b/contrib/lua/src/lparser.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lparser.h,v 1.76 2015/12/30 18:16:13 roberto Exp $
+** $Id: lparser.h,v 1.76.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Lua Parser
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lprefix.h
+++ b/contrib/lua/src/lprefix.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lprefix.h,v 1.2 2014/12/29 16:54:13 roberto Exp $
+** $Id: lprefix.h,v 1.2.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Definitions for Lua code that must come before any other header file
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lstate.c
+++ b/contrib/lua/src/lstate.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lstate.c,v 2.133 2015/11/13 12:16:51 roberto Exp $
+** $Id: lstate.c,v 2.133.1.1 2017/04/19 17:39:34 roberto Exp $
 ** Global State
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lstate.h
+++ b/contrib/lua/src/lstate.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lstate.h,v 2.133 2016/12/22 13:08:50 roberto Exp $
+** $Id: lstate.h,v 2.133.1.1 2017/04/19 17:39:34 roberto Exp $
 ** Global State
 ** See Copyright Notice in lua.h
 */
@@ -26,6 +26,24 @@
 ** 'tobefnz': all objects ready to be finalized;
 ** 'fixedgc': all objects that are not to be collected (currently
 ** only small strings, such as reserved words).
+**
+** Moreover, there is another set of lists that control gray objects.
+** These lists are linked by fields 'gclist'. (All objects that
+** can become gray have such a field. The field is not the same
+** in all objects, but it always has this name.)  Any gray object
+** must belong to one of these lists, and all objects in these lists
+** must be gray:
+**
+** 'gray': regular gray objects, still waiting to be visited.
+** 'grayagain': objects that must be revisited at the atomic phase.
+**   That includes
+**   - black objects got in a write barrier;
+**   - all kinds of weak tables during propagation phase;
+**   - all threads.
+** 'weak': tables with weak values to be cleared;
+** 'ephemeron': ephemeron tables with white->white entries;
+** 'allweak': tables with weak keys and/or weak values to be cleared.
+** The last three lists are used only during the atomic phase.
 
 */
 

--- a/contrib/lua/src/lstring.c
+++ b/contrib/lua/src/lstring.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lstring.c,v 2.56 2015/11/23 11:32:51 roberto Exp $
+** $Id: lstring.c,v 2.56.1.1 2017/04/19 17:20:42 roberto Exp $
 ** String table (keeps all strings handled by Lua)
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lstring.h
+++ b/contrib/lua/src/lstring.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lstring.h,v 1.61 2015/11/03 15:36:01 roberto Exp $
+** $Id: lstring.h,v 1.61.1.1 2017/04/19 17:20:42 roberto Exp $
 ** String table (keep all strings handled by Lua)
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lstrlib.c
+++ b/contrib/lua/src/lstrlib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lstrlib.c,v 1.254 2016/12/22 13:08:50 roberto Exp $
+** $Id: lstrlib.c,v 1.254.1.1 2017/04/19 17:29:57 roberto Exp $
 ** Standard library for string operations and pattern-matching
 ** See Copyright Notice in lua.h
 */
@@ -879,7 +879,7 @@ static int lua_number2strx (lua_State *L, char *buff, int sz,
       buff[i] = toupper(uchar(buff[i]));
   }
   else if (fmt[SIZELENMOD] != 'a')
-    luaL_error(L, "modifiers for format '%%a'/'%%A' not implemented");
+    return luaL_error(L, "modifiers for format '%%a'/'%%A' not implemented");
   return n;
 }
 
@@ -1199,8 +1199,8 @@ static int getnum (const char **fmt, int df) {
 static int getnumlimit (Header *h, const char **fmt, int df) {
   int sz = getnum(fmt, df);
   if (sz > MAXINTSIZE || sz <= 0)
-    luaL_error(h->L, "integral size (%d) out of limits [1,%d]",
-                     sz, MAXINTSIZE);
+    return luaL_error(h->L, "integral size (%d) out of limits [1,%d]",
+                            sz, MAXINTSIZE);
   return sz;
 }
 

--- a/contrib/lua/src/ltable.c
+++ b/contrib/lua/src/ltable.c
@@ -1,5 +1,5 @@
 /*
-** $Id: ltable.c,v 2.118 2016/11/07 12:38:35 roberto Exp $
+** $Id: ltable.c,v 2.118.1.4 2018/06/08 16:22:51 roberto Exp $
 ** Lua tables (hash)
 ** See Copyright Notice in lua.h
 */
@@ -223,7 +223,9 @@ static unsigned int computesizes (unsigned int nums[], unsigned int *pna) {
   unsigned int na = 0;  /* number of elements to go to array part */
   unsigned int optimal = 0;  /* optimal size for array part */
   /* loop while keys can fill more than half of total size */
-  for (i = 0, twotoi = 1; *pna > twotoi / 2; i++, twotoi *= 2) {
+  for (i = 0, twotoi = 1;
+       twotoi > 0 && *pna > twotoi / 2;
+       i++, twotoi *= 2) {
     if (nums[i] > 0) {
       a += nums[i];
       if (a > twotoi/2) {  /* more than half elements present? */
@@ -330,17 +332,34 @@ static void setnodevector (lua_State *L, Table *t, unsigned int size) {
 }
 
 
+typedef struct {
+  Table *t;
+  unsigned int nhsize;
+} AuxsetnodeT;
+
+
+static void auxsetnode (lua_State *L, void *ud) {
+  AuxsetnodeT *asn = cast(AuxsetnodeT *, ud);
+  setnodevector(L, asn->t, asn->nhsize);
+}
+
+
 void luaH_resize (lua_State *L, Table *t, unsigned int nasize,
                                           unsigned int nhsize) {
   unsigned int i;
   int j;
+  AuxsetnodeT asn;
   unsigned int oldasize = t->sizearray;
   int oldhsize = allocsizenode(t);
   Node *nold = t->node;  /* save old hash ... */
   if (nasize > oldasize)  /* array part must grow? */
     setarrayvector(L, t, nasize);
   /* create new hash part with appropriate size */
-  setnodevector(L, t, nhsize);
+  asn.t = t; asn.nhsize = nhsize;
+  if (luaD_rawrunprotected(L, auxsetnode, &asn) != LUA_OK) {  /* mem. error? */
+    setarrayvector(L, t, oldasize);  /* array back to its original size */
+    luaD_throw(L, LUA_ERRMEM);  /* rethrow memory error */
+  }
   if (nasize < oldasize) {  /* array part must shrink? */
     t->sizearray = nasize;
     /* re-insert elements from vanishing slice */
@@ -610,13 +629,13 @@ void luaH_setint (lua_State *L, Table *t, lua_Integer key, TValue *value) {
 }
 
 
-static int unbound_search (Table *t, unsigned int j) {
-  unsigned int i = j;  /* i is zero or a present index */
+static lua_Unsigned unbound_search (Table *t, lua_Unsigned j) {
+  lua_Unsigned i = j;  /* i is zero or a present index */
   j++;
   /* find 'i' and 'j' such that i is present and j is not */
   while (!ttisnil(luaH_getint(t, j))) {
     i = j;
-    if (j > cast(unsigned int, MAX_INT)/2) {  /* overflow? */
+    if (j > l_castS2U(LUA_MAXINTEGER) / 2) {  /* overflow? */
       /* table was built with bad purposes: resort to linear search */
       i = 1;
       while (!ttisnil(luaH_getint(t, i))) i++;
@@ -626,7 +645,7 @@ static int unbound_search (Table *t, unsigned int j) {
   }
   /* now do a binary search between them */
   while (j - i > 1) {
-    unsigned int m = (i+j)/2;
+    lua_Unsigned m = (i+j)/2;
     if (ttisnil(luaH_getint(t, m))) j = m;
     else i = m;
   }
@@ -638,7 +657,7 @@ static int unbound_search (Table *t, unsigned int j) {
 ** Try to find a boundary in table 't'. A 'boundary' is an integer index
 ** such that t[i] is non-nil and t[i+1] is nil (and 0 if t[1] is nil).
 */
-int luaH_getn (Table *t) {
+lua_Unsigned luaH_getn (Table *t) {
   unsigned int j = t->sizearray;
   if (j > 0 && ttisnil(&t->array[j - 1])) {
     /* there is a boundary in the array part: (binary) search for it */

--- a/contrib/lua/src/ltable.h
+++ b/contrib/lua/src/ltable.h
@@ -1,5 +1,5 @@
 /*
-** $Id: ltable.h,v 2.23 2016/12/22 13:08:50 roberto Exp $
+** $Id: ltable.h,v 2.23.1.2 2018/05/24 19:39:05 roberto Exp $
 ** Lua tables (hash)
 ** See Copyright Notice in lua.h
 */
@@ -54,7 +54,7 @@ LUAI_FUNC void luaH_resize (lua_State *L, Table *t, unsigned int nasize,
 LUAI_FUNC void luaH_resizearray (lua_State *L, Table *t, unsigned int nasize);
 LUAI_FUNC void luaH_free (lua_State *L, Table *t);
 LUAI_FUNC int luaH_next (lua_State *L, Table *t, StkId key);
-LUAI_FUNC int luaH_getn (Table *t);
+LUAI_FUNC lua_Unsigned luaH_getn (Table *t);
 
 
 #if defined(LUA_DEBUG)

--- a/contrib/lua/src/ltablib.c
+++ b/contrib/lua/src/ltablib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: ltablib.c,v 1.93 2016/02/25 19:41:54 roberto Exp $
+** $Id: ltablib.c,v 1.93.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Library for Table Manipulation
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/ltm.c
+++ b/contrib/lua/src/ltm.c
@@ -1,5 +1,5 @@
 /*
-** $Id: ltm.c,v 2.38 2016/12/22 13:08:50 roberto Exp $
+** $Id: ltm.c,v 2.38.1.1 2017/04/19 17:39:34 roberto Exp $
 ** Tag methods
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/ltm.h
+++ b/contrib/lua/src/ltm.h
@@ -1,5 +1,5 @@
 /*
-** $Id: ltm.h,v 2.22 2016/02/26 19:20:15 roberto Exp $
+** $Id: ltm.h,v 2.22.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Tag methods
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lua.c
+++ b/contrib/lua/src/lua.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lua.c,v 1.230 2017/01/12 17:14:26 roberto Exp $
+** $Id: lua.c,v 1.230.1.1 2017/04/19 17:29:57 roberto Exp $
 ** Lua stand-alone interpreter
 ** See Copyright Notice in lua.h
 */
@@ -138,7 +138,7 @@ static void print_usage (const char *badoption) {
   "Available options are:\n"
   "  -e stat  execute string 'stat'\n"
   "  -i       enter interactive mode after executing 'script'\n"
-  "  -l name  require library 'name'\n"
+  "  -l name  require library 'name' into global 'name'\n"
   "  -v       show version information\n"
   "  -E       ignore environment variables\n"
   "  --       stop handling options\n"

--- a/contrib/lua/src/lua.h
+++ b/contrib/lua/src/lua.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lua.h,v 1.332 2016/12/22 15:51:20 roberto Exp $
+** $Id: lua.h,v 1.332.1.2 2018/06/13 16:58:17 roberto Exp $
 ** Lua - A Scripting Language
 ** Lua.org, PUC-Rio, Brazil (http://www.lua.org)
 ** See Copyright Notice at the end of this file
@@ -19,11 +19,11 @@
 #define LUA_VERSION_MAJOR	"5"
 #define LUA_VERSION_MINOR	"3"
 #define LUA_VERSION_NUM		503
-#define LUA_VERSION_RELEASE	"4"
+#define LUA_VERSION_RELEASE	"5"
 
 #define LUA_VERSION	"Lua " LUA_VERSION_MAJOR "." LUA_VERSION_MINOR
 #define LUA_RELEASE	LUA_VERSION "." LUA_VERSION_RELEASE
-#define LUA_COPYRIGHT	LUA_RELEASE "  Copyright (C) 1994-2017 Lua.org, PUC-Rio"
+#define LUA_COPYRIGHT	LUA_RELEASE "  Copyright (C) 1994-2018 Lua.org, PUC-Rio"
 #define LUA_AUTHORS	"R. Ierusalimschy, L. H. de Figueiredo, W. Celes"
 
 
@@ -460,7 +460,7 @@ struct lua_Debug {
 
 
 /******************************************************************************
-* Copyright (C) 1994-2017 Lua.org, PUC-Rio.
+* Copyright (C) 1994-2018 Lua.org, PUC-Rio.
 *
 * Permission is hereby granted, free of charge, to any person obtaining
 * a copy of this software and associated documentation files (the

--- a/contrib/lua/src/luac.c
+++ b/contrib/lua/src/luac.c
@@ -1,5 +1,5 @@
 /*
-** $Id: luac.c,v 1.75 2015/03/12 01:58:27 lhf Exp $
+** $Id: luac.c,v 1.76 2018/06/19 01:32:02 lhf Exp $
 ** Lua compiler (saves bytecodes to files; also lists bytecodes)
 ** See Copyright Notice in lua.h
 */
@@ -206,7 +206,7 @@ int main(int argc, char* argv[])
 }
 
 /*
-** $Id: luac.c,v 1.75 2015/03/12 01:58:27 lhf Exp $
+** $Id: luac.c,v 1.76 2018/06/19 01:32:02 lhf Exp $
 ** print bytecodes
 ** See Copyright Notice in lua.h
 */
@@ -348,6 +348,7 @@ static void PrintCode(const Proto* f)
    case OP_ADD:
    case OP_SUB:
    case OP_MUL:
+   case OP_MOD:
    case OP_POW:
    case OP_DIV:
    case OP_IDIV:

--- a/contrib/lua/src/luaconf.h
+++ b/contrib/lua/src/luaconf.h
@@ -1,5 +1,5 @@
 /*
-** $Id: luaconf.h,v 1.259 2016/12/22 13:08:50 roberto Exp $
+** $Id: luaconf.h,v 1.259.1.1 2017/04/19 17:29:57 roberto Exp $
 ** Configuration file for Lua
 ** See Copyright Notice in lua.h
 */
@@ -618,6 +618,13 @@
 #if !defined(LUA_USE_C89)
 #define lua_strx2number(s,p)		lua_str2number(s,p)
 #endif
+
+
+/*
+@@ lua_pointer2str converts a pointer to a readable string in a
+** non-specified way.
+*/
+#define lua_pointer2str(buff,sz,p)	l_sprintf(buff,sz,"%p",p)
 
 
 /*

--- a/contrib/lua/src/lualib.h
+++ b/contrib/lua/src/lualib.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lualib.h,v 1.45 2017/01/12 17:14:26 roberto Exp $
+** $Id: lualib.h,v 1.45.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Lua standard libraries
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lundump.c
+++ b/contrib/lua/src/lundump.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lundump.c,v 2.44 2015/11/02 16:09:30 roberto Exp $
+** $Id: lundump.c,v 2.44.1.1 2017/04/19 17:20:42 roberto Exp $
 ** load precompiled Lua chunks
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lundump.h
+++ b/contrib/lua/src/lundump.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lundump.h,v 1.45 2015/09/08 15:41:05 roberto Exp $
+** $Id: lundump.h,v 1.45.1.1 2017/04/19 17:20:42 roberto Exp $
 ** load precompiled Lua chunks
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lutf8lib.c
+++ b/contrib/lua/src/lutf8lib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lutf8lib.c,v 1.16 2016/12/22 13:08:50 roberto Exp $
+** $Id: lutf8lib.c,v 1.16.1.1 2017/04/19 17:29:57 roberto Exp $
 ** Standard library for UTF-8 manipulation
 ** See Copyright Notice in lua.h
 */
@@ -171,7 +171,7 @@ static int byteoffset (lua_State *L) {
   }
   else {
     if (iscont(s + posi))
-      luaL_error(L, "initial position is a continuation byte");
+      return luaL_error(L, "initial position is a continuation byte");
     if (n < 0) {
        while (n < 0 && posi > 0) {  /* move back */
          do {  /* find beginning of previous character */

--- a/contrib/lua/src/lvm.c
+++ b/contrib/lua/src/lvm.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lvm.c,v 2.268 2016/02/05 19:59:14 roberto Exp $
+** $Id: lvm.c,v 2.268.1.1 2017/04/19 17:39:34 roberto Exp $
 ** Lua virtual machine
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lvm.h
+++ b/contrib/lua/src/lvm.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lvm.h,v 2.41 2016/12/22 13:08:50 roberto Exp $
+** $Id: lvm.h,v 2.41.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Lua virtual machine
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lzio.c
+++ b/contrib/lua/src/lzio.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lzio.c,v 1.37 2015/09/08 15:41:05 roberto Exp $
+** $Id: lzio.c,v 1.37.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Buffered streams
 ** See Copyright Notice in lua.h
 */

--- a/contrib/lua/src/lzio.h
+++ b/contrib/lua/src/lzio.h
@@ -1,5 +1,5 @@
 /*
-** $Id: lzio.h,v 1.31 2015/09/08 15:41:05 roberto Exp $
+** $Id: lzio.h,v 1.31.1.1 2017/04/19 17:20:42 roberto Exp $
 ** Buffered streams
 ** See Copyright Notice in lua.h
 */


### PR DESCRIPTION
**What does this PR do?**

Simple patch to upgrade Lua to 5.3.5. I have had no problems with this upgrade in my other lua projects and I don't expect you to have any issues as well.

**How does this PR change Premake's behavior?**

There should be no change functionally. The changes made were mostly internal and don't appear to be breaking changes. The changes that premake made to lauxlib.c and liolib.c were maintained.

pretest5 test was executed after this change and passed all tests.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [X] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
