### PR TITLE
Remove commands optimization which breaks tokens

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -1099,7 +1099,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nls src\ncp \"a\" \"b\"";
+			shellScript = "set -e\nif [ \"${CONFIGURATION}\" = \"Debug\" ]; then\nls src\ncp \"a\" \"b\"\nfi\nif [ \"${CONFIGURATION}\" = \"Release\" ]; then\nls src\ncp \"a\" \"b\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 		]]
@@ -1158,7 +1158,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nls src\nif [ \"${CONFIGURATION}\" = \"Debug\" ]; then\ncp a b\nfi";
+			shellScript = "set -e\nif [ \"${CONFIGURATION}\" = \"Debug\" ]; then\nls src\ncp a b\nfi\nif [ \"${CONFIGURATION}\" = \"Release\" ]; then\nls src\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 		]]

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -743,16 +743,7 @@
 		for _, node in ipairs(tr.products.children) do
 			local name = tr.project.name
 
-			-- This function checks whether there are build commands of a specific
-			-- type to be executed; they will be generated correctly, but the project
-			-- commands will not contain any per-configuration commands, so the logic
-			-- has to be extended a bit to account for that.
 			local function hasBuildCommands(which)
-				-- standard check...this is what existed before
-				if #tr.project[which] > 0 then
-					return true
-				end
-				-- what if there are no project-level commands? check configs...
 				for _, cfg in ipairs(tr.configs) do
 					if #cfg[which] > 0 then
 						return true
@@ -933,16 +924,13 @@
 		local wrapperWritten = false
 
 		local function doblock(id, name, which)
-			-- start with the project-level commands (most common)
-			local prjcmds = tr.project[which]
-			local commands = table.join(prjcmds, {})
-
 			-- see if there are any config-specific commands to add
+			local commands = {}
 			for _, cfg in ipairs(tr.configs) do
 				local cfgcmds = cfg[which]
-				if #cfgcmds > #prjcmds then
+				if #cfgcmds > 0 then
 					table.insert(commands, 'if [ "${CONFIGURATION}" = "' .. cfg.buildcfg .. '" ]; then')
-					for i = #prjcmds + 1, #cfgcmds do
+					for i = 1, #cfgcmds do
 						table.insert(commands, cfgcmds[i])
 					end
 					table.insert(commands, 'fi')


### PR DESCRIPTION
**What does this PR do?**

Closes #1013. When a build command contains a token which references a configuration, ex. `{cfg.platform}`, the platform optimizations removed by this commit would cause a crash: "Attempt to index a nil value (global 'cfg')".

**How does this PR change Premake's behavior?**

No breaking changes I'm aware of.

**Anything else we should know?**

Add any other context about your changes here.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
