### PR TITLE
Sort `buildinputs` and `buildoutputs` on xcode4

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -1332,15 +1332,15 @@
 			);
 			inputPaths = (
 				"file.a",
+				"file.3",
 				"file.1",
 				"file.2",
-				"file.3",
 			);
 			name = "Build \"file.a\"";
 			outputPaths = (
-				"file.4",
 				"file.5",
 				"file.6",
+				"file.4",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -1315,6 +1315,42 @@
 	end
 
 
+	function suite.PBXShellScriptBuildPhase_OnBuildInputsAnddOutputsOrder()
+		files { "file.a" }
+		filter { "files:file.a" }
+			buildcommands { "buildcmd" }
+			buildinputs { "file.3", "file.1", "file.2" }
+			buildoutputs { "file.5", "file.6", "file.4" }
+		prepare()
+		xcode.PBXShellScriptBuildPhase(tr)
+		test.capture [[
+/* Begin PBXShellScriptBuildPhase section */
+		0D594A1D2F24F74F6BDA205D /* Build "file.a" */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"file.a",
+				"file.1",
+				"file.2",
+				"file.3",
+			);
+			name = "Build \"file.a\"";
+			outputPaths = (
+				"file.4",
+				"file.5",
+				"file.6",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nif [ \"${CONFIGURATION}\" = \"Debug\" ]; then\n\tbuildcmd\nfi\nif [ \"${CONFIGURATION}\" = \"Release\" ]; then\n\tbuildcmd\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
+		]]
+	end
+
+
 ---------------------------------------------------------------------------
 -- PBXSourcesBuildPhase tests
 ---------------------------------------------------------------------------

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1111,12 +1111,12 @@
 								table.insert(commands, 'fi')
 								for _, v in ipairs(filecfg.buildinputs) do
 									if not table.indexof(inputs, v) then
-										table.insertsorted(inputs, v)
+										table.insert(inputs, v)
 									end
 								end
 								for _, v in ipairs(filecfg.buildoutputs) do
 									if not table.indexof(outputs, v) then
-										table.insertsorted(outputs, v)
+										table.insert(outputs, v)
 									end
 								end
 							end

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1110,10 +1110,14 @@
 								end
 								table.insert(commands, 'fi')
 								for _, v in ipairs(filecfg.buildinputs) do
-									inputs[v] = true
+									if not table.indexof(inputs, v) then
+										table.insertsorted(inputs, v)
+									end
 								end
 								for _, v in ipairs(filecfg.buildoutputs) do
-									outputs[v] = true
+									if not table.indexof(outputs, v) then
+										table.insertsorted(outputs, v)
+									end
 								end
 							end
 						end
@@ -1129,13 +1133,13 @@
 						_p(level+1,');')
 						_p(level+1,'inputPaths = (');
 						_p(level+2,'"%s",', xcode.escapeSetting(node.relpath))
-						for v, _ in pairs(inputs) do
+						for _, v in ipairs(inputs) do
 							_p(level+2,'"%s",', xcode.escapeSetting(project.getrelative(tr.project, v)))
 						end
 						_p(level+1,');')
 						_p(level+1,'name = %s;', xcode.stringifySetting('Build "' .. node.name .. '"'))
 						_p(level+1,'outputPaths = (')
-						for v, _ in pairs(outputs) do
+						for _, v in ipairs(outputs) do
 							_p(level+2,'"%s",', xcode.escapeSetting(project.getrelative (tr.project, v)))
 						end
 						_p(level+1,');')


### PR DESCRIPTION
**What does this PR do?**

Fixed a issue where xcodeproj would be modified even if the Premake script was not modified if multiple paths were specified for `buildinputs` and/or `buildoutputs`.

**How does this PR change Premake's behavior?**

The above issue was caused by an indeterminate sort order of Lua's key-value tables, so that part has been fixed.

**Anything else we should know?**

None.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes