### PR TITLE
Bootstrap.mak clean target(s)

### DIFF
--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -40,7 +40,7 @@ SRC		= src/host/*.c			\
 
 HOST_PLATFORM= none
 
-.PHONY: default none nix-clean windows-clean \
+.PHONY: default none clean nix-clean windows-clean \
 	mingw-clean mingw macosx macosx-clean osx-clean osx \
 	linux-clean linux bsd-clean bsd solaris-clean solaris \ 
 	haiku-clean haiku windows-base windows windows-msbuild
@@ -54,6 +54,20 @@ none:
 	@echo "   CC=mingw32-gcc mingw32-make -f Bootstrap.mak mingw CONFIG=x64"
 	@echo "or"
 	@echo "   make -f Bootstrap.mak HOST_PLATFORM"
+	@echo "where HOST_PLATFORM is one of these:"
+	@echo "   osx linux bsd"
+	@echo ""
+	@echo "To clean the source tree, run the same command by adding a '-clean' suffix to the target name."
+		@echo "Example"
+	@echo "   make -f Bootstrap.mak HOST_PLATFORM-clean"
+
+clean:
+	@echo "Please run the same command used for building by adding a '-clean' suffix to the target name."
+	@echo "   nmake -f Bootstrap.mak windows-clean"
+	@echo "or"
+	@echo "   CC=mingw32-gcc mingw32-make -f Bootstrap.mak mingw-clean CONFIG=x64"
+	@echo "or"
+	@echo "   make -f Bootstrap.mak HOST_PLATFORM-clean"
 	@echo "where HOST_PLATFORM is one of these:"
 	@echo "   osx linux bsd"
 

--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -39,6 +39,12 @@ SRC		= src/host/*.c			\
 		$(LUA_DIR)/lzio.c		\
 
 HOST_PLATFORM= none
+
+.PHONY: default none nix-clean windows-clean \
+	mingw-clean mingw macosx macosx-clean osx-clean osx \
+	linux-clean linux bsd-clean bsd solaris-clean solaris \ 
+	haiku-clean haiku windows-base windows windows-msbuild
+
 default: $(HOST_PLATFORM)
 
 none:
@@ -51,74 +57,77 @@ none:
 	@echo "where HOST_PLATFORM is one of these:"
 	@echo "   osx linux bsd"
 
-mingw: $(SRC)
+nix-clean:
+	$(SILENT) rm -rf ./bin
+	$(SILENT) rm -rf ./build
+	$(SILENT) rm -rf ./obj
+
+windows-clean:
 	$(SILENT) if exist .\bin rmdir /s /q .\bin
 	$(SILENT) if exist .\build rmdir /s /q .\build
 	$(SILENT) if exist .\obj rmdir /s /q .\obj
+	
+mingw-clean: windows-clean
+	
+mingw: mingw-clean
 	if not exist build\bootstrap (mkdir build\bootstrap)
-	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $? -lole32 -lversion
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lole32 -lversion
 	./build/bootstrap/premake_bootstrap embed
 	./build/bootstrap/premake_bootstrap --os=windows --to=build/bootstrap --cc=mingw gmake2
 	$(MAKE) -C build/bootstrap config=$(CONFIG)_$(PLATFORM)
 
 macosx: osx
 
-osx: $(SRC)
-	$(SILENT) rm -rf ./bin
-	$(SILENT) rm -rf ./build
-	$(SILENT) rm -rf ./obj
+macosx-clean: osx-clean
+
+osx-clean: nix-clean
+
+osx: osx-clean
 	mkdir -p build/bootstrap
-	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_MACOSX -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" -framework CoreServices -framework Foundation -framework Security -lreadline $?
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_MACOSX -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" -framework CoreServices -framework Foundation -framework Security -lreadline $(SRC)
 	./build/bootstrap/premake_bootstrap embed
 	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)
 
-linux: $(SRC)
-	$(SILENT) rm -rf ./bin
-	$(SILENT) rm -rf ./build
-	$(SILENT) rm -rf ./obj
+linux-clean: nix-clean
+
+linux: linux-clean
 	mkdir -p build/bootstrap
-	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $? -lm -ldl -lrt
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lm -ldl -lrt
 	./build/bootstrap/premake_bootstrap embed
 	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)
 
-bsd: $(SRC)
-	$(SILENT) rm -rf ./bin
-	$(SILENT) rm -rf ./build
-	$(SILENT) rm -rf ./obj
+bsd-clean: nix-clean
+
+bsd: bsd-clean
 	mkdir -p build/bootstrap
-	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $? -lm
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lm
 	./build/bootstrap/premake_bootstrap embed
 	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
 	$(MAKE) -C build/bootstrap -j`getconf NPROCESSORS_ONLN` config=$(CONFIG)
 
-solaris: $(SRC)
-	$(SILENT) rm -rf ./bin
-	$(SILENT) rm -rf ./build
-	$(SILENT) rm -rf ./obj
+solaris-clean: nix-clean
+
+solaris: solaris-clean
 	mkdir -p build/bootstrap
-	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $? -lm
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lm
 	./build/bootstrap/premake_bootstrap embed
 	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
 	$(MAKE) -C build/bootstrap -j`getconf NPROCESSORS_ONLN` config=$(CONFIG)
 
-haiku: $(SRC)
-	$(SILENT) rm -rf ./bin
-	$(SILENT) rm -rf ./build
-	$(SILENT) rm -rf ./obj
+haiku-clean: nix-clean
+
+haiku: haiku-clean
 	mkdir -p build/bootstrap
-	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -D_BSD_SOURCE -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $? -lbsd
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -D_BSD_SOURCE -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lbsd
 	./build/bootstrap/premake_bootstrap embed
 	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)
 
-windows-base: $(SRC)
-	$(SILENT) if exist .\bin rmdir /s /q .\bin
-	$(SILENT) if exist .\build rmdir /s /q .\build
-	$(SILENT) if exist .\obj rmdir /s /q .\obj
+windows-base: windows-clean
 	if not exist build\bootstrap (mkdir build\bootstrap)
-	cl /Fo.\build\bootstrap\ /Fe.\build\bootstrap\premake_bootstrap.exe /DPREMAKE_NO_BUILTIN_SCRIPTS /I"$(LUA_DIR)" /I"$(LUASHIM_DIR)" user32.lib ole32.lib advapi32.lib $**
+	cl /Fo.\build\bootstrap\ /Fe.\build\bootstrap\premake_bootstrap.exe /DPREMAKE_NO_BUILTIN_SCRIPTS /I"$(LUA_DIR)" /I"$(LUASHIM_DIR)" user32.lib ole32.lib advapi32.lib $(SRC)
 	.\build\bootstrap\premake_bootstrap.exe embed
 	.\build\bootstrap\premake_bootstrap --to=build/bootstrap $(MSDEV)
 


### PR DESCRIPTION
Bootstrap.mak can now clean itself using 
`make -f Bootstrap.mak <platform>-clean`

* Factorize cleanup tasks in two targets
	* windows-clean for windows systems
	* nix-clean: For all UNIX-based systems
* Add a "*-clean" target counterpart for each target as an alias of windows-clean or nix-clean
* Make each target invoke its *-clean target before running
* Replace use of $? / $** by explicit $(SRC) in build rules
	They cannot be used anymore due to the presence of the *-clean target in dependency list

**What does this PR do?**
Leaving premake source directory clean after an automatic build

Thanks for the contribution! Please provide a concise description of the problem this request solves.

**How does this PR change Premake's behavior?**
No behavior change. Just add new targets to Bootstrap.mak

Are there any breaking changes? Will any existing behavior change?
No.

**Anything else we should know?**
Tested manually on linux & macOS, Github actions run successfully

Add any other context about your changes here.

**Did you check all the boxes?**
Not sure I can write a test for that. Maybe a Github Action ?

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
