### PR TITLE
Fix openmp for xcode.

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -2693,6 +2693,32 @@
 		]]
 	end
 
+	function suite.XCBuildConfigurationProject_OnOpenMP()
+		openmp "On"
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = (
+					"-fopenmp",
+				);
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
 
 	function suite.XCBuildConfigurationProject_OnFloatStrict()
 		floatingpoint "Strict"

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1556,6 +1556,7 @@
 			["-ffast-math"]             = cfg.floatingpoint == "Fast",
 			["-fomit-frame-pointer"]    = cfg.omitframepointer == "On",
 			["-fno-omit-frame-pointer"] = cfg.omitframepointer == "Off",
+			["-fopenmp"]                = cfg.openmp == "On"
 		}
 
 		local flags = { }

--- a/website/docs/openmp.md
+++ b/website/docs/openmp.md
@@ -21,7 +21,7 @@ Project configurations.
 ### Availability ###
 
 Premake 5.0-beta1 or later for Visual Studio 2010+ and the MSC toolset.
-Premake 5.0-beta2 or later for the GCC and Clang toolsets.
+Premake 5.0-beta2 or later for the GCC and Clang toolsets and for xcode.
 
 ## Examples ##
 


### PR DESCRIPTION
**What does this PR do?**

pass `-fopenmp` in xcode generator when `openmp "On"` is provided

**How does this PR change Premake's behavior?**

xcode generator only

**Anything else we should know?**

MacOSX seems to need special install of gcc to have that flag accepted.
I didn"t have courage to do it for premake-sample-projects
so https://github.com/Jarod42/premake-sample-projects/actions/runs/2469814949 still fails my test
but flag is present in command line.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
