### PR TITLE
useFullPaths config property for Visual Studio projects

### DIFF
--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -1510,3 +1510,42 @@
 </ClCompile>
 		]]
 	end
+
+--
+-- If useFullPaths flag is set, add <UseFullPaths> element
+--
+
+	function suite.onUseFullPathsOff()
+		usefullpaths "Off"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<UseFullPaths>false</UseFullPaths>
+		]]
+	end
+
+	function suite.onUseFullPathsOn()
+		usefullpaths "On"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<UseFullPaths>true</UseFullPaths>
+		]]
+	end
+
+	function suite.onUseFullPathsNotSpecified()
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+</ClCompile>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -385,7 +385,8 @@
 			m.callingConvention,
 			m.languageStandard,
 			m.conformanceMode,
-			m.structMemberAlignment
+			m.structMemberAlignment,
+			m.useFullPaths
 		}
 
 		if cfg.kind == p.STATICLIB then
@@ -1501,6 +1502,16 @@
 		local value = map[cfg.structmemberalign]
 		if value then
 			m.element("StructMemberAlignment", nil, value)
+		end
+	end
+
+	function m.useFullPaths(cfg)
+		if cfg.useFullPaths ~= nil then
+			if cfg.useFullPaths then
+				m.element("UseFullPaths", nil, "true")
+			else
+				m.element("UseFullPaths", nil, "false")
+			end
 		end
 	end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -790,6 +790,12 @@
 	}
 
 	api.register {
+		name = "usefullpaths",
+		scope = "config",
+		kind = "boolean"
+	}
+
+	api.register {
 		name = "swiftversion",
 		scope = "config",
 		kind = "string",


### PR DESCRIPTION
**What does this PR do?**

Supports `usefullpaths` configuration property, which controls `/FC` compiler option.

**How does this PR change Premake's behavior?**

Support new configuration property.

**Anything else we should know?**

The property is supported by Visual Studio since 2010 https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/027c4t2s(v=vs.100), so tests are not version-specific.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
