### PR TITLE
Enable pchheader for Codelite.

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -188,43 +188,6 @@
 		}
 	end
 
-	local function getpch(cfg)
-		-- If there is no header, or if PCH has been disabled, I can early out
-		if not cfg.pchheader or cfg.flags.NoPCH then
-			return nil
-		end
-
-		-- Visual Studio requires the PCH header to be specified in the same way
-		-- it appears in the #include statements used in the source code; the PCH
-		-- source actual handles the compilation of the header. GCC compiles the
-		-- header file directly, and needs the file's actual file system path in
-		-- order to locate it.
-
-		-- To maximize the compatibility between the two approaches, see if I can
-		-- locate the specified PCH header on one of the include file search paths
-		-- and, if so, adjust the path automatically so the user doesn't have
-		-- add a conditional configuration to the project script.
-
-		local pch = cfg.pchheader
-		local found = false
-
-		-- test locally in the project folder first (this is the most likely location)
-		local testname = path.join(cfg.project.basedir, pch)
-		if os.isfile(testname) then
-			return project.getrelative(cfg.project, testname)
-		else
-			-- else scan in all include dirs.
-			for _, incdir in ipairs(cfg.includedirs) do
-				testname = path.join(incdir, pch)
-				if os.isfile(testname) then
-					return project.getrelative(cfg.project, testname)
-				end
-			end
-		end
-
-		return project.getrelative(cfg.project, path.getabsolute(pch))
-	end
-
 	function m.compiler(cfg)
 		if configuration_iscustombuild(cfg) or configuration_isfilelist(cfg) then
 			_p(3, '<Compiler Required="no"/>')
@@ -237,7 +200,7 @@
 		local cxxflags = table.concat(table.join(sysincludedirs, toolset.getcxxflags(cfg), forceincludes, cfg.buildoptions), ";")
 		local cflags   = table.concat(table.join(sysincludedirs, toolset.getcflags(cfg), forceincludes, cfg.buildoptions), ";")
 		local asmflags = ""
-		local pch      = getpch(cfg)
+		local pch      = p.tools.gcc.getpch(cfg)
 		local usepch   = "yes"
 		if pch == nil then
 			pch = "";

--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -188,6 +188,42 @@
 		}
 	end
 
+	local function getpch(cfg)
+		-- If there is no header, or if PCH has been disabled, I can early out
+		if not cfg.pchheader or cfg.flags.NoPCH then
+			return nil
+		end
+
+		-- Visual Studio requires the PCH header to be specified in the same way
+		-- it appears in the #include statements used in the source code; the PCH
+		-- source actual handles the compilation of the header. GCC compiles the
+		-- header file directly, and needs the file's actual file system path in
+		-- order to locate it.
+
+		-- To maximize the compatibility between the two approaches, see if I can
+		-- locate the specified PCH header on one of the include file search paths
+		-- and, if so, adjust the path automatically so the user doesn't have
+		-- add a conditional configuration to the project script.
+
+		local pch = cfg.pchheader
+		local found = false
+
+		-- test locally in the project folder first (this is the most likely location)
+		local testname = path.join(cfg.project.basedir, pch)
+		if os.isfile(testname) then
+			return project.getrelative(cfg.project, testname)
+		else
+			-- else scan in all include dirs.
+			for _, incdir in ipairs(cfg.includedirs) do
+				testname = path.join(incdir, pch)
+				if os.isfile(testname) then
+					return project.getrelative(cfg.project, testname)
+				end
+			end
+		end
+
+		return project.getrelative(cfg.project, path.getabsolute(pch))
+	end
 
 	function m.compiler(cfg)
 		if configuration_iscustombuild(cfg) or configuration_isfilelist(cfg) then
@@ -201,9 +237,14 @@
 		local cxxflags = table.concat(table.join(sysincludedirs, toolset.getcxxflags(cfg), forceincludes, cfg.buildoptions), ";")
 		local cflags   = table.concat(table.join(sysincludedirs, toolset.getcflags(cfg), forceincludes, cfg.buildoptions), ";")
 		local asmflags = ""
-		local pch      = ""
+		local pch      = getpch(cfg)
+		local usepch   = "yes"
+		if pch == nil then
+			pch = "";
+			usepch = "no"
+		end
 
-		_x(3, '<Compiler Options="%s" C_Options="%s" Assembler="%s" Required="yes" PreCompiledHeader="%s" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">', cxxflags, cflags, asmflags, pch)
+		_x(3, '<Compiler Options="%s" C_Options="%s" Assembler="%s" Required="yes" PreCompiledHeader="%s" PCHInCommandLine="%s" UseDifferentPCHFlags="no" PCHFlags="">', cxxflags, cflags, asmflags, pch, usepch)
 
 		for _, includedir in ipairs(cfg.includedirs) do
 			_x(4, '<IncludePath Value="%s"/>', project.getrelative(cfg.project, includedir))

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -93,6 +93,16 @@
 		]]
 	end
 
+	function suite.OnProjectCfg_Pch()
+		  pchheader "pch.h"
+		prepare()
+		codelite.project.compiler(cfg)
+		test.capture [[
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="pch.h" PCHInCommandLine="yes" UseDifferentPCHFlags="no" PCHFlags="">
+      </Compiler>
+		]]
+	end
+
 	function suite.OnProjectCfg_Linker()
 		prepare()
 		codelite.project.linker(cfg)

--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -567,50 +567,15 @@ end
 
 
 	function make.pch(cfg, toolset)
+		local pch = p.tools.gcc.getpch(cfg)
 		-- If there is no header, or if PCH has been disabled, I can early out
-		if not cfg.pchheader or cfg.flags.NoPCH then
+		if pch == nil then
 			return
-		end
-
-		-- Visual Studio requires the PCH header to be specified in the same way
-		-- it appears in the #include statements used in the source code; the PCH
-		-- source actual handles the compilation of the header. GCC compiles the
-		-- header file directly, and needs the file's actual file system path in
-		-- order to locate it.
-
-		-- To maximize the compatibility between the two approaches, see if I can
-		-- locate the specified PCH header on one of the include file search paths
-		-- and, if so, adjust the path automatically so the user doesn't have
-		-- add a conditional configuration to the project script.
-
-		local pch = cfg.pchheader
-		local found = false
-
-		-- test locally in the project folder first (this is the most likely location)
-		local testname = path.join(cfg.project.basedir, pch)
-		if os.isfile(testname) then
-			pch = project.getrelative(cfg.project, testname)
-			found = true
-		else
-			-- else scan in all include dirs.
-			for _, incdir in ipairs(cfg.includedirs) do
-				testname = path.join(incdir, pch)
-				if os.isfile(testname) then
-					pch = project.getrelative(cfg.project, testname)
-					found = true
-					break
-				end
-			end
-		end
-
-		if not found then
-			pch = project.getrelative(cfg.project, path.getabsolute(pch))
 		end
 
 		_x('  PCH = %s', pch)
 		_p('  GCH = $(OBJDIR)/$(notdir $(PCH)).gch')
 	end
-
 
 	function make.pchRules(prj)
 		_p('ifneq (,$(PCH))')

--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -368,44 +368,10 @@
 
 
 	function cpp.pch(cfg, toolset)
+		local pch = p.tools.gcc.getpch(cfg)
 		-- If there is no header, or if PCH has been disabled, I can early out
-		if not cfg.pchheader or cfg.flags.NoPCH then
+		if pch == nil then
 			return
-		end
-
-		-- Visual Studio requires the PCH header to be specified in the same way
-		-- it appears in the #include statements used in the source code; the PCH
-		-- source actual handles the compilation of the header. GCC compiles the
-		-- header file directly, and needs the file's actual file system path in
-		-- order to locate it.
-
-		-- To maximize the compatibility between the two approaches, see if I can
-		-- locate the specified PCH header on one of the include file search paths
-		-- and, if so, adjust the path automatically so the user doesn't have
-		-- add a conditional configuration to the project script.
-
-		local pch = cfg.pchheader
-		local found = false
-
-		-- test locally in the project folder first (this is the most likely location)
-		local testname = path.join(cfg.project.basedir, pch)
-		if os.isfile(testname) then
-			pch = project.getrelative(cfg.project, testname)
-			found = true
-		else
-			-- else scan in all include dirs.
-			for _, incdir in ipairs(cfg.includedirs) do
-				testname = path.join(incdir, pch)
-				if os.isfile(testname) then
-					pch = project.getrelative(cfg.project, testname)
-					found = true
-					break
-				end
-			end
-		end
-
-		if not found then
-			pch = project.getrelative(cfg.project, path.getabsolute(pch))
 		end
 
 		p.outln('PCH = ' .. pch)

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -297,9 +297,47 @@
 		return result
 	end
 
+	-- relative pch file path if any
+	function gcc.getpch(cfg)
+		-- If there is no header, or if PCH has been disabled, I can early out
+		if not cfg.pchheader or cfg.flags.NoPCH then
+			return nil
+		end
+
+		-- Visual Studio requires the PCH header to be specified in the same way
+		-- it appears in the #include statements used in the source code; the PCH
+		-- source actual handles the compilation of the header. GCC compiles the
+		-- header file directly, and needs the file's actual file system path in
+		-- order to locate it.
+
+		-- To maximize the compatibility between the two approaches, see if I can
+		-- locate the specified PCH header on one of the include file search paths
+		-- and, if so, adjust the path automatically so the user doesn't have
+		-- add a conditional configuration to the project script.
+
+		local pch = cfg.pchheader
+		local found = false
+
+		-- test locally in the project folder first (this is the most likely location)
+		local testname = path.join(cfg.project.basedir, pch)
+		if os.isfile(testname) then
+			return project.getrelative(cfg.project, testname)
+		else
+			-- else scan in all include dirs.
+			for _, incdir in ipairs(cfg.includedirs) do
+				testname = path.join(incdir, pch)
+				if os.isfile(testname) then
+					return project.getrelative(cfg.project, testname)
+				end
+			end
+		end
+
+		return project.getrelative(cfg.project, path.getabsolute(pch))
+	end
+
 --
 -- Return a list of decorated rpaths
--- 
+--
 -- @param cfg
 --    The configuration to query.
 -- @param dirs
@@ -328,10 +366,10 @@
 				rpath = "$$ORIGIN" .. rpath
 			end
 
-			if mode == "linker" then 
+			if mode == "linker" then
 				rpath = "-Wl,-rpath,'" .. rpath .. "'"
 			end
-			
+
 			table.insert(result, rpath)
 		end
 


### PR DESCRIPTION
**What does this PR do?**

Add missing support of pchheader for Codelite generator:

close #1621

**How does this PR change Premake's behavior?**

bug fixes of Codelite generator

**Anything else we should know?**

I also added pch to my sample tests in https://github.com/Jarod42/premake-sample-projects
My check there is partially broken as even if Codelite actually failed to build, test is marked as successful :-(
but log show the issue.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
