### PR TITLE
Fixed external library linking for Clang in VS2019+

### DIFF
--- a/modules/vstudio/tests/vc2019/test_link.lua
+++ b/modules/vstudio/tests/vc2019/test_link.lua
@@ -1,0 +1,43 @@
+--
+-- tests/actions/vstudio/vc2010/test_compile_settings.lua
+-- Validate compiler settings in Visual Studio 2019 C/C++ projects.
+-- Copyright (c) 2011-2020 Jason Perkins and the Premake project
+--
+
+local p = premake
+local suite = test.declare("vstudio_vs2019_compile_settings")
+local vc2010 = p.vstudio.vc2010
+local project = p.project
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2019")
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare(platform)
+		local cfg = test.getconfig(prj, "Debug", platform)
+		vc2010.configurationProperties(cfg)
+	end
+
+--
+-- Check link command for a static library using a clang toolset
+--
+
+	function suite.toolsetClangAdditionalDependencies()
+		function suite.additionalDependencies_onSystemLinks()
+			links { "lua", "zlib" }
+			toolset "clang"
+			prepare()
+			test.capture [[
+	<Link>
+		<SubSystem>Windows</SubSystem>
+		<AdditionalDependencies>lua.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			]]
+		end
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1397,7 +1397,7 @@
 		-- check to see if this project uses an external toolset. If so, let the
 		-- toolset define the format of the links
 		local toolset = config.toolset(cfg)
-		if toolset then
+		if cfg.system ~= premake.WINDOWS and toolset then
 			links = toolset.getlinks(cfg, not explicit)
 		else
 			links = vstudio.getLinks(cfg, explicit)


### PR DESCRIPTION
**What does this PR do?**

Fixes problems referenced in #1520 and #1507 where the clang toolset produces a bad external library path when used with VS2019.  Current behavior deferred the library generation to gcc's implementation, such that external libraries received the string "-lName" (e.g. "-lSDL") instead of "name.lib" (e.g. "SDL.lib").

**How does this PR change Premake's behavior?**

Changes the clang tool's `getlinks` method to defer to MSC when the action is VS2019 or newer.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
