### PR TITLE
NMake projects can now specify buildoptions and cppdialect

### DIFF
--- a/modules/vstudio/tests/vc2010/test_nmake_props.lua
+++ b/modules/vstudio/tests/vc2010/test_nmake_props.lua
@@ -184,6 +184,28 @@ command 2</NMakeBuildCommandLine>
 		]]
 	end
 
+	function suite.onCppDialect()
+		cppdialect "C++14"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
+	<AdditionalOptions>/std:c++14 %(AdditionalOptions)</AdditionalOptions>
+</PropertyGroup>
+		]]
+	end
+
+	function suite.onBuildOptions()
+		buildoptions { "testing" }
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<NMakeOutput>$(OutDir)MyProject</NMakeOutput>
+	<AdditionalOptions>testing %(AdditionalOptions)</AdditionalOptions>
+</PropertyGroup>
+		]]
+	end
+
 
 --
 -- Should not emit include dirs or preprocessor definitions if the project

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -267,7 +267,8 @@
 			m.nmakeRebuildCommands,
 			m.nmakeCleanCommands,
 			m.nmakePreprocessorDefinitions,
-			m.nmakeIncludeDirs
+			m.nmakeIncludeDirs,
+			m.additionalCompileOptions
 		}
 	end
 
@@ -1504,7 +1505,7 @@
 
 	function m.additionalCompileOptions(cfg, condition)
 		local opts = cfg.buildoptions
-		if _ACTION == "vs2015" then
+		if _ACTION == "vs2015" or vstudio.isMakefile(cfg) then
 			if (cfg.cppdialect == "C++14") then
 				table.insert(opts, "/std:c++14")
 			elseif (cfg.cppdialect == "C++17") then


### PR DESCRIPTION
**What does this PR do?**

Adds support for `buildoptions` and `cppdialect` for VS projects of using `kind "Makefile"`.

Fixes #1226

**How does this PR change Premake's behavior?**

Only as mentioned above, shouldn't have any breaking changes.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
