### PR TITLE
Added support for vcxitems project generation for VS2013+

### DIFF
--- a/modules/vstudio/_manifest.lua
+++ b/modules/vstudio/_manifest.lua
@@ -21,6 +21,7 @@ return {
 	"vs2010_rules_xml.lua",
 	"vs2012.lua",
 	"vs2013.lua",
+	"vs2013_vcxitems.lua",
 	"vs2015.lua",
 	"vs2017.lua",
 	"vs2019.lua"

--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -31,6 +31,7 @@ return {
 	"sln2005/test_projects.lua",
 	"sln2005/test_platforms.lua",
 	"sln2005/test_sections.lua",
+	"sln2005/test_shared_projects.lua",
 
 	-- Visual Studio 2002-2008 C/C++ projects
 	"vc200x/test_assembly_refs.lua",
@@ -90,4 +91,7 @@ return {
 	"vc2010/test_user_file.lua",
 	"vc2010/test_vectorextensions.lua",
 	"vc2010/test_ensure_nuget_imports.lua",
+
+	-- Visual Studio 2013+ C/C++ Shared Items projects
+	"vc2013/test_vcxitems.lua",
 }

--- a/modules/vstudio/tests/sln2005/test_platforms.lua
+++ b/modules/vstudio/tests/sln2005/test_platforms.lua
@@ -782,3 +782,23 @@ GlobalSection(SolutionConfigurationPlatforms) = preSolution
 EndGlobalSection
 		]]
 	end
+
+---
+-- Check that when a shared items project is specified that no entries are added
+-- to the project configuration platforms
+---
+
+	function suite.onSharedItemsProject()
+		p.action.set("vs2013")
+		project "MyProject"
+		kind "SharedItems"
+		prepare()
+		test.capture [[
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+	Debug|Win32 = Debug|Win32
+	Release|Win32 = Release|Win32
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+EndGlobalSection
+		]]
+	end

--- a/modules/vstudio/tests/sln2005/test_shared_projects.lua
+++ b/modules/vstudio/tests/sln2005/test_shared_projects.lua
@@ -1,0 +1,72 @@
+--
+-- tests/actions/vstudio/sln2005/test_shared_projects.lua
+-- Validate generation of Visual Studio 2005+ SharedMSBuildProjectFiles entries.
+-- Copyright (c) Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("vstudio_sln2005_shared_projects")
+	local sln2005 = p.vstudio.sln2005
+
+
+--
+-- Setup
+--
+
+	local wks
+
+	function suite.setup()
+		p.action.set("vs2013")
+		p.escaper(p.vstudio.vs2005.esc)
+		wks = workspace("MyWorkspace")
+		configurations { "Debug", "Release" }
+		language "C++"
+	end
+
+	local function prepare()
+		sln2005.reorderProjects(wks)
+		sln2005.sharedProjects(wks)
+	end
+
+--
+-- Test the shared projects listing
+--
+
+	function suite.noSharedProjects()
+		project "MyProject"
+		kind "ConsoleApp"
+		prepare()
+
+		test.isemptycapture()
+	end
+
+
+	function suite.onSharedProjects()
+		project "MyProject"
+		kind "SharedItems"
+		prepare()
+
+		test.capture [[
+GlobalSection(SharedMSBuildProjectFiles) = preSolution
+MyProject.vcxitems*{42b5dbc6-ae1f-903d-f75d-41e363076e92}*SharedItemsImports = 9
+EndGlobalSection
+		]]
+	end
+
+
+	function suite.onLinkedSharedProjects()
+		project "MyProject"
+		kind "SharedItems"
+
+		project "MyProject2"
+		kind "ConsoleApp"
+		links { "MyProject" }
+		prepare()
+
+		test.capture [[
+GlobalSection(SharedMSBuildProjectFiles) = preSolution
+MyProject.vcxitems*{42b5dbc6-ae1f-903d-f75d-41e363076e92}*SharedItemsImports = 9
+MyProject.vcxitems*{b45d52a2-a015-94ef-091d-6d4bf5f32ee0}*SharedItemsImports = 4
+EndGlobalSection
+		]]
+	end

--- a/modules/vstudio/tests/vc2010/test_project_refs.lua
+++ b/modules/vstudio/tests/vc2010/test_project_refs.lua
@@ -97,3 +97,20 @@
 </ItemGroup>
 		]]
 	end
+
+
+--
+-- Shared items projects are referenced differently
+--
+
+	function suite.sharedItemsProjects()
+		links { "MyProject" }
+		project("MyProject")
+		kind "SharedItems"
+		prepare()
+		test.capture [[
+<ImportGroup Label="Shared">
+	<Import Project="MyProject.vcxitems" Label="Shared" />
+</ImportGroup>
+		]]
+	end

--- a/modules/vstudio/tests/vc2013/test_vcxitems.lua
+++ b/modules/vstudio/tests/vc2013/test_vcxitems.lua
@@ -1,0 +1,109 @@
+--
+-- tests/actions/vstudio/vc2013/test_vcxitems.lua
+-- Validate generation of the vcxitems project.
+-- Copyright (c) Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("vstudio_vs2013_vcxitems")
+	local vc2013 = p.vstudio.vc2013
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2013")
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		kind "SharedItems"
+		prj = test.getproject(wks, 1)
+	end
+
+
+--
+-- Check the structure with the default project values.
+--
+
+	function suite.structureIsCorrect_onDefaultValues()
+		prepare()
+		vc2013.generate(prj)
+		test.capture [[
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup Label="Globals">
+		<MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+		<HasSharedItems>true</HasSharedItems>
+		<ItemsProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ItemsProjectGuid>
+	</PropertyGroup>
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ItemGroup>
+		<ProjectCapability Include="SourceItemsFromImports" />
+	</ItemGroup>
+</Project>
+		]]
+	end
+
+
+--
+-- Check the structure with files.
+--
+
+	function suite.structureIsCorrect_onFiles()
+		files { "test.h", "test.cpp" }
+		prepare()
+		vc2013.generate(prj)
+		test.capture [[
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup Label="Globals">
+		<MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+		<HasSharedItems>true</HasSharedItems>
+		<ItemsProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ItemsProjectGuid>
+	</PropertyGroup>
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<ItemGroup>
+		<ProjectCapability Include="SourceItemsFromImports" />
+	</ItemGroup>
+	<ItemGroup>
+		<ClInclude Include="$(MSBuildThisFileDirectory)test.h" />
+	</ItemGroup>
+	<ItemGroup>
+		<ClCompile Include="$(MSBuildThisFileDirectory)test.cpp" />
+	</ItemGroup>
+</Project>
+		]]
+	end
+
+
+--
+-- If the project name differs from the project filename, output a
+-- <ItemsProjectName> element to indicate that.
+--
+
+	function suite.projectName_OnFilename()
+		filename "MyProject_2013"
+		prepare()
+		vc2013.globals(prj)
+		test.capture [[
+<PropertyGroup Label="Globals">
+	<MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+	<HasSharedItems>true</HasSharedItems>
+	<ItemsProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ItemsProjectGuid>
+	<ItemsProjectName>MyProject</ItemsProjectName>
+</PropertyGroup>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj_filters.lua
+++ b/modules/vstudio/vs2010_vcxproj_filters.lua
@@ -78,12 +78,19 @@
 		if files and #files > 0 then
 			p.push('<ItemGroup>')
 			for _, file in ipairs(files) do
+				local rel = path.translate(file.relpath)
+
+				-- SharedItems projects paths are prefixed with a magical variable
+				if prj.kind == p.SHAREDITEMS then
+					rel = "$(MSBuildThisFileDirectory)" .. rel
+				end
+
 				if file.parent.path then
-					p.push('<%s Include=\"%s\">', tag, path.translate(file.relpath))
+					p.push('<%s Include=\"%s\">', tag, rel)
 					p.w('<Filter>%s</Filter>', path.translate(file.parent.path, '\\'))
 					p.pop('</%s>', tag)
 				else
-					p.w('<%s Include=\"%s\" />', tag, path.translate(file.relpath))
+					p.w('<%s Include=\"%s\" />', tag, rel)
 				end
 			end
 			p.pop('</ItemGroup>')

--- a/modules/vstudio/vs2013.lua
+++ b/modules/vstudio/vs2013.lua
@@ -25,7 +25,7 @@
 
 		-- The capabilities of this action
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "SharedItems" },
 		valid_languages = { "C", "C++", "C#", "F#" },
 		valid_tools     = {
 			cc     = { "msc"   },

--- a/modules/vstudio/vs2013_vcxitems.lua
+++ b/modules/vstudio/vs2013_vcxitems.lua
@@ -1,0 +1,142 @@
+--
+-- vs2013_vcxitems.lua
+-- Generate a Visual Studio 201x C/C++ shared items project.
+-- Copyright (c) Jason Perkins and the Premake project
+--
+
+	local p = premake
+	p.vstudio.vc2013 = {}
+
+	local vstudio = p.vstudio
+	local project = p.project
+	local config = p.config
+	local fileconfig = p.fileconfig
+	local tree = p.tree
+
+	local m = p.vstudio.vc2013
+	local vc2010 = p.vstudio.vc2010
+
+---
+-- Add namespace for element definition lists for p.callArray()
+---
+
+	m.elements = {}
+	m.conditionalElements = {}
+
+--
+-- Generate a Visual Studio 201x C++ project, with support for the new platforms API.
+--
+
+	m.elements.project = function(prj)
+		return {
+			vc2010.xmlDeclaration,
+			m.project,
+			m.globals,
+			m.itemDefinitionGroup,
+			m.itemGroup,
+			vc2010.files,
+		}
+	end
+
+	function m.generate(prj)
+		p.utf8()
+		p.callArray(m.elements.project, prj)
+		p.out('</Project>')
+	end
+
+--
+-- Output the XML declaration and opening <Project> tag.
+--
+
+	function m.project(prj)
+		p.push('<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">')
+	end
+
+--
+-- Write out the Globals property group.
+--
+
+	m.elements.globals = function(prj)
+		return {
+			m.msbuildAllProjects,
+			m.hasSharedItems,
+			m.itemsProjectGuid,
+			m.itemsProjectName,
+		}
+	end
+
+	function m.globals(prj)
+		vc2010.propertyGroup(nil, "Globals")
+		p.callArray(m.elements.globals, prj)
+		p.pop('</PropertyGroup>')
+	end
+
+	function m.msbuildAllProjects(prj)
+		vc2010.element("MSBuildAllProjects", nil, "$(MSBuildAllProjects);$(MSBuildThisFileFullPath)")
+	end
+
+	function m.hasSharedItems(prj)
+		vc2010.element("HasSharedItems", nil, "true")
+	end
+
+	function m.itemsProjectGuid(prj)
+		vc2010.element("ItemsProjectGuid", nil, "{%s}", prj.uuid)
+	end
+
+	function m.itemsProjectName(prj)
+		if prj.name ~= prj.filename then
+			vc2010.element("ItemsProjectName", nil, "%s", prj.name)
+		end
+	end
+
+--
+-- Write an item definition group, which contains all of the shared compile settings.
+--
+
+	m.elements.itemDefinitionGroup = function(prj)
+		return {
+			m.clCompile,
+		}
+	end
+
+	function m.itemDefinitionGroup(prj)
+		p.push('<ItemDefinitionGroup>')
+		p.callArray(m.elements.itemDefinitionGroup, prj)
+		p.pop('</ItemDefinitionGroup>')
+	end
+
+	m.elements.clCompile = function(prj)
+		return {
+			m.additionalIncludeDirectories,
+		}
+	end
+
+	function m.clCompile(prj)
+		p.push('<ClCompile>')
+		p.callArray(m.elements.clCompile, prj)
+		p.pop('</ClCompile>')
+	end
+
+	function m.additionalIncludeDirectories(prj)
+		vc2010.element("AdditionalIncludeDirectories", nil, '%s', '%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)')
+	end
+
+--
+-- Write an item group, which contains the project capability
+--
+
+	m.elements.itemGroup = function(prj)
+		return {
+			m.projectCapability,
+		}
+	end
+
+	function m.itemGroup(prj)
+		p.push('<ItemGroup>')
+		p.callArray(m.elements.itemGroup, prj)
+		p.pop('</ItemGroup>')
+	end
+
+	function m.projectCapability(prj)
+		p.w('<ProjectCapability Include="SourceItemsFromImports" />')
+	end

--- a/modules/vstudio/vs2015.lua
+++ b/modules/vstudio/vs2015.lua
@@ -25,7 +25,7 @@
 
 		-- The capabilities of this action
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "SharedItems" },
 		valid_languages = { "C", "C++", "C#", "F#" },
 		valid_tools     = {
 			cc     = { "msc"   },

--- a/modules/vstudio/vs2017.lua
+++ b/modules/vstudio/vs2017.lua
@@ -25,7 +25,7 @@
 
 		-- The capabilities of this action
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "SharedItems" },
 		valid_languages = { "C", "C++", "C#", "F#" },
 		valid_tools     = {
 			cc     = { "msc"   },

--- a/modules/vstudio/vs2019.lua
+++ b/modules/vstudio/vs2019.lua
@@ -25,7 +25,7 @@
 
 		-- The capabilities of this action
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "SharedItems" },
 		valid_languages = { "C", "C++", "C#", "F#" },
 		valid_tools     = {
 			cc     = { "msc"   },

--- a/modules/vstudio/vstudio.lua
+++ b/modules/vstudio/vstudio.lua
@@ -447,7 +447,11 @@
 		elseif project.isfsharp(prj) then
 			extension = ".fsproj"
 		elseif project.isc(prj) or project.iscpp(prj) then
-			extension = iif(_ACTION > "vs2008", ".vcxproj", ".vcproj")
+			if prj.kind == p.SHAREDITEMS then
+				extension = ".vcxitems"
+			else
+				extension = iif(_ACTION > "vs2008", ".vcxproj", ".vcproj")
+			end
 		end
 
 		return p.filename(prj, extension)
@@ -644,5 +648,6 @@
 	include("vs2010_rules_props.lua")
 	include("vs2010_rules_targets.lua")
 	include("vs2010_rules_xml.lua")
+	include("vs2013_vcxitems.lua")
 
 	return p.modules.vstudio

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -701,6 +701,7 @@
 			"StaticLib",
 			"WindowedApp",
 			"Utility",
+			"SharedItems",
 		},
 	}
 

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -46,6 +46,7 @@
 	premake.OFF         = "Off"
 	premake.POSIX       = "posix"
 	premake.PS3         = "ps3"
+	premake.SHAREDITEMS = "SharedItems"
 	premake.SHAREDLIB   = "SharedLib"
 	premake.STATICLIB   = "StaticLib"
 	premake.UNICODE     = "Unicode"


### PR DESCRIPTION
**What does this PR do?**

This PR adds support for the `vcxitems` project type that was added in VS2013.

**How does this PR change Premake's behavior?**

There shouldn't be any breaking changes, nor should this modify any existing behaviour except when generating a `vcxitems` project type.

**Anything else we should know?**

I have very limited experience with this project type - I don't find it very useful, but I already spent the effort supporting them.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
