### PR TITLE
Fix #1411: Remove "|"  from Codelite config names

### DIFF
--- a/modules/codelite/codelite.lua
+++ b/modules/codelite/codelite.lua
@@ -5,8 +5,9 @@
 -- Modified by: Andrea Zanellato
 --              Andrew Gough
 --              Manu Evans
+--              Jason Perkins
 -- Created:     2013/05/06
--- Copyright:   (c) 2008-2015 Jason Perkins and the Premake project
+-- Copyright:   (c) 2008-2020 Jason Perkins and the Premake project
 --
 
 	local p = premake
@@ -21,7 +22,8 @@
 	function codelite.cfgname(cfg)
 		local cfgname = cfg.buildcfg
 		if codelite.workspace.multiplePlatforms then
-			cfgname = string.format("%s|%s", cfg.platform, cfg.buildcfg)
+			-- Codelite breaks if "|" is used here, see #1411
+			cfgname = string.format("%s-%s", cfg.platform, cfg.buildcfg)
 		end
 		return cfgname
 	end

--- a/modules/codelite/tests/test_codelite_workspace.lua
+++ b/modules/codelite/tests/test_codelite_workspace.lua
@@ -191,3 +191,34 @@
 </CodeLite_Workspace>
     ]])
   end
+
+---
+-- Test handling of platforms
+---
+
+	function suite.onPlatforms()
+		workspace "MyWorkspace"
+		platforms { "x86_64", "x86" }
+
+		prepare()
+		test.capture [[
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+  <Project Name="MyProject" Path="MyProject.project"/>
+  <BuildMatrix>
+    <WorkspaceConfiguration Name="x86_64-Debug" Selected="yes">
+      <Project Name="MyProject" ConfigName="x86_64-Debug"/>
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="x86-Debug" Selected="yes">
+      <Project Name="MyProject" ConfigName="x86-Debug"/>
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="x86_64-Release" Selected="yes">
+      <Project Name="MyProject" ConfigName="x86_64-Release"/>
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="x86-Release" Selected="yes">
+      <Project Name="MyProject" ConfigName="x86-Release"/>
+    </WorkspaceConfiguration>
+  </BuildMatrix>
+</CodeLite_Workspace>
+		]]
+	end


### PR DESCRIPTION
**What does this PR do?**

Fix #1411 by removing the pipe symbol "|" from Codelite configuration names.

**How does this PR change Premake's behavior?**

The configuration names will now appear as `"platform-config"` e.g. `"x86-Debug"` instead of the previous `"x86|Debug"`. Note this only happens if the workspace has specified platforms.

**Anything else we should know?**

See #1411 for discussion about the fix.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
