### PR TITLE
add RemoveUnreferencedCodeData option to disable /Zc:inline

### DIFF
--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -1549,3 +1549,42 @@
 </ClCompile>
 		]]
 	end
+
+--
+-- If removeUnreferencedCodeData flag is set, add <RemoveUnreferencedCodeData> element
+--
+
+	function suite.onRemoveUnreferencedCodeDataOff()
+		removeunreferencedcodedata "Off"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<RemoveUnreferencedCodeData>false</RemoveUnreferencedCodeData>
+		]]
+	end
+
+	function suite.onRemoveUnreferencedCodeDataOn()
+		removeunreferencedcodedata "On"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<RemoveUnreferencedCodeData>true</RemoveUnreferencedCodeData>
+		]]
+	end
+
+	function suite.onRemoveUnreferencedCodeDataNotSpecified()
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+</ClCompile>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -386,7 +386,8 @@
 			m.languageStandard,
 			m.conformanceMode,
 			m.structMemberAlignment,
-			m.useFullPaths
+			m.useFullPaths,
+			m.removeUnreferencedCodeData
 		}
 
 		if cfg.kind == p.STATICLIB then
@@ -1511,6 +1512,16 @@
 				m.element("UseFullPaths", nil, "true")
 			else
 				m.element("UseFullPaths", nil, "false")
+			end
+		end
+	end
+
+	function m.removeUnreferencedCodeData(cfg)
+		if cfg.removeUnreferencedCodeData ~= nil then
+			if cfg.removeUnreferencedCodeData then
+				m.element("RemoveUnreferencedCodeData", nil, "true")
+			else
+				m.element("RemoveUnreferencedCodeData", nil, "false")
 			end
 		end
 	end

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -796,6 +796,12 @@
 	}
 
 	api.register {
+		name = "removeunreferencedcodedata",
+		scope = "config",
+		kind = "boolean"
+	}
+
+	api.register {
 		name = "swiftversion",
 		scope = "config",
 		kind = "string",

--- a/website/docs/removeunreferencedcodedata.md
+++ b/website/docs/removeunreferencedcodedata.md
@@ -1,0 +1,30 @@
+Sets the `RemoveUnreferencedCodeData` property for a configuration or all configurations within a project or workspace, adding or removing the `/Zc:inline[-]` build option.
+
+[/Zc:inline (Remove unreferenced COMDAT)](https://docs.microsoft.com/en-us/cpp/build/reference/zc-inline-remove-unreferenced-comdat?view=msvc-160)
+
+If this property is unset, it defaults to `true` in Visual Studio.
+
+```lua
+removeunreferencedcodedata ("value")
+```
+
+### Parameters ###
+
+`value` one of:
+* `on`  - Enables `RemoveUnreferencedCodeData`.
+* `off` - Disables `RemoveUnreferencedCodeData`.
+
+### Applies To ###
+
+Workspaces and projects.
+
+### Availability ###
+
+Premake 5.0 alpha 16 or later.
+
+### Examples ###
+
+```lua
+RemoveUnreferencedCodeData "Off"
+```
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -192,6 +192,7 @@ module.exports = {
 						'project',
 						'propertydefinition',
 						'rebuildcommands',
+						'removeunreferencedcodedata',
 						'resdefines',
 						'resincludedirs',
 						'resoptions',


### PR DESCRIPTION
**What does this PR do?**

This PR adds the option to properly toggle this Visual Studio project build option: https://docs.microsoft.com/en-us/cpp/build/reference/zc-inline-remove-unreferenced-comdat?view=msvc-160

**How does this PR change Premake's behavior?**

When specifying `removeunreferencedcodedata` "On" or "Off", `<RemoveUnreferencedCodeData>true</RemoveUnreferencedCodeData>` or `false` will be added to the vcxproj in each build config, similar to `usefullpaths`.

When it is not specified, nothing changes.

**Anything else we should know?**

By default, Visual Studio assumes this value to be true, when it is not specified. I was annoyed by this (I wanted to replicate compile options from an old project) and decided to add this.

I pretty much just copypasted the usefullpaths behaviour, so I don't expect this to misbehave :)

**Did you check all the boxes?**

- [ x ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ x ] Add unit tests showing fix or feature works; all tests pass
- [ x ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ x ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [ x ] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
