### PR TITLE
6.x - Move help option to help register file

### DIFF
--- a/core/modules/help/_register.lua
+++ b/core/modules/help/_register.lua
@@ -1,0 +1,8 @@
+commandLineOption {
+	trigger = '--help',
+	description = 'Display this information',
+	execute = function()
+		local help = require('help')
+		help.printHelp()
+	end
+}

--- a/core/modules/main/core_options.lua
+++ b/core/modules/main/core_options.lua
@@ -4,21 +4,13 @@
 
 local m = select(1, ...)
 
+register('help')
 
 commandLineOption {
 	trigger = '--file',
 	description = string.format('Read FILE as a Premake script; default is "%s"', m.PROJECT_SCRIPT_NAME),
 	value = 'FILE',
 	default = m.PROJECT_SCRIPT_NAME
-}
-
-commandLineOption { -- TODO: Move to help module; use `register()`
-	trigger = '--help',
-	description = 'Display this information',
-	execute = function()
-		local help = require('help')
-		help.printHelp()
-	end
 }
 
 commandLineOption {


### PR DESCRIPTION
**What does this PR do?**

Resolves a todo specified in [`core/modules/main/core_options.lua`](https://github.com/premake/premake-core/blob/6.x/core/modules/main/core_options.lua#L15) line 15. Relocates the `--help` command line argument to a `_register.lua` located in the help module and has the `core_options.lua` file register it.

**How does this PR change Premake's behavior?**

No noticeable or breaking change. Internally the help module would be registered rather than defining the command line argument with the rest of the main arguments.

**Anything else we should know?**

I wasn't too sure where to actually register the help module so I just did it in the same file it was defined in originally.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
