### PR TITLE
Initial C++20 module support for Visual Studio

### DIFF
--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -1180,8 +1180,8 @@
 		]]
 	end
 
-	function suite.onCompileAsCppModuleInterface()
-		compileas 'C++ModuleInterface'
+	function suite.onCompileAsCppModule()
+		compileas 'Module'
 		prepare()
 		test.capture [[
 <ClCompile>
@@ -1193,8 +1193,8 @@
 		]]
 	end
 
-	function suite.onCompileAsCppModulePartitionImplementation()
-		compileas 'C++ModulePartitionImplementation'
+	function suite.onCompileAsCppModulePartition()
+		compileas 'ModulePartition'
 		prepare()
 		test.capture [[
 <ClCompile>
@@ -1207,7 +1207,7 @@
 	end
 
 	function suite.onCompileAsCppHeaderUnit()
-		compileas 'C++HeaderUnit'
+		compileas 'HeaderUnit'
 		prepare()
 		test.capture [[
 <ClCompile>

--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -1180,6 +1180,45 @@
 		]]
 	end
 
+	function suite.onCompileAsCppModuleInterface()
+		compileas 'C++ModuleInterface'
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<CompileAs>CompileAsCppModule</CompileAs>
+</ClCompile>
+		]]
+	end
+
+	function suite.onCompileAsCppModulePartitionImplementation()
+		compileas 'C++ModulePartitionImplementation'
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<CompileAs>CompileAsCppModuleInternalPartition</CompileAs>
+</ClCompile>
+		]]
+	end
+
+	function suite.onCompileAsCppHeaderUnit()
+		compileas 'C++HeaderUnit'
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<CompileAs>CompileAsHeaderUnit</CompileAs>
+</ClCompile>
+		]]
+	end
+
 
 --
 -- Check handling of the C++14 & C++17 api

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1699,6 +1699,12 @@
 			m.element("CompileAs", condition, "CompileAsC")
 		elseif p.languages.iscpp(cfg.compileas) then
 			m.element("CompileAs", condition, "CompileAsCpp")
+		elseif cfg.compileas == "C++ModuleInterface" then
+			m.element("CompileAs", condition, "CompileAsCppModule")
+		elseif cfg.compileas == "C++ModulePartitionImplementation" then
+			m.element("CompileAs", condition, "CompileAsCppModuleInternalPartition")
+		elseif cfg.compileas == "C++HeaderUnit" then
+			m.element("CompileAs", condition, "CompileAsHeaderUnit")
 		end
 	end
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1699,11 +1699,11 @@
 			m.element("CompileAs", condition, "CompileAsC")
 		elseif p.languages.iscpp(cfg.compileas) then
 			m.element("CompileAs", condition, "CompileAsCpp")
-		elseif cfg.compileas == "C++ModuleInterface" then
+		elseif cfg.compileas == "Module" then
 			m.element("CompileAs", condition, "CompileAsCppModule")
-		elseif cfg.compileas == "C++ModulePartitionImplementation" then
+		elseif cfg.compileas == "ModulePartition" then
 			m.element("CompileAs", condition, "CompileAsCppModuleInternalPartition")
-		elseif cfg.compileas == "C++HeaderUnit" then
+		elseif cfg.compileas == "HeaderUnit" then
 			m.element("CompileAs", condition, "CompileAsHeaderUnit")
 		end
 	end

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -185,9 +185,9 @@
 			"C++",
 			"Objective-C",
 			"Objective-C++",
-			"C++ModuleInterface",
-			"C++ModulePartitionImplementation",
-			"C++HeaderUnit"
+			"Module",
+			"ModulePartition",
+			"HeaderUnit"
 		}
 	}
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -185,6 +185,9 @@
 			"C++",
 			"Objective-C",
 			"Objective-C++",
+			"C++ModuleInterface",
+			"C++ModulePartitionImplementation",
+			"C++HeaderUnit"
 		}
 	}
 


### PR DESCRIPTION
**What does this PR do?**

Visual Studio's C++ compiler now has feature-complete support for C++20 modules (see also [this link](https://devblogs.microsoft.com/cppblog/standard-c20-modules-support-with-msvc-in-visual-studio-2019-version-16-8/)). Playing around with it, it appears to be relatively stable too, disregarding some IntelliSense syntax highlighting issues. It appears this is the first IDE and compiler toolchain to have any usable support for C++20 modules. Therefore, I think it would be useful to add at least some initial support for C++20 modules to Premake. For a better understanding of how C++20 modules work and what type of translation units they introduce, I strongly recommend [this blog post and its follow-up posts](https://vector-of-bool.github.io/2019/03/10/modules-1.html).

This PR allows the use of 3 new values for Premake's "compileas" parameter. This parameter is used to set the value of the "Compile as" setting under the "Advanced" tab in the C/C++ source file properties, as dictated by the currently available options in Visual Studio. Given that the Visual Studio team has called their module implementation feature-complete, I doubt that the meaning of these options will change. At most, more options might be added in the future. The following values were added:

- "C++ModuleInterface": Used to designate the source file as a module interface unit for compilation.
- "C++ModulePartitionImplementation": Used to designate the source file as a module partition implementation unit for compilation. This type of module unit is also called a "module-internal partition" by Microsoft, though the C++20 standard does not give this type of module unit a specific name.
- "C++HeaderUnit": Used to designate the source file as a header unit for compilation.

 The PR also adds some unit tests, which of course ran fine. I also tested it in my personal project using a files filter and it works perfectly. 

**How does this PR change Premake's behavior?**

No breaking changes and no existing behavior changes. It just adds more options for the "compileas" parameter.

**Anything else we should know?**

The 3 new values were given names that I think are closest to the terms used for the different module unit types in the C++20 standard ([relevant section](http://eel.is/c%2B%2Bdraft/module.unit)). Of course, the other compilers and IDEs might set up their module support somewhat differently. I still think it would be useful to extend the "compileas" parameter in this way so that it can at least be used in the only IDE currently supporting modules.

And of course, thank you Open Collective for creating Premake! You have saved me from the eldritch horrors of CMake and have made my C++ projects so much easier to set up.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
