### PR TITLE
Disable network tests; add --test-all flag to enable

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Build
       run: make -f Bootstrap.mak linux CONFIG=${{ matrix.config }}
     - name: Test
-      run: bin/${{ matrix.config }}/premake5 test
+      run: bin/${{ matrix.config }}/premake5 test --test-all
     - name: Upload Artifacts
       if: matrix.config == 'release'
       uses: actions/upload-artifact@v2
@@ -34,7 +34,7 @@ jobs:
     - name: Build
       run: make -f Bootstrap.mak macosx CONFIG=${{ matrix.config }}
     - name: Test
-      run: bin/${{ matrix.config }}/premake5 test
+      run: bin/${{ matrix.config }}/premake5 test --test-all
     - name: Upload Artifacts
       if: matrix.config == 'release'
       uses: actions/upload-artifact@v2
@@ -56,7 +56,7 @@ jobs:
         nmake -f Bootstrap.mak MSDEV=vs2019 windows-msbuild PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }}
       shell: cmd
     - name: Test
-      run: bin\${{ matrix.config }}\premake5 test
+      run: bin\${{ matrix.config }}\premake5 test --test-all
       shell: cmd
     - name: Upload Artifacts
       if: matrix.config == 'release'

--- a/modules/vstudio/tests/cs2005/test_assembly_refs.lua
+++ b/modules/vstudio/tests/cs2005/test_assembly_refs.lua
@@ -148,6 +148,7 @@
 -- NuGet packages should get references.
 --
 
+if _OPTIONS["test-all"] then
 	function suite.nuGetPackages_net45()
 		dotnetframework "4.5"
 		nuget { "Newtonsoft.Json:10.0.2" }
@@ -175,12 +176,15 @@
 	</ItemGroup>
 		]]
 	end
+end
+
 
 --
 -- If there are multiple assemblies in the NuGet package, they all should be
 -- referenced.
 --
 
+if _OPTIONS["test-all"] then
 	function suite.nuGetPackages_multipleAssemblies()
 		dotnetframework "2.0"
 		nuget { "NUnit:3.6.1" }
@@ -198,12 +202,14 @@
 	</ItemGroup>
 		]]
 	end
+end
 
 
 --
 -- NuGet packages should respect copylocal() and the NoCopyLocal flag.
 --
 
+if _OPTIONS["test-all"] then
 	function suite.nugetPackages_onNoCopyLocal()
 		dotnetframework "2.0"
 		nuget { "NUnit:3.6.1" }
@@ -260,12 +266,15 @@
 	</ItemGroup>
 		]]
 	end
+end
+
 
 --
 -- NuGet packages with unconventional folder structures should be handled
 -- properly.
 --
 
+if _OPTIONS["test-all"] then
 	function suite.nuGetPackages_netFolder()
 		dotnetframework "4.5"
 		nuget { "MetroModernUI:1.4.0" }
@@ -287,3 +296,4 @@
 	</ItemGroup>
 		]]
 	end
+end

--- a/modules/vstudio/tests/cs2005/test_nuget_references.lua
+++ b/modules/vstudio/tests/cs2005/test_nuget_references.lua
@@ -32,8 +32,10 @@
 -- Check that we process Unix-style paths correctly.
 --
 
+if _OPTIONS["test-all"] then
 	function suite.unixPaths()
 		dotnetframework "4.6"
 		nuget "Mono.Cecil:0.9.6.4"
 		prepare()
 	end
+end

--- a/modules/vstudio/tests/vc2010/test_ensure_nuget_imports.lua
+++ b/modules/vstudio/tests/vc2010/test_ensure_nuget_imports.lua
@@ -42,6 +42,7 @@
 -- Writes the pre-build check that makes sure that all packages are installed.
 --
 
+if _OPTIONS["test-all"] then
 	function suite.structureIsCorrect()
 		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3" }
 		prepare()
@@ -56,3 +57,4 @@
 </Target>
 		]]
 	end
+end

--- a/modules/vstudio/tests/vc2010/test_extension_targets.lua
+++ b/modules/vstudio/tests/vc2010/test_extension_targets.lua
@@ -63,6 +63,7 @@
 -- Writes entries for NuGet packages.
 --
 
+if _OPTIONS["test-all"] then
 	function suite.addsImport_onEachNuGetPackage()
 		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3" }
 		prepare()
@@ -74,6 +75,7 @@
 </ImportGroup>
 		]]
 	end
+end
 
 
 --

--- a/premake5.lua
+++ b/premake5.lua
@@ -51,7 +51,13 @@
 
 
 	newoption {
-		trigger     = "test-only",
+		trigger = "test-all",
+		description = "Run all unit tests, including slower network and I/O"
+	}
+
+
+	newoption {
+		trigger = "test-only",
 		description = "When testing, run only the specified suite or test"
 	}
 
@@ -73,7 +79,7 @@
 		trigger = "no-zlib",
 		description = "Disable Zlib/Zip 3rd party lib"
 	}
-	
+
 	newoption {
 		trigger = "no-luasocket",
 		description = "Disable Luasocket 3rd party lib"
@@ -105,7 +111,7 @@
 		if not _OPTIONS["no-zlib"] then
 			defines { "PREMAKE_COMPRESSION" }
 		end
-		
+
 		if not _OPTIONS["no-curl"] then
 			defines { "CURL_STATICLIB", "PREMAKE_CURL"}
 		end
@@ -144,7 +150,7 @@
 			includedirs { "contrib/zlib", "contrib/libzip" }
 			links { "zip-lib", "zlib-lib" }
 		end
-		
+
 		if not _OPTIONS["no-curl"] then
 			includedirs { "contrib/curl/include" }
 			links { "curl-lib" }
@@ -214,20 +220,20 @@
 	group "contrib"
 		include "contrib/lua"
 		include "contrib/luashim"
-		
+
 		if not _OPTIONS["no-zlib"] then
 			include "contrib/zlib"
 			include "contrib/libzip"
 		end
-		
+
 		if not _OPTIONS["no-curl"] then
 			include "contrib/mbedtls"
 			include "contrib/curl"
-		end		
+		end
 
 	group "Binary Modules"
 		include "binmodules/example"
-		
+
 		if not _OPTIONS["no-luasocket"] then
 			include "binmodules/luasocket"
 		end

--- a/tests/base/test_http.lua
+++ b/tests/base/test_http.lua
@@ -1,16 +1,14 @@
 --
 -- tests/base/test_http.lua
 -- Tests the http API
--- Copyright (c) 2016 Jason Perkins and the Premake project
+-- Copyright (c) 2016, 2020 Jason Perkins and the Premake project
 --
 
+if http.get ~= nil and _OPTIONS["test-all"] then
 	local p = premake
 
-	-- only declare the suite as a test if http.get is an existing method.
-	local suite = {}
-	if http.get ~= nil then
-		suite = test.declare("premake_http")
-	end
+	local suite = test.declare("premake_http")
+
 
 	function suite.http_get()
 		local result, err = http.get("http://httpbin.org/user-agent")
@@ -56,6 +54,8 @@
 	end
 
 	-- Disable as httpbin.org returns 404 on this endpoint
+	-- See: https://github.com/postmanlabs/httpbin/issues/617
+
 	--[[
 	function suite.http_redirect()
 		local result, err, responseCode = http.get("http://httpbin.org/redirect/3")
@@ -81,3 +81,5 @@
 			test.fail(err);
 		end
 	end
+
+end


### PR DESCRIPTION
**What does this PR do?**

Hides the automated tests that require calls out to the network behind a new `--test-all` flag. Allows for faster TDD iterations for new development, and tests can now be run even when offline.

**How does this PR change Premake's behavior?**

Tests which require network access (HTTP, NuGet) will no longer run by default.

**Anything else we should know?**

I added the `--test-all` flag to the GitHub CI action, so we'll still be running them there. Open to discussion on whether that's a good idea or not.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
