### PR TITLE
Remove unavailable modules

### DIFF
--- a/website/community/modules.md
+++ b/website/community/modules.md
@@ -25,7 +25,7 @@ These add-on modules are available from other developers; follow the links for m
 
 ## Build System Modules
 
-* [CMake](https://github.com/Geequlim/premake-modules/tree/master/cmake) : CMakeLists exporter for premake
+* [CMake](https://github.com/Jarod42/premake-cmake) : CMakeLists exporter for premake
 * [Ninja](https://github.com/jimon/premake-ninja) : [Ninja](https://github.com/martine/ninja) support
 
 ## Tool Modules
@@ -36,7 +36,6 @@ These add-on modules are available from other developers; follow the links for m
 * [Generate compile_commands.json](https://github.com/tarruda/premake-export-compile-commands) : Export clang compilation database
 * [GitHub Packages](https://github.com/mversluys/premake-ghp) : Consume libraries directly from GitHub releases
 * [Pkgconfig](https://github.com/tarruda/premake-pkgconfig) : Pure lua implementation of pkgconfig for premake
-* [Pkgconfig](https://github.com/Geequlim/premake-modules/tree/master/pkgconfig) : pkg-config loader for premake
 * [Platform test](https://github.com/tarruda/premake-platform-test) : Perform platform checks in your premake configuration
 
 ## Library Modules


### PR DESCRIPTION
**What does this PR do?**

Removes links to modules resulting with 404.

I wonder if it would be better to link @Jarod42's [fork](https://github.com/Jarod42/premake-cmake) instead of the _original_ CMake module. As far as I know, the fork fixes several bugs?

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
