### PR TITLE
Migrate website to latest DocSearch

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -16,7 +16,8 @@ module.exports = {
 			additionalLanguages: ['lua'],
 		},
 		algolia: {
-			apiKey: '7440a29a5d611582272899683f54f54e',
+			appId: 'BZ59R9HF86',
+			apiKey: '83150c6f407bbeccf4a8873378f7c67c',
 			indexName: 'premake',
 		},
 		navbar: {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,7 +17,7 @@ module.exports = {
 		},
 		algolia: {
 			appId: 'BZ59R9HF86',
-			apiKey: '83150c6f407bbeccf4a8873378f7c67c',
+			apiKey: '5c08cdec7a7243eecb271c06cdba3b9f',
 			indexName: 'premake',
 		},
 		navbar: {


### PR DESCRIPTION
**What does this PR do?**

[DocSearch is migrating to a new Algolia backend](https://docusaurus.io/blog/2021/11/21/algolia-docsearch-migration). Adjust the API keys for the new account.

Closes #1776.

**How does this PR change Premake's behavior?**

There should be no behavior changes.

**Anything else we should know?**

I'm not sure how to test this? Hoping @KyrietS can provide some guidance before this merges.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] ~~Add unit tests showing fix or feature works; all tests pass~~
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
