### PR TITLE
`usingdirs` wiki typo

### DIFF
--- a/website/docs/usingdirs.md
+++ b/website/docs/usingdirs.md
@@ -1,7 +1,7 @@
 Specifies the file search paths for `using` statements.
 
 ```lua
-usingsdirs { "paths" }
+usingdirs { "paths" }
 ```
 
 ### Parameters ###


### PR DESCRIPTION
`usingsdirs` -> `usingdirs` in the first example.
