### PR TITLE
add assemblyDebug for vs2017

### DIFF
--- a/modules/vstudio/tests/vc2010/test_link.lua
+++ b/modules/vstudio/tests/vc2010/test_link.lua
@@ -722,3 +722,19 @@
 </Link>
 		]]
 	end
+
+	--
+-- Test ignoring default libraries with extensions specified.
+--
+
+	function suite.assemblyDebug()
+		assemblydebug "true"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<AssemblyDebug>true</AssemblyDebug>
+</Link>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -507,6 +507,7 @@
 				m.targetMachine,
 				m.additionalLinkOptions,
 				m.programDatabaseFile,
+				m.assemblyDebug,
 			}
 		end
 	end
@@ -1808,6 +1809,12 @@
 	function m.fullProgramDatabaseFile(cfg)
 		if _ACTION >= "vs2015" and cfg.symbols == "FastLink" then
 			m.element("FullProgramDatabaseFile", nil, "true")
+		end
+	end
+
+	function m.assemblyDebug(cfg)
+		if cfg.assemblydebug then
+      		m.element("AssemblyDebug", nil, "true")
 		end
 	end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1374,6 +1374,12 @@
 		}
 	}
 
+	api.register {
+		name = "assemblydebug",
+		scope = "config",
+		kind  = "boolean"
+	}	
+
 -----------------------------------------------------------------------------
 --
 -- Field name aliases for backward compatibility


### PR DESCRIPTION
**What does this PR do?**

I missed the "assemblyDebug" option for vcxprojects. This pull request introduces the keyword, generation and tests.

What is AssemblyDebug (Quote from VS2017):
/ASSEMBLYDEBUG emits the DebuggableAttribute attribute with debug information tracking and disables JIT optimizations.
https://docs.microsoft.com/de-de/cpp/build/reference/assemblydebug-add-debuggableattribute?view=vs-2019

**How does this PR change Premake's behavior?**

Nothing existing should change. It only adds another option.
