### PR TITLE
Improve issue #1310

### DIFF
--- a/src/host/path_join.c
+++ b/src/host/path_join.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include "path_isabsolute.h"
 
-#define DEFERRED_JOIN_DELIMITER '|'
+#define DEFERRED_JOIN_DELIMITER '\a'
 
 char* path_join_single(char* buffer, char* ptr, const char* part, int allowDeferredJoin)
 {

--- a/src/host/path_join.c
+++ b/src/host/path_join.c
@@ -137,20 +137,9 @@ int path_deferred_join(lua_State* L)
 }
 
 
-static char *find_next_deferred_join_delimiter(const char *buffer, int offset)
-{
-	char *ptr = strchr(buffer + offset, DEFERRED_JOIN_DELIMITER);
-	while (ptr != NULL && (*(ptr + 1) == ' ' || (ptr != buffer && *(ptr - 1) == ' ')))
-	{
-		ptr = strchr(ptr + 1, DEFERRED_JOIN_DELIMITER);
-	}
-	return ptr;
-}
-
-
 int do_path_has_deferred_join(const char* path)
 {
-	return (find_next_deferred_join_delimiter(path, 0) != NULL);
+	return (strchr(path, DEFERRED_JOIN_DELIMITER) != NULL);
 }
 
 
@@ -176,7 +165,7 @@ int path_resolve_deferred_join(lua_State* L)
 	inBuffer[len] = '\0';
 	char *parts[0x200];
 	// break up the string into parts and index the start of each part
-	nextPart = find_next_deferred_join_delimiter(inBuffer, 0);
+	nextPart = strchr(inBuffer, DEFERRED_JOIN_DELIMITER);
 	if (nextPart == NULL) // nothing to do
 	{
 		lua_pushlstring(L, inBuffer, len);
@@ -188,7 +177,7 @@ int path_resolve_deferred_join(lua_State* L)
 		*nextPart = '\0';
 		nextPart++;
 		parts[numParts++] = nextPart;
-		nextPart = find_next_deferred_join_delimiter(inBuffer, nextPart - inBuffer);
+		nextPart = strchr(nextPart, DEFERRED_JOIN_DELIMITER);
 	}
 
 	/* for each part... */

--- a/src/host/path_join.c
+++ b/src/host/path_join.c
@@ -137,9 +137,20 @@ int path_deferred_join(lua_State* L)
 }
 
 
+static char *find_next_deferred_join_delimiter(const char *buffer, int offset)
+{
+	char *ptr = strchr(buffer + offset, DEFERRED_JOIN_DELIMITER);
+	while (ptr != NULL && (*(ptr + 1) == ' ' || (ptr != buffer && *(ptr - 1) == ' ')))
+	{
+		ptr = strchr(ptr + 1, DEFERRED_JOIN_DELIMITER);
+	}
+	return ptr;
+}
+
+
 int do_path_has_deferred_join(const char* path)
 {
-	return (strchr(path, DEFERRED_JOIN_DELIMITER) != NULL);
+	return (find_next_deferred_join_delimiter(path, 0) != NULL);
 }
 
 
@@ -165,7 +176,7 @@ int path_resolve_deferred_join(lua_State* L)
 	inBuffer[len] = '\0';
 	char *parts[0x200];
 	// break up the string into parts and index the start of each part
-	nextPart = strchr(inBuffer, DEFERRED_JOIN_DELIMITER);
+	nextPart = find_next_deferred_join_delimiter(inBuffer, 0);
 	if (nextPart == NULL) // nothing to do
 	{
 		lua_pushlstring(L, inBuffer, len);
@@ -177,7 +188,7 @@ int path_resolve_deferred_join(lua_State* L)
 		*nextPart = '\0';
 		nextPart++;
 		parts[numParts++] = nextPart;
-		nextPart = strchr(nextPart, DEFERRED_JOIN_DELIMITER);
+		nextPart = find_next_deferred_join_delimiter(inBuffer, nextPart - inBuffer);
 	}
 
 	/* for each part... */

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -124,6 +124,22 @@
 		test.isfalse(path.hasdeferredjoin("p1/p2"))
 	end
 
+	function suite.has_deferred_join_true_OnPipe()
+		test.istrue(path.hasdeferredjoin("c1 p1|%{foo} | c2"))
+	end
+
+	function suite.has_deferred_join_false_OnPipe()
+		test.isfalse(path.hasdeferredjoin("c1 p1/p2 | c2"))
+	end
+
+	function suite.has_deferred_join_true_OnOr()
+		test.istrue(path.hasdeferredjoin("c1 p1|%{foo} || c2"))
+	end
+
+	function suite.has_deferred_join_false_OnOr()
+		test.isfalse(path.hasdeferredjoin("c1 p1/p2 || c2"))
+	end
+
 --
 -- path.resolvedeferredjoin() tests
 --
@@ -232,6 +248,21 @@
 		test.isequal("foo/bar/%{test}/foo", path.resolvedeferredjoin("foo/bar|%{test}/foo"))
 	end
 
+	function suite.resolve_deferred_join_ignoresPipe()
+		test.isequal("c1 p1/p2 | c2", path.resolvedeferredjoin("c1 p1/p2 | c2"))
+	end
+
+	function suite.resolve_deferred_join_OnPipe()
+		test.isequal("c1 p1/p2 | c2", path.resolvedeferredjoin("c1 p1|p2 | c2"))
+	end
+
+	function suite.resolve_deferred_join_ignoresOr()
+		test.isequal("c1 p1/p2 || c2", path.resolvedeferredjoin("c1 p1/p2 || c2"))
+	end
+
+	function suite.resolve_deferred_join_OnOr()
+		test.isequal("c1 p1/p2 || c2", path.resolvedeferredjoin("c1 p1|p2 || c2"))
+	end
 
 --
 -- path.getbasename() tests

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -101,7 +101,7 @@
 -- path.deferred_join() tests
 --
 	function suite.deferred_join_OnMaybeAbsolutePath()
-		test.isequal("p1|%{foo}", path.deferredjoin("p1", "%{foo}"))
+		test.isequal("p1\a%{foo}", path.deferredjoin("p1", "%{foo}"))
 	end
 
 	function suite.deferred_join_OnValidParts()
@@ -117,11 +117,27 @@
 --
 
 	function suite.has_deferred_join_true()
-		test.istrue(path.hasdeferredjoin("p1|%{foo}"))
+		test.istrue(path.hasdeferredjoin("p1\a%{foo}"))
 	end
 
 	function suite.has_deferred_join_false()
 		test.isfalse(path.hasdeferredjoin("p1/p2"))
+	end
+
+	function suite.has_deferred_join_true_OnPipe()
+		test.istrue(path.hasdeferredjoin("c1 p1\a%{foo} | c2"))
+	end
+
+	function suite.has_deferred_join_false_OnPipe()
+		test.isfalse(path.hasdeferredjoin("c1 p1/p2 | c2"))
+	end
+
+	function suite.has_deferred_join_true_OnOr()
+		test.istrue(path.hasdeferredjoin("c1 p1\a%{foo} || c2"))
+	end
+
+	function suite.has_deferred_join_false_OnOr()
+		test.isfalse(path.hasdeferredjoin("c1 p1/p2 || c2"))
 	end
 
 --
@@ -133,105 +149,120 @@
 	end
 
 	function suite.resolve_deferred_join_OnValidParts()
-		test.isequal("p1/p2", path.resolvedeferredjoin("p1|p2"))
+		test.isequal("p1/p2", path.resolvedeferredjoin("p1\ap2"))
 	end
 
 	function suite.resolve_deferred_join_OnAbsoluteWindowsPath()
-		test.isequal("C:/p2", path.resolvedeferredjoin("p1|C:/p2"))
+		test.isequal("C:/p2", path.resolvedeferredjoin("p1\aC:/p2"))
 	end
 
 	function suite.resolve_deferred_join_OnCurrentDirectory()
-		test.isequal("p2", path.resolvedeferredjoin(".|p2"))
+		test.isequal("p2", path.resolvedeferredjoin(".\ap2"))
 	end
 
 	function suite.resolve_deferred_join_OnBackToBasePath()
-		test.isequal("", path.resolvedeferredjoin("p1/p2/|../../"))
+		test.isequal("", path.resolvedeferredjoin("p1/p2/\a../../"))
 	end
 
 	function suite.resolve_deferred_join_OnBackToBasePathWithoutFinalSlash()
-		test.isequal("", path.resolvedeferredjoin("p1/p2/|../.."))
+		test.isequal("", path.resolvedeferredjoin("p1/p2/\a../.."))
 	end
 
 	function suite.resolve_deferred_join_OnBothUpTwoFolders()
-		test.isequal("../../../../foo", path.resolvedeferredjoin("../../|../../foo"))
+		test.isequal("../../../../foo", path.resolvedeferredjoin("../../\a../../foo"))
 	end
 
 	function suite.resolve_deferred_join_OnUptwoFolders()
-		test.isequal("p1/foo", path.resolvedeferredjoin("p1/p2/p3|../../foo"))
+		test.isequal("p1/foo", path.resolvedeferredjoin("p1/p2/p3\a../../foo"))
 	end
 
 	function suite.resolve_deferred_join_OnUptoBase()
-		test.isequal("foo", path.resolvedeferredjoin("p1/p2/p3|../../../foo"))
+		test.isequal("foo", path.resolvedeferredjoin("p1/p2/p3\a../../../foo"))
 	end
 
 	function suite.resolve_deferred_join_ignoreLeadingDots()
-		test.isequal("p1/p2/foo", path.resolvedeferredjoin("p1/p2|././foo"))
+		test.isequal("p1/p2/foo", path.resolvedeferredjoin("p1/p2\a././foo"))
 	end
 
 	function suite.resolve_deferred_join_OnUptoParentOfBase()
-		test.isequal("../../p1", path.resolvedeferredjoin("p1/p2/p3/p4/p5/p6/p7/|../../../../../../../../../p1"))
+		test.isequal("../../p1", path.resolvedeferredjoin("p1/p2/p3/p4/p5/p6/p7/\a../../../../../../../../../p1"))
 	end
 
 	function suite.resolve_deferred_join_onMoreThanTwoParts()
-		test.isequal("p1/p2/p3", path.resolvedeferredjoin("p1|p2|p3"))
+		test.isequal("p1/p2/p3", path.resolvedeferredjoin("p1\ap2\ap3"))
 	end
 
 	function suite.resolve_deferred_join_removesExtraInternalSlashes()
-		test.isequal("p1/p2", path.resolvedeferredjoin("p1/|p2"))
+		test.isequal("p1/p2", path.resolvedeferredjoin("p1/\ap2"))
 	end
 
 	function suite.resolve_deferred_join_removesTrailingSlash()
-		test.isequal("p1/p2", path.resolvedeferredjoin("p1|p2/"))
+		test.isequal("p1/p2", path.resolvedeferredjoin("p1\ap2/"))
 	end
 
 	function suite.resolve_deferred_join_ignoresEmptyParts()
-		test.isequal("p2", path.resolvedeferredjoin("|p2|"))
+		test.isequal("p2", path.resolvedeferredjoin("\ap2\a"))
 	end
 
 	function suite.resolve_deferred_join_canJoinBareSlash()
-		test.isequal("/Users", path.resolvedeferredjoin("/|Users"))
+		test.isequal("/Users", path.resolvedeferredjoin("/\aUsers"))
 	end
 
 	function suite.resolve_deferred_join_keepsLeadingEnvVar()
-		test.isequal("$(ProjectDir)/../../Bin", path.resolvedeferredjoin("$(ProjectDir)|../../Bin"))
+		test.isequal("$(ProjectDir)/../../Bin", path.resolvedeferredjoin("$(ProjectDir)\a../../Bin"))
 	end
 
 	function suite.resolve_deferred_join_keepsInternalEnvVar()
-		test.isequal("$(ProjectDir)/$(TargetName)/../../Bin", path.resolvedeferredjoin("$(ProjectDir)/$(TargetName)|../../Bin"))
+		test.isequal("$(ProjectDir)/$(TargetName)/../../Bin", path.resolvedeferredjoin("$(ProjectDir)/$(TargetName)\a../../Bin"))
 	end
 
 	function suite.resolve_deferred_join_keepsComplexInternalEnvVar()
-		test.isequal("$(ProjectDir)/myobj_$(Arch)/../../Bin", path.resolvedeferredjoin("$(ProjectDir)/myobj_$(Arch)|../../Bin"))
+		test.isequal("$(ProjectDir)/myobj_$(Arch)/../../Bin", path.resolvedeferredjoin("$(ProjectDir)/myobj_$(Arch)\a../../Bin"))
 	end
 
 	function suite.resolve_deferred_join_keepsRecursivePattern()
-		test.isequal("p1/**.lproj/../p2", path.resolvedeferredjoin("p1/**.lproj|../p2"))
+		test.isequal("p1/**.lproj/../p2", path.resolvedeferredjoin("p1/**.lproj\a../p2"))
 	end
 
 	function suite.resolve_deferred_join_keepsVSMacros()
-		test.isequal("p1/%(Filename).ext", path.resolvedeferredjoin("p1|%(Filename).ext"))
+		test.isequal("p1/%(Filename).ext", path.resolvedeferredjoin("p1\a%(Filename).ext"))
 	end
 
 	function suite.resolve_deferred_join_noCombineSingleDot()
-		test.isequal("p1/./../p2", path.resolvedeferredjoin("p1/.|../p2"))
+		test.isequal("p1/./../p2", path.resolvedeferredjoin("p1/.\a../p2"))
 	end
 
 	function suite.resolve_deferred_join_absolute_second_part()
-		test.isequal("$ORIGIN", path.resolvedeferredjoin("foo/bar|$ORIGIN"))
+		test.isequal("$ORIGIN", path.resolvedeferredjoin("foo/bar\a$ORIGIN"))
 	end
 
 	function suite.resolve_deferred_join_absolute_second_part1()
-		test.isequal("$(FOO)/bar", path.resolvedeferredjoin("foo/bar|$(FOO)/bar"))
+		test.isequal("$(FOO)/bar", path.resolvedeferredjoin("foo/bar\a$(FOO)/bar"))
 	end
 
 	function suite.resolve_deferred_join_absolute_second_part2()
-		test.isequal("%ROOT%/foo", path.resolvedeferredjoin("foo/bar|%ROOT%/foo"))
+		test.isequal("%ROOT%/foo", path.resolvedeferredjoin("foo/bar\a%ROOT%/foo"))
 	end
 
 	function suite.resolve_deferred_join_token_in_second_part()
-		test.isequal("foo/bar/%{test}/foo", path.resolvedeferredjoin("foo/bar|%{test}/foo"))
+		test.isequal("foo/bar/%{test}/foo", path.resolvedeferredjoin("foo/bar\a%{test}/foo"))
 	end
 
+	function suite.resolve_deferred_join_ignoresPipe()
+		test.isequal("c1 p1/p2 | c2", path.resolvedeferredjoin("c1 p1/p2 | c2"))
+	end
+
+	function suite.resolve_deferred_join_OnPipe()
+		test.isequal("c1 p1/p2 | c2", path.resolvedeferredjoin("c1 p1\ap2 | c2"))
+	end
+
+	function suite.resolve_deferred_join_ignoresOr()
+		test.isequal("c1 p1/p2 || c2", path.resolvedeferredjoin("c1 p1/p2 || c2"))
+	end
+
+	function suite.resolve_deferred_join_OnOr()
+		test.isequal("c1 p1/p2 || c2", path.resolvedeferredjoin("c1 p1\ap2 || c2"))
+	end
 
 --
 -- path.getbasename() tests

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -124,22 +124,6 @@
 		test.isfalse(path.hasdeferredjoin("p1/p2"))
 	end
 
-	function suite.has_deferred_join_true_OnPipe()
-		test.istrue(path.hasdeferredjoin("c1 p1|%{foo} | c2"))
-	end
-
-	function suite.has_deferred_join_false_OnPipe()
-		test.isfalse(path.hasdeferredjoin("c1 p1/p2 | c2"))
-	end
-
-	function suite.has_deferred_join_true_OnOr()
-		test.istrue(path.hasdeferredjoin("c1 p1|%{foo} || c2"))
-	end
-
-	function suite.has_deferred_join_false_OnOr()
-		test.isfalse(path.hasdeferredjoin("c1 p1/p2 || c2"))
-	end
-
 --
 -- path.resolvedeferredjoin() tests
 --
@@ -248,21 +232,6 @@
 		test.isequal("foo/bar/%{test}/foo", path.resolvedeferredjoin("foo/bar|%{test}/foo"))
 	end
 
-	function suite.resolve_deferred_join_ignoresPipe()
-		test.isequal("c1 p1/p2 | c2", path.resolvedeferredjoin("c1 p1/p2 | c2"))
-	end
-
-	function suite.resolve_deferred_join_OnPipe()
-		test.isequal("c1 p1/p2 | c2", path.resolvedeferredjoin("c1 p1|p2 | c2"))
-	end
-
-	function suite.resolve_deferred_join_ignoresOr()
-		test.isequal("c1 p1/p2 || c2", path.resolvedeferredjoin("c1 p1/p2 || c2"))
-	end
-
-	function suite.resolve_deferred_join_OnOr()
-		test.isequal("c1 p1/p2 || c2", path.resolvedeferredjoin("c1 p1|p2 || c2"))
-	end
 
 --
 -- path.getbasename() tests


### PR DESCRIPTION
**What does this PR do?**

-  If there is a whitespace immediately before and/or after `|`, it is not considered as a "deferred join delimiter".

**How does this PR change Premake's behavior?**

-  In most cases, directory names do not have leading and/or trailing whitespace.
  In most cases, whitespace is added before and after "pipe" and "or".
  In such cases, applying this PR eliminates issue #1310.

- if directory name has a leading and/or trailing whietspace, "deferred join delimiter" will not work properly.
  However, all existing tests passed without change.

**Anything else we should know?**

- This PR does not completely resolve issue #1310.
  So I don't write `close` comment.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions]([https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions))
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
