### PR TITLE
Fix case. 

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -388,19 +388,19 @@
 		local dependencies = {}
 		local makefilerules = {}
 		local function addrule(dependencies, makefilerules, config, filename)
-			if #config.buildcommands == 0 or #config.buildOutputs == 0 then
+			if #config.buildcommands == 0 or #config.buildoutputs == 0 then
 				return false
 			end
-			local inputs = table.implode(project.getrelative(cfg.project, config.buildInputs), "", "", " ")
+			local inputs = table.implode(project.getrelative(cfg.project, config.buildinputs), "", "", " ")
 			if filename ~= "" and inputs ~= "" then
 				filename = filename .. " "
 			end
-			local outputs = project.getrelative(cfg.project, config.buildOutputs[1])
+			local outputs = project.getrelative(cfg.project, config.buildoutputs[1])
 			local buildmessage = ""
 			if config.buildmessage then
 				buildmessage = "\t@{ECHO} " .. config.buildmessage .. "\n"
 			end
-			local commands = table.implode(config.buildCommands,"\t","\n","")
+			local commands = table.implode(config.buildcommands,"\t","\n","")
 			table.insert(makefilerules, os.translateCommandsAndPaths(outputs .. ": " .. filename .. inputs .. "\n" .. buildmessage .. commands, cfg.project.basedir, cfg.project.location))
 			table.insertflat(dependencies, outputs)
 			return true

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -430,7 +430,7 @@
 	end
 
 	function m.buildStep(cfg)
-		if #cfg.buildCommands > 0 or #cfg.buildOutputs > 0 or #cfg.buildInputs > 0 or cfg.buildMessage then
+		if #cfg.buildcommands > 0 or #cfg.buildoutputs > 0 or #cfg.buildinputs > 0 or cfg.buildmessage then
 
 			p.push('<CustomBuildStep>')
 			p.callArray(m.elements.buildStep, cfg)


### PR DESCRIPTION
**What does this PR do?**

Fix case of `buildOutputs`/`buildCommands`/`buildInputs`: lowercase instead of the aliases.
Fix [premake-qt](https://github.com/dcourtois/premake-qt) for codelite generator.

**How does this PR change Premake's behavior?**

No API changes

**Anything else we should know?**

Similar fixes has been applyed for premake-ninja/premake-cmake/premake-codeblocks

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
