### PR TITLE
Fixes the generation of source projects

### DIFF
--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -97,10 +97,15 @@ FOR /F "usebackq delims=" %%i in (`!VsWhereCmdLine!`) DO (
 	IF EXIST "%%i\VC\Auxiliary\Build\vcvars32.bat" (
 		CALL "%%i\VC\Auxiliary\Build\vcvars32.bat" && nmake MSDEV="%PremakeVsVersion%" -f Bootstrap.mak windows
 		EXIT /B %ERRORLEVEL%
+	) ELSE (
+		IF EXIST "%%i\VC\Auxiliary\Build\vcvars64.bat" (
+			CALL "%%i\VC\Auxiliary\Build\vcvars64.bat" && nmake MSDEV="%PremakeVsVersion%" -f Bootstrap.mak windows
+			EXIT /B %ERRORLEVEL%
+		)
 	)
 )
 
-ECHO Could not find vcvars32.bat to setup Visual Studio environment
+ECHO Could not find vcvars32.bat or vcvars64.bat to setup Visual Studio environment
 EXIT /B 2
 
 REM :VsWhereVisualBootstrap

--- a/premake5.lua
+++ b/premake5.lua
@@ -112,8 +112,10 @@
 			--
 			{ "Win32", "Same as x86" },
 			{ "x64", "Same as x86_64" },
+			--
+			{ "default", "Generates default platforms for targets, x86 and x86_64 projects for Windows." }
 		},
-		default = "x86",
+		default = "default",
 	}
 
 --
@@ -165,6 +167,9 @@
 
 		filter { "system:windows", "options:arch=x86_64 or arch=x64" }
 			platforms { "x64" }
+
+		filter { "system:windows", "options:arch=default" }
+			platforms { "x86", "x64" }
 
 		filter "configurations:Debug"
 			defines     "_DEBUG"

--- a/scripts/package.lua
+++ b/scripts/package.lua
@@ -24,6 +24,7 @@
 
 	if os.ishost("windows") then
 		allowedCompilers = {
+			"vs2022",
 			"vs2019",
 			"vs2017",
 			"vs2015",


### PR DESCRIPTION
**What does this PR do?**

#1629 introduced an issue that made it impossible to have both x86 and x64 published source packages.  This adds a "default" architecture flag, which produces project files with the default architectures of their exporter (except for windows, which exports both x86 and x64 explicitly).

In addition, we go ahead and add functionality the VS2022 exporter to the publish action and search for vcvars64.bat to fall back on if we can't find vcvars32.bat.

**How does this PR change Premake's behavior?**

Reverts the default behavior to pre-#1629 behavior.

**Anything else we should know?**

Closes #1862.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
