### PR TITLE
Improved net version check to also support net5.0 and beyond

### DIFF
--- a/modules/vstudio/tests/cs2005/test_netcore.lua
+++ b/modules/vstudio/tests/cs2005/test_netcore.lua
@@ -94,6 +94,14 @@ function suite.project_element_core()
     ]]
 end
 
+function suite.project_element_net5()
+    dotnetframework "net5.0"
+    prepareNetcore()
+    test.capture [[
+<Project Sdk="Microsoft.NET.Sdk">
+    ]]
+end
+
 function suite.project_element_framework()
     dotnetframework "4.7.2"
     prepareNetcore()

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -745,11 +745,7 @@
 			return false
 		end
 
-		if framework:find('^netcoreapp') ~= nil then
-			return true
-		end
-		
-		if framework:find('^netstandard') ~= nil then
+		if framework:find('^net') ~= nil then
 			return true
 		end
 


### PR DESCRIPTION
**What does this PR do?**

This changes the isNewFormatProject so that netcoreapp, netstandard, and the new net{version} (i.e. net5.0) are formatted using the new csproj format.

**How does this PR change Premake's behavior?**

Shouldn't break any existing usages. Will allow dotnetframework("net5.0") to work.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
