### PR TITLE
FIX #1508 move help and version to a new function

### DIFF
--- a/src/_premake_main.lua
+++ b/src/_premake_main.lua
@@ -215,16 +215,6 @@
 ---
 
 	function m.processCommandLine()
-		-- Process special options
-		if (_OPTIONS["version"]) then
-			printf(versionhelp, _PREMAKE_VERSION)
-			os.exit(0)
-		end
-
-		if (_OPTIONS["help"]) then
-			p.showhelp()
-			os.exit(1)
-		end
 
 		-- Validate the command-line arguments. This has to happen after the
 		-- script has run to allow for project-specific options
@@ -362,13 +352,29 @@
 		end
 	end
 
+---
+-- Process command line special options
+---
 
+function m.processCommandLineSpecialOptions()
+		
+		if (_OPTIONS["version"]) then
+			printf(versionhelp, _PREMAKE_VERSION)
+			os.exit(0)
+		end
+
+		if (_OPTIONS["help"]) then
+			p.showhelp()
+			os.exit(1)
+		end
+	end 
 
 --
 -- Script-side program entry point.
 --
 
 	m.elements = {
+		m.processCommandLineSpecialOptions,
 		m.tryHookDebugger,
 		m.installModuleLoader,
 		m.locateUserScript,


### PR DESCRIPTION
**What does this PR do?**

Solves the issue https://github.com/premake/premake-core/issues/1508 
**--help** and **--version** are not shown if there is a premake5.lua file with errors

**How does this PR change Premake's behavior?**

On help or version, display message and then exit

**Anything else we should know?**

Please review it and don't hesitate to contact me.
Thank you!