### PR TITLE
Use vswhere.exe in Windows pipeline

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -46,7 +46,7 @@ jobs:
         name: premake-macosx-${{ matrix.platform }}
         path: bin/${{ matrix.config }}/
   windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
         config: [debug, release]
@@ -56,9 +56,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Build
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
-        nmake -f Bootstrap.mak MSDEV=vs2019 windows-msbuild PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }}
-      shell: cmd
+        $vcvarsall_path = vswhere.exe -find VC\Auxiliary\Build\vcvarsall.bat
+        cmd.exe /c "call ""$vcvarsall_path"" x86_amd64 && nmake -f Bootstrap.mak MSDEV=vs2019 windows-msbuild PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }}"
     - name: Test
       run: bin\${{ matrix.config }}\premake5 test --test-all
       shell: cmd


### PR DESCRIPTION
**What does this PR do?**

Use `vswhere.exe` to get a path to the `vcvarsall.bat`.
My approach is that I use PowerShell to execute `vswhere.exe` and save its result to variable (`$vcvarsall_path`).
Then, run the script in legacy `cmd.exe`.

Resolves #1819 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
