### PR TITLE
Updated Bug Report Template to add exporter selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -21,6 +21,20 @@ Describe any steps you've taken to try to solve or workaround the bug.
 **How can we reproduce this?**
 Please provide a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) we can use to replicate the problem in our own development environments. Use [code blocks](https://help.github.com/en/articles/creating-and-highlighting-code-blocks) to format code and console output nicely.
 
+- [ ] Visual Studio 2022 (vs2022)
+- [ ] Visual Studio 2019 (vs2019)
+- [ ] Visual Studio 2017 (vs2017)
+- [ ] Visual Studio 2015 (vs2015)
+- [ ] Visual Studio 2012 (vs2012)
+- [ ] Visual Studio 2010 (vs2010)
+- [ ] Visual Studio 2008 (vs2008)
+- [ ] Visual Studio 2005 (vs2005)
+- [ ] GNU Makefile (gmake)
+- [ ] GNU Makefile 2 (gmake2)
+- [ ] XCode (xcode)
+- [ ] Codelite
+- [ ] Other (Please list below)
+
 **What version of Premake are you using?**
 `premake5 --version` will show you the version. If you are running a "-dev" version, please make sure you are up to date with the latest master branch.
 


### PR DESCRIPTION
**What does this PR do?**

Adds a selection for the bug report template to allow users to select the exporter they experience the bug on.

**How does this PR change Premake's behavior?**

No breaking changes.

**Anything else we should know?**

This will be useful in the future for more quickly hunting down bugs, especially for tooling with multiple versions supported.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
