### PR TITLE
Fix Codelite generation of empty source tree project.

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -116,6 +116,11 @@
 
 	function m.files(prj)
 		local tr = project.getsourcetree(prj)
+		if #tr.children == 0 then
+			-- handle project without files
+			_p(1, '<VirtualDirectory Name="%s"/>', tr.name)
+			return
+		end
 		tree.traverse(tr, {
 			-- folders are handled at the internal nodes
 			onbranchenter = function(node, depth)

--- a/modules/codelite/tests/test_codelite_project.lua
+++ b/modules/codelite/tests/test_codelite_project.lua
@@ -100,3 +100,11 @@
     </GlobalSettings>
 		]]
 	end
+
+	function suite.OnProject_EmptySourceFiles()
+		prepare()
+		codelite.project.files(prj)
+		test.capture [[
+  <VirtualDirectory Name="MyProject"/>
+		]]
+	end


### PR DESCRIPTION
**What does this PR do?**

Fix generation of codelite for project without files.

**How does this PR change Premake's behavior?**

Only affects codelite generator.

**Anything else we should know?**

No

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
