### PR TITLE
Allow wildcards in xcodebuildresources

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -98,6 +98,25 @@
 	end
 
 
+---
+-- Verify that files listed in xcodebuildresources are marked as resources
+---
+	function suite.PBXBuildFile_ListsXcodeBuildResources()
+		files { "file1.txt", "file01.png", "file02.png", "file-3.png" }
+		xcodebuildresources { "file1.txt", "**.png" }
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		628F3826BDD08B98912AD666 /* file-3.png in Resources */ = {isa = PBXBuildFile; fileRef = 992385EEB0362120A0521C2E /* file-3.png */; };
+		93485EDEC2DA2DD09DE76D1E /* file1.txt in Resources */ = {isa = PBXBuildFile; fileRef = 9F78562642667CD8D18C5C66 /* file1.txt */; };
+		C87AFEAA23BC521CF7169CEA /* file02.png in Resources */ = {isa = PBXBuildFile; fileRef = D54D8E32EC602964DC7C2472 /* file02.png */; };
+		EE9FC5C849E1193A1D3B6408 /* file01.png in Resources */ = {isa = PBXBuildFile; fileRef = 989B7E70AFAE19A29FCA14B0 /* file01.png */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
+
 ---------------------------------------------------------------------------
 -- PBXFileReference tests
 ---------------------------------------------------------------------------

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -48,8 +48,7 @@
 	end
 
 	function xcode.isItemResource(project, node)
-
-		local res;
+		local res
 
 		if project and project.xcodebuildresources then
 			if type(project.xcodebuildresources) == "table" then
@@ -59,20 +58,15 @@
 
 		local function checkItemInList(item, list)
 			if item then
-				if list then
-					if type(list) == "table" then
-						for _,v in pairs(list) do
-							if string.find(item, v) then
-								return true
-							end
-						end
+				for _,v in pairs(list) do
+					if string.find(item, path.wildcards(v)) then
+						return true
 					end
 				end
 			end
 			return false
 		end
 
-		--print (node.path, node.buildid, node.cfg, res)
 		if (checkItemInList(node.path, res)) then
 			return true
 		end


### PR DESCRIPTION
**What does this PR do?**

The `xcodebuildresources` script API really should use kind='list:file' to get the behavior for free, but the way it was originally coded makes it a more complex change. This is more of a short-term fix which interprets the (string) values from `xcodebuildresources` as Premake patterns, so you can do things like:

```lua
files {
    "**.h",
    "**.cpp",
    "**.png"
}

xcodebuildresources {
    "**.png"
}
```

This is an improved version of #1271.

**How does this PR change Premake's behavior?**

No breaking behavior. If anyone used Lua-style patterns in `xcodebuildresources` it will still work; this just adds the ability to use Premake patterns.

**Anything else we should know?**

I'm the one responsible for the awful Xcode generator. Seemed like a good idea at the time 🙄 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
