### PR TITLE
Fix MSC LTO, runtime, subsystem

### DIFF
--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -28,6 +28,15 @@
 -- Returns list of C compiler flags for a configuration.
 --
 
+	local function getRuntimeFlag(cfg, isstatic)
+		local rt = cfg.runtime
+		local flag = iif(isstatic, "/MT", "/MD")
+		if (rt == "Debug") or (rt == nil and config.isDebugBuild(cfg))  then
+			flag = flag .. "d"
+		end
+		return flag
+	end
+
 	msc.shared = {
 		clr = {
 			On = "/clr",
@@ -37,6 +46,7 @@
 		},
 		flags = {
 			FatalCompileWarnings = "/WX",
+			LinkTimeOptimization = "/GL",
 			MultiProcessorCompile = "/MP",
 			NoMinimalRebuild = "/Gm-",
 			OmitDefaultLibrary = "/Zl"
@@ -87,11 +97,11 @@
 		},
 		staticruntime = {
 			-- this option must always be emit (does it??)
-			_ = function(cfg) return iif(config.isDebugBuild(cfg), "/MDd", "/MD") end,
+			_ = function(cfg) return getRuntimeFlag(cfg, false) end,
 			-- runtime defaults to dynamic in VS
-			Default = function(cfg) return iif(config.isDebugBuild(cfg), "/MDd", "/MD") end,
-			On = function(cfg) return iif(config.isDebugBuild(cfg), "/MTd", "/MT") end,
-			Off = function(cfg) return iif(config.isDebugBuild(cfg), "/MDd", "/MD") end,
+			Default = function(cfg) return getRuntimeFlag(cfg, false) end,
+			On = function(cfg) return getRuntimeFlag(cfg, true) end,
+			Off = function(cfg) return getRuntimeFlag(cfg, false) end,
 		},
 		stringpooling = {
 			On = "/GF",
@@ -239,13 +249,14 @@
 	msc.linkerFlags = {
 		flags = {
 			FatalLinkWarnings = "/WX",
-			LinkTimeOptimization = "/GL",
+			LinkTimeOptimization = "/LTCG",
 			NoIncrementalLink = "/INCREMENTAL:NO",
 			NoManifest = "/MANIFEST:NO",
 			OmitDefaultLibrary = "/NODEFAULTLIB",
 		},
 		kind = {
 			SharedLib = "/DLL",
+			WindowedApp = "/SUBSYSTEM:WINDOWS"
 		},
 		symbols = {
 			On = "/DEBUG"

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -84,10 +84,16 @@
 		test.excludes("/Oy", msc.getcflags(cfg))
 	end
 
+	function suite.cflags_onLinkTimeOptimizations()
+		flags "LinkTimeOptimization"
+		prepare()
+		test.contains("/GL", msc.getcflags(cfg))
+	end
+
 	function suite.ldflags_onLinkTimeOptimizations()
 		flags "LinkTimeOptimization"
 		prepare()
-		test.contains("/GL", msc.getldflags(cfg))
+		test.contains("/LTCG", msc.getldflags(cfg))
 	end
 
 	function suite.cflags_onStringPoolingOn()
@@ -511,4 +517,57 @@
 		flags { "FatalCompileWarnings" }
 		prepare()
 		test.isequal({ "/WX", "/MD", "/EHsc" }, msc.getcxxflags(cfg))
+	end
+
+
+	--
+	-- Check handling of Run-Time Library flags.
+	--
+
+	function suite.cflags_onStaticRuntime()
+		staticruntime "On"
+		prepare()
+		test.isequal({ "/MT" }, msc.getcflags(cfg))
+	end
+
+	function suite.cflags_onDynamicRuntime()
+		staticruntime "Off"
+		prepare()
+		test.isequal({ "/MD" }, msc.getcflags(cfg))
+	end
+
+	function suite.cflags_onStaticRuntimeAndDebug()
+		staticruntime "On"
+		runtime "Debug"
+		prepare()
+		test.isequal({ "/MTd" }, msc.getcflags(cfg))
+	end
+
+	function suite.cflags_onDynamicRuntimeAndDebug()
+		staticruntime "Off"
+		runtime "Debug"
+		prepare()
+		test.isequal({ "/MDd" }, msc.getcflags(cfg))
+	end
+
+	function suite.cflags_onStaticRuntimeAndSymbols()
+		staticruntime "On"
+		symbols "On"
+		prepare()
+		test.isequal({ "/MTd", "/Z7" }, msc.getcflags(cfg))
+	end
+
+	function suite.cflags_onDynamicRuntimeAndSymbols()
+		staticruntime "Off"
+		symbols "On"
+		prepare()
+		test.isequal({ "/MDd", "/Z7" }, msc.getcflags(cfg))
+	end
+
+	function suite.cflags_onDynamicRuntimeAndReleaseAndSymbols()
+		staticruntime "Off"
+		runtime "Release"
+		symbols "On"
+		prepare()
+		test.isequal({ "/MD", "/Z7" }, msc.getcflags(cfg))
 	end


### PR DESCRIPTION
**What does this PR do?**

- Link-time optimizations now sets correct cl and ld flags.
- Run-Time selection now adheres to `runtime` setting.
- Set subsystem flag for `kind=="WindowedApp"` 

**How does this PR change Premake's behavior?**

- The different Warning flags should not cause any troubles in any consumers.
- All other changes do in fact change the behavior. They however fix something that was broken or didn't work before.

