### PR TITLE
Escape group names when creating rules

### DIFF
--- a/modules/gmake2/gmake2_workspace.lua
+++ b/modules/gmake2/gmake2_workspace.lua
@@ -128,7 +128,7 @@
 		local tr = p.workspace.grouptree(wks)
 		tree.traverse(tr, {
 			onbranch = function(n)
-				table.insert(groups, n.path)
+				table.insert(groups, p.esc(n.path))
 			end
 		})
 
@@ -146,7 +146,7 @@
 		local tr = p.workspace.grouptree(wks)
 		tree.traverse(tr, {
 			onbranch = function(n)
-				local rule = n.path .. ":"
+				local rule = p.esc(n.path) .. ":"
 				local projectTargets = {}
 				local groupTargets = {}
 				for i, c in pairs(n.children)


### PR DESCRIPTION
**What does this PR do?**

Closes #1868

**How does this PR change Premake's behavior?**

Changes the gmake2 output when there are spaces in the name of a group.  The name is escaped when it has whitespace.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
