### PR TITLE
Place all generated files in separate GENERATED list, so they all can…

### DIFF
--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -250,6 +250,11 @@
 		table.insert(fileset, filename)
 		cfg._gmake.filesets[kind] = fileset
 
+		local generatedKind = "GENERATED"
+		local generatedFileset = cfg._gmake.filesets[generatedKind] or {}
+		table.insert(generatedFileset, filename)
+		cfg._gmake.filesets[generatedKind] = generatedFileset
+
 		-- recursively setup rules.
 		cpp.addRuleFile(cfg, node)
 	end
@@ -715,9 +720,11 @@
 		_p('\t@echo Cleaning %s', cfg.project.name)
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) rm -f  $(TARGET)')
+		_p('\t$(SILENT) rm -rf $(GENERATED)')
 		_p('\t$(SILENT) rm -rf $(OBJDIR)')
 		_p('else')
 		_p('\t$(SILENT) if exist $(subst /,\\\\,$(TARGET)) del $(subst /,\\\\,$(TARGET))')
+		_p('\t$(SILENT) if exist $(subst /,\\\\,$(GENERATED)) rmdir /s /q $(subst /,\\\\,$(GENERATED))')
 		_p('\t$(SILENT) if exist $(subst /,\\\\,$(OBJDIR)) rmdir /s /q $(subst /,\\\\,$(OBJDIR))')
 		_p('endif')
 		_p('')

--- a/modules/gmake2/tests/test_gmake2_objects.lua
+++ b/modules/gmake2/tests/test_gmake2_objects.lua
@@ -41,8 +41,10 @@
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/hello.o
 OBJECTS += $(OBJDIR)/hello.o
 
 		]]
@@ -60,8 +62,10 @@ OBJECTS += $(OBJDIR)/hello.o
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/hello.o
 OBJECTS += $(OBJDIR)/hello.o
 
 		]]
@@ -82,12 +86,15 @@ OBJECTS += $(OBJDIR)/hello.o
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
 ifeq ($(config),debug)
+GENERATED += $(OBJDIR)/hello_debug.o
 OBJECTS += $(OBJDIR)/hello_debug.o
 
 else ifeq ($(config),release)
+GENERATED += $(OBJDIR)/hello_release.o
 OBJECTS += $(OBJDIR)/hello_release.o
 
 endif
@@ -107,8 +114,11 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/hello.o
+GENERATED += $(OBJDIR)/hello1.o
 OBJECTS += $(OBJDIR)/hello.o
 OBJECTS += $(OBJDIR)/hello1.o
 
@@ -122,8 +132,12 @@ OBJECTS += $(OBJDIR)/hello1.o
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/hello.o
+GENERATED += $(OBJDIR)/hello1.o
+GENERATED += $(OBJDIR)/hello11.o
 OBJECTS += $(OBJDIR)/hello.o
 OBJECTS += $(OBJDIR)/hello1.o
 OBJECTS += $(OBJDIR)/hello11.o
@@ -143,15 +157,20 @@ OBJECTS += $(OBJDIR)/hello11.o
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/hello.o
+GENERATED += $(OBJDIR)/hello11.o
 OBJECTS += $(OBJDIR)/hello.o
 OBJECTS += $(OBJDIR)/hello11.o
 
 ifeq ($(config),debug)
+GENERATED += $(OBJDIR)/hello111.o
 OBJECTS += $(OBJDIR)/hello111.o
 
 else ifeq ($(config),release)
+GENERATED += $(OBJDIR)/hello1.o
 OBJECTS += $(OBJDIR)/hello1.o
 
 endif
@@ -170,8 +189,11 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/Hello1.o
+GENERATED += $(OBJDIR)/hello.o
 OBJECTS += $(OBJDIR)/Hello1.o
 OBJECTS += $(OBJDIR)/hello.o
 
@@ -185,8 +207,12 @@ OBJECTS += $(OBJDIR)/hello.o
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/Hello11.o
+GENERATED += $(OBJDIR)/hello.o
+GENERATED += $(OBJDIR)/hello1.o
 OBJECTS += $(OBJDIR)/Hello11.o
 OBJECTS += $(OBJDIR)/hello.o
 OBJECTS += $(OBJDIR)/hello1.o
@@ -206,15 +232,20 @@ OBJECTS += $(OBJDIR)/hello1.o
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/Hello11.o
+GENERATED += $(OBJDIR)/hello.o
 OBJECTS += $(OBJDIR)/Hello11.o
 OBJECTS += $(OBJDIR)/hello.o
 
 ifeq ($(config),debug)
+GENERATED += $(OBJDIR)/Hello111.o
 OBJECTS += $(OBJDIR)/Hello111.o
 
 else ifeq ($(config),release)
+GENERATED += $(OBJDIR)/hello1.o
 OBJECTS += $(OBJDIR)/hello1.o
 
 endif
@@ -222,6 +253,38 @@ endif
 		]]
 	end
 
+
+--
+-- If there's a custom rule which generate C++ sources build outputs should be placed
+-- in separate list so they can be cleaned up properly.
+--
+
+	function suite.customBuildCommand_generatedCpp()
+		files { "interface.pkg","source.cpp" }
+		filter "files:**.pkg"
+			buildmessage "Binding pkg: %{file.name}"
+			buildcommands './tolua -o %{file.basename}.cpp -H %{file.basename}.h -n %{file.basename}}  %{file.abspath}'
+			buildoutputs { '%{file.basename}.cpp','%{file.basename}.h' }
+		prepare()
+		test.capture [[
+# File sets
+# #############################################
+
+CUSTOM :=
+GENERATED :=
+OBJECTS :=
+SOURCES :=
+
+CUSTOM += interface.h
+GENERATED += $(OBJDIR)/interface.o
+GENERATED += $(OBJDIR)/source.o
+GENERATED += interface.cpp
+GENERATED += interface.h
+OBJECTS += $(OBJDIR)/interface.o
+OBJECTS += $(OBJDIR)/source.o
+SOURCES += interface.cpp
+]]
+	end
 
 --
 -- If there's a custom rule for a non-C++ file extension, make sure that those
@@ -242,12 +305,15 @@ endif
 # #############################################
 
 CUSTOM :=
+GENERATED :=
 
 ifeq ($(config),debug)
 CUSTOM += obj/Debug/hello.luac
+GENERATED += obj/Debug/hello.luac
 
 else ifeq ($(config),release)
 CUSTOM += obj/Release/hello.luac
+GENERATED += obj/Release/hello.luac
 
 endif
 		]]
@@ -273,12 +339,15 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
 ifeq ($(config),debug)
+GENERATED += obj/Debug/hello.obj
 OBJECTS += obj/Debug/hello.obj
 
 else ifeq ($(config),release)
+GENERATED += obj/Release/hello.obj
 OBJECTS += obj/Release/hello.obj
 
 endif
@@ -306,12 +375,15 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
 ifeq ($(config),debug)
+GENERATED += obj/Debug/hello.obj
 OBJECTS += obj/Debug/hello.obj
 
 else ifeq ($(config),release)
+GENERATED += obj/Release/hello.obj
 OBJECTS += obj/Release/hello.obj
 
 endif
@@ -340,12 +412,15 @@ endif
 # #############################################
 
 CUSTOM :=
+GENERATED :=
 
 ifeq ($(config),debug)
 CUSTOM += obj/Debug/hello.obj
+GENERATED += obj/Debug/hello.obj
 
 else ifeq ($(config),release)
 CUSTOM += obj/Release/hello.obj
+GENERATED += obj/Release/hello.obj
 
 endif
 		]]
@@ -365,9 +440,11 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
 ifeq ($(config),release)
+GENERATED += $(OBJDIR)/hello.o
 OBJECTS += $(OBJDIR)/hello.o
 
 endif
@@ -384,9 +461,11 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
 ifeq ($(config),release)
+GENERATED += $(OBJDIR)/hello.o
 OBJECTS += $(OBJDIR)/hello.o
 
 endif


### PR DESCRIPTION
… be cleaned by clean target.

**What does this PR do?**

All files generated by regular or custom rules for gmake2/cpp projects will be placed in separate GENERATED list, and will be deleted on `make clean` invocation.

**How does this PR change Premake's behavior?**

All files generated by custom rules for gmake2/cpp will be deleted on `make clean` invocation

Are there any breaking changes? Will any existing behavior change?

Probably no. Yes, previously buildoutputs of custom rules gmake2/cpp was persisted after `make clean` now they will be deleted.

**Anything else we should know?**

I use tolua for lua-c++ bindings, with this change generated files will be properly cleaned on `make clean` step.

closes #1380

**Did you check all the boxes?**

- [v] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [v] Add unit tests showing fix or feature works; all tests pass
- [v] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [v] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [v] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
