### PR TITLE
[*] gmake2: fix unescaped ' ' characters in target directory and target

### DIFF
--- a/modules/gmake2/gmake2.lua
+++ b/modules/gmake2/gmake2.lua
@@ -268,13 +268,13 @@
 
 
 	function gmake2.target(cfg, toolset)
-		p.outln('TARGETDIR = ' .. project.getrelative(cfg.project, cfg.buildtarget.directory))
-		p.outln('TARGET = $(TARGETDIR)/' .. cfg.buildtarget.name)
+		p.outln('TARGETDIR = ' .. p.esc(project.getrelative(cfg.project, cfg.buildtarget.directory)))
+		p.outln('TARGET = $(TARGETDIR)/' .. p.esc(cfg.buildtarget.name))
 	end
 
 
 	function gmake2.objdir(cfg, toolset)
-		p.outln('OBJDIR = ' .. project.getrelative(cfg.project, cfg.objdir))
+		p.outln('OBJDIR = ' .. p.esc(project.getrelative(cfg.project, cfg.objdir)))
 	end
 
 


### PR DESCRIPTION
Projects, target directories, and object directories didn't account for users including spaces into their respective values.  This commit should fix that by wrapping the values with the global premake.esc function as used by `_x`.