### PR TITLE
Use windows-2019 instead of windows-lastest (temporarily)

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -46,7 +46,7 @@ jobs:
         name: premake-macosx-${{ matrix.platform }}
         path: bin/${{ matrix.config }}/
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         config: [debug, release]


### PR DESCRIPTION
**What does this PR do?**

GitHub updated its GH Actions environments and `windows-latest` is now 2022 by default (previously 2019). It caused our pipeline to fail.
This commit brings back a `windows-2019` environment in our GH Actions pipeline.

**Anything else we should know?**

We will discuss the upgrade back to `windows-latest` in #1819 
Briefly, I would like to use vswhere.exe in our pipeline to avoid hardcoding paths to Visual Studio.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

