### PR TITLE
Remove "*ng" action deprecation and auto-fix

### DIFF
--- a/src/_premake_main.lua
+++ b/src/_premake_main.lua
@@ -172,11 +172,6 @@
 ---
 
 	function m.prepareAction()
-		-- The "next-gen" actions have now replaced their deprecated counterparts.
-		-- Provide a warning for a little while before I remove them entirely.
-		if _ACTION and _ACTION:endswith("ng") then
-			p.warnOnce(_ACTION, "'%s' has been deprecated; use '%s' instead", _ACTION, _ACTION:sub(1, -3))
-		end
 		p.action.set(_ACTION)
 
 		-- Allow the action to initialize stuff.

--- a/src/base/action.lua
+++ b/src/base/action.lua
@@ -155,10 +155,6 @@
 ---
 
 	function action.get(name)
-		-- "Next-gen" actions are deprecated
-		if name and name:endswith("ng") then
-			name = name:sub(1, -3)
-		end
 		return action._list[name]
 	end
 


### PR DESCRIPTION
Fix #1601 

**What does this PR do?**
Remove deprecation warning and auto-renaming of actions ending with "ng"
