### PR TITLE
Added support for AppxManifest files

### DIFF
--- a/modules/vstudio/tests/vc2010/test_files.lua
+++ b/modules/vstudio/tests/vc2010/test_files.lua
@@ -89,6 +89,19 @@
 		]]
 	end
 
+	function suite.appxManifestCompile_onAppxManifestFile()
+		files { "hello.appxmanifest" }
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<AppxManifest Include="hello.appxmanifest">
+		<FileType>Document</FileType>
+		<SubType>Designer</SubType>
+	</AppxManifest>
+</ItemGroup>
+		]]
+	end
+
 
 --
 -- Check handling of buildaction.

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1049,6 +1049,32 @@
 
 
 ---
+-- AppxManifest group
+---
+	m.categories.AppxManifest = {
+		name       = "AppxManifest",
+		extensions = { ".appxmanifest" },
+		priority   = 12,
+
+		emitFiles = function(prj, group)
+			local fileFunc = {
+				m.fileType,
+				m.subType,
+			}
+
+			local fileCfgFunc = {
+				m.excludedFromBuild,
+			}
+
+			m.emitFiles(prj, group, "AppxManifest", fileFunc, fileCfgFunc)
+		end,
+
+		emitFilter = function(prj, group)
+			m.filterGroup(prj, group, "AppxManifest")
+		end
+	}
+
+---
 -- Categorize files into groups.
 ---
 	function m.categorizeSources(prj)
@@ -1846,6 +1872,11 @@
 
 	function m.fileType(cfg, file)
 		m.element("FileType", nil, "Document")
+	end
+
+
+	function m.subType(cfg, file)
+		m.element("SubType", nil, "Designer")
 	end
 
 


### PR DESCRIPTION
**What does this PR do?**

Adds VS category for AppxManifest files.

**How does this PR change Premake's behavior?**

I don't believe this will break anything. Will cause `.appxmanifest` files to be compiled.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
