### PR TITLE
Added clang as a valid option for projects generated with vs2019

### DIFF
--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -96,4 +96,7 @@ return {
 
 	-- Visual Studio 2013+ C/C++ Shared Items projects
 	"vc2013/test_vcxitems.lua",
+
+	-- Visual Studio 2019+ C/C++ Clang Projects
+	"vc2019/test_toolset_settings.lua"
 }

--- a/modules/vstudio/tests/vc2019/test_toolset_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_toolset_settings.lua
@@ -1,0 +1,59 @@
+--
+-- tests/actions/vstudio/vc2010/test_compile_settings.lua
+-- Validate compiler settings in Visual Studio 2019 C/C++ projects.
+-- Copyright (c) 2011-2020 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("vstudio_vs2019_compile_settings")
+	local vc2010 = p.vstudio.vc2010
+	local project = p.project
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2019")
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare(platform)
+		local cfg = test.getconfig(prj, "Debug", platform)
+		vc2010.configurationProperties(cfg)
+	end
+
+---
+-- Check the default project settings
+---
+
+	function suite.defaultSettings()
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v142</PlatformToolset>
+</PropertyGroup>
+		]]
+	end
+
+---
+-- Check the project settings with the clang toolset
+---
+
+	function suite.toolsetClang()
+		toolset "clang"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>ClangCL</PlatformToolset>
+</PropertyGroup>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1506,6 +1506,9 @@
 		if cfg.toolset and cfg.toolset:startswith("msc") then
 			local value = iif(cfg.unsignedchar, "On", "Off")
 			table.insert(opts, p.tools.msc.shared.unsignedchar[value])
+		elseif _ACTION >= "vs2019" and cfg.toolset and cfg.toolset == "clang" then
+			local value = iif(cfg.unsignedchar, "On", "Off")
+			table.insert(opts, p.tools.msc.shared.unsignedchar[value])
 		end
 
 		if #opts > 0 then
@@ -2331,10 +2334,16 @@
 
 	function m.platformToolset(cfg)
 		local tool, version = p.config.toolset(cfg)
+
+		if not version and _ACTION >= "vs2019" and cfg.toolset == "clang" then
+			version = "ClangCL"
+		end
+
 		if not version then
 			local value = p.action.current().toolset
 			tool, version = p.tools.canonical(value)
 		end
+
 		if version then
 			if cfg.kind == p.NONE or cfg.kind == p.MAKEFILE then
 				if p.config.hasFile(cfg, path.iscppfile) or _ACTION >= "vs2015" then

--- a/modules/vstudio/vs2019.lua
+++ b/modules/vstudio/vs2019.lua
@@ -28,7 +28,7 @@
 		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "SharedItems" },
 		valid_languages = { "C", "C++", "C#", "F#" },
 		valid_tools     = {
-			cc     = { "msc"   },
+			cc     = { "msc", "clang" },
 			dotnet = { "msnet" },
 		},
 


### PR DESCRIPTION
**What does this PR do?**

This PR unifies the functionality of the `clang` toolset across gmake/gmake2 and VS2019+ actions.  Formerly, `clang` would not resolve to a valid toolset, so it would be set to the default toolset of the Visual Studio version (e.g. `v142` for VS2019).  This allows the vs2010 project generator to resolve "clang" to the correct platform toolset in the project file.

**How does this PR change Premake's behavior?**

This break any code that was relying on the value `clang` to resolve to `v142` in VS2019.  Instead, `clang` now resolves to `ClangCL` in the `PlatformToolset` of the project file.  Issue #1461 describes the full affects of the changes.  This should only affect projects generated with the `vs2019` action.
