### PR TITLE
Fix export location for gmake

### DIFF
--- a/modules/gmake/gmake.lua
+++ b/modules/gmake/gmake.lua
@@ -98,6 +98,13 @@ function gmake.buildDom()
 	})
 
 	root.workspaces = root:fetchWorkspaces(gmake.fetchWorkspace)
+
+	for _, wks in ipairs(root.workspaces) do
+		for _, prj in ipairs(wks.projects) do
+			prj.exportPath = gmake.getMakefileName(prj, true, root)
+		end
+	end
+
 	return root
 end
 
@@ -297,9 +304,9 @@ end
 -- @returns
 --  Makefile if this project or workspace is unique to the folder, else .make
 ---
-function gmake.getMakefileName(this, searchprjs)
+function gmake.getMakefileName(this, searchprjs, domroot)
 	local count = 0
-	local root = gmake.buildDom()
+	local root = domroot or gmake.buildDom()
 	for _, wks in ipairs(root.workspaces) do
 		if wks.location == this.location then
 			count = count + 1

--- a/modules/gmake/src/wks.lua
+++ b/modules/gmake/src/wks.lua
@@ -182,7 +182,7 @@ function wks.projectRules(wk)
 		wl('ifneq (, $(config))')
 		export.indent()
 
-		local prjPath = gmake.getMakefileName(prj, true)
+		local prjPath = gmake.getMakefileName(prj, true, wk.root)
 		local prjDir = path.getDirectory(path.getRelative(wk.location, prjPath))
 		local prjName = path.getName(prjPath)
 
@@ -205,7 +205,7 @@ function wks.cleanRule(wk)
 	wl('clean:')
 	export.indent()
 	for _, prj in ipairs(wk.projects) do
-		local prjPath = gmake.getMakefileName(prj, true)
+		local prjPath = gmake.getMakefileName(prj, true, wk.root)
 		local prjDir = path.getDirectory(path.getRelative(wk.location, prjPath))
 		local prjName = path.getName(prjPath)
 


### PR DESCRIPTION
**What does this PR do?**

Fixes export location not being set in the gmake project generation. Missed in the initial PR.

**How does this PR change Premake's behavior?**

Fixes runtime error.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
