### PR TITLE
Added Unit Test for Workspace Generation

### DIFF
--- a/modules/gmake2/gmake2_workspace.lua
+++ b/modules/gmake2/gmake2_workspace.lua
@@ -183,7 +183,8 @@
 		for prj in p.workspace.eachproject(wks) do
 			local deps = project.getdependencies(prj)
 			deps = table.extract(deps, "name")
-			_p('%s:%s', p.esc(prj.name), gmake2.list(deps))
+
+			_p('%s:%s', p.esc(prj.name), gmake2.list(p.esc(deps)))
 
 			local cfgvar = gmake2.tovar(prj.name)
 			_p('ifneq (,$(%s_config))', cfgvar)

--- a/modules/gmake2/tests/_tests.lua
+++ b/modules/gmake2/tests/_tests.lua
@@ -13,4 +13,5 @@ return {
 	"test_gmake2_perfile_flags.lua",
 	"test_gmake2_target_rules.lua",
 	"test_gmake2_tools.lua",
+	"test_gmake2_wks.lua"
 }

--- a/modules/gmake2/tests/test_gmake2_wks.lua
+++ b/modules/gmake2/tests/test_gmake2_wks.lua
@@ -1,0 +1,70 @@
+local suite = test.declare("gmake2_wks")
+
+local p = premake
+local gmake2 = premake.modules.gmake2
+
+local wks, prj, cfg
+
+function suite.setup()
+	p.escaper(gmake2.esc)
+	wks = workspace("MyWorkspace")
+	configurations { "Debug", "Release" }
+end
+
+
+local function prepare()
+	wks = test.getWorkspace(wks)
+	prj = test.getproject(wks, 1)
+
+	gmake2.projectrules(wks)
+end
+
+
+function suite.projectwithspace()
+	project "My Project"
+
+	prepare()
+
+test.capture [[
+My\ Project:
+]]
+end
+
+
+function suite.projectwithdependencywithspace()
+	project "Dependency with Space"
+	project "My Project"
+		dependson { "Dependency With Space" }
+
+	prepare()
+
+test.capture [[
+Dependency\ with\ Space:
+ifneq (,$(Dependency_with_Space_config))
+	@echo "==== Building Dependency with Space ($(Dependency_with_Space_config)) ===="
+	@${MAKE} --no-print-directory -C . -f Dependency\ with\ Space.make config=$(Dependency_with_Space_config)
+endif
+
+My\ Project: Dependency\ with\ Space
+]]
+end
+
+
+function suite.projectwithdependencywithspaceinlocation()
+	project "Dependency with Space"
+		location "Location With Space"
+	project "My Project"
+		dependson { "Dependency With Space" }
+
+	prepare()
+
+test.capture [[
+Dependency\ with\ Space:
+ifneq (,$(Dependency_with_Space_config))
+	@echo "==== Building Dependency with Space ($(Dependency_with_Space_config)) ===="
+	@${MAKE} --no-print-directory -C Location\ With\ Space -f Makefile config=$(Dependency_with_Space_config)
+endif
+
+My\ Project: Dependency\ with\ Space
+]]
+end


### PR DESCRIPTION
Follow up on #1876.

**What does this PR do?**

Adds unit test, makes sure all escaping uses p.esc in the gmake workspace generation.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
