### PR TITLE
Fix MinGW builds of Premake

### DIFF
--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -52,13 +52,13 @@ none:
 	@echo "   osx linux bsd"
 
 mingw: $(SRC)
-	$(SILENT) rm -rf ./bin
-	$(SILENT) rm -rf ./build
-	$(SILENT) rm -rf ./obj
-	mkdir -p build/bootstrap
-	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $? -lole32
+	$(SILENT) if exist .\bin rmdir /s /q .\bin
+	$(SILENT) if exist .\build rmdir /s /q .\build
+	$(SILENT) if exist .\obj rmdir /s /q .\obj
+	if not exist build\bootstrap (mkdir build\bootstrap)
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $? -lole32 -lversion
 	./build/bootstrap/premake_bootstrap embed
-	./build/bootstrap/premake_bootstrap --os=windows --to=build/bootstrap gmake2
+	./build/bootstrap/premake_bootstrap --os=windows --to=build/bootstrap gmake2 --cc=mingw
 	$(MAKE) -C build/bootstrap config=$(CONFIG)_$(PLATFORM)
 
 macosx: osx

--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -45,7 +45,7 @@ none:
 	@echo "Please do"
 	@echo "   nmake -f Bootstrap.mak windows"
 	@echo "or"
-	@echo "   CC=mingw32-gcc mingw32-make -f Bootstrap.mak mingw"
+	@echo "   CC=mingw32-gcc mingw32-make -f Bootstrap.mak mingw CONFIG=x64"
 	@echo "or"
 	@echo "   make -f Bootstrap.mak HOST_PLATFORM"
 	@echo "where HOST_PLATFORM is one of these:"
@@ -58,7 +58,7 @@ mingw: $(SRC)
 	if not exist build\bootstrap (mkdir build\bootstrap)
 	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $? -lole32 -lversion
 	./build/bootstrap/premake_bootstrap embed
-	./build/bootstrap/premake_bootstrap --os=windows --to=build/bootstrap gmake2 --cc=mingw
+	./build/bootstrap/premake_bootstrap --os=windows --to=build/bootstrap --cc=mingw gmake2
 	$(MAKE) -C build/bootstrap config=$(CONFIG)_$(PLATFORM)
 
 macosx: osx

--- a/contrib/libzip/premake5.lua
+++ b/contrib/libzip/premake5.lua
@@ -16,6 +16,8 @@ project "zip-lib"
 
 	filter "system:windows"
 		defines { "_WINDOWS" }
+	filter { "system:windows", "toolset:mingw" }
+		defines { "HAVE_SSIZE_T_LIBZIP" }
 
 	filter "system:macosx"
 		defines { "HAVE_SSIZE_T_LIBZIP" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -126,7 +126,11 @@
 			defines     { "_CRT_SECURE_NO_DEPRECATE", "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_WARNINGS" }
 
 		filter { "system:windows", "configurations:Release" }
-			flags       { "NoIncrementalLink", "LinkTimeOptimization" }
+			flags       { "NoIncrementalLink" }
+
+		-- MinGW AR does not handle LTO out of the box and need a plugin to be setup
+		filter { "system:windows", "configurations:Release", "toolset:not mingw" }
+			flags		{ "LinkTimeOptimization" }
 
 	project "Premake5"
 		targetname  "premake5"
@@ -169,6 +173,8 @@
 
 		filter "system:windows"
 			links       { "ole32", "ws2_32", "advapi32" }
+		filter "toolset:mingw"
+			links		{ "version", "crypt32" }
 
 		filter "system:linux or bsd or hurd"
 			defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -172,9 +172,10 @@
 			targetdir   "bin/release"
 
 		filter "system:windows"
-			links       { "ole32", "ws2_32", "advapi32" }
+			links       { "ole32", "ws2_32", "advapi32", "version" }
+
 		filter "toolset:mingw"
-			links		{ "version", "crypt32" }
+			links		{ "crypt32" }
 
 		filter "system:linux or bsd or hurd"
 			defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }

--- a/src/_manifest.lua
+++ b/src/_manifest.lua
@@ -63,6 +63,7 @@
 		"tools/msc.lua",
 		"tools/snc.lua",
 		"tools/clang.lua",
+		"tools/mingw.lua",
 
 		-- Clean action
 		"actions/clean/_clean.lua",

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1652,6 +1652,7 @@
 		allowed = {
 			{ "clang", "Clang (clang)" },
 			{ "gcc", "GNU GCC (gcc/g++)" },
+			{ "mingw", "MinGW GCC (gcc/g++)" },
 		}
 	}
 

--- a/src/host/os_getversion.c
+++ b/src/host/os_getversion.c
@@ -55,6 +55,8 @@ int os_getversion(lua_State* L)
 
 #if defined(PLATFORM_WINDOWS)
 
+#pragma comment(lib, "version.lib")
+
 int getKernelVersion(struct OsVersionInfo* info)
 {
 	DWORD size = GetFileVersionInfoSizeA("kernel32.dll", NULL);

--- a/src/host/os_getversion.c
+++ b/src/host/os_getversion.c
@@ -55,8 +55,6 @@ int os_getversion(lua_State* L)
 
 #if defined(PLATFORM_WINDOWS)
 
-#pragma comment(lib, "version.lib")
-
 int getKernelVersion(struct OsVersionInfo* info)
 {
 	DWORD size = GetFileVersionInfoSizeA("kernel32.dll", NULL);

--- a/src/host/os_stat.c
+++ b/src/host/os_stat.c
@@ -13,7 +13,7 @@ int os_stat(lua_State* L)
 	const char* filename = luaL_checkstring(L, 1);
 
 #if PLATFORM_WINDOWS
-	struct _stat64i32 s;
+	struct _stat s;
 
 	wchar_t wide_filename[PATH_MAX];
 	if (MultiByteToWideChar(CP_UTF8, 0, filename, -1, wide_filename, PATH_MAX) == 0)

--- a/src/tools/mingw.lua
+++ b/src/tools/mingw.lua
@@ -1,0 +1,8 @@
+--
+-- mingw.lua
+-- MinGW toolset adapter for Premake
+-- Copyright (c) 2018 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	p.tools.mingw = p.tools.gcc


### PR DESCRIPTION
**What does this PR do?**

Gets Premake's bootstrap makefile to work properly with MinGW (64-bit only). This is an attempt to resurrect PR #1111.

Closes #559.

```sh
# To build with bootstrap script
set CC=gcc
mingw32-make -f Bootstrap.mak mingw PLATFORM=x64

# To build with Premake
premake5 --cc=mingw gmake2
mingw32-make config=debug_x64
```

**How does this PR change Premake's behavior?**

A few additions were made to Premake to improve support for MinGW specifically. Those were added by @tdesveauxPKFX in #1111, I've maintained them as is.

**Anything else we should know?**

I've successfully built Premake using the 64-bit version of MinGW using these changes. I was not able to build with the 32-bit version, though that may have  been a local setup issue; I didn't pursue it. Since, best I could tell, we aren't currently able to build with MinGW at all this seems like an incremental win.

I left @tdesveauxPKFX's commits intact so he would get some credit for the fix, since he did the bulk of the work on this one.

Two unit tests fail with the MinGW build:

1. `base_os.remove_ReturnsTrue_OnFile` gets an "Access denied" error when it tries to delete a temporary file
2. `premake_binmodules.testExample` fails with "module 'example' not found"

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] ~~Add unit tests showing fix or feature works; all tests pass~~ _(minimal code changes)_
- [x] ~~Mention any [related issues](https://github.com/premake/premake-core/issues)~~ 
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*