### PR TITLE
Add Metal shader files as source code

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -72,6 +72,17 @@
 		]]
 	end
 
+	function suite.PBXBuildFile_ListsMetalFileInResources()
+		files { "source.metal", "Info.plist" }
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		3873A08432355CF66C345EC4 /* source.metal in Resources */ = {isa = PBXBuildFile; fileRef = 35B2856C7E23699EC2C23BAC /* source.metal */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
 	function suite.PBXBuildFile_ListsResourceFilesOnlyOnceWithGroupID()
 		files { "English.lproj/MainMenu.xib", "French.lproj/MainMenu.xib" }
 		prepare()

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -42,6 +42,7 @@
 			[".s"] = "Sources",
 			[".S"] = "Sources",
 			[".swift"] = "Sources",
+			[".metal"] = "Resources",
 		}
 		if node.isResource then
 			return "Resources"
@@ -142,6 +143,7 @@
 			[".wav"]       = "audio.wav",
 			[".xcassets"]  = "folder.assetcatalog",
 			[".swift"]     = "sourcecode.swift",
+			[".metal"]     = "sourcecode.metal",
 		}
 		return types[path.getextension(node.path)] or "text"
 	end


### PR DESCRIPTION
**What does this PR do?**

Adds support for `.metal` files as Metal shader source code in Xcode.

**How does this PR change Premake's behavior?**

Xcode projects containing `.metal` files will compile those files into a Metal library.

**Anything else we should know?**

Xcode generally puts these in the Resources category so that's what I've done, but I don't know if that's strictly necessary.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
