### PR TITLE
Fix handling of mixed-case flags in option.each()

### DIFF
--- a/src/base/option.lua
+++ b/src/base/option.lua
@@ -120,8 +120,8 @@
 	function m.each()
 		-- sort the list by trigger
 		local keys = { }
-		for _, option in pairs(p.option.list) do
-			table.insert(keys, option.trigger)
+		for key in pairs(p.option.list) do
+			table.insert(keys, key)
 		end
 		table.sort(keys)
 

--- a/tests/base/test_option.lua
+++ b/tests/base/test_option.lua
@@ -43,3 +43,24 @@
 
 		test.isnotnil(p.option.get("testopt2"))
 	end
+
+
+---
+-- Make sure `each()` can handle mixed-case options.
+---
+
+	function suite.each_iteratesOnMixedCase()
+		newoption {
+			trigger = "TestOpt3",
+			description = "Testing",
+		}
+
+		local isFound = false
+		for opt in p.option.each() do
+			if opt.trigger == "TestOpt3" then
+				isFound = true
+			end
+		end
+
+		test.istrue(isFound)
+	end


### PR DESCRIPTION
**What does this PR do?**

Fixes handling of mixed case options ("MyFlag"), which were causing the `--help` output to fail.

**How does this PR change Premake's behavior?**

`premake.option.each()` will no longer break in when mixed case flags are present.

**Anything else we should know?**

Closes #1569.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
