### PR TITLE
Improve os match performance 

### DIFF
--- a/src/base/action.lua
+++ b/src/base/action.lua
@@ -122,16 +122,13 @@
 				onRule(rule)
 			end
 		end
-		local ret
+
 		if a.execute then
-			ret = a.execute()
+			a.execute()
 		end
 
 		if a.onEnd then
 			a.onEnd()
-		end
-		if a.execute then
-			return ret
 		end
 	end
 

--- a/src/base/action.lua
+++ b/src/base/action.lua
@@ -122,13 +122,16 @@
 				onRule(rule)
 			end
 		end
-
+		local ret
 		if a.execute then
-			a.execute()
+			ret = a.execute()
 		end
 
 		if a.onEnd then
 			a.onEnd()
+		end
+		if a.execute then
+			return ret
 		end
 	end
 

--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -354,7 +354,7 @@
 --    A table containing the matched file or directory names.
 ---
 
-	function os.match(mask)
+	function os.match(mask, matchType)
 		mask = path.normalize(mask)
 		local starpos = mask:find("%*")
 		local before = path.getdirectory(starpos and mask:sub(1, starpos - 1) or mask)
@@ -370,14 +370,14 @@
 
 		if recurse then
 			local submask = mask:sub(1, starpos) .. mask:sub(starpos + 2)
-			results = os.match(submask)
+			results = os.match(submask, matchType)
 
 			local pattern = mask:sub(1, starpos)
 			local m = os.matchstart(pattern)
 			while os.matchnext(m) do
 				if not os.matchisfile(m) then
 					local matchpath = path.join(before, os.matchname(m), mask:sub(starpos))
-					results = table.join(results, os.match(matchpath))
+					results = table.join(results, os.match(matchpath, matchType))
 				end
 			end
 			os.matchdone(m)
@@ -387,10 +387,17 @@
 				while os.matchnext(m) do
 				if not (slashpos and os.matchisfile(m)) then
 					local matchpath = path.join(before, matchpath, os.matchname(m))
+					
 					if after then
-						results = table.join(results, os.match(path.join(matchpath, after)))
+						results = table.join(results, os.match(path.join(matchpath, after), matchType))
 					else
+						if matchType == "file" and os.matchisfile(m) then
 						table.insert(results, matchpath)
+						elseif matchType == "folder" and not os.matchisfile(m) then
+							table.insert(results, matchpath)
+						else -- keep previous behaviour
+							table.insert(results, matchpath)	
+						end	
 						end
 					end
 				end
@@ -412,12 +419,7 @@
 ---
 
 	function os.matchdirs(mask)
-		local results = os.match(mask)
-		for i = #results, 1, -1 do
-			if not os.isdir(results[i]) then
-				table.remove(results, i)
-			end
-		end
+		local results = os.match(mask, "folder")
 		return results
 	end
 
@@ -433,12 +435,7 @@
 ---
 
 	function os.matchfiles(mask)
-		local results = os.match(mask)
-		for i = #results, 1, -1 do
-			if not os.isfile(results[i]) then
-				table.remove(results, i)
-			end
-		end
+		local results = os.match(mask, "file")
 		return results
 	end
 


### PR DESCRIPTION
**What does this PR do?**

It tries to improve performance on large projects by not checking if a matched item is a file or folder and makes the check directly in the os.match function where we already have that information.

**How does this PR change Premake's behavior?**

In `theory` the behaviour of premake itself will not change 
If no matchtype flag is passed to `os.match` the function will return all of the results as before

**Anything else we should know?**

this is part of the investigation with issue #1414

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] TODO Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
