### PR TITLE
6.x - Fix broken link to testing module

### DIFF
--- a/CHANGES_SINCE_V5.md
+++ b/CHANGES_SINCE_V5.md
@@ -49,7 +49,7 @@ local path = require('path')
 
 - **Improved command line option model and parsing.** The distinction between "options" and "actions" has been removed. All arguments may now specify an `execute()` method. The "=" is now optional when assigning values from the command line. The `_OPTIONS` global has been removed; use the `options` module for direct programmatic access.
 
-- **Preload magic replaced with `register()`.** Previously only core modules could register command line options and other settings on startup without actually loading the entire module. Any module may now include a `register.lua` script which can be loaded with `register('moduleName')`. See [the testing module](../modules/testing) for an example.
+- **Preload magic replaced with `register()`.** Previously only core modules could register command line options and other settings on startup without actually loading the entire module. Any module may now include a `register.lua` script which can be loaded with `register('moduleName')`. See [the testing module](./modules/testing) for an example.
 
 - **Exporters get more responsility.** The division of responsibilities has been shifted to give exporters significantly more control over how data is queried, inherited, and exported.
 


### PR DESCRIPTION
**What does this PR do?**

Fixes the link to the testing module in the v6 change list.

**How does this PR change Premake's behavior?**

No behavioral change

**Anything else we should know?**

Nope

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes