### PR TITLE
Do not add <Link> for .NET resources or the resource will not be properly embedded.

### DIFF
--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -156,7 +156,7 @@
 
 			if #contents > 0 or external then
 				_p(2,'<%s%s Include="%s">', info.action, condition, fname)
-				if external then
+				if external and info.action ~= "EmbeddedResource" then
 					_p(3,'<Link>%s</Link>', path.translate(link))
 				end
 				if #contents > 0 then


### PR DESCRIPTION
**What does this PR do?**

During generation of C# project I did notice resx files did not get properly embedded into the built assembly.

**How does this PR change Premake's behavior?**

EmbedResource actions or VS won't generate <Link>"file"</Link> tags anymore.

**Anything else we should know?**

There might be cases if the link is needed. Obviously I do not know the indepth internals of Visual Studio :(

