### PR TITLE
macOS deployment target support for gcc and clang

### DIFF
--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -75,7 +75,7 @@
 		local cflags = config.mapFlags(cfg, clang.cflags)
 
 		local flags = table.join(shared, cflags)
-		flags = table.join(flags, clang.getwarnings(cfg))
+		flags = table.join(flags, clang.getwarnings(cfg), clang.getsystemversionflags(cfg))
 
 		return flags
 	end
@@ -84,6 +84,23 @@
 		return gcc.getwarnings(cfg)
 	end
 
+--
+-- Returns C/C++ system version related build flags
+--
+
+	function clang.getsystemversionflags(cfg)
+		local flags = {}
+
+		if cfg.system == p.MACOSX or cfg.system == p.IOS then
+			local minVersion = p.project.systemversion(cfg)
+			if (type (minVersion) == "string") and (string.match(minVersion, "^%d+%.%d+") ~= nil) then
+				local name = iif(cfg.system == p.MACOSX, "macosx", "iphoneos")
+				table.insert (flags, "-m" .. name .. "-version-min=" .. p.project.systemversion(cfg))
+			end
+		end
+
+		return flags
+	end
 
 --
 -- Build a list of C++ compiler flags corresponding to the settings
@@ -103,7 +120,7 @@
 		local shared = config.mapFlags(cfg, clang.shared)
 		local cxxflags = config.mapFlags(cfg, clang.cxxflags)
 		local flags = table.join(shared, cxxflags)
-		flags = table.join(flags, clang.getwarnings(cfg))
+		flags = table.join(flags, clang.getwarnings(cfg), clang.getsystemversionflags(cfg))
 		return flags
 	end
 

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -93,7 +93,7 @@
 
 		if cfg.system == p.MACOSX or cfg.system == p.IOS then
 			local minVersion = p.project.systemversion(cfg)
-			if (type (minVersion) == "string") and (string.match(minVersion, "^%d+%.%d+") ~= nil) then
+			if minVersion ~= nil then
 				local name = iif(cfg.system == p.MACOSX, "macosx", "iphoneos")
 				table.insert (flags, "-m" .. name .. "-version-min=" .. p.project.systemversion(cfg))
 			end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -172,7 +172,7 @@
 
 		if cfg.system == p.MACOSX then
 			local minVersion = p.project.systemversion(cfg)
-			if (type (minVersion) == "string") and (string.match(minVersion, "^%d+%.%d+") ~= nil) then
+			if minVersion ~= nil then
 				table.insert (flags, "-mmacosx-version-min=" .. minVersion)
 			end
 		end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -144,7 +144,7 @@
 	function gcc.getcflags(cfg)
 		local shared_flags = config.mapFlags(cfg, gcc.shared)
 		local cflags = config.mapFlags(cfg, gcc.cflags)
-		local flags = table.join(shared_flags, cflags)
+		local flags = table.join(shared_flags, cflags, gcc.getsystemversionflags(cfg))
 		flags = table.join(flags, gcc.getwarnings(cfg))
 		return flags
 	end
@@ -161,6 +161,23 @@
 			table.insert(result, '-Werror=' .. fatal)
 		end
 		return result
+	end
+
+--
+-- Returns C/C++ system version build flags
+--
+
+	function gcc.getsystemversionflags(cfg)
+		local flags = {}
+
+		if cfg.system == p.MACOSX then
+			local minVersion = p.project.systemversion(cfg)
+			if (type (minVersion) == "string") and (string.match(minVersion, "^%d+%.%d+") ~= nil) then
+				table.insert (flags, "-mmacosx-version-min=" .. minVersion)
+			end
+		end
+
+		return flags
 	end
 
 
@@ -213,7 +230,7 @@
 		local shared_flags = config.mapFlags(cfg, gcc.shared)
 		local cxxflags = config.mapFlags(cfg, gcc.cxxflags)
 		local flags = table.join(shared_flags, cxxflags)
-		flags = table.join(flags, gcc.getwarnings(cfg))
+		flags = table.join(flags, gcc.getwarnings(cfg), gcc.getsystemversionflags(cfg))
 		return flags
 	end
 

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -61,5 +61,6 @@ return {
 	-- -- Toolset tests
 	"tools/test_dotnet.lua",
 	"tools/test_gcc.lua",
+	"tools/test_clang.lua",
 	"tools/test_msc.lua",
 }

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -45,9 +45,8 @@
 		test.contains({ "-mmacosx-version-min=10.9" }, clang.getcxxflags(cfg))
 	end
 
-	function suite.cxxflags_macosx_systemversion_invalid()
+	function suite.cxxflags_macosx_systemversion_unspecified()
 		system "MacOSX"
-		systemversion "weird"
 		prepare()
 		test.excludes({ "-mmacosx-version-min=10.9" }, clang.getcxxflags(cfg))
 	end

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -1,0 +1,72 @@
+--
+-- tests/test_clang.lua
+-- Automated test suite for the GCC toolset interface.
+-- Copyright (c) 2009-2013 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("tools_clang")
+
+	local clang = p.tools.clang
+	local project = p.project
+
+
+--
+-- Setup/teardown
+--
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		wks, prj = test.createWorkspace()
+		system "Linux"
+	end
+
+	local function prepare()
+		cfg = test.getconfig(prj, "Debug")
+	end
+
+
+--
+-- Check Mac OS X deployment target flags
+--
+
+	function suite.cflags_macosx_systemversion()
+		system "MacOSX"
+		systemversion "10.9"
+		prepare()
+		test.contains({ "-mmacosx-version-min=10.9" }, clang.getcflags(cfg))
+	end
+	
+	function suite.cxxflags_macosx_systemversion()
+		system "MacOSX"
+		systemversion "10.9"
+		prepare()
+		test.contains({ "-mmacosx-version-min=10.9" }, clang.getcxxflags(cfg))
+	end
+
+	function suite.cxxflags_macosx_systemversion_invalid()
+		system "MacOSX"
+		systemversion "weird"
+		prepare()
+		test.excludes({ "-mmacosx-version-min=10.9" }, clang.getcxxflags(cfg))
+	end
+	
+--
+-- Check iOS deployment target flags
+--
+
+	function suite.cflags_ios_systemversion()
+		system "iOS"
+		systemversion "12.1"
+		prepare()
+		test.contains({ "-miphoneos-version-min=12.1" }, clang.getcflags(cfg))
+	end
+	
+	function suite.cxxflags_ios_systemversion()
+		system "iOS"
+		systemversion "5.0"
+		prepare()
+		test.contains({ "-miphoneos-version-min=5.0" }, clang.getcxxflags(cfg))
+	end
+	

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -381,6 +381,31 @@
 		prepare()
 		test.contains({ "-dynamiclib" }, gcc.getldflags(cfg))
 	end
+	
+--
+-- Check Mac OS X deployment target flags
+--
+
+	function suite.cflags_macosx_systemversion()
+		system "MacOSX"
+		systemversion "10.9"
+		prepare()
+		test.contains({ "-mmacosx-version-min=10.9" }, gcc.getcflags(cfg))
+	end
+	
+	function suite.cxxflags_macosx_systemversion()
+		system "MacOSX"
+		systemversion "10.9:10.15"
+		prepare()
+		test.contains({ "-mmacosx-version-min=10.9" }, gcc.getcxxflags(cfg))
+	end
+	
+	function suite.cxxflags_macosx_systemversion_invalid()
+		system "MacOSX"
+		systemversion "strange"
+		prepare()
+		test.excludes({ "-mmacosx-version-min=10.9" }, gcc.getcxxflags(cfg))
+	end
 
 
 --

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -400,9 +400,8 @@
 		test.contains({ "-mmacosx-version-min=10.9" }, gcc.getcxxflags(cfg))
 	end
 	
-	function suite.cxxflags_macosx_systemversion_invalid()
+	function suite.cxxflags_macosx_systemversion_unspecified()
 		system "MacOSX"
-		systemversion "strange"
 		prepare()
 		test.excludes({ "-mmacosx-version-min=10.9" }, gcc.getcxxflags(cfg))
 	end


### PR DESCRIPTION
Use the value of systemversion to set the Apple-specific gcc/clang option -mmacosx-version-min=<version>, equivalent of the Xcode setting MACOSX_DEPLOYMENT_TARGET
add tests for gcc and clang

**How does this PR change Premake's behavior?**
add -mmacosx-version-min= build flag on macOS when the project defines a systemversion.

Are there any breaking changes? Will any existing behavior change?
This flag will be added in all actions that use the gcc/clang getcflags and getcxxflags method. The Xcode action doesn't. It already has a similar behavior but use a Xcode setting insteaod.

**Anything else we should know?**
Tested on a real project on Linux (no changes) and macOS .

Add any other context about your changes here.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
