### PR TITLE
Use "to" option to set targetdir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ matrix:
 
 script:
  - make -f Bootstrap.mak $TRAVIS_OS_NAME CONFIG=${CONFIGURATION}
- - bin/${CONFIGURATION}/premake5 test
+ - build/bootstrap/bin/${CONFIGURATION}/premake5 test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ build_script:
   - cmd: nmake -f Bootstrap.mak MSDEV=vs2015 windows PLATFORM=%PLATFORM% CONFIG=%CONFIGURATION%
 
 test_script:
-  - cmd: bin\%CONFIGURATION%\premake5 test
+  - cmd: build\bootstrap\bin\%CONFIGURATION%\premake5 test

--- a/premake4.lua
+++ b/premake4.lua
@@ -8,6 +8,7 @@
 -- default when folks build using the makefile. That way they don't have to
 -- worry about the /scripts argument and all that.
 --
+local base = _OPTIONS["to"] or "."
 
 	solution "Premake5"
 		configurations { "Release", "Debug" }
@@ -39,12 +40,12 @@
 		}
 
 		configuration "Debug"
-			targetdir   "bin/debug"
+			targetdir   ( path.join(base, "bin/debug") )
 			defines     "_DEBUG"
 			flags       { "Symbols" }
 
 		configuration "Release"
-			targetdir   "bin/release"
+			targetdir   ( path.join(base, "bin/release") )
 			defines     "NDEBUG"
 			flags       { "OptimizeSize" }
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -8,7 +8,7 @@
 --
 
 	local corePath = _SCRIPT_DIR
-
+	local base = _OPTIONS["to"] or "."
 
 --
 -- Disable deprecation warnings for myself, so that older development
@@ -160,12 +160,12 @@
 		}
 
 		filter "configurations:Debug"
-			targetdir   "bin/debug"
+			targetdir   ( path.join(base, "bin/debug") )
 			debugargs   { "--scripts=%{prj.location}/%{path.getrelative(prj.location, prj.basedir)}", "test" }
 			debugdir    "."
 
 		filter "configurations:Release"
-			targetdir   "bin/release"
+			targetdir   ( path.join(base, "bin/release") )
 
 		filter "system:windows"
 			links       { "ole32", "ws2_32", "advapi32" }
@@ -229,6 +229,6 @@
 --
 
 	if _ACTION == "clean" then
-		os.rmdir("bin")
+		os.rmdir(path.join(base, "bin"))
 		os.rmdir("build")
 	end


### PR DESCRIPTION
**What does this PR do?**

Extends the existing "to" option (i.e. `premake5 --to=build gmake`) to also change `targetdir`, so the `bin` folder and Premake binaries end up in the same folder as the project files that were used to build them.

Thanks to @KOLANICH for the original PR (#1372). This one has been rebased against master and squashed, the CI builds fixed, and this description added.

**How does this PR change Premake's behavior?**

Previously, `premake5 --to=build gmake` would only change the location of the generated project files. When you ran `make` against those files, the libraries and object files would get placed in the `build` folder, but the `bin` folder would still be out next to the `Premake5.lua` script in the parent folder.

With this change, the `bin` folder will also get placed in `build`, make it easier to find.

**Anything else we should know?**

The [Building Premake](https://github.com/premake/premake-core/wiki/Building-Premake) wiki page will need to be updated to reflect this change. I have it on my list to update once this lands.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] ~~Add unit tests showing fix or feature works; all tests pass~~ (n/a)
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
