### PR TITLE
clang Use `llvm-ar` linker when LTO flag is set.

### DIFF
--- a/modules/gmake/tests/cpp/test_clang.lua
+++ b/modules/gmake/tests/cpp/test_clang.lua
@@ -44,3 +44,20 @@ ifeq ($(config),debug)
 		]]
 	end
 
+	function suite.usesCorrectCompilersAndLinkTimeOptimization()
+		flags { "LinkTimeOptimization" }
+		make.cppConfigs(prj)
+		test.capture [[
+ifeq ($(config),debug)
+  ifeq ($(origin CC), default)
+    CC = clang
+  endif
+  ifeq ($(origin CXX), default)
+    CXX = clang++
+  endif
+  ifeq ($(origin AR), default)
+    AR = llvm-ar
+  endif
+		]]
+	end
+

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -324,9 +324,13 @@
 	clang.tools = {
 		cc = "clang",
 		cxx = "clang++",
-		ar = "ar"
+		ar = function(cfg) return iif(cfg.flags.LinkTimeOptimization, "llvm-ar", "ar") end
 	}
 
 	function clang.gettoolname(cfg, tool)
-		return clang.tools[tool]
+		local value = clang.tools[tool]
+		if type(value) == "function" then
+			value = value(cfg)
+		end
+		return value
 	end


### PR DESCRIPTION
**What does this PR do?**

Changes the static linker from `ar` to `llvm-ar` when the `clang` toolset is used and the `LinkTimeOptimization` flag is set.
Although many times `GNU ar` will also work, for some clang features like `-flto` (link-time optimisation, I only came across this one but could be more) `llvm-ar` is needed.

**How does this PR change Premake's behavior?**

It should not break or change build-file output for existing projects (that may not have `llvm-ar` installed) since `llvm-ar` is only conditionally used and still defaults to `ar`.

**Anything else we should know?**

Before this change, it was not possible to use the `LinkTimeOptimization` flag with the clang toolset unless using the "AR=llvm-ar" environment variable.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
