### PR TITLE
Add support of openmp for gcc/clang.

### DIFF
--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -49,6 +49,7 @@
 			Fast = "-ffast-math",
 		},
 		strictaliasing = gcc.shared.strictaliasing,
+		openmp = gcc.shared.openmp,
 		optimize = {
 			Off = "-O0",
 			On = "-O2",

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -67,6 +67,9 @@
 			Level2 = { "-fstrict-aliasing", "-Wstrict-aliasing=2" },
 			Level3 = { "-fstrict-aliasing", "-Wstrict-aliasing=3" },
 		},
+		openmp = {
+			On = "-fopenmp"
+		},
 		optimize = {
 			Off = "-O0",
 			On = "-O2",

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -68,4 +68,20 @@
 		prepare()
 		test.contains({ "-miphoneos-version-min=5.0" }, clang.getcxxflags(cfg))
 	end
-	
+
+--
+-- Check handling of openmp.
+--
+
+	function suite.cflags_onOpenmpOn()
+		openmp "On"
+		prepare()
+		test.contains("-fopenmp", clang.getcflags(cfg))
+	end
+
+	function suite.cflags_onOpenmpOff()
+		openmp "Off"
+		prepare()
+		test.excludes("-fopenmp", clang.getcflags(cfg))
+	end
+

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -702,6 +702,21 @@
 		test.contains({ "-fstrict-aliasing", "-Wstrict-aliasing=3" }, gcc.getcflags(cfg))
 	end
 
+--
+-- Check handling of openmp.
+--
+
+	function suite.cflags_onOpenmpOn()
+		openmp "On"
+		prepare()
+		test.contains("-fopenmp", gcc.getcflags(cfg))
+	end
+
+	function suite.cflags_onOpenmpOff()
+		openmp "Off"
+		prepare()
+		test.excludes("-fopenmp", gcc.getcflags(cfg))
+	end
 
 --
 -- Check handling of system search paths.

--- a/website/docs/openmp.md
+++ b/website/docs/openmp.md
@@ -20,12 +20,8 @@ Project configurations.
 
 ### Availability ###
 
-Premake 5.0-beta1 or later. Currently only implemented for Visual Studio 2010+. As a workaround for other toolsets, you can use [buildoptions](buildoptions.md) like this:
-
-```lua
-filter "toolset:not msc*"
-	buildoptions "-fopenmp"
-```
+Premake 5.0-beta1 or later for Visual Studio 2010+ and the MSC toolset.
+Premake 5.0-beta2 or later for the GCC and Clang toolsets.
 
 ## Examples ##
 


### PR DESCRIPTION
**What does this PR do?**

Extend `openmp` to be supported by gcc/clang

**How does this PR change Premake's behavior?**

By adding support for gcc/clang to existing `openmp`.

**Anything else we should know?**

Also tested with https://github.com/Jarod42/premake-sample-projects branch OpenMP

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
