### PR TITLE
Fix the return value of some os functions

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -497,43 +497,55 @@
 		if type(f) == "string" then
 			local p = os.matchfiles(f)
 			for _, v in pairs(p) do
-				local ok, err = builtin_remove(v)
+				local ok, err, code = builtin_remove(v)
 				if not ok then
-					return ok, err
+					return ok, err, code
 				end
+			end
+			if #p == 0 then
+				return nil, "Couldn't find any file matching: " .. f, 1
 			end
 		-- in case of table, match files for every table entry
 		elseif type(f) == "table" then
 			for _, v in pairs(f) do
-				local ok, err = os.remove(v)
+				local ok, err, code = os.remove(v)
 				if not ok then
-					return ok, err
+					return ok, err, code
 				end
 			end
 		end
+
+		return true
 	end
 
 
 --
 -- Remove a directory, along with any contained files or subdirectories.
 --
+-- @return true on success, false and an appropriate error message on error
 
 	local builtin_rmdir = os.rmdir
 	function os.rmdir(p)
 		-- recursively remove subdirectories
 		local dirs = os.matchdirs(p .. "/*")
 		for _, dname in ipairs(dirs) do
-			os.rmdir(dname)
+			local ok, err = os.rmdir(dname)
+			if not ok then
+				return ok, err
+			end
 		end
 
 		-- remove any files
 		local files = os.matchfiles(p .. "/*")
 		for _, fname in ipairs(files) do
-			os.remove(fname)
+			local ok, err = os.remove(fname)
+			if not ok then
+				return ok, err
+			end
 		end
 
 		-- remove this directory
-		builtin_rmdir(p)
+		return builtin_rmdir(p)
 	end
 
 

--- a/src/host/os_remove.c
+++ b/src/host/os_remove.c
@@ -1,6 +1,6 @@
 /**
- * \file   os_rmdir.c
- * \brief  Remove a subdirectory.
+ * \file   os_remove.c
+ * \brief  Remove a file on Windows.
  * \author Copyright (c) 2002-2013 Jason Perkins and the Premake project
  */
 

--- a/src/host/os_rename.c
+++ b/src/host/os_rename.c
@@ -1,6 +1,6 @@
 /**
-* \file   os_rmdir.c
-* \brief  Remove a subdirectory.
+* \file   os_rename.c
+* \brief  Rename a path on Windows.
 * \author Copyright (c) 2002-2013 Jason Perkins and the Premake project
 */
 

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -373,3 +373,80 @@
 		test.isequal('cmdtool "../foo/path1" "../foo/path2/"', os.translateCommandsAndPaths("cmdtool %[path1] %[path2/]", '../foo', '.', 'osx'))
 	end
 
+
+--
+-- Helpers
+--
+
+	local tmpname = function()
+		local p = os.tmpname()
+		os.remove(p) -- just needed on POSIX
+		return p
+	end
+
+	local tmpfile = function()
+		local p = tmpname()
+		if os.ishost("windows") then
+			os.execute("type nul >" .. p)
+		else
+			os.execute("touch " .. p)
+		end
+		return p
+	end
+
+	local tmpdir = function()
+		local p = tmpname()
+		os.mkdir(p)
+		return p
+	end
+
+
+--
+-- os.remove() tests.
+--
+
+	function suite.remove_ReturnsError_OnNonExistingPath()
+		local ok, err, exitcode = os.remove(tmpname())
+		test.isnil(ok)
+		test.isequal("string", type(err))
+		test.isequal("number", type(exitcode))
+		test.istrue(0 ~= exitcode)
+	end
+
+	function suite.remove_ReturnsError_OnDirectory()
+		local ok, err, exitcode = os.remove(tmpdir())
+		test.isnil(ok)
+		test.isequal("string", type(err))
+		test.isequal("number", type(exitcode))
+		test.istrue(0 ~= exitcode)
+	end
+
+	function suite.remove_ReturnsTrue_OnFile()
+		local ok, err, exitcode = os.remove(tmpfile())
+		test.isequal(true, ok)
+		test.isnil(err)
+		test.isnil(exitcode)
+	end
+
+
+--
+-- os.rmdir() tests.
+--
+
+	function suite.rmdir_ReturnsError_OnNonExistingPath()
+		local ok, err = os.rmdir(tmpname())
+		test.isnil(ok)
+		test.isequal("string", type(err))
+	end
+
+	function suite.rmdir_ReturnsError_OnFile()
+		local ok, err = os.rmdir(tmpfile())
+		test.isnil(ok)
+		test.isequal("string", type(err))
+	end
+
+	function suite.rmdir_ReturnsTrue_OnDirectory()
+		local ok, err = os.rmdir(tmpdir())
+		test.isequal(true, ok)
+		test.isnil(err)
+	end


### PR DESCRIPTION
**What does this PR do?**

Fix the return values for os.rmdir and os.remove so they're consistent with the [Premake documentation](https://github.com/premake/premake-core/wiki/os.rmdir) and the [standard Lua ones](https://www.lua.org/manual/5.3/manual.html#pdf-os.remove).

**How does this PR change Premake's behavior?**

These functions now report some status that wasn't reported before, so the user can check it if needed. It was confusing not getting any result values in some cases, specially in a function that overrides the standard Lua library.

**Anything else we should know?**

I've just tested my changes on macOS. The test suite passes but I'm not sure if there may be anything that relies on the previous behavior (now there are some shortcuts when something can't be removed).
I also added a tiny mostly-unrelated commit to fix some comments on related files, I hope it's okay to have it here.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [x] Minimize the number of commits