### PR TITLE
Added check for missing values in documentation to docs-check action

### DIFF
--- a/scripts/docscheck.lua
+++ b/scripts/docscheck.lua
@@ -6,7 +6,20 @@
 	for k,v in pairs(premake.field._loweredList) do
 		local docfilepath = "../website/docs/" .. k .. ".md"
 		local exists = os.isfile(docfilepath)
-		if not exists then
+		if exists then
+			local docfile = io.open(docfilepath, "r")
+			local text = docfile:read("*all")
+			docfile:close()
+			-- Verify that every value is listed
+			if type(v.allowed) == "table" then
+				for _,value in ipairs(v.allowed) do
+					if type(value) == "string" and not string.find(text, value, 1, true) then
+						count = count + 1
+						print(k .. " missing value `" .. value .. "`")
+					end
+				end
+			end
+		else
 			print("Missing documentation file for: ", k)
 			count = count + 1
 		end

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -13,6 +13,11 @@ architecture ("value")
 * `x86_64`
 * `ARM`
 * `ARM64`
+* `armv5`: Only supported in VSAndroid projects
+* `armv7`: Only supported in VSAndroid projects
+* `aarch64`: Only supported in VSAndroid projects
+* `mips`: Only supported in VSAndroid projects
+* `mips64`: Only supported in VSAndroid projects
 
 Additional values that are aliases for the above:
 

--- a/website/docs/clr.md
+++ b/website/docs/clr.md
@@ -17,6 +17,7 @@ See [/clr (Common Language Runtime Compilation)](http://msdn.microsoft.com/en-us
 | Pure        | Enable pure mode MSIL. Equivalent to "On" for .NET projects.           |
 | Safe        | Enable verifiable MSIL. Equivalent to "On" for .NET projects.          |
 | Unsafe      | Enable unsafe operations. Equivalent to "On" for Managed C++ projects. |
+| NetCore     | Needs documentation                                                    |
 
 CLR settings that do not make sense for the current configuration, such setting CLR support for a C# project to "Off", will be ignored.
 

--- a/website/docs/debugformat.md
+++ b/website/docs/debugformat.md
@@ -10,7 +10,10 @@ debugformat "format"
 
 | Value       | Description                                                                                 |
 |-------------|---------------------------------------------------------------------------------------------|
+| Default     | Specifies default debug format should be used by toolset.                                   |
 | c7          | Specifies that MSVC should store debuginfo in the objects rather than a separate .pdb file. |
+| Dwarf       | Needs documentation                                                                         |
+| SplitDwarf  | Needs documetation                                                                          |
 
 **Note for Visual Studio Users:** Use [editandcontinue](editandcontinue.md) to control the `/Zi` and `/ZI` switches; see [this discussion](https://github.com/premake/premake-core/issues/1425) for more information.
 

--- a/website/docs/debugger.md
+++ b/website/docs/debugger.md
@@ -10,6 +10,10 @@ debugger "value"
 * `Default` - needs documentation.
 * `GDB` - needs documentation.
 * `LLDB` - needs documentation.
+* `VisualStudioLocal` - needs documentation.
+* `VisualStudioRemote` - needs documentation.
+* `VisualStudioWebBrowser` - needs documentation.
+* `VisualStudioWebService` - needs documentation.
 
 ### Applies To ###
 

--- a/website/docs/editandcontinue.md
+++ b/website/docs/editandcontinue.md
@@ -8,7 +8,7 @@ If no value is set for a configuration, the toolset's default setting (usually "
 
 ### Parameters ###
 
-`value` is a boolean value, i.e. "On" or "Off".
+`value` is a boolean value, i.e. "On" or "Off". Specifying "Default" will act the same as specifying no value, the toolset's default setting will be used.
 
 ### Applies To ###
 

--- a/website/docs/exceptionhandling.md
+++ b/website/docs/exceptionhandling.md
@@ -14,6 +14,8 @@ exceptionhandling ("value")
 | On      | Turn on exceptions.                               |
 | Off     | Turn off exceptions.                              |
 | SEH     | Turn on exceptions and use [structured exception handling](https://msdn.microsoft.com/en-us/library/windows/desktop/ms680657(v=vs.85).aspx) when available. |
+| CThrow  | Needs documentation                               |
+| UnwindTables | Needs documentation                          |
 
 
 ### Applies To ###

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -40,6 +40,50 @@ flags { "flag_list" }
 | C++14                 | Pass the c++14 flag to the gcc/clang compilers (msvc ignores this currently) |
 | C90                   | Pass the c90 flag to the gcc/clang compilers (msvc ignores this currently) |
 | C99                   | Pass the c99 flag to the gcc/clang compilers (msvc ignores this currently) |
+| Component             | Needs documentation                                                        |
+| DebugEnvsDontMerge    | Needs documentation                                                        |
+| DebugEnvsInherit      | Needs documentation                                                        |
+| EnableSSE             | Needs documentation                                                        |
+| EnableSSE2            | Needs documentation                                                        |
+| ExtraWarnings         | Needs documentation                                                        |
+| FloatFast             | Needs documentation                                                        |
+| FloatStrict           | Needs documentation                                                        |
+| Managed               | Needs documentation                                                        |
+| NoNativeWChar         | Needs documentation                                                        |
+| NoEditAndContinue     | Needs documentation                                                        |
+| NoWarnings            | Needs documentation                                                        |
+| Optimize              | Needs documentation                                                        |
+| OptimizeSize          | Needs documentation                                                        |
+| OptimizeSpeed         | Needs documentation                                                        |
+| ReleaseRuntime        | Needs documentation                                                        |
+| Symbols               | Needs documentation                                                        |
+| C11                   | Needs documentation                                                        |
+| CodeCoverage          | Needs documentation                                                        |
+| Color                 | Needs documentation                                                        |
+| Documentation         | Needs documentation                                                        |
+| GenerateHeader        | Needs documentation                                                        |
+| GenerateJSON          | Needs documentation                                                        |
+| GenerateMap           | Needs documentation                                                        |
+| LowMem                | Needs documentation                                                        |
+| Profile               | Needs documentation                                                        |
+| Quiet                 | Needs documentation                                                        |
+| RetainPaths           | Needs documentation                                                        |
+| SymbolsLikeC          | Needs documentation                                                        |
+| UnitTest              | Needs documentation                                                        |
+| UseLDC                | Needs documentation                                                        |
+| ProfileGC             | Needs documentation                                                        |
+| StackFrame            | Needs documentation                                                        |
+| StackStomp            | Needs documentation                                                        |
+| AllInstantiate        | Needs documentation                                                        |
+| BetterC               | Needs documentation                                                        |
+| PerformSyntaxCheckOnly| Needs documentation                                                        |
+| ShowCommandLine       | Needs documentation                                                        |
+| Verbose               | Needs documentation                                                        |
+| ShowTLS               | Needs documentation                                                        |
+| ShowGC                | Needs documentation                                                        |
+| IgnorePragma          | Needs documentation                                                        |
+| ShowDependencies      | Needs documentation                                                        |
+| Thumb                 | Needs documentation                                                        |
 
 ### Applies To ###
 

--- a/website/docs/floatingpoint.md
+++ b/website/docs/floatingpoint.md
@@ -15,6 +15,7 @@ If no value is set for a configuration, the toolset's default floating point set
 | Default     | Use the toolset's floating point settings.                        |
 | Fast        | Enable floating point optimizations at the expense of accuracy.   |
 | Strict      | Improve floating point consistency at the expense of performance. |
+| None        | Needs documentation                                               |
 
 ### Applies To ###
 
@@ -23,6 +24,8 @@ Project configurations.
 ### Availability ###
 
 Premake 5.0 or later.
+
+The **None** option is only available for VisualD projects.
 
 ### Examples ###
 

--- a/website/docs/kind.md
+++ b/website/docs/kind.md
@@ -18,6 +18,7 @@ kind ("kind")
 | Utility     | A configuration which contains only custom build rules. |
 | None        | A configuration which is not included in the build. Useful for projects containing only web pages, header files, or support documentation. |
 | Packaging   | A configuration type to create .androidproj files, which build the apk in an Android application under Visual Studio. _Note, this was previously `AndroidProj`._ |
+| SharedItems | A special configuration type which doesn't contain any build settings of its own, instead using the build settings of any projects that link it. |
 
 
 ### Applies To ###
@@ -28,6 +29,7 @@ Project configurations.
 
 The **Makefile**,  and **None** kinds are only available in Premake 5.0 and later, and are currently only supported for Visual Studio. 
 The **Utility** kind is only available for Visual Studio and gmake2, as well as very limited support in gmake.
+The **SharedItems** kind is only available for Visual Studio 2013 and later.
 
 ### Examples ###
 

--- a/website/docs/sharedlibtype.md
+++ b/website/docs/sharedlibtype.md
@@ -9,6 +9,7 @@ sharedlibtype "value"
 `value` one of:
 * `OSXBundle` - needs documentation.
 * `OSXFramework` - needs documentation.
+* `XCTest` - needs documentation.
 
 ### Applies To ###
 

--- a/website/docs/staticruntime.md
+++ b/website/docs/staticruntime.md
@@ -8,9 +8,9 @@ staticruntime "value"
 
 | Value      | Visual Studio                                 | XCode     | gmake     |
 |------------|-----------------------------------------------|-----------|-----------|
-| `on`       | Sets `<RuntimeLibrary>` to "MultiThreaded"    | No Effect | No Effect |
-| `off`      | Sets `<RuntimeLibrary>` to "MultiThreadedDLL" | No Effect | No Effect |
-| `default`  | Does not set a value for `<RuntimeLibrary>`   | No Effect | No Effect |
+| `Default`  | Does not set a value for `<RuntimeLibrary>`   | No Effect | No Effect |
+| `On`       | Sets `<RuntimeLibrary>` to "MultiThreaded"    | No Effect | No Effect |
+| `Off`      | Sets `<RuntimeLibrary>` to "MultiThreadedDLL" | No Effect | No Effect |
 
 ### Applies To ###
 

--- a/website/docs/system.md
+++ b/website/docs/system.md
@@ -11,8 +11,10 @@ If no system is specified, Premake will identify and target the current operatin
 `value` is one of:
 
 * aix
+* android
 * bsd
 * [haiku](http://www.haiku-os.org)
+* ios
 * linux
 * macosx
 * solaris

--- a/website/docs/visibility.md
+++ b/website/docs/visibility.md
@@ -14,7 +14,8 @@ By default, the generated project files will use the compilers default settings 
 |-------------|--------------|
 | `Default`   | gcc          |
 | `Hidden`    | gcc          |
-| `Inline`    | gcc          |
+| `Internal`  | gcc          |
+| `Protected` | gcc          |
 
 ### Applies To ###
 

--- a/website/docs/warnings.md
+++ b/website/docs/warnings.md
@@ -15,6 +15,8 @@ If no value is set for a configuration, the toolset's default warning level will
 | Off         | Do not show any warning messages.                      |
 | Default     | Use the toolset's default warning level.               |
 | Extra       | Enable the toolset's maximum warning level.            |
+| High        | Needs documentation                                    |
+| Everything  | Needs documentation                                    |
 
 ### Applies To ###
 


### PR DESCRIPTION
- Added missing values in documentation files

**What does this PR do?**

Adds missing values in the documentation, and adds check for missing values to docs-check action.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

Various values added to docs in this PR require proper documentation. The `flags` API should probably have a separate table for deprecated values.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
