### PR TITLE
Fix systemversion("latest") on VS2017

### DIFF
--- a/modules/android/tests/test_android_project.lua
+++ b/modules/android/tests/test_android_project.lua
@@ -44,6 +44,7 @@
 		test.capture [[
 <PropertyGroup Label="Globals">
 	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
 	<Keyword>Android</Keyword>
 	<RootNamespace>MyProject</RootNamespace>
 	<MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>

--- a/modules/vstudio/tests/vc2010/test_globals.lua
+++ b/modules/vstudio/tests/vc2010/test_globals.lua
@@ -254,31 +254,43 @@
 		]]
 	end
 
---
--- Check that the "latest" systemversion works.
--- note: we override the os.getWindowsRegistry method for reliable tests.
---
+---
+-- Check handling of systemversion("latest")
+---
 
-	function suite.windowsTargetPlatformVersionLatest_on2017()
+function suite.windowsTargetPlatformVersion_latest_on2015()
+	p.action.set("vs2015")
+	systemversion "latest"
+	prepare()
+	test.capture [[
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
+	<Keyword>Win32Proj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
+	]]
+end
+
+
+	function suite.windowsTargetPlatformVersion_latest_on2017()
 		p.action.set("vs2017")
 		systemversion "latest"
-		local oldRegistry = os["getWindowsRegistry"]
-		os["getWindowsRegistry"] = function (key) return "10.0.11111" end
 		prepare()
-		os["getWindowsRegistry"] = oldRegistry
 		test.capture [[
 <PropertyGroup Label="Globals">
 	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
 	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
 	<Keyword>Win32Proj</Keyword>
 	<RootNamespace>MyProject</RootNamespace>
-	<WindowsTargetPlatformVersion>10.0.11111.0</WindowsTargetPlatformVersion>
+	<LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+	<WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
 </PropertyGroup>
 		]]
 	end
 
-	
-	function suite.windowsTargetPlatformVersionLatest_on2019()
+
+	function suite.windowsTargetPlatformVersion_latest_on2019()
 		p.action.set("vs2019")
 		systemversion "latest"
 		prepare()
@@ -293,49 +305,12 @@
 		]]
 	end
 
---
--- Check that the "latest" systemversion will not add <WindowsTargetPlatformVersion>
--- when the action is less than 2017
---
 
-	function suite.windowsTargetPlatformVersionLatest_on2015()
-		p.action.set("vs2015")
-		systemversion "latest"
-		prepare()
-		test.capture [[
-<PropertyGroup Label="Globals">
-	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
-	<Keyword>Win32Proj</Keyword>
-	<RootNamespace>MyProject</RootNamespace>
-</PropertyGroup>
-		]]
-	end
-	
-	function suite.windowsTargetPlatformVersionMultipleConditional_on2015Default()
-		p.action.set("vs2015")
-		filter "Debug"
-			systemversion "10.0.10240.0"
-		filter "Release"
-			systemversion "10.0.10240.1"
-		prepare()
-		test.capture [[
-<PropertyGroup Label="Globals">
-	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
-	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
-	<Keyword>Win32Proj</Keyword>
-	<RootNamespace>MyProject</RootNamespace>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Globals">
-	<WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-</PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Globals">
-	<WindowsTargetPlatformVersion>10.0.10240.1</WindowsTargetPlatformVersion>
-</PropertyGroup>
-		]]
-	end
-	
-	function suite.windowsTargetPlatformVersionGlobalMultipleConditional_on2015Default()
+---
+-- Check handling of per-configuration systemversion
+---
+
+	function suite.windowsTargetPlatformVersion_perConfig_on2015()
 		p.action.set("vs2015")
 		systemversion "8.1"
 		filter "Debug"
@@ -359,4 +334,31 @@
 </PropertyGroup>
 		]]
 	end
-	
+
+
+	function suite.windowsTargetPlatformVersion_perConfig_on2017()
+		p.action.set("vs2017")
+		systemversion "8.1"
+		filter "Debug"
+			systemversion "latest"
+		filter "Release"
+			systemversion "10.0.10240.1"
+		prepare()
+		test.capture [[
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
+	<Keyword>Win32Proj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+	<LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+	<WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Globals">
+	<WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Globals">
+	<WindowsTargetPlatformVersion>10.0.10240.1</WindowsTargetPlatformVersion>
+</PropertyGroup>
+		]]
+	end
+


### PR DESCRIPTION
**What does this PR do?**

My take on a cleaned-up version of #1317. Implements [the workaround described here](https://developercommunity.visualstudio.com/content/problem/140294/windowstargetplatformversion-makes-it-impossible-t.html) to enable VS 2017 to discover the correct version of the Windows 10 SDK.

h/t to @jeaiii to discovering the fix, and putting together [the original PR](https://github.com/premake/premake-core/pull/1317).

**How does this PR change Premake's behavior?**

Should not be any breaking changes. Does add this markup to every VS 2017 project, regardless of whether `systemversion("latest")` is used or not:

```xml
<LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
```

The alternative is to scan through all of the project configurations to see if the value has been set or not before writing, but the markup is ignored if not used, and querying all of the configurations can be relatively expensive. If no one complains, this is a more efficient approach.

**Anything else we should know?**

No.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) N/A
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
