### PR TITLE
Add shaderincludedirs to fxcompile configuration

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -40,6 +40,14 @@
 	}
 
 	p.api.register {
+		name = "shaderincludedirs",
+		scope = "config",
+		kind = "list:directory",
+		tokens = true,
+		pathVars = true,
+	}
+
+	p.api.register {
 		name = "shadertype",
 		scope = "config",
 		kind = "string",

--- a/modules/vstudio/tests/vc2010/test_fxcompile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_fxcompile_settings.lua
@@ -78,6 +78,35 @@
 	end
 
 ---
+-- Test FxCompileAdditionalIncludeDirectories
+---
+
+	function suite.onFxCompileAdditionalIncludeDirectories()
+		files { "shader.hlsl" }
+		shaderincludedirs { "../includes" }
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<AdditionalIncludeDirectories>..\includes;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+</FxCompile>
+		]]
+	end
+
+
+	function suite.onFxCompileAdditionalIncludeDirectories_multipleDefines()
+		files { "shader.hlsl" }
+		shaderincludedirs { "../includes", "otherpath/embedded" }
+
+		prepare()
+		test.capture [[
+<FxCompile>
+	<AdditionalIncludeDirectories>..\includes;otherpath\embedded;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+</FxCompile>
+		]]
+	end
+
+---
 -- Test FxCompileShaderType
 ---
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -403,6 +403,7 @@
 	m.elements.fxCompile = function(cfg)
 		return {
 			m.fxCompilePreprocessorDefinition,
+			m.fxCompileAdditionalIncludeDirs,
 			m.fxCompileShaderType,
 			m.fxCompileShaderModel,
 			m.fxCompileShaderEntry,
@@ -806,6 +807,7 @@
 					return {
 						m.excludedFromBuild,
 						m.fxCompilePreprocessorDefinition,
+						m.fxCompileAdditionalIncludeDirs,
 						m.fxCompileShaderType,
 						m.fxCompileShaderModel,
 						m.fxCompileShaderEntry,
@@ -2692,6 +2694,12 @@
 		end
 	end
 
+	function m.fxCompileAdditionalIncludeDirs(cfg, condition)
+		if cfg.shaderincludedirs and #cfg.shaderincludedirs > 0 then
+			local dirs = vstudio.path(cfg, cfg.shaderincludedirs)
+			m.element('AdditionalIncludeDirectories', condition, "%s;%%(AdditionalIncludeDirectories)", table.concat(dirs, ";"))
+		end
+	end
 
 	function m.fxCompileShaderType(cfg, condition)
 		if cfg.shadertype then


### PR DESCRIPTION
**What does this PR do?**

Finishes up PR #1259. The original description is "Added shaderincludedirs to the visual studio configuration for fxcompile. Kept name inline with the premake includedirs."

Changed the field type to "list:directory" to match [includedirs](https://github.com/premake/premake-core/wiki/includedirs).

**How does this PR change Premake's behavior?**

Just adds a new API. No changes otherwise.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
