### PR TITLE
contrib/curl: update ifdef condition for MCST-LCC compiler

### DIFF
--- a/contrib/curl/include/curl/curlbuild.h
+++ b/contrib/curl/include/curl/curlbuild.h
@@ -288,7 +288,7 @@
 #  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__LCC__)
-#  if defined(__e2k__) /* MCST eLbrus C Compiler */
+#  if defined(__MCST__) /* MCST eLbrus Compiler Collection */
 #    define CURL_SIZEOF_LONG           8
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"


### PR DESCRIPTION
**What does this PR do?**

Backport from Curl - https://github.com/curl/curl/pull/8546

**How does this PR change Premake's behavior?**

This PR doesn't change Premake's behaviour to the end user.

**Anything else we should know?**

In mcst-lcc compiler => 1.25 added a new macro definition to determine compiler

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
