### PR TITLE
Added missing compileas values to docs

### DIFF
--- a/website/docs/compileas.md
+++ b/website/docs/compileas.md
@@ -10,6 +10,11 @@ compileas "value"
 * `Default` - Compile based on file extensions that have been built into premake.
 * `C` - Compile as a C source file.
 * `C++` - Compile as a C++ source file.
+* `Objective-C` - Compile as an Objective-C source file.
+* `Objective-C++` - Compile as an Objective-C++ source file.
+* `Module` - Needs documentation
+* `ModulePartition` - Needs documentation
+* `HeaderUnit` - Needs documentation
 
 ### Applies To ###
 


### PR DESCRIPTION
**What does this PR do?**

Adds missing values to `compileas` documentation.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

I wasn't sure what the `Module`, `ModulePartition` and `HeaderUnit` values actually do, so I left these as "needs documentation".

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
