### PR TITLE
Fix premake4.lua bootstrap build script

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -19,7 +19,7 @@
 		kind        "ConsoleApp"
 		defines     { "PREMAKE_NO_BUILTIN_SCRIPTS" }
 		flags       { "No64BitChecks", "ExtraWarnings", "StaticRuntime" }
-		includedirs { "contrib/lua/src" }
+		includedirs { "contrib/lua/src", "contrib/luashim" }
 
 		files
 		{


### PR DESCRIPTION
This PR add the missing include dir and fix '"luashim.h" not found' error when using premake4 bootstrap.