### PR TITLE
Fixed issue with os.matchfiles and symlinks

### DIFF
--- a/src/host/os_match.c
+++ b/src/host/os_match.c
@@ -161,9 +161,10 @@ int os_matchisfile(lua_State* L)
 {
 	MatchInfo* m = (MatchInfo*)lua_touserdata(L, 1);
 #if defined(_DIRENT_HAVE_D_TYPE)
-	if (m->entry->d_type != DT_UNKNOWN)
+	// Dirent marks symlinks as DT_LNK, not (DT_LNK|DT_DIR). The fallback handles symlinks using stat.
+	if (m->entry->d_type == DT_DIR)
 	{
-		lua_pushboolean(L, (m->entry->d_type == DT_DIR) == 0);
+		lua_pushboolean(L, 0);
 	}
 	else
 #endif

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -124,6 +124,20 @@
 		test.istrue(table.contains(result, "folder/subfolder/hello.txt"))
 	end
 
+	function suite.matchfiles_onSymbolicLink()
+		if os.istarget("macosx")
+			or os.istarget("linux")
+			or os.istarget("solaris")
+			or os.istarget("bsd")
+		then
+			os.execute("cd folder && ln -s subfolder symlinkfolder && cd ..")
+			local result = os.matchfiles("folder/**/*.txt")
+			os.execute("rm folder/symlinkfolder")
+			premake.modules.self_test.print(table.tostring(result))
+			test.istrue(table.contains(result, "folder/symlinkfolder/hello.txt"))
+		end
+	end
+
 
 --
 -- os.pathsearch() tests


### PR DESCRIPTION
**What does this PR do?**

`os.matchfiles` works with symlinks. Fixes #1459 

**How does this PR change Premake's behavior?**

Symlinks will be followed correctly, those relying on this not happening will have to exclude the symlinks.

**Anything else we should know?**

N/A.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
