### PR TITLE
AllowUnsafeBlocks will now be a project level property in new format

### DIFF
--- a/modules/vstudio/tests/cs2005/test_compiler_props.lua
+++ b/modules/vstudio/tests/cs2005/test_compiler_props.lua
@@ -39,7 +39,6 @@
 		]]
 	end
 
-
 --
 -- Check handling of the Unsafe flag.
 --
@@ -52,6 +51,17 @@
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		]]
+	end
+
+	function suite.allowUnsafeBlocks_onUnsafeFlagNonConfigOnNetcore()
+		dotnetframework "netcoreapp3.1"
+		clr "Unsafe"
+		prepare()
+		test.capture [[
+		<DefineConstants></DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
 		]]
 	end
 

--- a/modules/vstudio/tests/cs2005/test_netcore.lua
+++ b/modules/vstudio/tests/cs2005/test_netcore.lua
@@ -7,6 +7,7 @@
 local p = premake
 local suite = test.declare("vstudio_cs2005_netcore_prj")
 local dn2005 = p.vstudio.dotnetbase
+local cs2005 = p.vstudio.cs2005
 local project = p.project
 
 
@@ -34,6 +35,13 @@ end
 
 local function prepareNetcore()
     dn2005.projectElement(prj)
+end
+
+local function prepareProjectProperties()
+    local localProj = test.getproject(wks, 1)
+
+    dn2005.prepare(cs2005)
+    dn2005.projectProperties(localProj)
 end
 
 function suite.targetFrameworkProperty_framework()
@@ -99,5 +107,20 @@ function suite.project_element_framework()
     prepareNetcore()
     test.capture [[
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    ]]
+end
+
+function suite.allowUnsafeProperty_core()
+    dotnetframework "netcoreapp2.2"
+    clr "Unsafe"
+    prepareProjectProperties()
+    test.capture [[
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<TargetFramework>netcoreapp2.2</TargetFramework>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+	</PropertyGroup>
     ]]
 end

--- a/modules/vstudio/vs2005_csproj.lua
+++ b/modules/vstudio/vs2005_csproj.lua
@@ -47,6 +47,7 @@
 				dotnetbase.rootNamespace,
 				dotnetbase.assemblyName,
 				dotnetbase.netcore.targetFramework,
+				dotnetbase.allowUnsafeBlocks,
 				dotnetbase.fileAlignment,
 				dotnetbase.bindingRedirects,
 				dotnetbase.netcore.useWpf,

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -252,8 +252,8 @@
 		_p(2,'<ErrorReport>prompt</ErrorReport>')
 		_p(2,'<WarningLevel>4</WarningLevel>')
 
-		if cfg.clr == "Unsafe" then
-			_p(2,'<AllowUnsafeBlocks>true</AllowUnsafeBlocks>')
+		if not dotnetbase.isNewFormatProject(cfg) then
+			dotnetbase.allowUnsafeBlocks(cfg)
 		end
 
 		if cfg.flags.FatalCompileWarnings then
@@ -771,5 +771,11 @@
 	function dotnetbase.netcore.useWpf(cfg)
 		if cfg.flags.WPF then
 			_p(2,'<UseWpf>true</UseWpf>')
+		end
+	end
+
+	function dotnetbase.allowUnsafeBlocks(cfg)
+		if cfg.clr == "Unsafe" then
+			_p(2,'<AllowUnsafeBlocks>true</AllowUnsafeBlocks>')
 		end
 	end


### PR DESCRIPTION
**What does this PR do?**

Moves the location of AllowUnsafeBlocks into the top-level project settings on net format C# projects.
Closes #1549 

**How does this PR change Premake's behavior?**

Should not affect existing .NET Framework projects. Will affect .NET Standard, .NET Core, and .NET projects by fixing conditionally block placed AllowUsingBlocks, which were being ignored by the compiler.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
