### PR TITLE
Fix build failed in mingw x86

### DIFF
--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -88,7 +88,7 @@ mingw: mingw-clean
 	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lole32 -lversion
 	./build/bootstrap/premake_bootstrap embed
 	./build/bootstrap/premake_bootstrap --arch=$(PLATFORM) --os=windows --to=build/bootstrap --cc=mingw gmake2
-	$(MAKE) -C build/bootstrap config=$(CONFIG)_$(PLATFORM)
+	$(MAKE) -C build/bootstrap config=$(CONFIG)_$(PLATFORM:x86=win32)
 
 macosx: osx
 


### PR DESCRIPTION

**What does this PR do?**

Fixes  build failed in mingw x86 with v5.0.0-beta1 version. Here is the output:

Makefile:34: *** "invalid configuration release_x86".  Stop.
mingw32-make: *** [Bootstrap.mak:91: mingw] Error 2

**How does this PR change Premake's behavior?**

No changes other than the fix.

**Anything else we should know?**

Nope.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
