### PR TITLE
add support for external warning levels in visual studio

### DIFF
--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2762,7 +2762,6 @@
 	end
 
 
-
 	function m.disableSpecificWarnings(cfg, condition)
 		if #cfg.disablewarnings > 0 then
 			local warnings = table.concat(cfg.disablewarnings, ";")

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -356,6 +356,7 @@
 		local calls = {
 			m.precompiledHeader,
 			m.warningLevel,
+			m.externalWarningLevel,
 			m.treatWarningAsError,
 			m.disableSpecificWarnings,
 			m.treatSpecificWarningsAsErrors,
@@ -2133,7 +2134,7 @@
 	function m.includePath(cfg)
 		local dirs = vstudio.path(cfg, cfg.sysincludedirs)
 		if #dirs > 0 then
-			m.element("IncludePath", nil, "%s;$(IncludePath)", table.concat(dirs, ";"))
+			m.element("ExternalIncludePath", nil, "%s;$(ExternalIncludePath)", table.concat(dirs, ";"))
 		end
 	end
 
@@ -2761,6 +2762,7 @@
 	end
 
 
+
 	function m.disableSpecificWarnings(cfg, condition)
 		if #cfg.disablewarnings > 0 then
 			local warnings = table.concat(cfg.disablewarnings, ";")
@@ -2815,6 +2817,11 @@
 		if cfg.warnings then
 			m.element("WarningLevel", condition, map[cfg.warnings] or "Level3")
 		end
+	end
+
+	function m.externalWarningLevel(cfg)
+		local map = { Off = "TurnOffAllWarnings", High = "Level4", Extra = "Level4", Everything = "EnableAllWarnings" }
+		m.element("ExternalWarningLevel", nil, map[cfg.externalwarnings] or "Level3")
 	end
 
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1361,6 +1361,19 @@
 	}
 
 	api.register {
+		name = "externalwarnings",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Off",
+			"Default",
+			"High",
+			"Extra",
+			"Everything",
+		}
+	}
+
+	api.register {
 		name = "largeaddressaware",
 		scope = "config",
 		kind = "boolean",

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -96,6 +96,12 @@
 			Extra = "/W4",
 			Everything = "/Wall",
 		},
+		externalwarnings = {
+			Off = "/W0",
+			High = "/W4",
+			Extra = "/W4",
+			Everything = "/Wall",
+		},
 		staticruntime = {
 			-- this option must always be emit (does it??)
 			_ = function(cfg) return getRuntimeFlag(cfg, false) end,

--- a/website/docs/externalwarnings.md
+++ b/website/docs/externalwarnings.md
@@ -1,4 +1,4 @@
-Controls the number of warnings that are shown by the compiler. This setting only applies to visual studio 17 and newer. It will control the warnings shown for includes given by sysincludedirs
+Controls the number of warnings that are shown by the compiler. This setting only applies to Visual Studio 17 and newer. It will control the warnings shown for includes given by [sysincludedirs](sysincludedirs.md).
 
 ```lua
 externalwarnings "value"

--- a/website/docs/externalwarnings.md
+++ b/website/docs/externalwarnings.md
@@ -1,0 +1,34 @@
+Controls the number of warnings that are shown by the compiler. This setting only applies to visual studio 17 and newer. It will control the warnings shown for includes given by sysincludedirs
+
+```lua
+externalwarnings "value"
+```
+
+If no value is set for a configuration, the toolset's default warning level will be used.
+
+### Parameters ###
+
+`value` specifies the desired level of warning:
+
+| Value       | Description                                            |
+|-------------|--------------------------------------------------------|
+| Off         | Do not show any warning messages.                      |
+| Default     | Use the toolset's default warning level.               |
+| Extra       | Enable the toolset's maximum warning level.            |
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0
+
+### Examples ###
+
+```lua
+externalwarnings "Extra"
+```
+
+### See Also ###
+* [sysincludedirs](sysincludedirs.md)

--- a/website/docs/sysincludedirs.md
+++ b/website/docs/sysincludedirs.md
@@ -9,7 +9,7 @@ For Visual Studio, these paths are placed in the "VC++ Directories" properties p
 For GCC and Clang, they are preceded with the `-isystem` flag, rather than `-I`. For toolsets which do not support the concept of system include directories, they are treated as a normal include directory.
 
 Include files located via a system include directory are treated as correct: no warnings will be shown for the contents of the file.
-Note that this is different for visual studio.
+Note that this is different for Visual Studio.
 
 ### Parameters ###
 

--- a/website/docs/sysincludedirs.md
+++ b/website/docs/sysincludedirs.md
@@ -4,9 +4,12 @@ Specifies the system include file search paths.
 sysincludedirs { "paths" }
 ```
 
-For Visual Studio, these paths are placed in the "VC++ Directories" properties panel. For GCC and Clang, they are preceded with the `-isystem` flag, rather than `-I`. For toolsets which do not support the concept of system include directories, they are treated as a normal include directory.
+For Visual Studio, these paths are placed in the "VC++ Directories" properties panel under "External Include Directories". Note that unlike gcc and clang this does not control warning levels. See externalwarnings to control the warning level for sysincludes in visual studio.
+
+For GCC and Clang, they are preceded with the `-isystem` flag, rather than `-I`. For toolsets which do not support the concept of system include directories, they are treated as a normal include directory.
 
 Include files located via a system include directory are treated as correct: no warnings will be shown for the contents of the file.
+Note that this is different for visual studio.
 
 ### Parameters ###
 
@@ -38,3 +41,4 @@ sysincludedirs { "../includes/**" }
 
 * [includedirs](includedirs.md)
 * [syslibdirs](syslibdirs.md)
+* [externalwarnings](externalwarnings.md)


### PR DESCRIPTION
**What does this PR do?**
Add support for external warnings in visual studio

**How does this PR change Premake's behavior?**
sysincludedirs now works slightly different for visual studio.  Instead of adding the paths in sysincludedirs  "VC++ Directories" properties panel under "Include Directories" it will add it to "External Include Directories"

**Anything else we should know?**
It was only tested on visual studio 2019.

closes #1692

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

