### PR TITLE
Added NetCore to CLR API

### DIFF
--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -156,6 +156,17 @@
 	<CLRSupport>Pure</CLRSupport>
 		]]
 	end
+	
+	function suite.clrSupport_onClrNetCore()
+		clr "NetCore"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CLRSupport>NetCore</CLRSupport>
+		]]
+	end
 
 
 --

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -165,6 +165,7 @@
 			"Pure",
 			"Safe",
 			"Unsafe",
+			"NetCore",
 		}
 	}
 


### PR DESCRIPTION
**What does this PR do?**

Added NetCore CLR option for MSVC to Visual Studio CLR API.  Closes #1545

**How does this PR change Premake's behavior?**

There are no breaking changes, only new functionality.

**Anything else we should know?**

Add any other context about your changes here.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
