### PR TITLE
os.outputof: add a second argument to select which stream to output

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -456,11 +456,24 @@
 --
 -- Run a shell command and return the output.
 --
+-- @param cmd Command to execute
+-- @param streams Standard stream(s) to output
+-- 		Must be one of 
+--		- "botn" (default)
+--		- "output" Return standard output stream content only
+--		- "error" Return standard error stream content only
+--
 
-	function os.outputof(cmd)
+	function os.outputof(cmd, streams)
 		cmd = path.normalize(cmd)
+		local redirection = " 2>&1"
+		if streams == "output" then
+			redirection = " 2>/dev/null"
+		elseif streams == "error" then
+			redirection = " 2>&1 1>/dev/null"
+		end
 
-		local pipe = io.popen(cmd .. " 2>&1")
+		local pipe = io.popen(cmd .. redirection)
 		local result = pipe:read('*a')
 		local success, what, code = pipe:close()
 		if success then

--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -466,11 +466,16 @@
 
 	function os.outputof(cmd, streams)
 		cmd = path.normalize(cmd)
-		local redirection = " 2>&1"
-		if streams == "output" then
+		streams = streams or "both"
+		local redirection
+		if streams == "both" then
+			redirection = " 2>&1"
+		elseif streams == "output" then
 			redirection = " 2>/dev/null"
 		elseif streams == "error" then
 			redirection = " 2>&1 1>/dev/null"
+		else
+			error ('Invalid stream(s) selection. "output", "error", or "both" expected.')
 		end
 
 		local pipe = io.popen(cmd .. redirection)

--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -459,7 +459,7 @@
 -- @param cmd Command to execute
 -- @param streams Standard stream(s) to output
 -- 		Must be one of 
---		- "botn" (default)
+--		- "both" (default)
 --		- "output" Return standard output stream content only
 --		- "error" Return standard error stream content only
 --

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -184,8 +184,26 @@
 			end
 		end
 	end
-
-
+	
+	-- Check outputof content
+	function suite.outputof_streams_output()
+		if (os.istarget("macosx")
+			or os.istarget("linux")
+			or os.istarget("solaris")
+			or os.istarget("bsd"))
+			and os.isdir (_TESTS_DIR)
+		then
+			local ob, e = os.outputof ("ls " .. _TESTS_DIR .. "/base")
+			local oo, e = os.outputof ("ls " .. _TESTS_DIR .. "/base", "output")
+			test.isequal (oo, ob)
+			local s, e = string.find (oo, "test_os.lua")
+			test.istrue(s ~= nil)
+			
+			local o, e = os.outputof ("ls " .. cwd .. "/base", "error")
+			test.istrue(o == nil or #o == 0)
+		end
+	end
+	
 --
 -- os.translateCommand() tests
 --


### PR DESCRIPTION
    local o, e = os.outputof(cmd, streams)

    Where streams could be one of
    - "output" Only return standard output stream content
    - "error" Only return standard error stream content
    - "both" (default) Return both streams content

**How does this PR change Premake's behavior?**
Allow to filter standard output or error stream content from os.outputof() return value.
Ignoring error output is important when the invoked command may return an exit code 0 (success) but output some content on the error stream which will pollute the text result.

Are there any breaking changes? Will any existing behavior change?
The default behavior follow the previous one (report both streams)

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
