### PR TITLE
Mesh and amplification shader type for Visual Studio

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -64,6 +64,8 @@
 			"Hull",
 			"Domain",
 			"Compute",
+			"Mesh",
+			"Amplification",
 			"Texture",
 			"RootSignature",
 		}


### PR DESCRIPTION
**What does this PR do?**
Adding two additional shader types for Visual Studio. These are the new additions to DirectX, mesh and amplification shaders.

Thanks for the contribution! Please provide a concise description of the problem this request solves.

**How does this PR change Premake's behavior?**
Allows for two more values in the shadertype directive.

Are there any breaking changes? Will any existing behavior change?
Not that I know of.

