### PR TITLE
[Codelite] Only active (i.e. unique) configuration should be selected.

### DIFF
--- a/modules/codelite/codelite_workspace.lua
+++ b/modules/codelite/codelite_workspace.lua
@@ -82,10 +82,12 @@
 
 		-- for each workspace config
 		p.push('<BuildMatrix>')
+		local selected = "yes" -- only one configuration should be selected
 		for cfg in workspace.eachconfig(wks) do
 
 			local cfgname = codelite.cfgname(cfg)
-			p.push('<WorkspaceConfiguration Name="%s" Selected="yes">', cfgname)
+			p.push('<WorkspaceConfiguration Name="%s" Selected="%s">', cfgname, selected)
+			selected = "no"
 
 			local tr = workspace.grouptree(wks)
 			tree.traverse(tr, {

--- a/modules/codelite/tests/test_codelite_workspace.lua
+++ b/modules/codelite/tests/test_codelite_workspace.lua
@@ -42,7 +42,7 @@
   <BuildMatrix>
     <WorkspaceConfiguration Name="Debug" Selected="yes">
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="Release" Selected="yes">
+    <WorkspaceConfiguration Name="Release" Selected="no">
     </WorkspaceConfiguration>
   </BuildMatrix>
 </CodeLite_Workspace>
@@ -59,7 +59,7 @@
     <WorkspaceConfiguration Name="Debug" Selected="yes">
       <Project Name="MyProject" ConfigName="Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="Release" Selected="yes">
+    <WorkspaceConfiguration Name="Release" Selected="no">
       <Project Name="MyProject" ConfigName="Release"/>
     </WorkspaceConfiguration>
   </BuildMatrix>
@@ -80,7 +80,7 @@
       <Project Name="MyProject" ConfigName="Debug"/>
       <Project Name="MyProject2" ConfigName="Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="Release" Selected="yes">
+    <WorkspaceConfiguration Name="Release" Selected="no">
       <Project Name="MyProject" ConfigName="Release"/>
       <Project Name="MyProject2" ConfigName="Release"/>
     </WorkspaceConfiguration>
@@ -105,7 +105,7 @@
     <WorkspaceConfiguration Name="Debug" Selected="yes">
       <Project Name="MyProject" ConfigName="Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="Release" Selected="yes">
+    <WorkspaceConfiguration Name="Release" Selected="no">
       <Project Name="MyProject" ConfigName="Release"/>
     </WorkspaceConfiguration>
   </BuildMatrix>
@@ -124,7 +124,7 @@
     <WorkspaceConfiguration Name="Debug" Selected="yes">
       <Project Name="MyProject" ConfigName="Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="Release" Selected="yes">
+    <WorkspaceConfiguration Name="Release" Selected="no">
       <Project Name="MyProject" ConfigName="Release"/>
     </WorkspaceConfiguration>
   </BuildMatrix>
@@ -145,7 +145,7 @@
     <WorkspaceConfiguration Name="Debug" Selected="yes">
       <Project Name="MyProject" ConfigName="Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="Release" Selected="yes">
+    <WorkspaceConfiguration Name="Release" Selected="no">
       <Project Name="MyProject" ConfigName="Release"/>
     </WorkspaceConfiguration>
   </BuildMatrix>
@@ -182,7 +182,7 @@
       <Project Name="MyGroupedProject" ConfigName="Debug"/>
       <Project Name="MyGrouplessProject" ConfigName="Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="Release" Selected="yes">
+    <WorkspaceConfiguration Name="Release" Selected="no">
       <Project Name="MyNestedGroupedProject" ConfigName="Release"/>
       <Project Name="MyGroupedProject" ConfigName="Release"/>
       <Project Name="MyGrouplessProject" ConfigName="Release"/>
@@ -209,13 +209,13 @@
     <WorkspaceConfiguration Name="x86_64-Debug" Selected="yes">
       <Project Name="MyProject" ConfigName="x86_64-Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="x86-Debug" Selected="yes">
+    <WorkspaceConfiguration Name="x86-Debug" Selected="no">
       <Project Name="MyProject" ConfigName="x86-Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="x86_64-Release" Selected="yes">
+    <WorkspaceConfiguration Name="x86_64-Release" Selected="no">
       <Project Name="MyProject" ConfigName="x86_64-Release"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="x86-Release" Selected="yes">
+    <WorkspaceConfiguration Name="x86-Release" Selected="no">
       <Project Name="MyProject" ConfigName="x86-Release"/>
     </WorkspaceConfiguration>
   </BuildMatrix>


### PR DESCRIPTION
**What does this PR do?**

Fix active configuration under codelite

**How does this PR change Premake's behavior?**

Only codelite generator is changed.

**Anything else we should know?**

To reproduce the issue:

- create a project with 3 configurations in premake (Debug, Profile, Release)
- generate for codelite
  - Here all 3 configurations are the active one :/
  - codelite handles the conflict by selecting the first active (so Debug in that case)

- open codelite
- switch to Release (so now Debug is not active, Release is (still) active, Profile is untouched (so active))
  - Profile is selected

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

