### PR TITLE
Fix author name and update time on pages

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: '14'


### PR DESCRIPTION
**What does this PR do?**

Currently, every page has the same author and update time. 

![image](https://user-images.githubusercontent.com/19170699/121592530-18082400-ca3b-11eb-88ba-5362a38250ed.png)


The problem is that `actions/checkout@v2` fetches only last commit by default but docusaurus needs to know about every file's history to generate proper metadata. This PR fixes the issue.

```
with:
  fetch-depth: 0
```
this tells `actions/checkout@v2` to fetch all commits, all branches, all tags, etc.

Working demo: [here](https://kyriets.github.io/premake-core/docs/What-Is-Premake)

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
