### PR TITLE
Fix curl header search path

### DIFF
--- a/contrib/curl/premake5.lua
+++ b/contrib/curl/premake5.lua
@@ -1,7 +1,8 @@
 project "curl-lib"
 	language    "C"
 	kind        "StaticLib"
-	includedirs { "include", "lib", "../mbedtls/include/" }
+	sysincludedirs { "include" }
+	includedirs { "lib", "../mbedtls/include" }
 	defines     { "BUILDING_LIBCURL", "CURL_STATICLIB", "HTTP_ONLY" }
 	warnings    "off"
 


### PR DESCRIPTION
Consider curl include directory as system header search path to match #include directives with angle brackets.

**What does this PR do?**
Fix premake xcode4 project

**How does this PR change Premake's behavior?**
Nothing. Just allow to generate a correct project to build premake with modern Xcode

**Anything else we should know?**
Xcode is by default less tolerant regarding mismatch between user header search path (#include "...") and system header search path (#include <...>). 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
