### PR TITLE
Fix #1795: project generation fails with "Error: attempt to index a function value"

### DIFF
--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -658,7 +658,7 @@
 		-- If a tool was not found, check to see if there is a function in the
 		-- table to check against.  For each function in the table, check if
 		-- the value is allowed (break early if so).
-		if not canonical then
+		if not canonical and type(field.allowed) == "table" then
 			for _, allow in ipairs(field.allowed)
 			do
 				if type(allow) == "function" then


### PR DESCRIPTION
**What does this PR do?**

Only allow "table" type to be passed into `ipairs()` in the code `api.lua`, line `661`.
Closes #1795.

**How does this PR change Premake's behavior?**

No premake behavioral change, but prevents error when invalid type being passed to `ipairs()`.

**Anything else we should know?**

No.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
