### PR TITLE
Fixes incorrect C# File Mappings for VS

### DIFF
--- a/modules/vstudio/tests/cs2005/projectsettings.lua
+++ b/modules/vstudio/tests/cs2005/projectsettings.lua
@@ -48,6 +48,7 @@
 		<AppDesignerFolder>Properties</AppDesignerFolder>
 		<RootNamespace>MyProject</RootNamespace>
 		<AssemblyName>MyProject</AssemblyName>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -67,6 +68,7 @@
 		<AppDesignerFolder>Properties</AppDesignerFolder>
 		<RootNamespace>MyProject</RootNamespace>
 		<AssemblyName>MyProject</AssemblyName>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -90,6 +92,7 @@
 		<TargetFrameworkProfile>
 		</TargetFrameworkProfile>
 		<FileAlignment>512</FileAlignment>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -109,6 +112,7 @@
 		<AssemblyName>MyProject</AssemblyName>
 		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -129,6 +133,7 @@
 		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -149,6 +154,7 @@
 		<TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -168,6 +174,7 @@
 		<TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -190,6 +197,7 @@
 		<RootNamespace>MyProject</RootNamespace>
 		<AssemblyName>MyProject</AssemblyName>
 		<TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -210,6 +218,7 @@
 		<RootNamespace>MyProject</RootNamespace>
 		<AssemblyName>MyProject</AssemblyName>
 		<TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -234,6 +243,7 @@
 		<RootNamespace>MyProject</RootNamespace>
 		<AssemblyName>MyProject</AssemblyName>
 		<LangVersion>6</LangVersion>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -257,6 +267,7 @@
 		<AppDesignerFolder>Properties</AppDesignerFolder>
 		<RootNamespace>MyCompany.MyProject</RootNamespace>
 		<AssemblyName>MyProject</AssemblyName>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end
@@ -286,6 +297,7 @@
 		</TargetFrameworkProfile>
 		<FileAlignment>512</FileAlignment>
 		<ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 		]]
 	end

--- a/modules/vstudio/tests/cs2005/test_netcore.lua
+++ b/modules/vstudio/tests/cs2005/test_netcore.lua
@@ -129,6 +129,7 @@ function suite.allowUnsafeProperty_core()
 		<TargetFramework>netcoreapp2.2</TargetFramework>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
     ]]
 end

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -81,6 +81,14 @@
 		_p(1,'<PropertyGroup>')
 		local cfg = project.getfirstconfig(prj)
 		p.callArray(dotnetbase.elements.projectProperties, cfg)
+		local platforms = prj.platforms
+		if platforms ~= nil and #platforms > 0 then
+			table.replace(platforms, 'Win32', 'x86')
+			table.replace(platforms, 'x86_64', 'x64')
+			_p(2, '<Platforms>%s</Platforms>', table.concat(platforms, ';'))
+		else
+			_p(2, '<Platforms>AnyCPU</Platforms>')
+		end
 		_p(1,'</PropertyGroup>')
 	end
 


### PR DESCRIPTION
**What does this PR do?**

Closes #1865.  Without this, no platforms were ever emitted, which is invalid in VS2022.

**How does this PR change Premake's behavior?**

Always emits a platform block. This is not tested in VS2019 or earlier.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
