### PR TITLE
Always use `llvm-ar` for Clang

### DIFF
--- a/modules/gmake/tests/cpp/test_clang.lua
+++ b/modules/gmake/tests/cpp/test_clang.lua
@@ -39,7 +39,7 @@ ifeq ($(config),debug)
     CXX = clang++
   endif
   ifeq ($(origin AR), default)
-    AR = ar
+    AR = llvm-ar
   endif
 		]]
 	end

--- a/modules/gmake2/tests/test_gmake2_clang.lua
+++ b/modules/gmake2/tests/test_gmake2_clang.lua
@@ -39,7 +39,7 @@ ifeq ($(origin CXX), default)
   CXX = clang++
 endif
 ifeq ($(origin AR), default)
-  AR = ar
+  AR = llvm-ar
 endif
 ]]
 	end

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -324,7 +324,7 @@
 	clang.tools = {
 		cc = "clang",
 		cxx = "clang++",
-		ar = function(cfg) return iif(cfg.flags.LinkTimeOptimization, "llvm-ar", "ar") end
+		ar = "llvm-ar"
 	}
 
 	function clang.gettoolname(cfg, tool)


### PR DESCRIPTION
**What does this PR do?**

Adjusts the Clang toolset adapter to always use its included `llvm-ar` instead of `ar`, which may or may not be installed. Fixes #1752.

**How does this PR change Premake's behavior?**

No changes other than described.

**Anything else we should know?**

Nope.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
