### PR TITLE
Encourage contributors to align the docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,5 +17,6 @@ Add any other context about your changes here.
 - [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
 - [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
 - [ ] Minimize the number of commits
+- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
 
 *You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,8 @@ Some tips...
 
 - Write tests! You don't need to go crazy, but we will expect a unit test or two to show that your fix or feature does what it says, and doesn't break in the future. There are many test examples in Premake's source code, covering both the [modules](https://github.com/premake/premake-core/tree/master/modules) and the [core](https://github.com/premake/premake-core/tree/master/tests). Feel free to copy!
 
+- Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes. Keeping docs up to date is very important for all users of Premake.
+
 - When you submit a change, try to limit the number of commits involved. A single commit is ideal.
 
 - Follow our coding conventions, which we've intentionally kept quite minimal.

--- a/website/README.md
+++ b/website/README.md
@@ -2,6 +2,16 @@
 
 Premake website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
 
+All docs pages can be found in the `docs/` folder.
+
+## Adding a new entry to the docs
+Editing our documentation website is very simple. You don't have to build a whole website for this. All pages are stored in Markdown files, so in order to add a new entry:
+
+1. Add a new Markdown file into the `docs/` folder. Follow naming conventions there.
+2. Add your Markdown file's name into the `sidebars.js`. Make sure you've kept alphabetical order among category items.
+
+*Use other files as references.*
+
 ## Installation
 
 ```


### PR DESCRIPTION
**What does this PR do?**

Premake has evolved over the years, but its documentation has not kept up with the changes. Even now there are a few pending PRs introducing new features, flags and options but none of them would be mentioned in our docs after merge. Since contributing to the docs is possible now, I'd like to see people improving Premake along with its documentation. 

This PR introduces a new box for every Pull Request:

- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

**How does this PR change Premake's behavior?**

*No changes in behaviour*

**Anything else we should know?**

*No*

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] ~Add unit tests showing fix or feature works; all tests pass~
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
