### PR TITLE
Fix quote escaping in Codelite.

### DIFF
--- a/modules/codelite/codelite.lua
+++ b/modules/codelite/codelite.lua
@@ -40,7 +40,7 @@
 		local result = value:gsub('&', '&amp;')
 		result = result:gsub('<', '&lt;')
 		result = result:gsub('>', '&gt;')
-		result = result:gsub('"', '\\&quot;')
+		result = result:gsub('"', '&quot;')
 		return result
 	end
 

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -77,7 +77,7 @@
         <Preprocessor Value="TEST"/>
         <Preprocessor Value="DEF"/>
         <Preprocessor Value="VAL=1"/>
-        <Preprocessor Value="ESCAPE=\&quot;WITH\ SPACE\&quot;"/>
+        <Preprocessor Value="ESCAPE=&quot;WITH\ SPACE&quot;"/>
       </Compiler>
 		]]
 	end


### PR DESCRIPTION
**What does this PR do?**

Fix quote escaping in Codelite.
-> fix define with quote
-> fix SharedLib (at least on windows).

improve/fix #1275


**How does this PR change Premake's behavior?**

No Core changes, only codelite generator

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
