### PR TITLE
Add VS 2022 bootstrapping support

### DIFF
--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -33,6 +33,9 @@ IF "%vsversion%" == "vs2010" (
 ) ELSE IF "%vsversion%" == "vs2019" (
 	CALL :VsWhereVisualBootstrap "%vsversion%" "16.0" "17.0"
 
+) ELSE IF "%vsversion%" == "vs2022" (
+	CALL :VsWhereVisualBootstrap "%vsversion%" "17.0" "18.0"
+
 ) ELSE (
 	ECHO Unrecognized Visual Studio version %vsversion%
 	EXIT /B 2


### PR DESCRIPTION
**What does this PR do?**

Adds a check for "vs2022" in Bootstrap.bat (for building from source on Windows).

**How does this PR change Premake's behavior?**

This is a small change I had to make in order to be able to build premake with Visual Studio 2022 RC support (had to build from the repo). Related change: #1704

**Anything else we should know?**

I added both 17.0 and 18.0, following the previous version check pattern.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
