### PR TITLE
Added Ability to Disable JMC in Visual Studio

### DIFF
--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -97,6 +97,8 @@ return {
 	-- Visual Studio 2013+ C/C++ Shared Items projects
 	"vc2013/test_vcxitems.lua",
 
-	-- Visual Studio 2019+ C/C++ Clang Projects
+	-- Visual Studio 2019+ C/C++ Projects
+	"vc2019/test_compile_settings.lua",
+	"vc2019/test_link.lua",
 	"vc2019/test_toolset_settings.lua"
 }

--- a/modules/vstudio/tests/vc2019/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_compile_settings.lua
@@ -1,0 +1,41 @@
+--
+-- tests/actions/vstudio/vc2010/test_compile_settings.lua
+-- Validate compiler settings in Visual Studio 2019 C/C++ projects.
+-- Copyright (c) 2011-2020 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("vstudio_vs2019_compile_settings")
+	local vc2010 = p.vstudio.vc2010
+	local project = p.project
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2019")
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare(platform)
+		local cfg = test.getconfig(prj, "Debug", platform)
+		vc2010.clCompile(cfg)
+	end
+
+--
+-- Check ClCompile for SupportJustMyCode
+--
+	function suite.SupportJustMyCode()
+		justmycode "Off"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<SupportJustMyCode>false</SupportJustMyCode>
+		]]
+	end

--- a/modules/vstudio/tests/vc2019/test_link.lua
+++ b/modules/vstudio/tests/vc2019/test_link.lua
@@ -5,7 +5,7 @@
 --
 
 local p = premake
-local suite = test.declare("vstudio_vs2019_compile_settings")
+local suite = test.declare("vstudio_vs2019_link")
 local vc2010 = p.vstudio.vc2010
 local project = p.project
 

--- a/modules/vstudio/tests/vc2019/test_toolset_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_toolset_settings.lua
@@ -5,7 +5,7 @@
 --
 
 	local p = premake
-	local suite = test.declare("vstudio_vs2019_compile_settings")
+	local suite = test.declare("vstudio_vs2019_toolset_settings")
 	local vc2010 = p.vstudio.vc2010
 	local project = p.project
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -365,6 +365,7 @@
 			m.optimization,
 			m.functionLevelLinking,
 			m.intrinsicFunctions,
+			m.justMyCodeDebugging,
 			m.minimalRebuild,
 			m.omitFramePointers,
 			m.stringPooling,
@@ -2122,6 +2123,13 @@
 		end
 	end
 
+	function m.justMyCodeDebugging(cfg)
+		local jmc = cfg.justmycode
+
+		if _ACTION >= "vs2017" and jmc == "Off" then
+			m.element("SupportJustMyCode", nil, "false")
+		end
+	end
 
 	function m.keyword(prj)
 		-- try to determine what kind of targets we're building here

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1411,6 +1411,15 @@
 		kind  = "boolean"
 	}
 
+	api.register {
+		name = "justmycode",
+		scope = "project",
+		kind = "string",
+		allowed = {
+			"Off"
+		}
+	}
+
 -----------------------------------------------------------------------------
 --
 -- Field name aliases for backward compatibility

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -105,6 +105,9 @@
 		},
 		omitframepointer = {
 			On = "/Oy"
+		},
+		justmycode = {
+			Off = "false"
 		}
 
 	}


### PR DESCRIPTION
**What does this PR do?**

This PR resolves #1526.  It adds a "jmc" option to projects in order to disable just my code debugging.

Usage:
```lua
project "SomeProject"
   justmycode "Off"
```

**How does this PR change Premake's behavior?**

There is no change for preexisting projects, thus it is a non-breaking change.  By settings `justmycode` to `"Off"` in a VS2017 or newer project, it adds a flag to the project file to disable JMC.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
