### PR TITLE
Improved test runner usage

### DIFF
--- a/modules/self-test/self-test.lua
+++ b/modules/self-test/self-test.lua
@@ -41,12 +41,27 @@
 		m.loadTestsFromManifests()
 		m.detectDuplicateTests = false
 
-		local test, err = m.getTestWithIdentifier(_OPTIONS["test-only"])
-		if err then
-			error(err, 0)
+		local tests = {}
+		local isAction = true
+		for i, arg in ipairs(_ARGS) do
+			local _tests, err = m.getTestsWithIdentifier(arg)
+			if err then
+				error(err, 0)
+			end
+			
+			tests = table.join(tests, _tests)
+		end
+		
+		if #tests == 0 or _OPTIONS["test-only"] ~= nil then
+			local _tests, err = m.getTestsWithIdentifier(_OPTIONS["test-only"])
+			if err then
+				error(err, 0)
+			end
+
+			tests = table.join(tests, _tests)
 		end
 
-		local passed, failed = m.runTest(test)
+		local passed, failed = m.runTest(tests)
 
 		if failed > 0 then
 			printf("\n %d FAILED TEST%s", failed, iif(failed > 1, "S", ""))

--- a/modules/self-test/test_runner.lua
+++ b/modules/self-test/test_runner.lua
@@ -15,12 +15,12 @@
 
 
 
-	function m.runTest(test)
+	function m.runTest(tests)
 		local failed = 0
 		local failedTests = {}
 
 		local suites = m.getSuites()
-		local suitesKeys, suiteTestsKeys, totalTestCount = _.preprocessTests(suites, test)
+		local suitesKeys, suiteTestsKeys, totalTestCount = _.preprocessTests(suites, tests)
 
 		_.log(term.lightGreen, "[==========]", string.format(" Running %d tests from %d test suites.", totalTestCount, #suitesKeys))
 		local startTime = os.clock()
@@ -128,30 +128,36 @@
 
 
 
-	function _.preprocessTests(suites, filter)
+	function _.preprocessTests(suites, filters)
 		local suitesKeys = {}
 		local suiteTestsKeys = {}
 		local totalTestCount = 0
+		
+		for i, filter in ipairs(filters) do
+			for suiteName, suite in pairs(suites) do
+				if not m.isSuppressed(suiteName) and suite ~= nil and (not filter.suiteName or filter.suiteName == suiteName) then
+					local test = {}
 
-		for suiteName, suite in pairs(suites) do
-			if not m.isSuppressed(suiteName) and suite ~= nil and (not filter.suiteName or filter.suiteName == suiteName) then
-				local test = {}
+					test.suiteName = suiteName
+					test.suite = suite
 
-				table.insertsorted(suitesKeys, suiteName)
+					if not table.contains(suitesKeys, suiteName) then
+						table.insertsorted(suitesKeys, suiteName)
+						suiteTestsKeys[suiteName] = {}
+					end
 
-				test.suiteName = suiteName
-				test.suite = suite
+					for testName, testFunction in pairs(suite) do
+						test.testName = testName
+						test.testFunction = testFunction
 
-				suiteTestsKeys[suiteName] = {}
-				for testName, testFunction in pairs(suite) do
-					test.testName = testName
-					test.testFunction = testFunction
-
-					if m.isValid(test) and not m.isSuppressed(test.suiteName .. "." .. test.testName) and (not filter.testName or filter.testName == testName) then
-						table.insertsorted(suiteTestsKeys[suiteName], testName)
+						if m.isValid(test) and not m.isSuppressed(test.suiteName .. "." .. test.testName) and (not filter.testName or filter.testName == testName) then
+							if not table.contains(suiteTestsKeys[suiteName], testName) then
+								table.insertsorted(suiteTestsKeys[suiteName], testName)
+								totalTestCount = totalTestCount + 1
+							end
+						end
 					end
 				end
-				totalTestCount = totalTestCount + #suiteTestsKeys[suiteName]
 			end
 		end
 


### PR DESCRIPTION
**What does this PR do?**

This PR extends the test runner to allow for some of the discussed items in #1114; wildcard support and specifying tests without using `--test-only`.

**How does this PR change Premake's behavior?**

This shouldn't break the old functionality, but does extend it as mentioned above.

**Anything else we should know?**

I wrote this several months before the commit date suggests, so I'm not sure where I got up to with it but it does seem to work. Some of the changes might be for the comma separated list, but I couldn't see anything to suggest I added support for that and it didn't work when tested.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
