### PR TITLE
Handle `buildcommand` for Codelite.

### DIFF
--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -203,6 +203,51 @@
 		]]
 	end
 
+	function suite.OnProjectCfg_BuildCommand()
+		files {"/c/foo.txt", "/c/bar.txt"}
+		buildinputs { "/c/toto.txt", "/c/extra_dependency" }
+		buildoutputs { "/c/toto.c" }
+		buildcommands { "test", "test /c/toto.c" }
+		buildmessage "Some message"
+		prepare()
+		codelite.project.additionalRules(cfg)
+		test.capture [[
+      <AdditionalRules>
+        <CustomPostBuild/>
+        <CustomPreBuild>/c/toto.c
+/c/toto.c: /c/toto.txt /c/extra_dependency
+	@echo Some message
+	test
+	test /c/toto.c
+</CustomPreBuild>
+      </AdditionalRules>]]
+	end
+
+	function suite.OnProjectCfg_BuildCommandPerFile()
+		files {"/c/foo.txt", "/c/bar.txt"}
+		filter "files:**.txt"
+			buildinputs { "/c/%{file.basename}.h", "/c/extra_dependency" }
+			buildoutputs { "/c/%{file.basename}.c" }
+			buildcommands { "test", "test /c/%{file.basename}" }
+			buildmessage "Some message"
+		prepare()
+		codelite.project.additionalRules(cfg)
+		test.capture [[
+      <AdditionalRules>
+        <CustomPostBuild/>
+        <CustomPreBuild>/c/bar.c /c/foo.c
+/c/bar.c: /c/bar.txt /c/bar.h /c/extra_dependency
+	@echo Some message
+	test
+	test /c/bar
+
+/c/foo.c: /c/foo.txt /c/foo.h /c/extra_dependency
+	@echo Some message
+	test
+	test /c/foo
+</CustomPreBuild>
+      </AdditionalRules>]]
+	end
 
 	function suite.OnProjectCfg_General()
 		system "Windows"


### PR DESCRIPTION
**What does this PR do?**

Handle buildcommand/buildmessage/buildinputs/buildoutputs for Codelite

**How does this PR change Premake's behavior?**

Only Codelite generator

**Anything else we should know?**

Added sample project for https://github.com/Jarod42/premake-sample-projects

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
