### PR TITLE
Include the configuration condition for ExternalWarningLevel.

### DIFF
--- a/modules/vstudio/tests/vc2022/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2022/test_compile_settings.lua
@@ -25,6 +25,11 @@ local function prepare(platform)
 	vc2010.clCompile(cfg)
 end
 
+local function prepareFiles(platform)
+	prj = test.getproject(wks, 1)
+	vc2010.files(prj)
+end
+
 --
 -- Check ClCompile for ExternalWarningLevel
 --
@@ -88,6 +93,19 @@ function suite.ExternalWarningLevelEverything()
 	]]
 end
 
+function suite.ExternalWarningLevelOnFile()
+	files { "hello1.cpp", "hello2.cpp" }
+	filter { "files:hello2.cpp" }
+		externalwarnings "High"
+	prepareFiles()
+	test.capture [[
+<ItemGroup>
+	<ClCompile Include="hello1.cpp" />
+	<ClCompile Include="hello2.cpp">
+		<ExternalWarningLevel>Level4</ExternalWarningLevel>
+	]]
+end
+
 --
 -- Check ClCompile for TreatAngleIncludeAsExternal
 --
@@ -114,5 +132,18 @@ function suite.TreatAngleIncludeAsExternalOff()
 	<Optimization>Disabled</Optimization>
 	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 	<TreatAngleIncludeAsExternal>false</TreatAngleIncludeAsExternal>
+	]]
+end
+
+function suite.TreatAngleIncludeAsExternalOnFile()
+	files { "hello1.cpp", "hello2.cpp" }
+	filter { "files:hello2.cpp" }
+		externalanglebrackets "On"
+	prepareFiles()
+	test.capture [[
+<ItemGroup>
+	<ClCompile Include="hello1.cpp" />
+	<ClCompile Include="hello2.cpp">
+		<TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
 	]]
 end

--- a/modules/vstudio/tests/vc2022/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2022/test_compile_settings.lua
@@ -147,3 +147,16 @@ function suite.TreatAngleIncludeAsExternalOnFile()
 		<TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
 	]]
 end
+
+function suite.TreatAngleIncludeAsExternalOffFile()
+	files { "hello1.cpp", "hello2.cpp" }
+	filter { "files:hello2.cpp" }
+		externalanglebrackets "Off"
+	prepareFiles()
+	test.capture [[
+<ItemGroup>
+	<ClCompile Include="hello1.cpp" />
+	<ClCompile Include="hello2.cpp">
+		<TreatAngleIncludeAsExternal>false</TreatAngleIncludeAsExternal>
+	]]
+end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -820,8 +820,8 @@
 						m.runtimeTypeInfo,
 						m.warningLevelFile,
 						m.compileAsWinRT,
-						m.externalWarningLevel,
-						m.externalAngleBrackets,
+						m.externalWarningLevelFile,
+						m.externalAngleBracketsFile,
 					}
 				else
 					return {
@@ -2854,15 +2854,36 @@
 	end
 
 
-	function m.externalWarningLevel(cfg, condition)
+	function m.externalWarningLevel(cfg)
 		if _ACTION >= "vs2022" then
 			local map = { Off = "TurnOffAllWarnings", High = "Level4", Extra = "Level4", Everything = "Level4" }
-			m.element("ExternalWarningLevel", condition, map[cfg.externalwarnings] or "Level3")
+			m.element("ExternalWarningLevel", nil, map[cfg.externalwarnings] or "Level3")
+		end
+	end
+
+
+	function m.externalWarningLevelFile(cfg, condition)
+		if _ACTION >= "vs2022" then
+			if cfg.externalwarnings then
+				local map = { Off = "TurnOffAllWarnings", High = "Level4", Extra = "Level4", Everything = "Level4" }
+				m.element("ExternalWarningLevel", condition, map[cfg.externalwarnings] or "Level3")
+			end
 		end
 	end
 
 
 	function m.externalAngleBrackets(cfg)
+		if _ACTION >= "vs2022" then
+			if cfg.externalanglebrackets == p.OFF then
+				m.element("TreatAngleIncludeAsExternal", nil, "false")
+			elseif cfg.externalanglebrackets == p.ON then
+				m.element("TreatAngleIncludeAsExternal", nil, "true")
+			end
+		end
+	end
+
+
+	function m.externalAngleBracketsFile(cfg, condition)
 		if _ACTION >= "vs2022" then
 			if cfg.externalanglebrackets == p.OFF then
 				m.element("TreatAngleIncludeAsExternal", condition, "false")

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2854,10 +2854,10 @@
 	end
 
 
-	function m.externalWarningLevel(cfg)
+	function m.externalWarningLevel(cfg, condition)
 		if _ACTION >= "vs2022" then
 			local map = { Off = "TurnOffAllWarnings", High = "Level4", Extra = "Level4", Everything = "Level4" }
-			m.element("ExternalWarningLevel", nil, map[cfg.externalwarnings] or "Level3")
+			m.element("ExternalWarningLevel", condition, map[cfg.externalwarnings] or "Level3")
 		end
 	end
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -821,7 +821,7 @@
 						m.warningLevelFile,
 						m.compileAsWinRT,
 						m.externalWarningLevelFile,
-						m.externalAngleBracketsFile,
+						m.externalAngleBrackets,
 					}
 				else
 					return {
@@ -2872,18 +2872,7 @@
 	end
 
 
-	function m.externalAngleBrackets(cfg)
-		if _ACTION >= "vs2022" then
-			if cfg.externalanglebrackets == p.OFF then
-				m.element("TreatAngleIncludeAsExternal", nil, "false")
-			elseif cfg.externalanglebrackets == p.ON then
-				m.element("TreatAngleIncludeAsExternal", nil, "true")
-			end
-		end
-	end
-
-
-	function m.externalAngleBracketsFile(cfg, condition)
+	function m.externalAngleBrackets(cfg, condition)
 		if _ACTION >= "vs2022" then
 			if cfg.externalanglebrackets == p.OFF then
 				m.element("TreatAngleIncludeAsExternal", condition, "false")


### PR DESCRIPTION
**What does this PR do?**

Fixes a bug with ExternalWarningLevel where the entry would be duplicated for every configuration you had.

Before:
```xml
<ClCompile Include="file.cpp">
  <ExternalWarningLevel>Level3</ExternalWarningLevel>
  <ExternalWarningLevel>Level3</ExternalWarningLevel>
  <ExternalWarningLevel>Level3</ExternalWarningLevel>
  <ExternalWarningLevel>Level3</ExternalWarningLevel>
</ClCompile>
```   
After:
```xml
<ClCompile Include="file.cpp">
  <ExternalWarningLevel>Level3</ExternalWarningLevel>
</ClCompile>
```

**How does this PR change Premake's behavior?**

No breaking changes.

**Anything else we should know?**

The bug was introduced with changeset 065b3acb2fdbb137e95fa1d59f4f37c5e4b334e6.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
