### PR TITLE
Fix --help output when using mixed-case command line options

### DIFF
--- a/src/base/option.lua
+++ b/src/base/option.lua
@@ -65,6 +65,7 @@
 --
 
 	m.list = {}
+	setmetatable(m.list, _OPTIONS_metatable)
 
 
 --
@@ -88,7 +89,7 @@
 		end
 
 		-- add it to the master list
-		p.option.list[opt.trigger:lower()] = opt
+		p.option.list[opt.trigger] = opt
 
 		-- if it has a default value, set it.
 		if opt.default and not _OPTIONS[opt.trigger] then
@@ -121,7 +122,7 @@
 		-- sort the list by trigger
 		local keys = { }
 		for _, option in pairs(p.option.list) do
-			table.insert(keys, option.trigger)
+			table.insert(keys, option.trigger:lower())
 		end
 		table.sort(keys)
 

--- a/tests/base/test_option.lua
+++ b/tests/base/test_option.lua
@@ -13,11 +13,28 @@
 --
 
 	function suite.setup()
+		suite._OPTIONS = _OPTIONS
+		_OPTIONS = {}
+		setmetatable(_OPTIONS, getmetatable(suite._OPTIONS))
+
+		suite.optionList = p.option.list
+		p.option.list = {}
+		setmetatable(p.option.list, getmetatable(suite.optionList))
+
 		_OPTIONS["testopt"] = "testopt"
 	end
 
+	local function printTriggers()
+		_p("-- begin options --")
+		for option in p.option.each() do
+			_p("trigger: " .. option.trigger)
+		end
+		_p("-- end options --")
+	end
+
 	function suite.teardown()
-		_OPTIONS["testopt"] = nil
+		_OPTIONS = suite._OPTIONS
+		p.option.list = suite.optionList
 	end
 
 
@@ -42,4 +59,34 @@
 		}
 
 		test.isnotnil(p.option.get("testopt2"))
+	end
+
+--
+-- Make sure the help logic that sorts options into categories
+-- is able to account for newoption triggers with mixed case
+--
+
+	function suite.iteratesCorrectOption_onMixedCase()
+		newoption {
+			trigger = "testopt1",
+			description = "Testing",
+		}
+		newoption {
+			trigger = "TestOpt2",
+			description = "Testing",
+		}
+		newoption {
+			trigger = "testopt3",
+			description = "Testing",
+		}
+
+		printTriggers()
+
+		test.capture [[
+-- begin options --
+trigger: testopt1
+trigger: TestOpt2
+trigger: testopt3
+-- end options --
+		]]
 	end


### PR DESCRIPTION
**What does this PR do?**

Prior to this PR, using `--help` would silently fail at iterating over the options table when `newoption` was used to add a trigger that contained capital letters. 

**How does this PR change Premake's behavior?**

using `--help` should now properly display all user-defined options

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
