### PR TITLE
Improve uuid generation on Linux

### DIFF
--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -107,7 +107,7 @@ linux-clean: nix-clean
 
 linux: linux-clean
 	mkdir -p build/bootstrap
-	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lm -ldl -lrt
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lm -ldl -lrt -luuid
 	./build/bootstrap/premake_bootstrap embed
 	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)

--- a/premake5.lua
+++ b/premake5.lua
@@ -248,7 +248,7 @@
 			defines     { "LUA_USE_MACOSX" }
 			links       { "CoreServices.framework", "Foundation.framework", "Security.framework", "readline" }
 			
-		filter "system:linux or macosx"
+		filter "system:linux"
 			links		{ "uuid" }
 
 		filter { "system:macosx", "action:gmake" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -247,6 +247,9 @@
 		filter "system:macosx"
 			defines     { "LUA_USE_MACOSX" }
 			links       { "CoreServices.framework", "Foundation.framework", "Security.framework", "readline" }
+			
+		filter "system:linux or macosx"
+			links		{ "uuid" }
 
 		filter { "system:macosx", "action:gmake" }
 			toolset "clang"

--- a/src/host/os_uuid.c
+++ b/src/host/os_uuid.c
@@ -8,6 +8,8 @@
 
 #if PLATFORM_WINDOWS
 #include <objbase.h>
+#elif PLATFORM_LINUX
+#include <uuid/uuid.h>
 #endif
 
 
@@ -49,6 +51,8 @@ int os_uuid(lua_State* L)
 	{
 #if PLATFORM_WINDOWS
 		CoCreateGuid((GUID*)bytes);
+#elif PLATFORM_LINUX
+		uuid_generate(bytes);
 #else
 		int result;
 


### PR DESCRIPTION
**What does this PR do?**

Makes use of Linux's uuid header to generate a uuid instead of reading from `/dev/urandom`.

**How does this PR change Premake's behavior?**

No breaking changes or behavior differences should occur.

**Anything else we should know?**

This does create the requirement of having the `libuuid`/`uuid-dev` package in order to build

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
