### PR TITLE
Auto detect C++ dialect (gcc && msvc)

### DIFF
--- a/modules/d/actions/vcxproj.lua
+++ b/modules/d/actions/vcxproj.lua
@@ -455,27 +455,7 @@
 		end
 
 		if cfg.cppdialect and cfg.cppdialect ~= "Default" then
-			local cppMap = {
-				["C++latest"] = "c++17", -- TODO: keep this up to date >_<
-				["C++98"] = "c++98",
-				["C++0x"] = "c++11",
-				["C++11"] = "c++11",
-				["C++1y"] = "c++14",
-				["C++14"] = "c++14",
-				["C++1z"] = "c++17",
-				["C++17"] = "c++17",
-				["C++2a"] = "c++20",
-				["C++20"] = "c++20",
-				["gnu++98"] = "c++98",
-				["gnu++0x"] = "c++11",
-				["gnu++11"] = "c++11",
-				["gnu++1y"] = "c++14",
-				["gnu++14"] = "c++14",
-				["gnu++1z"] = "c++17",
-				["gnu++17"] = "c++17",
-				["gnu++2a"] = "c++20",
-				["gnu++20"] = "c++20",
-			}
+			local cppMap = 	p.api.getCPPDialect()
 			if cppMap[cfg.cppdialect] ~= nil then
 				table.insert(opts, "-extern-std=" .. cppMap[cfg.cppdialect])
 			end

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -1177,3 +1177,48 @@
 	function newoption(opt)
 		p.option.add(opt)
 	end
+
+--
+-- Generate C++ dialect
+--
+
+
+	function api.getCPPDialect()
+		-- Must be arrays is sorted (less to more standard)
+		local possible_standards = {
+			"C++98", 
+			"C++0x",
+			"C++11",
+			"C++1y",
+			"C++14",
+			"C++1z",
+			"C++17",
+			"C++2a",
+			"C++20",
+		}
+		local possible_gnu_standards = {
+			"gnu++98",
+			"gnu++0x",
+			"gnu++11",
+			"gnu++1y",
+			"gnu++14",
+			"gnu++1z",
+			"gnu++17",
+			"gnu++1a",
+			"gnu++20",
+		}
+		-- create is empty hash-table
+		local dialect = {}
+
+		-- building hash-table dialect
+		for _, std_name in ipairs(possible_standards) do
+			dialect[std_name] = "-std=" .. string.lower(string.sub(std_name, 1, 1)) .. string.sub(std_name, 2)
+		end
+		for _, std_name in ipairs(possible_gnu_standards) do
+			dialect[std_name] = "-std=" .. std_name
+		end
+		-- Auto C++latest detect
+		local latest = possible_standards[#possible_standards]
+		dialect["C++latest"] = "-std=" .. string.lower(string.sub(latest, 1, 1)) .. string.sub(latest, 2)
+		return dialect
+	end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -193,26 +193,7 @@
 		flags = {
 			NoBufferSecurityCheck = "-fno-stack-protector",
 		},
-		cppdialect = {
-			["C++98"] = "-std=c++98",
-			["C++0x"] = "-std=c++0x",
-			["C++11"] = "-std=c++11",
-			["C++1y"] = "-std=c++1y",
-			["C++14"] = "-std=c++14",
-			["C++1z"] = "-std=c++1z",
-			["C++17"] = "-std=c++17",
-			["C++2a"] = "-std=c++2a",
-			["C++20"] = "-std=c++20",
-			["gnu++98"] = "-std=gnu++98",
-			["gnu++0x"] = "-std=gnu++0x",
-			["gnu++11"] = "-std=gnu++11",
-			["gnu++1y"] = "-std=gnu++1y",
-			["gnu++14"] = "-std=gnu++14",
-			["gnu++1z"] = "-std=gnu++1z",
-			["gnu++17"] = "-std=gnu++17",
-			["gnu++2a"] = "-std=gnu++2a",
-			["gnu++20"] = "-std=gnu++20",
-		},
+		cppdialect = p.api.getCPPDialect(),
 		rtti = {
 			Off = "-fno-rtti"
 		},

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -830,6 +830,13 @@
 		test.contains({ }, gcc.getcflags(cfg))
 	end
 
+	function suite.cxxflags_onCppLatest()
+		cppdialect "C++latest"
+		prepare()
+		test.contains({ "-std=c++20" }, gcc.getcxxflags(cfg))
+		test.contains({ }, gcc.getcflags(cfg))
+	end
+
 	function suite.cxxflags_onCppGnu98()
 		cppdialect "gnu++98"
 		prepare()


### PR DESCRIPTION
**What does this PR do?**

Added the ability to easily change the version of standards for C ++ (so far only for GCC and MSVC)

**How does this PR change Premake's behavior?**

No

**Anything else we should know?**

It is now possible to use C++ latest with GCC. In addition, it is now easier to update the versions of standards (now there is no duplicate code, it is replaced by a function)

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

