### PR TITLE
E2K: fixed build by MCST lcc compiler

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -9,25 +9,7 @@ consider running:
 
 This file contains a list of people who've made non-trivial contributions
 to Premake 5.  People who commit code to the project are encouraged to
-add their names here. And many thanks to those who contributed fixes and
-improvements to earlier versions of Premake (feel free to add your name
-in here too)!
-
-Original design and implementation:
-  Jason Perkins <starkos@industriousone.com>
-
-Main Contributors
-  Blizzard Entertainment (contact tvandijck@blizzard.com)
-  Manu Evans <https://github.com/TurkeyMan>
-  Sam Surtees <s.surtees@lorgames.com>
-
-Builds and Infrastructure:
-  Mihai Sebea <http://twitter.com/mihai_sebea>
-    * Nightly binary packages
-    * Nightly Jenkins builds and error reports
-
-Patch contributors:
-  Bastien Brunnenstein <bastien.brunnenstein@ubisoft.com>
+add their names here. And many thanуцуцЦЕУцуеom>
     * support wildcards in path tokens
   Damien Courtois <https://github.com/dcourtois>
     * module loading fixes

--- a/contrib/curl/include/curl/curlbuild.h
+++ b/contrib/curl/include/curl/curlbuild.h
@@ -288,19 +288,34 @@
 #  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__LCC__)
-#  define CURL_SIZEOF_LONG           4
-#  define CURL_TYPEOF_CURL_OFF_T     long
-#  define CURL_FORMAT_CURL_OFF_T     "ld"
-#  define CURL_FORMAT_CURL_OFF_TU    "lu"
-#  define CURL_FORMAT_OFF_T          "%ld"
-#  define CURL_SIZEOF_CURL_OFF_T     4
-#  define CURL_SUFFIX_CURL_OFF_T     L
-#  define CURL_SUFFIX_CURL_OFF_TU    UL
-#  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
+#  if defined(__e2k__) /* MCST eLbrus C Compiler */
+#    define CURL_SIZEOF_LONG           8
+#    define CURL_TYPEOF_CURL_OFF_T     long
+#    define CURL_FORMAT_CURL_OFF_T     "ld"
+#    define CURL_FORMAT_CURL_OFF_TU    "lu"
+#    define CURL_FORMAT_OFF_T          "%ld"
+#    define CURL_SIZEOF_CURL_OFF_T     8
+#    define CURL_SUFFIX_CURL_OFF_T     L
+#    define CURL_SUFFIX_CURL_OFF_TU    UL
+#    define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
+#    define CURL_SIZEOF_CURL_SOCKLEN_T 4
+#    define CURL_PULL_SYS_TYPES_H      1
+#    define CURL_PULL_SYS_SOCKET_H     1
+#  else                /* Local (or Little) C Compiler */
+#    define CURL_SIZEOF_LONG           4
+#    define CURL_TYPEOF_CURL_OFF_T     long
+#    define CURL_FORMAT_CURL_OFF_T     "ld"
+#    define CURL_FORMAT_CURL_OFF_TU    "lu"
+#    define CURL_FORMAT_OFF_T          "%ld"
+#    define CURL_SIZEOF_CURL_OFF_T     4
+#    define CURL_SUFFIX_CURL_OFF_T     L
+#    define CURL_SUFFIX_CURL_OFF_TU    UL
+#    define CURL_TYPEOF_CURL_SOCKLEN_T int
+#    define CURL_SIZEOF_CURL_SOCKLEN_T 4
+#  endif
 
 #elif defined(__SYMBIAN32__)
-#  if defined(__EABI__)  /* Treat all ARM compilers equally */
+#  if defined(__EABI__) /* Treat all ARM compilers equally */
 #    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
@@ -539,7 +554,8 @@
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  elif defined(__LP64__) || \
-        defined(__x86_64__) || defined(__ppc64__) || defined(__PPC64__) || defined(__sparc64__)
+        defined(__x86_64__) || defined(__ppc64__) || defined(__PPC64__) || defined(__sparc64__) || \
+        defined(__e2k__) /* MCST Elbrus 2000 */
 #    define CURL_SIZEOF_LONG           8
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"

--- a/src/host/curl_utils.c
+++ b/src/host/curl_utils.c
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * \file   curl_utils.c
 * \brief  curl utilities for the http library.
 * \author Copyright (c) 2017 Tom van Dijck, João Matos and the Premake project


### PR DESCRIPTION
- fixed build by MCST lcc compiler on MCST Elbrus 2000 architecture when using Curl
- strip UTF-8 BOM for compability with MCST lcc compiler < 1.24

e2k (Elbrus 2000) - this is VLIW/EPIC architecture, like Intel Itanium architecture.

About this architecture:
- https://en.wikipedia.org/wiki/Elbrus_2000