### PR TITLE
Add "support" for `kind "None"` (as do nothing) for gmake/gmake2.

### DIFF
--- a/modules/gmake/_preload.lua
+++ b/modules/gmake/_preload.lua
@@ -17,7 +17,7 @@
 		description     = "Generate GNU makefiles for POSIX, MinGW, and Cygwin",
 		toolset         = "gcc",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Utility", "Makefile" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Utility", "Makefile", "None" },
 		valid_languages = { "C", "C++", "C#" },
 		valid_tools     = {
 			cc     = { "clang", "gcc" },
@@ -26,13 +26,17 @@
 
 		onWorkspace = function(wks)
 			p.escaper(p.make.esc)
+			wks.projects = table.filter(wks.projects, function(prj) return p.action.supports(prj.kind) and prj.kind ~= p.NONE end)
 			p.generate(wks, p.make.getmakefilename(wks, false), p.make.generate_workspace)
 		end,
 
 		onProject = function(prj)
 			p.escaper(p.make.esc)
 			local makefile = p.make.getmakefilename(prj, true)
-			if prj.kind == p.UTILITY then
+
+			if not p.action.supports(prj.kind) or prj.kind == p.NONE then
+				return
+			elseif prj.kind == p.UTILITY then
 				p.generate(prj, makefile, p.make.utility.generate)
 			elseif prj.kind == p.MAKEFILE then
 				p.generate(prj, makefile, p.make.makefile.generate)

--- a/modules/gmake2/_preload.lua
+++ b/modules/gmake2/_preload.lua
@@ -17,7 +17,7 @@
 		description     = "Generate GNU makefiles for POSIX, MinGW, and Cygwin",
 		toolset         = "gcc",
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Utility", "Makefile" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Utility", "Makefile", "None" },
 
 		valid_languages = { "C", "C++", "C#" },
 
@@ -33,13 +33,17 @@
 
 		onWorkspace = function(wks)
 			p.escaper(p.modules.gmake2.esc)
+			wks.projects = table.filter(wks.projects, function(prj) return p.action.supports(prj.kind) and prj.kind ~= p.NONE end)
 			p.generate(wks, p.modules.gmake2.getmakefilename(wks, false), p.modules.gmake2.generate_workspace)
 		end,
 
 		onProject = function(prj)
 			p.escaper(p.modules.gmake2.esc)
 			local makefile = p.modules.gmake2.getmakefilename(prj, true)
-			if prj.kind == p.UTILITY then
+
+			if not p.action.supports(prj.kind) or prj.kind == p.NONE then
+				return
+			elseif prj.kind == p.UTILITY then
 				p.generate(prj, makefile, p.modules.gmake2.utility.generate)
 			elseif prj.kind == p.MAKEFILE then
 				p.generate(prj, makefile, p.modules.gmake2.makefile.generate)

--- a/website/docs/kind.md
+++ b/website/docs/kind.md
@@ -27,7 +27,8 @@ Project configurations.
 
 ### Availability ###
 
-The **Makefile**,  and **None** kinds are only available in Premake 5.0 and later, and are currently only supported for Visual Studio. 
+The **Makefile** kind is available in Premake 5.0 and later, and are supported for Visual Studio.
+The **None** kind is available in Premake 5.0 and later, and are supported for gmake, gmake2 and Visual Studio.
 The **Utility** kind is only available for Visual Studio and gmake2, as well as very limited support in gmake.
 The **SharedItems** kind is only available for Visual Studio 2013 and later.
 


### PR DESCRIPTION
**What does this PR do?**

Add "support" for `kind "None"` (as do nothing) for gmake/gmake2.

**How does this PR change Premake's behavior?**

Just change gmake/gmake2 generators.

**Anything else we should know?**

closes #1149
Tested also with my testing repo https://github.com/Jarod42/premake-sample-projects/tree/GMakeKindNone

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
