### PR TITLE
Added vs-latest action

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -21,6 +21,7 @@
 	include("vs2015.lua")
 	include("vs2017.lua")
 	include("vs2019.lua")
+	include("vslatest.lua")
 
 	-- Initialize Specific API
 
@@ -169,5 +170,6 @@
 			_ACTION == "vs2015" or
 			_ACTION == "vs2017" or
 			_ACTION == "vs2019" or
+			_ACTION == "vs-latest" or
 			false;
 	end

--- a/modules/vstudio/tests/vc2010/test_platform_toolset.lua
+++ b/modules/vstudio/tests/vc2010/test_platform_toolset.lua
@@ -57,6 +57,17 @@
 <PlatformToolset>v120</PlatformToolset>
 		]]
 	end
+	
+	function suite.correctDefault_onVSLatest()
+		p.action.set("vs-latest")
+		prepare()
+
+		local latest = getLatestVisualStudioVersion()
+
+		test.capture([[
+<PlatformToolset>]] .. latest.toolset .. [[</PlatformToolset>]]
+		)
+	end
 
 
 --

--- a/modules/vstudio/vslatest.lua
+++ b/modules/vstudio/vslatest.lua
@@ -1,0 +1,58 @@
+--
+-- vslatest.lua
+-- Extend the existing exporters with support for Visual Studio 2019.
+-- Copyright (c) Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local vstudio = p.vstudio
+	local latest = nil
+
+	function getLatestVisualStudioVersion()
+		-- Get the most recent version installed
+		if latest == nil then
+			local version = nil
+			if os.host() == 'windows' then
+				local ver, err = os.outputof('"C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -property catalog_productLineVersion')
+				if err ~= nil and err == 0 then
+					version = 'vs' .. ver
+				end
+			end
+
+			if version == nil then
+				version = "vs2019"
+				print("No Visual Studio installation found using vswhere.exe. Defaulting to " .. _ACTION .. ".")
+			end
+
+			latest = p.action.get(version)
+		end
+	
+		return latest
+	end
+
+---
+-- Define the Visual Studio Latest export action.
+---
+
+	newaction {
+		-- Metadata for the command line and help system
+		
+		trigger	    = "vs-latest",
+		shortname   = "Visual Studio - Latest",
+		description = "Generate Visual Studio project files of latest installation",
+
+		-- Copy data from the latest vs action
+		
+		targetos         = getLatestVisualStudioVersion().targetos,
+		toolset          = getLatestVisualStudioVersion().toolset,
+		valid_kinds      = getLatestVisualStudioVersion().valid_kinds,
+		valid_tools      = getLatestVisualStudioVersion().valid_tools,
+		onWorkspace      = getLatestVisualStudioVersion().onWorkspace,
+		onProject        = getLatestVisualStudioVersion().onProject,
+		onRule           = getLatestVisualStudioVersion().onRule,
+		onCleanWorkspace = getLatestVisualStudioVersion().onCleanWorkspace,
+		onCleanProject   = getLatestVisualStudioVersion().onCleanProject,
+		onCleanTarget    = getLatestVisualStudioVersion().onCleanTarget,
+		pathVars         = getLatestVisualStudioVersion().pathVars,
+		vstudio          = getLatestVisualStudioVersion().vstudio,
+	}


### PR DESCRIPTION
**What does this PR do?**

This adds a `vs-latest` action (closes #1479).  When `vs-latest` is invoked, it checks for the `vswhere` executable on this system and runs it to determine the latest VS version.  If no version is found, `vswhere` does not exist, or the operating system is not windows, it defaults to `vs2019`, the current version as of writing this PR.

**How does this PR change Premake's behavior?**

There are no breaking changes to the API.  This only adds functionality as described above.

**Anything else we should know?**

This makes passing the unit tests dependent upon the machine that the tests are run on.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
