### PR TITLE
Simplified unit test to resolve path issues

### DIFF
--- a/modules/gmake2/tests/test_gmake2_buildcmds.lua
+++ b/modules/gmake2/tests/test_gmake2_buildcmds.lua
@@ -4,19 +4,10 @@
 local suite = test.declare("gmake2_buildcommands")
 local gmake2 = premake.modules.gmake2
 
-premake.api.register {
-	name     = 'test_libdir', -- this controls the targetdir for StaticLib projects.
-	scope    = 'config',
-	kind     = 'path',
-	tokens   = true,
-	pathVars = true,
-}
-
 local wks, prj, cfg
 
 function suite.setup()
 	wks = workspace("MyWorkspace")
-	test_libdir   (path.join(_MAIN_SCRIPT_DIR, 'lib'))
 	configurations { "Debug", "Release" }
 	prj = test.createProject(wks)
 end
@@ -39,8 +30,8 @@ function suite.postbuildcommands()
 
 	postbuildcommands
 	{
-		"mkdir %{cfg.test_libdir}/www",
-		"mkdir %{cfg.test_libdir}/www"
+		"mkdir lib/www",
+		"mkdir lib/www"
 	}
 
 	prepare()


### PR DESCRIPTION
**What does this PR do?**

This PR resolves #1354 by simplifying the unit test to just what is required, testing the output of the build commands for the `gmake2` action.

**How does this PR change Premake's behavior?**

This PR doesn't change Premake's behaviour to the end user.

**Anything else we should know?**

No.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
