### PR TITLE
Disabling inherited dependencies

### DIFF
--- a/modules/vstudio/tests/vc2010/test_link.lua
+++ b/modules/vstudio/tests/vc2010/test_link.lua
@@ -745,12 +745,11 @@
 
 	function suite.inheritDependenciesOff()
 		inheritdependencies "Off"
-		links { "kernel32" }
 		prepare()
 		test.capture [[
 <Link>
 	<SubSystem>Windows</SubSystem>
-	<AdditionalDependencies>kernel32.lib</AdditionalDependencies>
+	<AdditionalDependencies></AdditionalDependencies>
 	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 </Link>
 		]]

--- a/modules/vstudio/tests/vc2010/test_link.lua
+++ b/modules/vstudio/tests/vc2010/test_link.lua
@@ -723,7 +723,7 @@
 		]]
 	end
 
-	--
+--
 -- Test ignoring default libraries with extensions specified.
 --
 
@@ -735,6 +735,36 @@
 	<SubSystem>Windows</SubSystem>
 	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 	<AssemblyDebug>true</AssemblyDebug>
+</Link>
+		]]
+	end
+
+--
+-- Test for not including additional dependencies.
+--
+
+	function suite.inheritDependenciesOff()
+		inheritdependencies "Off"
+		links { "kernel32" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<AdditionalDependencies>kernel32.lib</AdditionalDependencies>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+</Link>
+		]]
+	end
+
+	function suite.inheritDependenciesOn()
+		inheritdependencies "On"
+		links { "kernel32" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<AdditionalDependencies>kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 </Link>
 		]]
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1416,16 +1416,17 @@
 			links = vstudio.getLinks(cfg, explicit)
 		end
 
-		if #links > 0 then
-			links = path.translate(table.concat(links, ";"))
+		links = path.translate(table.concat(links, ";"))
 
-			local additional = ";%(AdditionalDependencies)"
-			if cfg.inheritdependencies ~= nil then
-				if not cfg.inheritdependencies then
-					additional = ""
-				end
+		local additional = ";%(AdditionalDependencies)"
+		if cfg.inheritdependencies ~= nil then
+			if not cfg.inheritdependencies then
+				additional = ""
 			end
+		end
 
+		-- If there are no links and dependencies should be inherited, the tag doesn't have to be generated.
+		if #links > 0 or additional == "" then
 			m.element("AdditionalDependencies", nil, "%s%s", links, additional)
 		end
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1418,7 +1418,15 @@
 
 		if #links > 0 then
 			links = path.translate(table.concat(links, ";"))
-			m.element("AdditionalDependencies", nil, "%s;%%(AdditionalDependencies)", links)
+
+			local additional = ";%(AdditionalDependencies)"
+			if cfg.inheritdependencies ~= nil then
+				if not cfg.inheritdependencies then
+					additional = ""
+				end
+			end
+
+			m.element("AdditionalDependencies", nil, "%s%s", links, additional)
 		end
 	end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -639,6 +639,12 @@
 	}
 
 	api.register {
+		name = "inheritdependencies",
+		scope = "config",
+		kind = "boolean",
+	}
+
+	api.register {
 		name = "icon",
 		scope = "project",
 		kind = "file",

--- a/website/docs/inheritdependencies.md
+++ b/website/docs/inheritdependencies.md
@@ -4,10 +4,12 @@ inheritdependencies
 inheritdependencies "value"
 ```
 
+For Visual Studio project files, this controls the generation of the `%(AdditionalDependencies)` entry in the list of libraries that a project links. 
+
 ### Parameters ###
 
 `value` one of:
-* `On` - The project(s) will inherit library dependencies based on the parent project and project default settings. This is the default behavior.
+* `On` - The project(s) will inherit library dependencies based on the parent project (if any) and project default settings. This is the default behavior.
 * `Off` - The project(s) will not inherit any library dependencies. Only explicitly specified dependencies will be linked.
 
 ## Applies To ###
@@ -16,7 +18,7 @@ The `config` scope.
 
 ### Availability ###
 
-Visual Studio 2019 and later.
+Visual Studio 2015 and later.
 Premake 5.0-beta2 or later.
 
 ### Examples ###

--- a/website/docs/inheritdependencies.md
+++ b/website/docs/inheritdependencies.md
@@ -1,0 +1,27 @@
+inheritdependencies
+
+```lua
+inheritdependencies "value"
+```
+
+### Parameters ###
+
+`value` one of:
+* `On` - The project(s) will inherit library dependencies based on the parent project and project default settings. This is the default behavior.
+* `Off` - The project(s) will not inherit any library dependencies. Only explicitly specified dependencies will be linked.
+
+## Applies To ###
+
+The `config` scope.
+
+### Availability ###
+
+Visual Studio 2019 and later.
+Premake 5.0-beta2 or later.
+
+### Examples ###
+
+```lua
+inheritdependencies "Off"
+```
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -175,6 +175,7 @@ module.exports = {
 						'implibsuffix',
 						'importdirs',
 						'includedirs',
+						'inheritdependencies',
 						'inlinesvisibility',
 						'inlining',
 						'intrinsics',


### PR DESCRIPTION
**What does this PR do?**

Implements a new Boolean config setting `inheritdependencies` that allows disabling or explicitly enabling the inheritance of dependencies from project default settings or parent projects in Visual Studio. Under Windows by default for C++ projects, this has for example the effect of linking Windows system libraries such as kernel32 and user32 if enabled. When disabled, only explicitly specified libraries will be linked.

**How does this PR change Premake's behavior?**

It doesn't. Only new behavior.

**Anything else we should know?**

This was implemented as a response to #1733.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [X] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
