### PR TITLE
Fixed edge case in path.normalize

### DIFF
--- a/src/host/path_normalize.c
+++ b/src/host/path_normalize.c
@@ -181,8 +181,7 @@ int path_normalize(lua_State* L)
 
 		// path is surrounded with quotes
 		if (readPtr != endPtr &&
-			IS_QUOTE(*readPtr) && IS_QUOTE(endPtr[-1]) &&
-			*readPtr == endPtr[-1])
+			IS_QUOTE(*readPtr))
 		{
 			*(writePtr++) = *(readPtr++);
 		}

--- a/tests/base/test_path.lua
+++ b/tests/base/test_path.lua
@@ -740,3 +740,19 @@
 		-- End
 		test.isequal("../../test/${MYVAR}", path.normalize("../../test/${MYVAR}"))
 	end
+
+	function suite.normalize_quotedpath_withTokens()
+		-- Premake tokens
+		test.isequal("\"%{wks.location}../../test\"", path.normalize("\"%{wks.location}../../test\""))
+		-- Visual Studio var
+		test.isequal("\"$(SolutionDir)../../test\"", path.normalize("\"$(SolutionDir)../../test\""))
+		-- Windows env var
+		test.isequal("\"%APPDATA%../../test\"", path.normalize("\"%APPDATA%../../test\""))
+		-- Unix env var
+		test.isequal("\"${HOME}../../test\"", path.normalize("\"${HOME}../../test\""))
+
+		-- Middle
+		test.isequal("\"../../${MYVAR}/../test\"", path.normalize("\"../../${MYVAR}/../test\""))
+		-- End
+		test.isequal("\"../../test/${MYVAR}\"", path.normalize("\"../../test/${MYVAR}\""))
+	end


### PR DESCRIPTION
**What does this PR do?**

Fixes edge cases that results in `../../` being truncated - see #1283 for more details. Closes #1283.

**How does this PR change Premake's behavior?**

There may be a breaking change, but none of the unit tests covered such a case. Paths that start with `"../../$` or `"../../%` or `"../../ ` will now work correctly.

**Anything else we should know?**

None.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
