### PR TITLE
6.x - string.expandWildcards implementation

### DIFF
--- a/core/modules/string/string.lua
+++ b/core/modules/string/string.lua
@@ -14,7 +14,6 @@ end
 ---
 -- Returns a new string with any Premake pattern tokens (i.e. `*`) expanded to Lua patterns.
 --
--- TODO: Just a placeholder at the moment; needs implementation.
 -- TODO: Move this to C; gets called a lot.
 --
 -- @param value
@@ -26,7 +25,8 @@ end
 ---
 
 function string.expandWildcards(value)
-	return value, true
+	local expanded = string.patternFromWildcards(value)
+	return expanded, value ~= expanded
 end
 
 

--- a/core/modules/string/tests/string_pattern_tests.lua
+++ b/core/modules/string/tests/string_pattern_tests.lua
@@ -8,3 +8,15 @@ end
 function StringPatternTests.patternFromWildcards_replacesStarWithLuaPattern()
 	test.isEqual('ab.*', string.patternFromWildcards('ab*'))
 end
+
+function StringPatternTests.expandWildcards_leavesUnchanged_onNoWildcards()
+	local value, hasTokens = string.expandWildcards('abcd')
+	test.isEqual('abcd', value)
+	test.isEqual(false, hasTokens)
+end
+
+function StringPatternTests.expandWildcards_replacesStarWithLuaPattern()
+	local value, hasTokens = string.expandWildcards('ab*')
+	test.isEqual('ab.*', value)
+	test.isEqual(true, hasTokens)
+end


### PR DESCRIPTION
**What does this PR do?**

Provides an implementation for `string.expandWildcards`.

**How does this PR change Premake's behavior?**

The function will no longer return placeholders and will act as it should. Uses `string.patternFromWildcards` internally.

**Anything else we should know?**

Since `string.patternFromWildcards` is implemented in C I was unsure if the todo calling for this function to be moved to C is still applicable. If it is, I'd be able to move it either in another commit in this pr or by making a new pr. Also, I believe this implementation is applicable to `path.expandWildcards`, however, it breaks a few tests in the field module so it requires a bit more looking into.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
