### PR TITLE
Change Visual Studio Version to 17 so sln is opened with VS2022

### DIFF
--- a/modules/vstudio/tests/sln2005/test_header.lua
+++ b/modules/vstudio/tests/sln2005/test_header.lua
@@ -76,3 +76,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 		]]
 	end
+
+
+	function suite.on2022()
+		p.action.set("vs2022")
+		prepare()
+		test.capture [[
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+		]]
+	end

--- a/modules/vstudio/vs2022.lua
+++ b/modules/vstudio/vs2022.lua
@@ -60,7 +60,7 @@ newaction {
 
 	vstudio = {
 		solutionVersion = "12",
-		versionName     = "Version 16",
+		versionName     = "Version 17",
 		targetFramework = "4.7.2",
 		toolsVersion    = "15.0",
 		userToolsVersion = "Current",


### PR DESCRIPTION
**What does this PR do?**

Change the VS version from 16 to 17 so to correctly match what VS2022 solutions look like.

**How does this PR change Premake's behavior?**

None

**Anything else we should know?**

None

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [X] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
