### PR TITLE
xcode4: Fix missing link of sibling project with custom targetextension

### DIFF
--- a/modules/xcode/tests/test_xcode_dependencies.lua
+++ b/modules/xcode/tests/test_xcode_dependencies.lua
@@ -198,6 +198,24 @@
 		]]
 	end
 
+function suite.PBXFrameworksBuildPhase_ListsDependencies_OnSharedLibWithTargetExtension()
+		kind "SharedLib"
+		targetextension ".plugin"
+		prepare()
+		xcode.PBXFrameworksBuildPhase(tr)
+		test.capture [[
+/* Begin PBXFrameworksBuildPhase section */
+		9FDD37564328C0885DF98D96 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6B7205267D294518F2973366 /* libMyProject2-d.plugin in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+		]]
+	end
 ---------------------------------------------------------------------------
 -- PBXCopyFilesBuildPhaseForEmbedFrameworks tests
 ---------------------------------------------------------------------------

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -46,6 +46,8 @@
 		}
 		if node.isResource then
 			return "Resources"
+		elseif node.cfg and (node.cfg.kind == p.SHAREDLIB or node.cfg.kind == p.STATICLIB) then
+			return "Frameworks"
 		end
 		return categories[path.getextension(node.name)]
 	end


### PR DESCRIPTION
When a node category cannot be determined by extension,
use the configuration kind when available.

Add unit test to illustrate the case.

**What does this PR do?**
Project with a custom targetextension were not linked to other projects 
because the strategy used to determine Xocde node type was uniquely based
on node name extension.
This patch adds a "last chance" fallback based on attached configuration kind

**How does this PR change Premake's behavior?**
Fix a edge case bug. Should not change the behavior for most common cases.

**Anything else we should know?**
I kept the previous behavior as the main strategy to avoid breaking changes.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
