### PR TITLE
Requireopt

### DIFF
--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -67,19 +67,34 @@
 -- @param versions
 --    An optional version criteria string; see premake.checkVersion()
 --    for more information on the format.
+-- @param silent
+--		By default, the require function throws an error when the
+--		module could not be loaded.
+--		If silent is true, the function will just return false nad the error message. 
 -- @return
 --    If successful, the loaded module, which is also stored into the
 --    global package.loaded table.
 ---
 
-	premake.override(_G, "require", function(base, modname, versions)
+	premake.override(_G, "require", function(base, modname, versions, silent)
 		local result, mod = pcall(base,modname)
 		if not result then
+			if silent then
+				return result, mod
+			end
 			error(mod, 3)
 		end
 		if mod and versions and not premake.checkVersion(mod._VERSION, versions) then
-			error(string.format("module %s %s does not meet version criteria %s",
-				modname, mod._VERSION or "(none)", versions), 3)
+			local message = string.format("module %s %s does not meet version criteria %s",
+				modname, mod._VERSION or "(none)", versions)
+			if silent then
+				return false, message
+			end 
+			error(message, 3)
 		end
 		return mod
 	end)
+
+	function requireopt(modname, versions)
+		return require(modname, versions, true)	
+	end

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -9,6 +9,7 @@ return {
 	"base/test_detoken.lua",
 	"base/test_include.lua",
 	"base/test_module_loader.lua",
+	"base/test_module_loader_silent.lua",
 	"base/test_option.lua",
 	"base/test_os.lua",
 	"base/test_override.lua",

--- a/tests/base/test_module_loader_silent.lua
+++ b/tests/base/test_module_loader_silent.lua
@@ -1,0 +1,31 @@
+--
+-- tests/base/test_module_loader_silent.lua
+-- Test the custom module loader with silent option.
+-- Copyright (c) 2012-2022 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("module_loader_silent")
+
+--
+-- Setup
+--
+
+	function suite.setup()
+	end
+
+	function suite.teardown()
+	end
+
+--
+-- Check that premake's module loader will failed to
+-- load module silently
+--
+
+	function suite.silentLoadingFailure()
+		local result, msg = require("i-am-not-a-module", nil, true)
+		test.isfalse(result)
+		p.w(msg)
+		test.capture("module 'i-am-not-a-module' not found")
+	end
+	

--- a/website/docs/require.md
+++ b/website/docs/require.md
@@ -1,7 +1,7 @@
 An extension of [Lua's require() function](http://www.lua.org/pil/8.1.html) which adds support for Premake modules and version checking.
 
 ```lua
-require ("modname", "versions")
+require ("modname", "versions", silent)
 ```
 
 Premake will use its [extended set of module locations](Locating-Scripts.md) when locating the requested module.
@@ -12,10 +12,15 @@ Premake will use its [extended set of module locations](Locating-Scripts.md) whe
 
 `versions` is an optional string of a version requirements. See the examples below for more information on the format of the requirements string. If the requirements are not met, an error will be raised.
 
+`silent` will change the default error handling behavior.
+By default, `require` raises an error if the module could not be loaded
+or if the module version odes not meat the `versions` criteria.
+If `silent` is set, the `require` function will return `false` and the error message instead.
+
 
 ### Returns ###
 
-The module object.
+The module object on success, `false, error_message` on error when `silent` is set.
 
 
 ### Availability ###
@@ -59,3 +64,4 @@ require("foo", ">=1.1")
 ### See Also ###
 
 * [_PREMAKE_VERSION](premake_PREMAKE_VERSION.md)
+* [requireopt](requireopt.md)

--- a/website/docs/requireopt.md
+++ b/website/docs/requireopt.md
@@ -1,0 +1,28 @@
+Require a module or return `false` if module could not be loaded.
+
+
+```lua
+requireopt ("modname", "versions")
+```
+
+`requireopt` is an alias of `require(modname, versions, true)`
+
+### Returns ###
+
+* The module on success
+* `false`, `error_message` on error
+
+### Examples ###
+
+```
+local optionalmodule = require "not-mandatory-but-recommended"
+if not optionalmodule
+then
+	premake.warn ("You will not run this at full power")
+end
+```
+
+### See Also ###
+
+* [require](require.md)
+* [dofileopt](dofileopt.md)


### PR DESCRIPTION
**What does this PR do?**

Adds new API `requireopt()` to require a module without throwing an error

**How does this PR change Premake's behavior?**

Also adds a third argument `silent` to the existing `require()` (default: false)

**Anything else we should know?**

Use case: Have a way to handle optional modules. 
Example
```
local doxygen = requireopt("doxygen")
if doxygen then
  doxyfile {
    project_name = "..."
  }
end
```

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
