### PR TITLE
Use single value for settings on xcode

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -61,6 +61,17 @@
 		]]
 	end
 
+	function suite.PBXBuildFile_ListsSwiftSources()
+		files { "source.swift", "Info.plist" }
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		4616E7383FD8A3AA79D7A578 /* source.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2BDAE0539CBF12983B9120 /* source.swift */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
 	function suite.PBXBuildFile_ListsResourceFilesOnlyOnceWithGroupID()
 		files { "English.lproj/MainMenu.xib", "French.lproj/MainMenu.xib" }
 		prepare()
@@ -3553,6 +3564,83 @@
 		]]
 	end
 
+	function suite.XCBuildConfigurationProject_OnSwift4_0()
+		workspace("MyWorkspace")
+		swiftversion("4.0")
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SWIFT_VERSION = 4.0;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationProject_OnSwift4_2()
+		workspace("MyWorkspace")
+		swiftversion("4.2")
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SWIFT_VERSION = 4.2;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationProject_OnSwift5_0()
+		workspace("MyWorkspace")
+		swiftversion("5.0")
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SWIFT_VERSION = 5.0;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
 
 ---------------------------------------------------------------------------
 -- XCBuildConfigurationList tests

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -2294,9 +2294,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OBJROOT = obj/Debug;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_LDFLAGS = (
-					"-lldap",
-				);
+				OTHER_LDFLAGS = "-lldap";
 				SYMROOT = bin/Debug;
 			};
 			name = Debug;
@@ -2477,9 +2475,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OBJROOT = obj/Debug;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CFLAGS = (
-					"-ffast-math",
-				);
+				OTHER_CFLAGS = "-ffast-math";
 				SYMROOT = bin/Debug;
 			};
 			name = Debug;
@@ -2584,9 +2580,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OBJROOT = obj/Debug;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CFLAGS = (
-					"-fomit-frame-pointer",
-				);
+				OTHER_CFLAGS = "-fomit-frame-pointer";
 				SYMROOT = bin/Debug;
 			};
 			name = Debug;
@@ -2612,9 +2606,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OBJROOT = obj/Debug;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CFLAGS = (
-					"-fomit-frame-pointer",
-				);
+				OTHER_CFLAGS = "-fomit-frame-pointer";
 				SYMROOT = bin/Debug;
 			};
 			name = Debug;
@@ -2640,9 +2632,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OBJROOT = obj/Debug;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CFLAGS = (
-					"-fno-omit-frame-pointer",
-				);
+				OTHER_CFLAGS = "-fno-omit-frame-pointer";
 				SYMROOT = bin/Debug;
 			};
 			name = Debug;

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -219,9 +219,9 @@
 			value(level, name)
 		elseif type(value) ~= 'table' then
 			_p(level, '%s = %s;', stringifySetting(name), stringifySetting(value))
-		elseif #value == 1 then
-			_p(level, '%s = %s;', stringifySetting(name), stringifySetting(value[1]))
-		elseif #value > 1 then
+		--elseif #value == 1 then
+			--_p(level, '%s = %s;', stringifySetting(name), stringifySetting(value[1]))
+		elseif #value >= 1 then
 			_p(level, '%s = (', stringifySetting(name))
 			for _, item in ipairs(value) do
 				_p(level + 1, '%s,', stringifySetting(item))

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -41,6 +41,7 @@
 			[".icns"] = "Resources",
 			[".s"] = "Sources",
 			[".S"] = "Sources",
+			[".swift"] = "Sources",
 		}
 		if node.isResource then
 			return "Resources"
@@ -140,7 +141,7 @@
 			[".bmp"]       = "image.bmp",
 			[".wav"]       = "audio.wav",
 			[".xcassets"]  = "folder.assetcatalog",
-
+			[".swift"]     = "sourcecode.swift",
 		}
 		return types[path.getextension(node.path)] or "text"
 	end
@@ -218,9 +219,9 @@
 			value(level, name)
 		elseif type(value) ~= 'table' then
 			_p(level, '%s = %s;', stringifySetting(name), stringifySetting(value))
-		--elseif #value == 1 then
-			--_p(level, '%s = %s;', stringifySetting(name), stringifySetting(value[1]))
-		elseif #value >= 1 then
+		elseif #value == 1 then
+			_p(level, '%s = %s;', stringifySetting(name), stringifySetting(value[1]))
+		elseif #value > 1 then
 			_p(level, '%s = (', stringifySetting(name))
 			for _, item in ipairs(value) do
 				_p(level + 1, '%s,', stringifySetting(item))
@@ -1292,7 +1293,16 @@
 		end
 	end
 
-
+	function xcode.XCBuildConfiguration_SwiftLanguageVersion(settings, cfg)
+		-- if no swiftversion is provided, don't set swift version
+		-- Projects with swift files but without swift version will refuse 
+		-- to build on Xcode but setting a default SWIFT_VERSION may have 
+		-- unexpected interactions with other systems like cocoapods
+		if cfg.swiftversion then
+			settings['SWIFT_VERSION'] = cfg.swiftversion
+		end
+	end
+	
 	function xcode.XCBuildConfiguration_Project(tr, cfg)
 		local settings = {}
 
@@ -1459,6 +1469,8 @@
 		elseif cfg.warnings == "Everything" then
 			settings['WARNING_CFLAGS'] = '-Weverything'
 		end
+
+		xcode.XCBuildConfiguration_SwiftLanguageVersion(settings, cfg)
 
 		overrideSettings(settings, cfg.xcodebuildsettings)
 

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -189,9 +189,9 @@
 			value(level, name)
 		elseif type(value) ~= 'table' then
 			_p(level, '%s = %s;', xcode.stringifySetting(name), xcode.stringifySetting(value))
-		--elseif #value == 1 then
-			--_p(level, '%s = %s;', xcode.stringifySetting(name), xcode.stringifySetting(value[1]))
-		elseif #value >= 1 then
+		elseif #value == 1 then
+			_p(level, '%s = %s;', xcode.stringifySetting(name), xcode.stringifySetting(value[1]))
+		elseif #value > 1 then
 			_p(level, '%s = (', xcode.stringifySetting(name))
 			for _, item in ipairs(value) do
 				_p(level + 1, '%s,', xcode.stringifySetting(item))

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -783,6 +783,17 @@
 	}
 
 	api.register {
+		name = "swiftversion",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"4.0",
+			"4.2",
+			"5.0",
+		}
+	}
+
+	api.register {
 		name = "libdirs",
 		scope = "config",
 		kind = "list:directory",


### PR DESCRIPTION
**What does this PR do?**
This PR includes the changes of https://github.com/premake/premake-core/pull/1477 . I don't know how I could split those PRs to include tests for both of them

This pull request enables single setting formatting fox xcode projects.
If you use cocoapods and it finds SWIFT_VERSION on a xcode setting formatted as a list cocoapods is not able to read the swift version and fails

**How does this PR change Premake's behavior?**
It changes how xcode settings are formatted on the pbxproj file. Before this they were formatted as single element lists
```
SWIFT_VERSION = (
                    4.0,
                );
```
After this it will be generated as
```
SWIFT_VERSION = 4.0;
```

Are there any breaking changes? Will any existing behavior change?
I checked on our own projects and this syntax works on Xcode
**Anything else we should know?**

Add any other context about your changes here.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
