### PR TITLE
C# Symbol Premake -> VS Mapping Changes

### DIFF
--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -12,6 +12,7 @@ return {
 	"cs2005/test_compiler_props.lua",
 	"cs2005/test_no_warn.lua",
 	"cs2005/test_debug_props.lua",
+	"cs2005/test_debug_props_2019.lua",
 	"cs2005/test_files.lua",
 	"cs2005/test_icon.lua",
 	"cs2005/test_netcore.lua",

--- a/modules/vstudio/tests/cs2005/test_debug_props_2019.lua
+++ b/modules/vstudio/tests/cs2005/test_debug_props_2019.lua
@@ -1,0 +1,130 @@
+--
+-- tests/actions/vstudio/cs2005/test_debug_props_2019.lua
+-- Test debugging and optimization flags block of a Visual Studio 2019+ C# project.
+-- Copyright (c) 2012-2021 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("vstudio_cs2005_debug_props_2019")
+	local cs2005 = p.vstudio.cs2005
+	local dn2005 = p.vstudio.dotnetbase
+	local project = p.project
+
+
+--
+-- Setup and teardown
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2019")
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare()
+		local cfg = test.getconfig(prj, "Debug")
+		dn2005.debugProps(cfg)
+	end
+
+
+--
+-- Check the handling of the Symbols flag.
+--
+
+	function suite.debugSymbols_onNoSymbolsFlag()
+		prepare()
+		test.capture [[
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<Optimize>false</Optimize>
+		]]
+	end
+
+	function suite.debugSymbols_onSymbolsFlag()
+		symbols "On"
+		prepare()
+		test.capture [[
+		<DebugType>pdbonly</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<Optimize>false</Optimize>
+		]]
+	end
+
+	function suite.debugSymbols_fullSymbolsFlag()
+		symbols "Full"
+		prepare()
+		test.capture [[
+		<DebugType>full</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<Optimize>false</Optimize>
+		]]
+	end
+
+	function suite.debugSymbols_offSymbolsFlag()
+		symbols "Off"
+		prepare()
+		test.capture [[
+		<DebugType>none</DebugType>
+		<DebugSymbols>false</DebugSymbols>
+		<Optimize>false</Optimize>
+		]]
+	end
+
+---
+--- Check handling of debug parameters.
+---
+
+	function suite.debugCommandParameters()
+		debugargs "foobar"
+
+		local cfg = test.getconfig(prj, "Debug")
+		dn2005.debugCommandParameters(cfg)
+
+		test.capture [[
+		<Commandlineparameters>foobar</Commandlineparameters>
+		]]
+	end
+
+	function suite.debugStartArguments()
+		debugargs "foobar"
+		local cfg = test.getconfig(prj, "Debug")
+		cs2005.localDebuggerCommandArguments(cfg)
+		test.capture [[
+<StartArguments>foobar</StartArguments>
+		]]
+	end
+
+--
+-- Check handling of optimization flags.
+--
+
+	function suite.optimize_onOptimizeFlag()
+		optimize "On"
+		prepare()
+		test.capture [[
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<Optimize>true</Optimize>
+		]]
+	end
+
+	function suite.optimize_onOptimizeSizeFlag()
+		optimize "Size"
+		prepare()
+		test.capture [[
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<Optimize>true</Optimize>
+		]]
+	end
+
+	function suite.optimize_onOptimizeSpeedFlag()
+		optimize "Speed"
+		prepare()
+		test.capture [[
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<Optimize>true</Optimize>
+		]]
+	end

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -278,11 +278,27 @@
 --
 
 	function dotnetbase.debugProps(cfg)
-		if cfg.symbols == p.ON then
-			_p(2,'<DebugSymbols>true</DebugSymbols>')
-			_p(2,'<DebugType>full</DebugType>')
+		if _ACTION >= "vs2019" then
+			if cfg.symbols == "Full" then
+				_p(2,'<DebugType>full</DebugType>')
+				_p(2,'<DebugSymbols>true</DebugSymbols>')
+			elseif cfg.symbols == p.OFF then
+				_p(2,'<DebugType>none</DebugType>')
+				_p(2,'<DebugSymbols>false</DebugSymbols>')
+			elseif cfg.symbols == p.ON or cfg.symbols == "FastLink" then
+				_p(2,'<DebugType>pdbonly</DebugType>')
+				_p(2,'<DebugSymbols>true</DebugSymbols>')
+			else
+				_p(2,'<DebugType>portable</DebugType>')
+				_p(2,'<DebugSymbols>true</DebugSymbols>')
+			end
 		else
-			_p(2,'<DebugType>pdbonly</DebugType>')
+			if cfg.symbols == p.ON then
+				_p(2,'<DebugSymbols>true</DebugSymbols>')
+				_p(2,'<DebugType>full</DebugType>')
+			else
+				_p(2,'<DebugType>pdbonly</DebugType>')
+			end
 		end
 		_p(2,'<Optimize>%s</Optimize>', iif(config.isOptimizedBuild(cfg), "true", "false"))
 	end


### PR DESCRIPTION
**What does this PR do?**

This PR closes #1670.  It allows for `none` to be set for the debug symbol value of Visual Studio C# projects.

**How does this PR change Premake's behavior?**

Previous Mapping

| Premake Symbol Value  | Visual Studio C# Project Value |
|-----------------------|--------------------------------|
| Off, Full, FastLink, Default | pdbonly |
| On | full |

New/Proposed Mapping

| Premake Symbol Value  | Visual Studio C# Project Value |
|-----------------------|--------------------------------|
| Off | none |
| On, FastLink | pdbonly |
| Full | full |
| Default | portable |

This changes the behavior of the `Off`, `On`, `Full`, and `Default` C# symbol outputs.

**Anything else we should know?**

The rational behind the change of `Default` to map to `portable` is because VS2019 defaults to `portable` for the debug symbol output.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes (Not applicable, no new API added)

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
