### PR TITLE
Added COPYFILE and COPYDIR tokens

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -572,6 +572,12 @@
 			copy = function(v)
 				return "cp -rf " .. path.normalize(v)
 			end,
+			copyfile = function(v)
+				return "cp -f " .. path.normalize(v)
+			end,
+			copydir = function(v)
+				return "cp -rf " .. path.normalize(v)
+			end,
 			delete = function(v)
 				return "rm -f " .. path.normalize(v)
 			end,
@@ -605,6 +611,17 @@
 				src = string.match(src, '^.*%S')
 
 				return "IF EXIST " .. src .. "\\ (xcopy /Q /E /Y /I " .. v .. " > nul) ELSE (xcopy /Q /Y /I " .. v .. " > nul)"
+			end,
+			copyfile = function(v)
+				v = path.translate(path.normalize(v))
+				-- XCOPY doesn't have a switch to assume destination is a file when it doesn't exist.
+				-- A trailing * will suppress the prompt but requires the file extensions be the same length.
+				-- Just use COPY instead, it actually works.
+				return "copy /B /Y " .. v
+			end,
+			copydir = function(v)
+				v = path.translate(path.normalize(v))
+				return "xcopy /Q /E /Y /I " .. v
 			end,
 			delete = function(v)
 				return "del " .. path.translate(path.normalize(v))


### PR DESCRIPTION
**What does this PR do?**

Adds new tokens, `{COPYFILE}` and `{COPYDIR}` to resolve issues with `XCOPY` being unable to copy a file.

**How does this PR change Premake's behavior?**

No, this does not replace or remove the existing and broken `{COPY}` token.

**Anything else we should know?**

This most likely will need more work to be done for all the edge cases where `COPY` differs to `cp` and `XCOPY` differs to `cp`. See #1232 for examples of differences with folder copying.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
