### PR TITLE
Enable enablewarnings() for MSC

### DIFF
--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -363,10 +363,14 @@
 	function msc.getwarnings(cfg)
 		local result = {}
 
-		-- NOTE: VStudio can't enable specific warnings (workaround?)
+		for _, enable in ipairs(cfg.enablewarnings) do
+			table.insert(result, '/w1"' .. enable .. '"')
+		end
+
 		for _, disable in ipairs(cfg.disablewarnings) do
 			table.insert(result, '/wd"' .. disable .. '"')
 		end
+
 		for _, fatal in ipairs(cfg.fatalwarnings) do
 			table.insert(result, '/we"' .. fatal .. '"')
 		end

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -235,7 +235,7 @@
 		disablewarnings { "disable" }
 		fatalwarnings { "fatal" }
 		prepare()
-		test.contains({ '/wd"disable"', '/we"fatal"' }, msc.getcflags(cfg))
+		test.contains({ '/w1"enable"', '/wd"disable"', '/we"fatal"' }, msc.getcflags(cfg))
 	end
 
 	function suite.ldflags_OnFatalWarnings()


### PR DESCRIPTION
**What does this PR do?**

Adds support for Premake's `enablewarnings()` call to MSC and Visual Studio. From the [original pull request](https://github.com/premake/premake-core/pull/1374): _"This pull request makes it so any warnings that are specifically enabled are set to level 1, which enables them as long as the user has the warning level at least level 1."_

h/t @TrianglesPCT for the idea.

**How does this PR change Premake's behavior?**

Values set for `enablewarnings()` will now be applied to the MSC switches. This may cause a change in behavior if warnings had been previously enabled but ignored.

**Anything else we should know?**

No.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) _(n/a)_
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
