### PR TITLE
Added GitHub Actions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,40 @@
+name: CI Workflow
+
+on: [push, pull_request]
+
+jobs:
+  linux-and-macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        config: [debug, release]
+        include:
+          - os: ubuntu-latest
+            osname: linux
+          - os: macos-latest
+            osname: osx
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build
+      run: make -f Bootstrap.mak ${{ matrix.osname }} CONFIG=${{ matrix.config }}
+    - name: Test
+      run: bin/${{ matrix.config }}/premake5 test
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        config: [debug, release]
+        platform: [Win32, x64]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+        nmake -f Bootstrap.mak MSDEV=vs2019 windows-msbuild PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }}
+      shell: cmd
+    - name: Test
+      run: bin\${{ matrix.config }}\premake5 test
+      shell: cmd


### PR DESCRIPTION
**What does this PR do?**

This adds GitHub Actions to do CI as a potential replacement for both Travis-CI and AppVeyor.

**How does this PR change Premake's behavior?**

N/A.

**Anything else we should know?**

Windows builds use `windows-msbuild` instead of `windows`, the upgrade is unnecessary.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
