### PR TITLE
Fix D module compiler output for visual studio

### DIFF
--- a/modules/d/_preload.lua
+++ b/modules/d/_preload.lua
@@ -54,6 +54,11 @@
 		"ShowDependencies",
 	})
 
+	api.addAllowed("toolset", {
+		"dmd",
+		"gdc",
+		"ldc",
+	})
 
 --
 -- Register some D specific properties

--- a/modules/d/actions/gmake.lua
+++ b/modules/d/actions/gmake.lua
@@ -205,7 +205,7 @@
 			-- identify the toolset used by this configurations (would be nicer if
 			-- this were computed and stored with the configuration up front)
 
-			local toolset = p.tools[_OPTIONS.dc or cfg.toolset or "dmd"]
+			local toolset = m.make.getToolset(cfg)
 			if not toolset then
 				error("Invalid toolset '" + (_OPTIONS.dc or cfg.toolset) + "'")
 			end
@@ -215,6 +215,14 @@
 			_p('endif')
 			_p('')
 		end
+	end
+
+	function m.make.getToolset(cfg)
+		local toolset, err = p.api.checkValue(p.fields.toolset, _OPTIONS.dc or cfg.toolset or "dmd")
+		if err then
+			error { msg=err }
+		end
+		return p.tools[toolset]
 	end
 
 	function m.make.dTools(cfg, toolset)

--- a/modules/d/actions/visuald.lua
+++ b/modules/d/actions/visuald.lua
@@ -175,7 +175,12 @@
 			_p(2,'<ignoreUnsupportedPragmas>0</ignoreUnsupportedPragmas>')
 
 			local compiler = { dmd="0", gdc="1", ldc="2" }
-			m.visuald.element(2, "compiler", compiler[_OPTIONS.dc or cfg.toolset or "dmd"])
+			local compilerName, err = p.api.checkValue(p.fields.toolset, _OPTIONS.dc or cfg.toolset or "dmd")
+			if err then
+				error { msg=err }
+			end
+
+			m.visuald.element(2, "compiler", compiler[compilerName])
 
 			m.visuald.element(2, "otherDMD", '0')
 			m.visuald.element(2, "program", '$(DMDInstallDir)windows\\bin\\dmd.exe')

--- a/modules/d/tests/test_gmake.lua
+++ b/modules/d/tests/test_gmake.lua
@@ -30,7 +30,7 @@
 	local function prepare_cfg(calls)
 		prj = p.workspace.getproject(wks, 1)
 		local cfg = test.getconfig(prj, "Debug")
-		local toolset = p.tools.dmd
+		local toolset = m.make.getToolset(cfg) or p.tools.dmd
 		p.callArray(calls, cfg, toolset)
 	end
 
@@ -191,5 +191,32 @@ all: $(TARGETDIR) prebuild prelink $(TARGET)
 		test.capture [[
 all: $(TARGETDIR) $(OBJDIR) prebuild prelink $(TARGET)
 	@:
+		]]
+	end
+
+	function suite.make_dTools_dmd()
+		toolset "dmd"
+
+		prepare_cfg({ m.make.dTools })
+		test.capture [[
+  DC = dmd
+		]]
+	end
+	
+	function suite.make_dTools_gdc()
+		toolset "gdc"
+
+		prepare_cfg({ m.make.dTools })
+		test.capture [[
+  DC = gdc
+		]]
+	end
+
+	function suite.make_dTools_ldc()
+		toolset "ldc"
+
+		prepare_cfg({ m.make.dTools })
+		test.capture [[
+  DC = ldc2
 		]]
 	end

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -350,6 +350,13 @@
 			end
 		else
 			field.allowed = field.allowed or {}
+
+			-- If we are trying to add where the current value is a function,
+			-- put the function in a table
+			if type(field.allowed) == "function" then
+				field.allowed = { field.allowed }
+			end
+
 			if field.allowed[value:lower()] == nil then
 				table.insert(field.allowed, value)
 				field.allowed[value:lower()] = value
@@ -644,6 +651,23 @@
 				canonical = field.allowed(value, kind or "string")
 			else
 				canonical = field.allowed[lowerValue]
+			end
+		end
+
+
+		-- If a tool was not found, check to see if there is a function in the
+		-- table to check against.  For each function in the table, check if
+		-- the value is allowed (break early if so).
+		if not canonical then
+			for _, allow in ipairs(field.allowed)
+			do
+				if type(allow) == "function" then
+					canonical = allow(value, kind or "string")
+				end
+
+				if canonical then
+					break
+				end
 			end
 		end
 

--- a/website/docs/toolset.md
+++ b/website/docs/toolset.md
@@ -10,12 +10,15 @@ If no toolset is specified for a configuration, the system or IDE default will b
 
 `identifier` is a string identifier for the toolset. Premake includes the following toolsets by default.
 
-| **Toolset identifier**   |  **Description**                 |
-|------------|------------------------------------------------|
-| `clang`    | [Clang](http://clang.llvm.org)                 |
-| `dotnet`   | The system's default C# compiler               |
-| `gcc`      | [GNU Compiler Collection](https://gcc.gnu.org) |
-| `msc`      | Microsoft C/C++ compiler                       |
+| **Toolset identifier**   |  **Description**                                |
+|------------|---------------------------------------------------------------|
+| `clang`    | [Clang](http://clang.llvm.org)                                |
+| `dmd`      | [Reference D Compiler](https://dlang.org/dmd-windows.html)    |
+| `dotnet`   | The system's default C# compiler                              |
+| `gcc`      | [GNU Compiler Collection](https://gcc.gnu.org)                |
+| `gdc`      | [GNU Compiler Collection D Compiler](https://gdcproject.org/) |
+| `ldc`      | [LLVM D Compiler](https://wiki.dlang.org/LDC)                 |
+| `msc`      | Microsoft C/C++ compiler                                      |
 
 If a specific toolset version is desired, it may be specified as part of the identifer, separated by a dash. See the examples below.
 


### PR DESCRIPTION
**What does this PR do?**

This fixes the output for the D compiler.  In Visual Studio, this forces a compiler to be set in the project file.

The problem was that the toolset for D projects was always being set to "msc-v142" for Visual Studio 2019 (did not check the value for previous versions of VS).  If the toolset was defined in the premake script, it was not an allowed value.  The only way for this to work previously was by using `--dc=dmd` (change dmd to your preferred D compiler).

**How does this PR change Premake's behavior?**

There are no breaking changes.  All changes are to fix the "D" module (and allow for other module support).  Premake now supports the "dmd", "gdc", and "ldc" toolset options for D projects.  This was done by adding them to the allowed values in the "toolset" premake field.

Usage:

```lua
workspace "test"
    configurations { "debug" }

    project "t"
        kind "ConsoleApp"
        language "D"
        toolset "dmd"
        files "**.d"
```

| Module / Toolset | Old Output | New Output |
| --- | --- |
| VS 2019 / dmd | <compiler /> | <compiler>0</compiler> |
| VS 2019 / gdc | <compiler /> | <compiler>1</compiler> |
| VS 2019 / ldc | <compiler /> | <compiler>2</compiler> |

**Anything else we should know?**

Closes #1603

So what next? The gmake module still needs work to actually function.  When running with "gmake" on the command line, it still attempts to go through the C++ module instead of the D module.  In order to minimize the number of changes in the review, I will leave that for another day.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
