### PR TITLE
Add missing support for prebuildmessage/postbuildmessage for Codelite.

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -314,10 +314,14 @@
 	end
 
 	function m.preBuild(cfg)
-		if #cfg.prebuildcommands > 0 then
+		if #cfg.prebuildcommands > 0 or cfg.prebuildmessage then
 			_p(3, '<PreBuild>')
-			local commands = os.translateCommandsAndPaths(cfg.prebuildcommands, cfg.project.basedir, cfg.project.location)
 			p.escaper(codelite.escElementText)
+			if cfg.prebuildmessage then
+				local command = os.translateCommandsAndPaths("@{ECHO} " .. cfg.prebuildmessage, cfg.project.basedir, cfg.project.location)
+				_x(4, '<Command Enabled="yes">%s</Command>', command)
+			end
+			local commands = os.translateCommandsAndPaths(cfg.prebuildcommands, cfg.project.basedir, cfg.project.location)
 			for _, command in ipairs(commands) do
 				_x(4, '<Command Enabled="yes">%s</Command>', command)
 			end
@@ -327,10 +331,14 @@
 	end
 
 	function m.postBuild(cfg)
-		if #cfg.postbuildcommands > 0 then
+		if #cfg.postbuildcommands > 0  or cfg.postbuildmessage then
 			_p(3, '<PostBuild>')
-			local commands = os.translateCommandsAndPaths(cfg.postbuildcommands, cfg.project.basedir, cfg.project.location)
 			p.escaper(codelite.escElementText)
+			if cfg.postbuildmessage then
+				local command = os.translateCommandsAndPaths("@{ECHO} " .. cfg.postbuildmessage, cfg.project.basedir, cfg.project.location)
+				_x(4, '<Command Enabled="yes">%s</Command>', command)
+			end
+			local commands = os.translateCommandsAndPaths(cfg.postbuildcommands, cfg.project.basedir, cfg.project.location)
 			for _, command in ipairs(commands) do
 				_x(4, '<Command Enabled="yes">%s</Command>', command)
 			end

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -181,6 +181,29 @@
 		]]
 	end
 
+	function suite.OnProjectCfg_PreBuildMessage()
+		prebuildmessage "test"
+		prepare()
+		codelite.project.preBuild(cfg)
+		test.capture [[
+      <PreBuild>
+        <Command Enabled="yes">@echo test</Command>
+      </PreBuild>
+		]]
+	end
+
+	function suite.OnProjectCfg_PostBuildMessage()
+		postbuildmessage "test"
+		prepare()
+		codelite.project.postBuild(cfg)
+		test.capture [[
+      <PostBuild>
+        <Command Enabled="yes">@echo test</Command>
+      </PostBuild>
+		]]
+	end
+
+
 	function suite.OnProjectCfg_General()
 		system "Windows"
 		prepare()


### PR DESCRIPTION
**What does this PR do?**

Add missing support for prebuildmessage/postbuildmessage for Codelite.

**How does this PR change Premake's behavior?**

Change only Codelite generator.

**Anything else we should know?**

closes #1643

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
