### PR TITLE
Adding documentation for module options

### DIFF
--- a/website/docs/compileas.md
+++ b/website/docs/compileas.md
@@ -12,9 +12,9 @@ compileas "value"
 * `C++` - Compile as a C++ source file.
 * `Objective-C` - Compile as an Objective-C source file.
 * `Objective-C++` - Compile as an Objective-C++ source file.
-* `Module` - Needs documentation
-* `ModulePartition` - Needs documentation
-* `HeaderUnit` - Needs documentation
+* `Module` - Compile as a C++20 module interface unit.
+* `ModulePartition` - Compile as a C++20 module interface partition.
+* `HeaderUnit` - Compile as a C++20 header unit.
 
 ### Applies To ###
 
@@ -22,7 +22,7 @@ The `workspace`, `project` or `file` scope.
 
 ### Availability ###
 
-Premake 5.0.0 alpha 13 or later.
+Premake 5.0.0 alpha 13 or later. The options **Module**, **ModulePartition** and **HeaderUnit** are only available in Premake 5.0-beta1 or later and only implemented for Visual Studio 2019+.
 
 ### Examples ###
 


### PR DESCRIPTION
**What does this PR do?**

The website currently does not fully document the module-related options for the `compileas` setting. I implemented these settings in #1570. I added basic descriptions about what the individual settings do. The terms used reflect those used in the C++20 standard. I think more detailed descriptions aren't necessary, as they would probably easily branch out into a lengthy description of C++20 modules, which shouldn't be the purpose of this page.

**How does this PR change Premake's behavior?**

In no way. It's purely documentation.

**Anything else we should know?**

No.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [X] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
