### PR TITLE
Disable redirect test until HTTP endpoint is fixed

### DIFF
--- a/tests/base/test_http.lua
+++ b/tests/base/test_http.lua
@@ -55,6 +55,8 @@
 		test.isequal(responseCode, 418)
 	end
 
+	-- Disable as httpbin.org returns 404 on this endpoint
+	--[[
 	function suite.http_redirect()
 		local result, err, responseCode = http.get("http://httpbin.org/redirect/3")
 		if result then
@@ -63,6 +65,7 @@
 			test.fail(err);
 		end
 	end
+	]]
 
 	function suite.http_headers()
 		local result, err, responseCode = http.get("http://httpbin.org/headers", {


### PR DESCRIPTION
**What does this PR do?**

Disables a test due to external site not working as expected.

**How does this PR change Premake's behavior?**

N/A.

**Anything else we should know?**

N/A.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
