### PR TITLE
Added API for CompileAsWinRT

### DIFF
--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -1627,3 +1627,58 @@
 </ClCompile>
 		]]
 	end
+
+--
+-- If consumewinrtextension flag is set, add <CompileAsWinRT> element
+--
+
+	function suite.onconsumewinrtextensionOff()
+		p.action.set("vs2019")
+		consumewinrtextension "Off"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<CompileAsWinRT>false</CompileAsWinRT>
+		]]
+	end
+
+	function suite.onconsumewinrtextensionOn()
+		p.action.set("vs2019")
+		consumewinrtextension "On"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<CompileAsWinRT>true</CompileAsWinRT>
+		]]
+	end
+
+	function suite.onconsumewinrtextensionNotSpecified()
+		p.action.set("vs2019")
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+</ClCompile>
+		]]
+	end
+
+	function suite.onconsumewinrtextensionOn_BeforeVS2019()
+		p.action.set("vs2017")
+		consumewinrtextension "On"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+</ClCompile>
+		]]
+	end

--- a/modules/vstudio/tests/vc2010/test_files.lua
+++ b/modules/vstudio/tests/vc2010/test_files.lua
@@ -903,3 +903,37 @@
 </ItemGroup>
 		]]
 	end
+	
+--
+-- test consumewinrtextension set for a single file
+--
+
+	function suite.consumewinrtextensionPerFile()
+		p.action.set("vs2019")
+		files { "hello.cpp", "hello2.cpp" }
+		filter { "files:hello.cpp" }
+			consumewinrtextension 'On'
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="hello.cpp">
+		<CompileAsWinRT>true</CompileAsWinRT>
+	</ClCompile>
+	<ClCompile Include="hello2.cpp" />
+</ItemGroup>
+		]]
+	end
+
+	function suite.consumewinrtextensionPerFile_BeforeVS2019()
+		p.action.set("vs2017")
+		files { "hello.cpp", "hello2.cpp" }
+		filter { "files:hello.cpp" }
+			consumewinrtextension 'On'
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="hello.cpp" />
+	<ClCompile Include="hello2.cpp" />
+</ItemGroup>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -392,7 +392,8 @@
 			m.conformanceMode,
 			m.structMemberAlignment,
 			m.useFullPaths,
-			m.removeUnreferencedCodeData
+			m.removeUnreferencedCodeData,
+			m.compileAsWinRT,
 		}
 
 		if cfg.kind == p.STATICLIB then
@@ -815,6 +816,7 @@
 						m.compileAs,
 						m.runtimeTypeInfo,
 						m.warningLevelFile,
+						m.compileAsWinRT,
 					}
 				else
 					return {
@@ -1527,6 +1529,14 @@
 				m.element("RemoveUnreferencedCodeData", nil, "true")
 			else
 				m.element("RemoveUnreferencedCodeData", nil, "false")
+			end
+		end
+	end
+
+	function m.compileAsWinRT(cfg, condition)
+		if _ACTION >= "vs2019" then
+			if cfg and cfg.consumewinrtextension ~= nil then
+				m.element("CompileAsWinRT", condition, iif(cfg.consumewinrtextension, "true", "false"))
 			end
 		end
 	end

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -204,6 +204,12 @@
 	}
 
 	api.register {
+		name = "consumewinrtextension",
+		scope = "config",
+		kind = "boolean",
+	}
+
+	api.register {
 		name = "copylocal",
 		scope = "config",
 		kind = "list:mixed",

--- a/website/docs/consumewinrtextension.md
+++ b/website/docs/consumewinrtextension.md
@@ -1,0 +1,28 @@
+Enables the WinRT extension, C++/CX, for the specified projects/files.
+
+```lua
+consumewinrtextension "value"
+```
+
+### Parameters ###
+
+`value` is one of:
+* `Default` - Compiles the file using the default for the toolset. (Default is `Off`)
+* `On` - Compiles the file with the WinRT extension enabled.
+* `Off` - Compiles the file without the WinRT extension enabled.
+
+### Applies To ###
+
+The `workspace`, `project` or `file` scope.
+
+### Availability ###
+
+Premake 5.0.0 Beta 2 or later and only implemented for Visual Studio 2019+.
+
+### Examples ###
+
+```lua
+filter { "files:**_winrt.cpp" }
+    consumewinrtextension "On"
+```
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -94,6 +94,7 @@ module.exports = {
 						'configuration',
 						'configurations',
 						'conformancemode',
+						'consumewinrtextension',
 						'copylocal',
 						'cppdialect',
 						'csversion',


### PR DESCRIPTION
**What does this PR do?**

Adds API to consume the Windows Runtime language extensions.

**How does this PR change Premake's behavior?**

No breaking changes, only adds the element when the API is set.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
