### PR TITLE
Fixed bug with linkgroups only working on Premake projects

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -467,11 +467,6 @@
 			end
 		end
 
-		if not nogroups and #result > 1 and (cfg.linkgroups == p.ON) then
-			table.insert(result, 1, "-Wl,--start-group")
-			table.insert(result, "-Wl,--end-group")
-		end
-
 		-- The "-l" flag is fine for system libraries
 		local links = config.getlinks(cfg, "system", "fullpath")
 		local static_syslibs = {"-Wl,-Bstatic"}
@@ -510,6 +505,11 @@
 			move(static_syslibs, result)
 		end
 		move(shared_syslibs, result)
+
+		if not nogroups and #result > 1 and (cfg.linkgroups == p.ON) then
+			table.insert(result, 1, "-Wl,--start-group")
+			table.insert(result, "-Wl,--end-group")
+		end
 
 		return result
 	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -505,6 +505,24 @@
 
 
 --
+-- Test that sibling and external links are grouped when required
+--
+
+	function suite.linkgroups_onSiblingAndExternalLibrary()
+		links { "MyProject2", "ExternalProj" }
+		linkgroups "On"
+
+		test.createproject(wks)
+		system "Linux"
+		kind "StaticLib"
+		targetdir "lib"
+
+		prepare()
+		test.isequal({ "-Wl,--start-group", "lib/libMyProject2.a", "-lExternalProj", "-Wl,--end-group" }, gcc.getlinks(cfg))
+	end
+
+
+--
 -- When linking object files, leave off the "-l".
 --
 


### PR DESCRIPTION
**What does this PR do?**

`linksgroups` now applies to all `links` instead of just the Premake projects. Closes #1265

**How does this PR change Premake's behavior?**

I don't believe there's any breaking change, projects will now link correctly to external libraries.

**Anything else we should know?**

None

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
