### PR TITLE
Changed MMD to MD in gmake/gmake2 outputs for gcc/clang.

### DIFF
--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -442,7 +442,7 @@ end
 
 
 	function make.cppDependencies(prj)
-		-- include the dependencies, built by GCC (with the -MMD flag)
+		-- include the dependencies, built by GCC (with the -MD flag)
 		_p('-include $(OBJECTS:%%.o=%%.d)')
 		_p('ifneq (,$(PCH))')
 			_p('  -include $(OBJDIR)/$(notdir $(PCH)).d')

--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -779,7 +779,7 @@
 
 
 	function cpp.dependencies(prj)
-		-- include the dependencies, built by GCC (with the -MMD flag)
+		-- include the dependencies, built by GCC (with the -MD flag)
 		_p('-include $(OBJECTS:%%.o=%%.d)')
 		_p('ifneq (,$(PCH))')
 			_p('  -include $(PCH_PLACEHOLDER).d')

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -21,7 +21,7 @@
 		system = {
 			haiku = "-MMD",
 			wii = { "-MMD", "-MP", "-I$(LIBOGC_INC)", "$(MACHDEP)" },
-			_ = { "-MMD", "-MP" }
+			_ = { "-MD", "-MP" }
 		}
 	}
 

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -53,9 +53,9 @@
 -- By default, the -MMD -MP are used to generate dependencies.
 --
 
-	function suite.cppflags_defaultWithMMD()
+	function suite.cppflags_defaultWithMD()
 		prepare()
-		test.contains({"-MMD", "-MP"}, gcc.getcppflags(cfg))
+		test.contains({"-MD", "-MP"}, gcc.getcppflags(cfg))
 	end
 
 


### PR DESCRIPTION
**What does this PR do?**

Changes "-MMD" to "-MD" for all platforms but "wii" and "haiku".

**How does this PR change Premake's behavior?**

No breaking changes AFAIK.

**Anything else we should know?**

Closes #1801 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
