### PR TITLE
Fix sysincludedirs for codelite.

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -196,9 +196,10 @@
 		end
 
 		local toolset = m.getcompiler(cfg)
+		local sysincludedirs = toolset.getincludedirs(cfg, {}, cfg.sysincludedirs)
 		local forceincludes = toolset.getforceincludes(cfg)
-		local cxxflags = table.concat(table.join(toolset.getcxxflags(cfg), forceincludes, cfg.buildoptions), ";")
-		local cflags   = table.concat(table.join(toolset.getcflags(cfg), forceincludes, cfg.buildoptions), ";")
+		local cxxflags = table.concat(table.join(sysincludedirs, toolset.getcxxflags(cfg), forceincludes, cfg.buildoptions), ";")
+		local cflags   = table.concat(table.join(sysincludedirs, toolset.getcflags(cfg), forceincludes, cfg.buildoptions), ";")
 		local asmflags = ""
 		local pch      = ""
 
@@ -241,7 +242,7 @@
 		local options = table.concat(cfg.resoptions, ";")
 
 		_x(3, '<ResourceCompiler Options="%s%s" Required="yes">', defines, options)
-		for _, includepath in ipairs(table.join(cfg.includedirs, cfg.resincludedirs)) do
+		for _, includepath in ipairs(table.join(cfg.sysincludedirs, cfg.includedirs, cfg.resincludedirs)) do
 			_x(4, '<IncludePath Value="%s"/>', project.getrelative(cfg.project, includepath))
 		end
 		_p(3, '</ResourceCompiler>')

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -57,11 +57,12 @@
 	end
 
 	function suite.OnProjectCfg_Includes()
+		sysincludedirs { "sysdir", "sysdir2/"}
 		includedirs { "dir/", "dir2" }
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
+      <Compiler Options="-isystem sysdir;-isystem sysdir2" C_Options="-isystem sysdir;-isystem sysdir2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
         <IncludePath Value="dir"/>
         <IncludePath Value="dir2"/>
       </Compiler>
@@ -126,12 +127,16 @@
 
 	function suite.OnProjectCfg_ResInclude()
 		files { "x.rc" }
-		resincludedirs { "dir/" }
+		includedirs { "dir/" }
+		sysincludedirs { "sysdir/" }
+		resincludedirs { "resdir/" }
 		prepare()
 		codelite.project.resourceCompiler(cfg)
 		test.capture [[
       <ResourceCompiler Options="" Required="yes">
+        <IncludePath Value="sysdir"/>
         <IncludePath Value="dir"/>
+        <IncludePath Value="resdir"/>
       </ResourceCompiler>
 		]]
 	end

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -57,17 +57,27 @@
 	end
 
 	function suite.OnProjectCfg_Includes()
-		sysincludedirs { "sysdir", "sysdir2/"}
 		includedirs { "dir/", "dir2" }
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="-isystem sysdir;-isystem sysdir2" C_Options="-isystem sysdir;-isystem sysdir2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
         <IncludePath Value="dir"/>
         <IncludePath Value="dir2"/>
       </Compiler>
 		]]
 	end
+
+	function suite.OnProjectCfg_SysIncludes()
+		sysincludedirs { "sysdir", "sysdir2/"}
+		prepare()
+		codelite.project.compiler(cfg)
+		test.capture [[
+      <Compiler Options="-isystem sysdir;-isystem sysdir2" C_Options="-isystem sysdir;-isystem sysdir2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
+      </Compiler>
+		]]
+	end
+
 
 	function suite.OnProjectCfg_Defines()
 		defines { "TEST", "DEF", "VAL=1", "ESCAPE=\"WITH SPACE\"" }
@@ -127,16 +137,36 @@
 
 	function suite.OnProjectCfg_ResInclude()
 		files { "x.rc" }
-		includedirs { "dir/" }
+		resincludedirs { "dir/" }
+		prepare()
+		codelite.project.resourceCompiler(cfg)
+		test.capture [[
+      <ResourceCompiler Options="" Required="yes">
+        <IncludePath Value="dir"/>
+      </ResourceCompiler>
+		]]
+	end
+
+	function suite.OnProjectCfg_ResRegularInclude()
+		files { "x.rc" }
+		includedirs { "regulardir/" }
+		prepare()
+		codelite.project.resourceCompiler(cfg)
+		test.capture [[
+      <ResourceCompiler Options="" Required="yes">
+        <IncludePath Value="regulardir"/>
+      </ResourceCompiler>
+		]]
+	end
+
+	function suite.OnProjectCfg_ResSysInclude()
+		files { "x.rc" }
 		sysincludedirs { "sysdir/" }
-		resincludedirs { "resdir/" }
 		prepare()
 		codelite.project.resourceCompiler(cfg)
 		test.capture [[
       <ResourceCompiler Options="" Required="yes">
         <IncludePath Value="sysdir"/>
-        <IncludePath Value="dir"/>
-        <IncludePath Value="resdir"/>
       </ResourceCompiler>
 		]]
 	end


### PR DESCRIPTION
**What does this PR do?**

Implement sysincludedirs for codelite.

**How does this PR change Premake's behavior?**

No changes in Premake core. only in codelite generator.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
