### PR TITLE
Make enablewarnings work on MSVC

### DIFF
--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -363,7 +363,10 @@
 	function msc.getwarnings(cfg)
 		local result = {}
 
-		-- NOTE: VStudio can't enable specific warnings (workaround?)
+		--we can enable specific warnings on msvc by setting them to lvl 1
+		for _, enable in ipairs(cfg.enablewarnings) do
+			table.insert(result, '/w1"' .. enable .. '"')
+		end
 		for _, disable in ipairs(cfg.disablewarnings) do
 			table.insert(result, '/wd"' .. disable .. '"')
 		end


### PR DESCRIPTION
Make enablewarnings actually do something

**What does this PR do?**
enablewarnings currently does nothing on MSVC. 
This pull request makes it so any warnings that are specifically enabled are set to level 1, which enables them as long as the user has the warning level at least level 1.

Thanks for the contribution! Please provide a concise description of the problem this request solves.

**How does this PR change Premake's behavior?**
enablewarnings will work on msvc

Are there any breaking changes? Will any existing behavior change?
If people were using enablewarnings they may not have noticed it wasn't doing anything on MSVC, it will now do something, but this may cause them to hit warnings they did not previously hit.

**Anything else we should know?**
Don't think so

Add any other context about your changes here.

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [ ] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
