### PR TITLE
Runpathdirs improvements

### DIFF
--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -533,7 +533,7 @@ end
 
 
 	function make.ldFlags(cfg, toolset)
-		local flags = table.join(toolset.getLibraryDirectories(cfg), toolset.getrunpathdirs(cfg, cfg.runpathdirs), toolset.getldflags(cfg), cfg.linkoptions)
+		local flags = table.join(toolset.getLibraryDirectories(cfg), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), toolset.getldflags(cfg), cfg.linkoptions)
 		_p('  ALL_LDFLAGS += $(LDFLAGS)%s', make.list(flags))
 	end
 

--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -468,7 +468,7 @@
 
 
 	function cpp.ldFlags(cfg, toolset)
-		local flags = table.join(toolset.getLibraryDirectories(cfg), toolset.getrunpathdirs(cfg, cfg.runpathdirs), toolset.getldflags(cfg), cfg.linkoptions)
+		local flags = table.join(toolset.getLibraryDirectories(cfg), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), toolset.getldflags(cfg), cfg.linkoptions)
 		p.outln('ALL_LDFLAGS += $(LDFLAGS)' .. gmake2.list(flags))
 	end
 

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -2298,6 +2298,32 @@
 		]]
 	end
 
+	function suite.XCBuildConfigurationProject_OnRunPathSearchPaths()
+		runpathdirs { "plugins" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@loader_path/../../plugins",
+				);
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
 
 	function suite.XCBuildConfigurationProject_OnLinks()
 		links { "Cocoa.framework", "ldap" }

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1403,6 +1403,9 @@
 		end
 		settings['FRAMEWORK_SEARCH_PATHS'] = cfg.frameworkdirs
 
+		local runpathdirs = table.join (cfg.runpathdirs, config.getsiblingtargetdirs (cfg))
+		settings['LD_RUNPATH_SEARCH_PATHS'] = toolset.getrunpathdirs(cfg, runpathdirs, "path")
+
 		local objDir = path.getrelative(tr.project.location, cfg.objdir)
 		settings['OBJROOT'] = objDir
 

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -274,6 +274,23 @@
 --    The corresponding value of DEBUG_INFORMATION_FORMAT, or 'dwarf-with-dsym' if invalid
 --
 
+	function xcode.getToolSet(cfg)
+		local default = "clang"
+		local minOSVersion = project.systemversion(cfg)
+		if minOSVersion ~= nil
+			and cfg.system == p.MACOSX
+			and p.checkVersion(minOSVersion, "<10.7")
+		then
+			default = "gcc"
+		end
+
+		local toolset = p.tools[_OPTIONS.cc or cfg.toolset or default]
+		if not toolset then
+			error("Invalid toolset '" .. cfg.toolset .. "'")
+		end
+		return toolset
+	end
+
 	function xcode.getdebugformat(cfg)
 		local formats = {
 			["Dwarf"]      = "dwarf",
@@ -1285,6 +1302,7 @@
 	
 	function xcode.XCBuildConfiguration_Project(tr, cfg)
 		local settings = {}
+		local toolset = xcode.getToolSet(cfg)
 
 		local archs = {
 			Native = "$(NATIVE_ARCH_ACTUAL)",

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -329,6 +329,29 @@
 
 
 --
+-- Returns the list of sibling target directories
+-- 
+-- @param cfg
+--    The configuration object to query.
+-- @return 
+--    Absolute path list
+--
+	function config.getsiblingtargetdirs(cfg)
+		local paths = {}
+		for _, sibling in ipairs(config.getlinks(cfg, "siblings", "object")) do
+			if (sibling.kind == p.SHAREDLIB) then
+				local p = sibling.linktarget.directory
+				if not (table.contains(paths, p)) then
+					table.insert(paths, p)
+				end
+			end
+		end
+
+		return paths
+	end
+
+
+--
 -- Determines the correct runtime library for a configuration.
 --
 -- @param cfg

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -299,10 +299,20 @@
 
 --
 -- Return a list of decorated rpaths
+-- 
+-- @param cfg
+--    The configuration to query.
+-- @param dirs
+--    List of absolute paths
+-- @param mode
+--    Output mode
+--    - "linker" (default) Linker rpath instructions
+--    - "path" List of path relative to configuration target directory
 --
 
-	function gcc.getrunpathdirs(cfg, dirs)
+	function gcc.getrunpathdirs(cfg, dirs, mode)
 		local result = {}
+		mode = iif (mode == nil, "linker", mode)
 
 		if not (table.contains(os.getSystemTags(cfg.system), "darwin")
 				or (cfg.system == p.LINUX)) then
@@ -312,7 +322,7 @@
 		local rpaths = {}
 
 		-- User defined runpath search paths
-		for _, fullpath in ipairs(cfg.runpathdirs) do
+		for _, fullpath in ipairs(dirs) do
 			local rpath = path.getrelative(cfg.buildtarget.directory, fullpath)
 			if not (table.contains(rpaths, rpath)) then
 				table.insert(rpaths, rpath)
@@ -338,7 +348,11 @@
 				rpath = "$$ORIGIN" .. rpath
 			end
 
-			table.insert(result, "-Wl,-rpath,'" .. rpath .. "'")
+			if mode == "linker" then 
+				rpath = "-Wl,-rpath,'" .. rpath .. "'"
+			end
+			
+			table.insert(result, rpath)
 		end
 
 		return result

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -319,28 +319,8 @@
 			return result
 		end
 
-		local rpaths = {}
-
-		-- User defined runpath search paths
 		for _, fullpath in ipairs(dirs) do
 			local rpath = path.getrelative(cfg.buildtarget.directory, fullpath)
-			if not (table.contains(rpaths, rpath)) then
-				table.insert(rpaths, rpath)
-			end
-		end
-
-		-- Automatically add linked shared libraries path relative to target directory
-		for _, sibling in ipairs(config.getlinks(cfg, "siblings", "object")) do
-			if (sibling.kind == p.SHAREDLIB) then
-				local fullpath = sibling.linktarget.directory
-				local rpath = path.getrelative(cfg.buildtarget.directory, fullpath)
-				if not (table.contains(rpaths, rpath)) then
-					table.insert(rpaths, rpath)
-				end
-			end
-		end
-
-		for _, rpath in ipairs(rpaths) do
 			if table.contains(os.getSystemTags(cfg.system), "darwin") then
 				rpath = "@loader_path/" .. rpath
 			elseif (cfg.system == p.LINUX) then


### PR DESCRIPTION
**What does this PR do?**
Fix and improve run path search paths support on gmake actions. Add support for xcode4

**How does this PR change Premake's behavior?**
Automatically added run path search paths from sibling library is now handled by exporters instead of toolset. The previous behavior may not be accurate for all build system.

Are there any breaking changes? Will any existing behavior change?
Not really, only gmake 1&2 supported runpathdirs and the behavior did not change for these exporters.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
