### PR TITLE
Deprecate configuration()

### DIFF
--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -1149,6 +1149,8 @@
 ---
 
 	function configuration(terms)
+		-- Sep 16 2021
+		premake.warnOnce("configuration", "`configuration` has been deprecated; use `filter` instead (https://premake.github.io/docs/Filters/)")
 		if terms then
 			if (type(terms) == "table" and #terms == 1 and terms[1] == "*") or (terms == "*") then
 				terms = nil

--- a/website/docs/Command-Line-Arguments.md
+++ b/website/docs/Command-Line-Arguments.md
@@ -40,10 +40,10 @@ newoption {
 Note the commas after each key-value pair; this is required Lua syntax for a table. Once added to your script, the option will appear in the help text, and you may use the trigger as a keyword in your configuration blocks.
 
 ```lua
-configuration "with-opengl"
+filter { "options:with-opengl" }
    links { "opengldrv" }
 
-configuration "not with-opengl"
+filter { "not options:with-opengl" }
    links { "direct3ddrv" }
 ```
 
@@ -58,7 +58,8 @@ newoption {
       { "opengl",    "OpenGL" },
       { "direct3d",  "Direct3D (Windows only)" },
       { "software",  "Software Renderer" }
-   }
+   },
+   default = "opengl"
 }
 ```
 
@@ -74,28 +75,14 @@ As before, this new option will be integrated into the help text, along with a d
 Unlike the example above, you now use the _value_ as a keyword in your configuration blocks.
 
 ```lua
-configuration "opengl"
+filter { "options:gfxapi=opengl" }
    links { "opengldrv" }
 
-configuration "direct3d"
+filter { "options:gfxapi=direct3d" }
     links { "direct3ddrv" }
 
-configuration "software"
+filter { "options:gfxapi=software" }
     links { "softwaredrv" }
-```
-
-Or you could be more clever.
-
-```lua
-links { _OPTIONS["gfxapi"] .. "drv" }
-```
-
-In this example, you would also want to provide a default behavior for the case where no option is specified. You could place a bit of code like this anywhere in your script.
-
-```lua
-if not _OPTIONS["gfxapi"] then
-   _OPTIONS["gfxapi"] = "opengl"
-end
 ```
 
 As a last example of options, you may want to specify an option that accepts an unconstrained value, such as an output path. Just leave off the list of allowed values.

--- a/website/docs/buildoptions.md
+++ b/website/docs/buildoptions.md
@@ -23,6 +23,6 @@ Premake 4.0 or later.
 Use `pkg-config` style configuration when building on Linux with GCC. Build options are always compiler specific and should be targeted to a particular toolset.
 
 ```lua
-configuration { "linux", "gmake" }
+filter { "system:linux", "action:gmake" }
   buildoptions { "`wx-config --cxxflags`", "-ansi", "-pedantic" }
 ```

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -4,7 +4,7 @@ Limits the subsequent build settings to a particular environment.
 configuration { "keywords" }
 ```
 
-**This function will soon be deprecated and its use is discouraged.** Use the new [filter()](filter.md) function instead; you will get more granular matching and much better performance.
+**This function has been deprecated in Premake 5.0 beta1.** Use the new [filter()](filter.md) function instead; you will get more granular matching and much better performance. `configuration()` will be not supported in Premake 6.
 
 ### Parameters ###
 

--- a/website/docs/debugargs.md
+++ b/website/docs/debugargs.md
@@ -23,6 +23,6 @@ Premake 4.4 or later.
 ### Examples ###
 
 ```lua
-configuration "Debug"
+filter { "configurations:Debug" }
    debugargs { "--append", "somefile.txt" }
 ```

--- a/website/docs/debugdir.md
+++ b/website/docs/debugdir.md
@@ -24,6 +24,6 @@ Premake 4.4 or later.
 ### Examples ###
 
 ```lua
-configuration "Debug"
+filter { "configurations:Debug" }
    debugdir "bin/debug"
 ```

--- a/website/docs/implibsuffix.md
+++ b/website/docs/implibsuffix.md
@@ -20,7 +20,7 @@ Premake 4.0 or later.
 
 ```lua
 -- Add "-d" to debug versions of files
-configuration "Debug"
+filter { "configurations:Debug" }
    implibsuffix "-d"
 ```
 

--- a/website/docs/linkoptions.md
+++ b/website/docs/linkoptions.md
@@ -22,6 +22,6 @@ Premake 4.0 or later.
 Use `pkg-config` style configuration when building on Linux with GCC. Build options are always linker specific and should be targeted to a particular toolset.
 
 ```lua
-configuration { "linux", "gmake" }
+filter { "system:linux", "action:gmake" }
   linkoptions { "`wx-config --libs`" }
 ```

--- a/website/docs/links.md
+++ b/website/docs/links.md
@@ -31,13 +31,13 @@ Premake 4.0 or later.
 Link against some system libraries.
 
 ```lua
-configuration "windows"
+filter { "system:windows" }
    links { "user32", "gdi32" }
 
-configuration "linux"
+filter { "system:linux" }
    links { "m", "png" }
 
-configuration "macosx"
+filter { "system:macosx" }
    -- OS X frameworks need the extension to be handled properly
    links { "Cocoa.framework", "png" }
   ```

--- a/website/docs/postbuildcommands.md
+++ b/website/docs/postbuildcommands.md
@@ -19,10 +19,10 @@ Premake 4.4 or later.
 ### Examples ###
 
 ```lua
-configuration "windows"
+filter { "system:windows" }
    postbuildcommands { "copy default.config bin\\project.config" }
 
-configuration "not windows"
+filter { "not system:windows" }
    postbuildcommands { "cp default.config bin/project.config" }
 ```
 

--- a/website/docs/prebuildcommands.md
+++ b/website/docs/prebuildcommands.md
@@ -19,10 +19,10 @@ Premake 4.4 or later.
 ### Examples ###
 
 ```lua
-configuration "windows"
+filter { "system:windows" }
    prebuildcommands { "copy default.config bin\\project.config" }
 
-configuration "not windows"
+filter { "not system:windows" }
    prebuildcommands { "cp default.config bin/project.config" }
 ```
 

--- a/website/docs/prelinkcommands.md
+++ b/website/docs/prelinkcommands.md
@@ -19,10 +19,10 @@ Premake 4.4 or later.
 ### Examples ###
 
 ```lua
-configuration "windows"
+filter { "system:windows" }
    prelinkcommands { "copy default.config bin\\project.config" }
 
-configuration "not windows"
+filter { "not system:windows" }
    prelinkcommands { "cp default.config bin/project.config" }
 ```
 

--- a/website/docs/resoptions.md
+++ b/website/docs/resoptions.md
@@ -21,6 +21,6 @@ Premake 4.0 or later.
 Use `pkg-config` style configuration when building on Linux with GCC. Build options are always compiler specific and should be targeted to a particular toolset.
 
 ```lua
-configuration { "linux", "gmake" }
+filter { "system:linux", "action:gmake" }
   resoptions { "`wx-config --cxxflags`", "-ansi", "-pedantic" }
 ```

--- a/website/docs/targetdir.md
+++ b/website/docs/targetdir.md
@@ -25,10 +25,10 @@ This project separates its compiled output by configuration type.
 ```lua
 project "MyProject"
 
-  configuration "Debug"
+  filter { "configurations:Debug" }
     targetdir "bin/debug"
 
-  configuration "Release"
+  filter { "configurations:Release" }
     targetdir "bin/release"
 ```
 

--- a/website/docs/targetsuffix.md
+++ b/website/docs/targetsuffix.md
@@ -20,7 +20,7 @@ Premake 4.0 or later.
 
 ```lua
 -- Add "-d" to debug versions of files
-configuration "Debug"
+filter { "configurations:Debug" }
    targetsuffix "-d"
 ```
 


### PR DESCRIPTION
**What does this PR do?**

Marks `configuration()` as deprecated. We'll continue supporting it for 5.0, but it will not be included in Premake 6.

**How does this PR change Premake's behavior?**

No breaking changes, just a warning message.

**Anything else we should know?**

Nope.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] ~~Add unit tests showing fix or feature works; all tests pass~~ (n/a)
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
