### PR TITLE
Add support of `kind "None"` for Codelite.

### DIFF
--- a/modules/codelite/_preload.lua
+++ b/modules/codelite/_preload.lua
@@ -22,7 +22,7 @@
 
 		-- The capabilities of this action
 
-		valid_kinds     = { "ConsoleApp", "WindowedApp", "Makefile", "SharedLib", "StaticLib", "Utility" },
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "Makefile", "None", "SharedLib", "StaticLib", "Utility" },
 		valid_languages = { "C", "C++" },
 		valid_tools     = {
 			cc = { "gcc", "clang", "msc" }

--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -86,6 +86,8 @@
 		ConsoleApp = "Console",
 		WindowedApp = "Console",
 		Makefile = "",
+		None = "",
+		Utility = "",
 		SharedLib = "Library",
 		StaticLib = "Library"
 	}
@@ -189,7 +191,7 @@
 	end
 
 	function m.compiler(cfg)
-		if configuration_iscustombuild(cfg) or configuration_isfilelist(cfg) then
+		if cfg.project.kind == p.NONE or configuration_iscustombuild(cfg) or configuration_isfilelist(cfg) then
 			_p(3, '<Compiler Required="no"/>')
 			return
 		end
@@ -219,7 +221,7 @@
 	end
 
 	function m.linker(cfg)
-		if configuration_iscustombuild(cfg) or configuration_isfilelist(cfg) then
+		if cfg.project.kind == p.NONE or configuration_iscustombuild(cfg) or configuration_isfilelist(cfg) then
 			_p(3, '<Linker Required="no"/>')
 			return
 		end
@@ -471,6 +473,7 @@
 		SharedLib   = "Dynamic Library",
 		StaticLib   = "Static Library",
 		WindowedApp = "Executable",
+		None = "",
 		Utility     = "",
 	}
 
@@ -493,7 +496,7 @@
 			local cfgname  = codelite.cfgname(cfg)
 			local compiler = m.getcompilername(cfg)
 			local debugger = m.debuggers[cfg.debugger] or m.debuggers.Default
-			local type = m.types[cfg.kind]
+			local type = m.types[cfg.kind] or ""
 
 			_x(2, '<Configuration Name="%s" CompilerType="%s" DebuggerType="%s" Type="%s" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">', cfgname, compiler, debugger, type)
 

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -27,6 +27,14 @@
 		cfg = test.getconfig(prj, "Debug")
 	end
 
+	function suite.OnProjectCfg_KindNone()
+		kind "None"
+		prepare()
+		codelite.project.compiler(cfg)
+		test.capture [[
+      <Compiler Required="no"/>
+		]]
+	end
 
 	function suite.OnProjectCfg_Compiler()
 		prepare()
@@ -100,6 +108,15 @@
 		test.capture [[
       <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="pch.h" PCHInCommandLine="yes" UseDifferentPCHFlags="no" PCHFlags="">
       </Compiler>
+		]]
+	end
+
+	function suite.OnProjectCfg_LinkerKindNone()
+		kind "None"
+		prepare()
+		codelite.project.linker(cfg)
+		test.capture [[
+      <Linker Required="no"/>
 		]]
 	end
 

--- a/website/docs/kind.md
+++ b/website/docs/kind.md
@@ -27,9 +27,9 @@ Project configurations.
 
 ### Availability ###
 
-The **Makefile** kind is available in Premake 5.0 and later, and are supported for Visual Studio.
-The **None** kind is available in Premake 5.0 and later, and are supported for gmake, gmake2 and Visual Studio.
-The **Utility** kind is only available for Visual Studio and gmake2, as well as very limited support in gmake.
+The **Makefile** kind is available in Premake 5.0 and later, and are supported for Visual Studio and Codelite.
+The **None** kind is available in Premake 5.0 and later, and are supported for gmake, gmake2, Codelite and Visual Studio.
+The **Utility** kind is only available for Visual Studio, Codelite and gmake2, as well as very limited support in gmake.
 The **SharedItems** kind is only available for Visual Studio 2013 and later.
 
 ### Examples ###


### PR DESCRIPTION
**What does this PR do?**

Add support of `kind "None"` for Codelite.
-> project without compilation/link

**How does this PR change Premake's behavior?**

Only Codelite generator is changed

**Anything else we should know?**

Also tested on my integration test repo:
https://github.com/Jarod42/premake-sample-projects/runs/4332430852?check_suite_focus=true

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
