### PR TITLE
Remove checkFunc from Resource files

### DIFF
--- a/modules/vstudio/tests/vc2010/test_files.lua
+++ b/modules/vstudio/tests/vc2010/test_files.lua
@@ -278,6 +278,19 @@
 		prepare()
 		test.capture [[
 <ItemGroup>
+	<ResourceCompile Include="hello.rc">
+		<ExcludedFromBuild>true</ExcludedFromBuild>
+	</ResourceCompile>
+</ItemGroup>
+		]]
+	end
+
+	function suite.includedFromBuild_onResourceFile_nonWindows()
+		files { "hello.rc" }
+		system "Linux"
+		prepare()
+		test.capture [[
+<ItemGroup>
 	<ResourceCompile Include="hello.rc" />
 </ItemGroup>
 		]]

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -865,9 +865,7 @@
 				m.excludedFromBuild
 			}
 
-			m.emitFiles(prj, group, "ResourceCompile", nil, fileCfgFunc, function(cfg)
-				return cfg.system == p.WINDOWS
-			end)
+			m.emitFiles(prj, group, "ResourceCompile", nil, fileCfgFunc)
 		end,
 
 		emitFilter = function(prj, group)


### PR DESCRIPTION
**What does this PR do?**

This is a second attempt at fixing [1172](https://github.com/premake/premake-core/issues/1172). I've removed the function entirely according to @starkos [comment](https://github.com/premake/premake-core/pull/1196#issuecomment-541748863).

**How does this PR change Premake's behavior?**

Are there any breaking changes? Will any existing behavior change?

- .rc files are now included by default for non-windows systems

Add any other context about your changes here.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
