### PR TITLE
Replace debuggerflavor with debugger (take #2)

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -24,6 +24,11 @@
 
 	-- Initialize Specific API
 
+	p.api.addAllowed("debugger", "VisualStudioLocal")
+	p.api.addAllowed("debugger", "VisualStudioRemote")
+	p.api.addAllowed("debugger", "VisualStudioWebBrowser")
+	p.api.addAllowed("debugger", "VisualStudioWebService")
+
 	p.api.register {
 		name = "shaderoptions",
 		scope = "config",
@@ -131,7 +136,7 @@
 		tokens = true,
 	}
 
-	p.api.register {
+	p.api.register {   -- DEPRECATED 2019-10-21
 		name = "debuggerflavor",
 		scope = "config",
 		kind = "string",
@@ -142,6 +147,12 @@
 			"WebService"
 		}
 	}
+
+	p.api.deprecateField("debuggerflavor", 'Use `debugger` instead.',
+	function(value)
+		debugger('VisualStudio' .. value)
+	end)
+
 
 --
 -- Decide when the full module should be loaded.

--- a/modules/vstudio/tests/vc2010/test_debug_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_debug_settings.lua
@@ -102,11 +102,27 @@ foo=bar</LocalDebuggerEnvironment>
 	end
 
 --
--- Test Debugger Flavor
+-- Test debugger flavors
 --
 
-	function suite.debuggerFlavor_OnWindowsLocal()
-		debuggerflavor "Local"
+	function suite.debugger_OnWindowsDefault()
+		debugger "Default"
+		prepare()
+		test.capture [[
+
+		]]
+	end
+
+	function suite.debugger_OnWindowsUnavailable()
+		debugger "GDB"
+		prepare()
+		test.capture [[
+
+		]]
+	end
+
+	function suite.debugger_OnWindowsLocal()
+		debugger "VisualStudioLocal"
 		prepare()
 		test.capture [[
 <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
@@ -114,9 +130,19 @@ foo=bar</LocalDebuggerEnvironment>
 	end
 
 	function suite.debuggerFlavor_OnWindowsRemote()
-		debuggerflavor "Remote"
+		debugger "VisualStudioRemote"
 		prepare()
 		test.capture [[
+<DebuggerFlavor>WindowsRemoteDebugger</DebuggerFlavor>
+		]]
+	end
+
+	function suite.debuggerFlavor_OnDebugDirAndDebugger()
+		debugdir "bin/debug"
+		debugger "VisualStudioRemote"
+		prepare()
+		test.capture [[
+<LocalDebuggerWorkingDirectory>bin\debug</LocalDebuggerWorkingDirectory>
 <DebuggerFlavor>WindowsRemoteDebugger</DebuggerFlavor>
 		]]
 	end

--- a/modules/vstudio/vs2010_vcxproj_user.lua
+++ b/modules/vstudio/vs2010_vcxproj_user.lua
@@ -80,13 +80,13 @@
 
 	function m.debuggerFlavor(cfg)
 		local map = {
-			Local = "WindowsLocalDebugger",
-			Remote = "WindowsRemoteDebugger",
-			WebBrowser = "WebBrowserDebugger",
-			WebService = "WebServiceDebugger"
+			VisualStudioLocal = "WindowsLocalDebugger",
+			VisualStudioRemote = "WindowsRemoteDebugger",
+			VisualStudioWebBrowser = "WebBrowserDebugger",
+			VisualStudioWebService = "WebServiceDebugger"
 		}
 
-		local value = map[cfg.debuggerflavor]
+		local value = map[cfg.debugger]
 		if value then
 			p.w('<DebuggerFlavor>%s</DebuggerFlavor>', value)
 		elseif cfg.debugdir or cfg.debugcommand then


### PR DESCRIPTION
**What does this PR do?**

A replacement for PR #1063 with additional fixes. The original message: "Remove duplicate in APIs as `debugger` can be used to set `DebuggerFlavor` in Visual Studio."

Closes #1060.

**How does this PR change Premake's behavior?**

Deprecates the Visual Studio-specific `debuggerflavor()` in favor of `debugger()`. 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
