### PR TITLE
6.x - Improve uuid generation on Linux

### DIFF
--- a/core/host/src/host/pmk_uuid.c
+++ b/core/host/src/host/pmk_uuid.c
@@ -2,6 +2,8 @@
 
 #if PLATFORM_WINDOWS
 #include <Objbase.h>
+#elif PLATFORM_LINUX
+#include <uuid/uuid.h>
 #endif
 
 
@@ -39,6 +41,8 @@ int pmk_uuid(char* result, const char* value)
 	{
 #if PLATFORM_WINDOWS
 		CoCreateGuid((GUID*)bytes);
+#elif PLATFORM_LINUX
+		uuid_generate(bytes);
 #else
 		/* not sure how to get a UUID for non-Windows platforms, so fake it */
 		FILE* rnd = fopen("/dev/urandom", "rb");

--- a/premake5.lua
+++ b/premake5.lua
@@ -64,6 +64,9 @@ project 'Premake6'
 	filter { 'system:windows', 'configurations:Release' }
 		flags { 'NoIncrementalLink', 'LinkTimeOptimization' }
 
+	filter 'system:linux'
+		links { 'uuid' }
+
 	filter 'system:linux or bsd or hurd'
 		defines { 'LUA_USE_POSIX', 'LUA_USE_DLOPEN' }
 		links { 'm' }


### PR DESCRIPTION
This is pretty much just the changes from #1867 but for the 6.x branch.

**What does this PR do?**

Makes use of Linux's uuid header to generate a uuid instead of reading from `/dev/urandom`.

**How does this PR change Premake's behavior?**

No breaking changes or behavior differences should occur.

**Anything else we should know?**

This does create the requirement of having the `libuuid`/`uuid-dev` package in order to build. Also, I didn't check the `all tests pass` box since I couldn't get the tests working in the first place

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
