### PR TITLE
VS2022 Exporter

### DIFF
--- a/modules/vstudio/_manifest.lua
+++ b/modules/vstudio/_manifest.lua
@@ -24,5 +24,6 @@ return {
 	"vs2013_vcxitems.lua",
 	"vs2015.lua",
 	"vs2017.lua",
-	"vs2019.lua"
+	"vs2019.lua",
+	"vs2022.lua"
 }

--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -21,6 +21,7 @@
 	include("vs2015.lua")
 	include("vs2017.lua")
 	include("vs2019.lua")
+	include("vs2022.lua")
 
 	-- Initialize Specific API
 

--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -101,5 +101,8 @@ return {
 	-- Visual Studio 2019+ C/C++ Projects
 	"vc2019/test_compile_settings.lua",
 	"vc2019/test_link.lua",
-	"vc2019/test_toolset_settings.lua"
+	"vc2019/test_toolset_settings.lua",
+
+	-- Visual Studio 2022+ C/C++ Projects
+	"vc2022/test_toolset_settings.lua"
 }

--- a/modules/vstudio/tests/vc2022/test_toolset_settings.lua
+++ b/modules/vstudio/tests/vc2022/test_toolset_settings.lua
@@ -1,0 +1,59 @@
+--
+-- tests/actions/vstudio/vc2010/test_compile_settings.lua
+-- Validate compiler settings in Visual Studio 2022 C/C++ projects.
+-- Copyright (c) 2011-2021 Jason Perkins and the Premake project
+--
+
+local p = premake
+local suite = test.declare("vstudio_vs2022_toolset_settings")
+local vc2010 = p.vstudio.vc2010
+local project = p.project
+
+--
+-- Setup
+--
+
+local wks, prj
+
+function suite.setup()
+	p.action.set("vs2022")
+	wks, prj = test.createWorkspace()
+end
+
+local function prepare(platform)
+	local cfg = test.getconfig(prj, "Debug", platform)
+	vc2010.configurationProperties(cfg)
+end
+
+---
+-- Check the default project settings
+---
+
+function suite.defaultSettings()
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v143</PlatformToolset>
+</PropertyGroup>
+	]]
+end
+
+---
+-- Check the project settings with the clang toolset
+---
+
+function suite.toolsetClang()
+	toolset "clang"
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>ClangCL</PlatformToolset>
+</PropertyGroup>
+	]]
+end

--- a/modules/vstudio/vs2022.lua
+++ b/modules/vstudio/vs2022.lua
@@ -1,0 +1,69 @@
+--
+-- vs2022.lua
+-- Extend the existing exporters with support for Visual Studio 2022.
+-- Copyright (c) Jason Perkins and the Premake project
+--
+
+local p = premake
+local vstudio = p.vstudio
+
+---
+-- Define the Visual Studio 2019 export action.
+---
+
+newaction {
+	-- Metadata for the command line and help system
+
+	trigger     = "vs2022",
+	shortname   = "Visual Studio 2022",
+	description = "Generate Visual Studio 2022 project files",
+
+	-- Visual Studio always uses Windows path and naming conventions
+
+	targetos = "windows",
+	toolset  = "msc-v143",
+
+	-- The capabilities of this action
+
+	valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Makefile", "None", "Utility", "SharedItems" },
+	valid_languages = { "C", "C++", "C#", "F#" },
+	valid_tools     = {
+		cc     = { "msc", "clang" },
+		dotnet = { "msnet" },
+	},
+
+	-- Workspace and project generation logic
+
+	onWorkspace = function(wks)
+		p.vstudio.vs2005.generateSolution(wks)
+	end,
+	onProject = function(prj)
+		p.vstudio.vs2010.generateProject(prj)
+	end,
+	onRule = function(rule)
+		p.vstudio.vs2010.generateRule(rule)
+	end,
+
+	onCleanWorkspace = function(wks)
+		p.vstudio.cleanSolution(wks)
+	end,
+	onCleanProject = function(prj)
+		p.vstudio.cleanProject(prj)
+	end,
+	onCleanTarget = function(prj)
+		p.vstudio.cleanTarget(prj)
+	end,
+
+	pathVars = vstudio.vs2010.pathVars,
+
+	-- This stuff is specific to the Visual Studio exporters
+
+	vstudio = {
+		solutionVersion = "12",
+		versionName     = "Version 16",
+		targetFramework = "4.7.2",
+		toolsVersion    = "15.0",
+		userToolsVersion = "Current",
+		filterToolsVersion = "4.0",
+	}
+}


### PR DESCRIPTION
**What does this PR do?**

Adds VS2022 support for C++ projects. Closes #1674. Needs follow on for research and implementation of C# projects in VS2022.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

Add any other context about your changes here.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
