### PR TITLE
Fix v6 bootstrapping from v5

### DIFF
--- a/src/_premake_main.lua
+++ b/src/_premake_main.lua
@@ -68,6 +68,12 @@
 			name .. ".lua"
 		}
 
+		-- If this module is being requested by an embedded script, favor embedded modules.
+		-- This helps prevent local scripts from interfering with release build bootstrapping.
+		if string.startswith(_SCRIPT_DIR, '$/') then
+			table.insert(paths, 1, '$/' .. full)
+		end
+
 		-- try to locate the module
 		for _, p in ipairs(paths) do
 			local file = os.locate(p)
@@ -118,8 +124,9 @@
 			local preloader = name .. "/_preload.lua"
 			preloader = os.locate("modules/" .. preloader) or os.locate(preloader)
 			if preloader then
-				m._preloaded[name] = include(preloader)
-				if not m._preloaded[name] then
+				local modulePath = path.getdirectory(preloader)
+				m._preloaded[modulePath] = include(preloader)
+				if not m._preloaded[modulePath] then
 					p.warn("module '%s' should return function from _preload.lua", name)
 				end
 			else
@@ -306,9 +313,11 @@
 		end
 
 		-- any modules need to load to support this project?
-		for module, func in pairs(m._preloaded) do
-			if not package.loaded[module] and shouldLoad(func) then
-				require(module)
+		for modulePath, func in pairs(m._preloaded) do
+			local moduleName = path.getbasename(modulePath)
+			if not package.loaded[moduleName] and shouldLoad(func) then
+				_SCRIPT_DIR = modulePath
+				require(moduleName)
 			end
 		end
 	end

--- a/src/host/os_locate.c
+++ b/src/host/os_locate.c
@@ -36,6 +36,12 @@ int os_locate(lua_State* L)
 	for (i = 1; i <= nArgs; ++i) {
 		const char* name = lua_tostring(L, i);
 
+		/* Direct path to an embedded file? */
+		if (name[0] == '$' && name[1] == '/' && premake_find_embedded_script(name + 2)) {
+			lua_pushvalue(L, i);
+			return 1;
+		}
+
 		/* Direct path to file? Return as absolute path */
 		if (do_isfile(L, name)) {
 			lua_pushcfunction(L, path_getabsolute);


### PR DESCRIPTION
**What does this PR do?**

**Updated—my first build didn't catch all cases.**

Trying to bootstrap the Premake6 build using Premake5 can throw an error "module 'dom' not found". This fix prevents Premake5 from picking up the v6 modules when run within a v6 source directory, by always loading modules from the same directory where their `_preload.lua` script was located.

**How does this PR change Premake's behavior?**

If an embedded script calls `require()`, embedded modules will now be given precedence over scripts on the local file system. This situation only occurs during the bootstrapping phase of a release build, and in that situation we should always be using the embedded scripts, since what's on the file system might not be in sync with the native code used in the build.

In addition to fixing v6 bootstrapping, this should also help with using v5 to bootstrap a new v5 build as well.

**Anything else we should know?**

Nope.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] ~~Add unit tests showing fix or feature works; all tests pass~~ _(no great way to unit test this)_
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
