### PR TITLE
Add OpenMP support for VisualStudio

### DIFF
--- a/modules/vstudio/tests/vc2019/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_compile_settings.lua
@@ -39,3 +39,30 @@
 	<SupportJustMyCode>false</SupportJustMyCode>
 		]]
 	end
+
+--
+-- Check ClCompile for OpenMPSupport
+--
+	function suite.openmpOn()
+		openmp "On"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<OpenMPSupport>true</OpenMPSupport>
+		]]
+	end
+
+	function suite.openmpOff()
+		openmp "Off"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<OpenMPSupport>false</OpenMPSupport>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -370,6 +370,7 @@
 			m.functionLevelLinking,
 			m.intrinsicFunctions,
 			m.justMyCodeDebugging,
+			m.supportOpenMP,
 			m.minimalRebuild,
 			m.omitFramePointers,
 			m.stringPooling,
@@ -2160,6 +2161,14 @@
 
 		if _ACTION >= "vs2017" and jmc == "Off" then
 			m.element("SupportJustMyCode", nil, "false")
+		end
+	end
+
+	function m.supportOpenMP(cfg)
+		if cfg.openmp == "On" then
+			m.element("OpenMPSupport", nil, "true")
+		elseif cfg.openmp == "Off" then
+			m.element("OpenMPSupport", nil, "false")
 		end
 	end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1449,6 +1449,16 @@
 		}
 	}
 
+	api.register {
+		name = "openmp",
+		scope = "project",
+		kind = "string",
+		allowed = {
+			"On",
+			"Off"
+		}
+	}
+
 -----------------------------------------------------------------------------
 --
 -- Field name aliases for backward compatibility

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -118,6 +118,10 @@
 		},
 		justmycode = {
 			Off = "false"
+		},
+		openmp = {
+			On = "/openmp",
+			Off = "/openmp-"
 		}
 
 	}

--- a/website/docs/openmp.md
+++ b/website/docs/openmp.md
@@ -1,0 +1,34 @@
+Enable or disable [OpenMP](https://en.wikipedia.org/wiki/OpenMP).
+
+```lua
+openmp "value"
+```
+If no value is set for a configuration, the toolset's default OpenMP option (usually Off) will be performed.
+
+### Parameters ###
+
+`value` is one of:
+
+| Value   | Description                                       |
+|---------|---------------------------------------------------|
+| On      | Turn on OpenMP.                                   |
+| Off     | Turn off OpenMP.                                  |
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0-beta1 or later. Currently only implemented for Visual Studio 2010+. As a workaround for other toolsets, you can use [buildoptions](buildoptions.md) like this:
+
+```lua
+filter "toolset:not msc*"
+	buildoptions "-fopenmp"
+```
+
+## Examples ##
+
+```lua
+openmp "On"
+```

--- a/website/docs/optimize.md
+++ b/website/docs/optimize.md
@@ -4,7 +4,7 @@ The **optimize** function specifies the level and type of optimization used whil
 optimize "value"
 ```
 
-If no value is set for a configuration, the toolsets default optimization (usually none) will be performed.
+If no value is set for a configuration, the toolset's default optimization (usually none) will be performed.
 
 ### Parameters ###
 

--- a/website/docs/strictaliasing.md
+++ b/website/docs/strictaliasing.md
@@ -4,7 +4,7 @@ Sets the level of allowed pointer aliasing.
 strictaliasing "value"
 ```
 
-If no value is set for a configuration, the toolsets settings will be used.
+If no value is set for a configuration, the toolset's settings will be used.
 
 ### Parameters ###
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -176,6 +176,7 @@ module.exports = {
 						'nuget',
 						'nugetsource',
 						'objdir',
+						'openmp',
 						'optimize',
 						'pchheader',
 						'pchsource',


### PR DESCRIPTION
**What does this PR do?**

When I tried to use Premake5 to set VisualStudio project property -> C++ -> Language -> Open MP Support, I didn't find any solution. I learned that [issue 1312](https://github.com/premake/premake-core/issues/1312) reported in the past and it also didn't get answered. So this PR add support for this compile option.

Closes #1312 

**How does this PR change Premake's behavior?**

It will add `<OpenMPSupport>true</OpenMPSupport>` node inside `<ClCompile>...</ClCompile>` group

**Anything else we should know?**

No.

**Did you check all the boxes?**

- [Yes] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [Yes] Add unit tests showing fix or feature works; all tests pass
- [Yes] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [Yes] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [Yes] Minimize the number of commits
- [Yes] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
