### PR TITLE
Initial support for generating netcore and netstandard projects

### DIFF
--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -14,6 +14,7 @@ return {
 	"cs2005/test_debug_props.lua",
 	"cs2005/test_files.lua",
 	"cs2005/test_icon.lua",
+	"cs2005/test_netcore.lua",
 	"cs2005/test_nuget_config.lua",
 	"cs2005/test_nuget_packages_config.lua",
 	"cs2005/test_nuget_references.lua",

--- a/modules/vstudio/tests/cs2005/test_netcore.lua
+++ b/modules/vstudio/tests/cs2005/test_netcore.lua
@@ -1,0 +1,103 @@
+--
+-- tests/actions/vstudio/cs2005/test_output_props.lua
+-- Test the target output settings of a Visual Studio 2005+ C# project.
+-- Copyright (c) 2012-2013 Jason Perkins and the Premake project
+--
+
+local p = premake
+local suite = test.declare("vstudio_cs2005_netcore_prj")
+local dn2005 = p.vstudio.dotnetbase
+local project = p.project
+
+
+--
+-- Setup and teardown
+--
+
+local wks, prj
+
+function suite.setup()
+    p.action.set("vs2005")
+    wks, prj = test.createWorkspace()
+    language "C#"
+end
+
+local function targetFrameworkPrepare()
+    local cfg = test.getconfig(prj, "Debug")
+    dn2005.netcore.targetFramework(cfg)
+end
+
+local function targetFrameworkVersionPrepare()
+    local cfg = test.getconfig(prj, "Debug")
+    dn2005.targetFrameworkVersion(cfg)
+end
+
+local function prepareNetcore()
+    dn2005.projectElement(prj)
+end
+
+function suite.targetFrameworkProperty_framework()
+    dotnetframework "4.7.2"
+    targetFrameworkPrepare()
+    test.isemptycapture()
+end
+
+function suite.targetFrameworkProperty_core()
+    dotnetframework "netcoreapp2.2"
+    targetFrameworkPrepare()
+    test.capture [[
+		<TargetFramework>netcoreapp2.2</TargetFramework>
+	]]
+end
+
+function suite.targetFrameworkProperty_standard()
+    dotnetframework "netstandard1.2"
+    targetFrameworkPrepare()
+    test.capture [[
+		<TargetFramework>netstandard1.2</TargetFramework>
+    ]]
+end
+
+function suite.targetFrameworkVersionProperty_framework()
+    dotnetframework "4.7.2"
+    targetFrameworkVersionPrepare()
+    test.capture [[
+		<TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    ]]
+end
+
+function suite.targetFrameworkVersionProperty_core()
+    dotnetframework "netcoreapp2.2"
+    targetFrameworkVersionPrepare()
+    test.isemptycapture()
+end
+
+function suite.targetFrameworkVersionProperty_standard()
+    dotnetframework "netstandard1.2"
+    targetFrameworkVersionPrepare()
+    test.isemptycapture()
+end
+
+function suite.project_element_standard()
+    dotnetframework "netstandard1.2"
+    prepareNetcore()
+    test.capture [[
+<Project Sdk="Microsoft.NET.Sdk">
+    ]]
+end
+
+function suite.project_element_core()
+    dotnetframework "netcoreapp1.2"
+    prepareNetcore()
+    test.capture [[
+<Project Sdk="Microsoft.NET.Sdk">
+    ]]
+end
+
+function suite.project_element_framework()
+    dotnetframework "4.7.2"
+    prepareNetcore()
+    test.capture [[
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    ]]
+end

--- a/modules/vstudio/vs2005_csproj.lua
+++ b/modules/vstudio/vs2005_csproj.lua
@@ -17,36 +17,61 @@
 
 	cs2005.elements = {}
 
-	cs2005.elements.project = function ()
-		return {
-			dotnetbase.xmlDeclaration,
-			dotnetbase.projectElement,
-			dotnetbase.commonProperties,
-			dotnetbase.projectProperties,
-			dotnetbase.configurations,
-			dotnetbase.applicationIcon,
-			dotnetbase.references
-		}
+	cs2005.elements.project = function (prj)
+		if dotnetbase.isNewFormatProject(prj) then
+			return {
+				dotnetbase.projectElement,
+				dotnetbase.projectProperties,
+				dotnetbase.configurations,
+				dotnetbase.applicationIcon,
+				dotnetbase.references
+			}
+		else
+			return {
+				dotnetbase.xmlDeclaration,
+				dotnetbase.projectElement,
+				dotnetbase.commonProperties,
+				dotnetbase.projectProperties,
+				dotnetbase.configurations,
+				dotnetbase.applicationIcon,
+				dotnetbase.references
+			}
+		end
 	end
 
-	cs2005.elements.projectProperties = function ()
-		return {
-			dotnetbase.configurationCondition,
-			dotnetbase.platformCondition,
-			dotnetbase.productVersion,
-			dotnetbase.schemaVersion,
-			dotnetbase.projectGuid,
-			dotnetbase.outputType,
-			dotnetbase.appDesignerFolder,
-			dotnetbase.rootNamespace,
-			dotnetbase.assemblyName,
-			dotnetbase.targetFrameworkVersion,
-			dotnetbase.targetFrameworkProfile,
-			dotnetbase.fileAlignment,
-			dotnetbase.bindingRedirects,
-			dotnetbase.projectTypeGuids,
-			dotnetbase.csversion
-		}
+	cs2005.elements.projectProperties = function (cfg)
+		if dotnetbase.isNewFormatProject(cfg) then
+			return {
+				dotnetbase.outputType,
+				dotnetbase.appDesignerFolder,
+				dotnetbase.rootNamespace,
+				dotnetbase.assemblyName,
+				dotnetbase.netcore.targetFramework,
+				dotnetbase.fileAlignment,
+				dotnetbase.bindingRedirects,
+				dotnetbase.netcore.useWpf,
+				dotnetbase.csversion,
+				dotnetbase.netcore.enableDefaultCompileItems,
+			}
+		else
+			return {
+				dotnetbase.configurationCondition,
+				dotnetbase.platformCondition,
+				dotnetbase.productVersion,
+				dotnetbase.schemaVersion,
+				dotnetbase.projectGuid,
+				dotnetbase.outputType,
+				dotnetbase.appDesignerFolder,
+				dotnetbase.rootNamespace,
+				dotnetbase.assemblyName,
+				dotnetbase.targetFrameworkVersion,
+				dotnetbase.targetFrameworkProfile,
+				dotnetbase.fileAlignment,
+				dotnetbase.bindingRedirects,
+				dotnetbase.projectTypeGuids,
+				dotnetbase.csversion,
+			}
+		end
 	end
 
 	cs2005.elements.configuration = function ()
@@ -65,13 +90,15 @@
 	end
 
 	function cs2005.targets(prj)
-		local bin = iif(_ACTION <= "vs2010", "MSBuildBinPath", "MSBuildToolsPath")
-		_p(1,'<Import Project="$(%s)\\Microsoft.CSharp.targets" />', bin)
-		_p(1,'<!-- To modify your build process, add your task inside one of the targets below and uncomment it.')
-		_p(1,'     Other similar extension points exist, see Microsoft.Common.targets.')
-		_p(1,'<Target Name="BeforeBuild">')
-		_p(1,'</Target>')
-		_p(1,'<Target Name="AfterBuild">')
-		_p(1,'</Target>')
-		_p(1,'-->')
+		if not dotnetbase.isNewFormatProject(prj) then
+			local bin = iif(_ACTION <= "vs2010", "MSBuildBinPath", "MSBuildToolsPath")
+			_p(1,'<Import Project="$(%s)\\Microsoft.CSharp.targets" />', bin)
+			_p(1,'<!-- To modify your build process, add your task inside one of the targets below and uncomment it.')
+			_p(1,'     Other similar extension points exist, see Microsoft.Common.targets.')
+			_p(1,'<Target Name="BeforeBuild">')
+			_p(1,'</Target>')
+			_p(1,'<Target Name="AfterBuild">')
+			_p(1,'</Target>')
+			_p(1,'-->')
+		end
 	end

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -17,7 +17,12 @@
 
 	dotnetbase.elements = {}
 	dotnetbase.langObj = {}
+	dotnetbase.netcore = {}
 
+	dotnetbase.targetFormats = {}
+	dotnetbase.targetFormats.framework = {}
+	dotnetbase.targetFormats.core = {}
+	dotnetbase.targetFormats.standard = {}
 
 --
 -- Generate a Visual Studio 200x dotnet project, with support for the new platforms API.
@@ -55,12 +60,20 @@
 --
 
 	function dotnetbase.projectElement(prj)
-		local ver = ''
-		local action = p.action.current()
-		if action.vstudio.toolsVersion then
-			ver = string.format(' ToolsVersion="%s"', action.vstudio.toolsVersion)
+		if dotnetbase.isNewFormatProject(prj) then
+			if prj.flags.WPF then
+				_p('<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">')
+			else				
+				_p('<Project Sdk="Microsoft.NET.Sdk">')
+			end
+		else
+			local ver = ''
+			local action = p.action.current()
+			if action.vstudio.toolsVersion then
+				ver = string.format(' ToolsVersion="%s"', action.vstudio.toolsVersion)
+			end
+			_p('<Project%s DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">', ver)
 		end
-		_p('<Project%s DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">', ver)
 	end
 
 
@@ -291,7 +304,7 @@
 		-- Want to set BaseIntermediateOutputPath because otherwise VS will create obj/
 		-- anyway. But VS2008 throws up ominous warning if present.
 		local objdir = vstudio.path(cfg, cfg.objdir)
-		if _ACTION > "vs2008" then
+		if _ACTION > "vs2008" and not dotnetbase.isNewFormatProject(cfg) then
 			_x(2,'<BaseIntermediateOutputPath>%s\\</BaseIntermediateOutputPath>', objdir)
 			_p(2,'<IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>')
 		else
@@ -476,10 +489,16 @@
 -- Write the list of project dependencies.
 --
 	function dotnetbase.projectReferences(prj)
-		_p(1,'<ItemGroup>')
+		if not dotnetbase.isNewFormatProject(prj) then
+			_p(1,'<ItemGroup>')
+		end
 
 		local deps = project.getdependencies(prj, 'linkOnly')
 		if #deps > 0 then
+			if dotnetbase.isNewFormatProject(prj) then
+				_p(1,'<ItemGroup>')
+			end
+
 			for _, dep in ipairs(deps) do
 				local relpath = vstudio.path(prj, vstudio.projectfile(dep))
 				_x(2,'<ProjectReference Include="%s">', relpath)
@@ -492,9 +511,15 @@
 
 				_p(2,'</ProjectReference>')
 			end
+
+			if dotnetbase.isNewFormatProject(prj) then
+				_p(1,'</ItemGroup>')
+			end
 		end
 
-		_p(1,'</ItemGroup>')
+		if not dotnetbase.isNewFormatProject(prj) then
+			_p(1,'</ItemGroup>')
+		end
 	end
 
 --
@@ -608,7 +633,9 @@
 
 
 	function dotnetbase.assemblyName(cfg)
-		_p(2,'<AssemblyName>%s</AssemblyName>', cfg.buildtarget.basename)
+		if not dotnetbase.isNewFormatProject(cfg) --[[or cfg.assemblyname]] then
+			_p(2,'<AssemblyName>%s</AssemblyName>', cfg.buildtarget.basename)
+		end
 	end
 
 
@@ -625,14 +652,14 @@
 
 
 	function dotnetbase.fileAlignment(cfg)
-		if _ACTION >= "vs2010" then
+		if _ACTION >= "vs2010" and not dotnetbase.isNewFormatProject(cfg) then
 			_p(2,'<FileAlignment>512</FileAlignment>')
 		end
 	end
 
 
 	function dotnetbase.bindingRedirects(cfg)
-		if _ACTION >= "vs2015" then
+		if _ACTION >= "vs2015" and not dotnetbase.isNewFormatProject(cfg) then
 			_p(2, '<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>')
 		end
 	end
@@ -668,7 +695,9 @@
 
 
 	function dotnetbase.rootNamespace(cfg)
-		_p(2,'<RootNamespace>%s</RootNamespace>', cfg.namespace or cfg.buildtarget.basename)
+		if not dotnetbase.isNewFormatProject(cfg) or cfg.namespace then
+			_p(2,'<RootNamespace>%s</RootNamespace>', cfg.namespace or cfg.buildtarget.basename)
+		end
 	end
 
 
@@ -690,7 +719,7 @@
 	function dotnetbase.targetFrameworkVersion(cfg)
 		local action = p.action.current()
 		local framework = cfg.dotnetframework or action.vstudio.targetFramework
-		if framework then
+		if framework and not dotnetbase.isNewFormatProject(cfg) then
 			_p(2,'<TargetFrameworkVersion>v%s</TargetFrameworkVersion>', framework)
 		end
 	end
@@ -715,3 +744,37 @@
 		end
 	end
 
+	function dotnetbase.isNewFormatProject(cfg)
+		local framework = cfg.dotnetframework or action.vstudio.targetFramework
+		if not framework then
+			return false
+		end
+
+		if framework:find('^netcoreapp') ~= nil then
+			return true
+		end
+		
+		if framework:find('^netstandard') ~= nil then
+			return true
+		end
+
+		return false
+	end
+
+	function dotnetbase.netcore.targetFramework(cfg)
+		local action = p.action.current()
+		local framework = cfg.dotnetframework or action.vstudio.targetFramework
+		if framework and dotnetbase.isNewFormatProject(cfg) then
+			_p(2,'<TargetFramework>%s</TargetFramework>', framework)
+		end
+	end
+
+	function dotnetbase.netcore.enableDefaultCompileItems(cfg)
+		_p(2,'<EnableDefaultCompileItems>%s</EnableDefaultCompileItems>', iif(cfg.enableDefaultCompileItems, "true", "false"))
+	end
+
+	function dotnetbase.netcore.useWpf(cfg)
+		if cfg.flags.WPF then
+			_p(2,'<UseWpf>true</UseWpf>')
+		end
+	end

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -19,11 +19,6 @@
 	dotnetbase.langObj = {}
 	dotnetbase.netcore = {}
 
-	dotnetbase.targetFormats = {}
-	dotnetbase.targetFormats.framework = {}
-	dotnetbase.targetFormats.core = {}
-	dotnetbase.targetFormats.standard = {}
-
 --
 -- Generate a Visual Studio 200x dotnet project, with support for the new platforms API.
 --
@@ -745,7 +740,7 @@
 	end
 
 	function dotnetbase.isNewFormatProject(cfg)
-		local framework = cfg.dotnetframework or action.vstudio.targetFramework
+		local framework = cfg.dotnetframework
 		if not framework then
 			return false
 		end

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -594,6 +594,13 @@
 	}
 
 	api.register {
+		name = "enabledefaultcompileitems",
+		scope = "config",
+		kind = "boolean",
+		default = false
+	}
+
+	api.register {
 		name = "csversion",
 		scope = "config",
 		kind = "string",


### PR DESCRIPTION
**What does this PR do?**

Resolves #1010 

This adds support for generating netcore and netstandard projects via the dotnetframework property. It also adds support for the property used to enable WPF.

**How does this PR change Premake's behavior?**

I've added a new method in dotnetbase called "isNewFormatProject". This is used to control the differences between .NET Framework and netcore/netstandard projects. Rather than keep a list of all frameworks, it determines any version starting with "netcoreapp" or "netstandard" should use the new project format rules. This method will need to be updated once .NET 5 is released as it's very likely to use the netcore format.

**Anything else we should know?**

This changelist does not add support for targetting multiple frameworks. It should be easy to do, but I'd prefer to add it to another PR as I'm not sure how to test it.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*



