### PR TITLE
Fix Codelite/gmake2 `buildmessage` escaping.

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -325,7 +325,7 @@
 			_p(3, '<PreBuild>')
 			p.escaper(codelite.escElementText)
 			if cfg.prebuildmessage then
-				local command = os.translateCommandsAndPaths("@{ECHO} " .. cfg.prebuildmessage, cfg.project.basedir, cfg.project.location)
+				local command = os.translateCommandsAndPaths("@{ECHO} " .. p.quote(cfg.prebuildmessage), cfg.project.basedir, cfg.project.location)
 				_x(4, '<Command Enabled="yes">%s</Command>', command)
 			end
 			local commands = os.translateCommandsAndPaths(cfg.prebuildcommands, cfg.project.basedir, cfg.project.location)
@@ -342,7 +342,7 @@
 			_p(3, '<PostBuild>')
 			p.escaper(codelite.escElementText)
 			if cfg.postbuildmessage then
-				local command = os.translateCommandsAndPaths("@{ECHO} " .. cfg.postbuildmessage, cfg.project.basedir, cfg.project.location)
+				local command = os.translateCommandsAndPaths("@{ECHO} " .. p.quote(cfg.postbuildmessage), cfg.project.basedir, cfg.project.location)
 				_x(4, '<Command Enabled="yes">%s</Command>', command)
 			end
 			local commands = os.translateCommandsAndPaths(cfg.postbuildcommands, cfg.project.basedir, cfg.project.location)
@@ -398,7 +398,7 @@
 			local outputs = project.getrelative(cfg.project, config.buildoutputs[1])
 			local buildmessage = ""
 			if config.buildmessage then
-				buildmessage = "\t@{ECHO} " .. config.buildmessage .. "\n"
+				buildmessage = "\t@{ECHO} " .. p.quote(config.buildmessage) .. "\n"
 			end
 			local commands = table.implode(config.buildcommands,"\t","\n","")
 			table.insert(makefilerules, os.translateCommandsAndPaths(outputs .. ": " .. filename .. inputs .. "\n" .. buildmessage .. commands, cfg.project.basedir, cfg.project.location))

--- a/modules/codelite/tests/test_codelite_additional_rules.lua
+++ b/modules/codelite/tests/test_codelite_additional_rules.lua
@@ -111,11 +111,11 @@
         <CustomPostBuild/>
         <CustomPreBuild>test.obj test2.obj
 test.obj: test.rule
-	@echo Rule-ing test.rule
+	@echo "Rule-ing test.rule"
 	dorule -p       "test.rule"
 
 test2.obj: test2.rule
-	@echo Rule-ing test2.rule
+	@echo "Rule-ing test2.rule"
 	dorule -p -p2      "test2.rule"
 </CustomPreBuild>
       </AdditionalRules>
@@ -156,19 +156,19 @@ test2.obj: test2.rule
         <CustomPostBuild/>
         <CustomPreBuild>test.obj test2.obj test3.obj test4.obj
 test.obj: test.rule
-	@echo Rule-ing test.rule
+	@echo "Rule-ing test.rule"
 	dorule   testValue1 testValue2     "test.rule"
 
 test2.obj: test2.rule
-	@echo Rule-ing test2.rule
+	@echo "Rule-ing test2.rule"
 	dorule    -StestValue1 -StestValue2    "test2.rule"
 
 test3.obj: test3.rule
-	@echo Rule-ing test3.rule
+	@echo "Rule-ing test3.rule"
 	dorule     testValue1,testValue2   "test3.rule"
 
 test4.obj: test4.rule
-	@echo Rule-ing test4.rule
+	@echo "Rule-ing test4.rule"
 	dorule      -OtestValue1,testValue2  "test4.rule"
 </CustomPreBuild>
       </AdditionalRules>
@@ -197,11 +197,11 @@ test4.obj: test4.rule
         <CustomPostBuild/>
         <CustomPreBuild>test.obj test2.obj
 test.obj: test.rule
-	@echo Rule-ing test.rule
+	@echo "Rule-ing test.rule"
 	dorule       S0 "test.rule"
 
 test2.obj: test2.rule
-	@echo Rule-ing test2.rule
+	@echo "Rule-ing test2.rule"
 	dorule       S1 "test2.rule"
 </CustomPreBuild>
       </AdditionalRules>
@@ -221,7 +221,27 @@ test2.obj: test2.rule
         <CustomPostBuild/>
         <CustomPreBuild>toto.c
 toto.c: toto.txt extra_dependency
-	@echo Some message
+	@echo "Some message"
+	test
+	test toto.c
+</CustomPreBuild>
+      </AdditionalRules>]]
+	end
+
+	function suite.buildCommand_escaping()
+		files {"foo.txt", "bar.txt"}
+		buildinputs { "toto.txt", "extra_dependency" }
+		buildoutputs { "toto.c" }
+		buildcommands { "test", "test toto.c" }
+		buildmessage '"Some message"'
+		prepare()
+		codelite.project.additionalRules(cfg)
+		test.capture [[
+      <AdditionalRules>
+        <CustomPostBuild/>
+        <CustomPreBuild>toto.c
+toto.c: toto.txt extra_dependency
+	@echo "\"Some message\""
 	test
 	test toto.c
 </CustomPreBuild>
@@ -242,12 +262,12 @@ toto.c: toto.txt extra_dependency
         <CustomPostBuild/>
         <CustomPreBuild>bar.c foo.c
 bar.c: bar.txt bar.h extra_dependency
-	@echo Some message
+	@echo "Some message"
 	test
 	test bar
 
 foo.c: foo.txt foo.h extra_dependency
-	@echo Some message
+	@echo "Some message"
 	test
 	test foo
 </CustomPreBuild>

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -204,7 +204,7 @@
 		codelite.project.preBuild(cfg)
 		test.capture [[
       <PreBuild>
-        <Command Enabled="yes">@echo test</Command>
+        <Command Enabled="yes">@echo "test"</Command>
       </PreBuild>
 		]]
 	end
@@ -215,7 +215,7 @@
 		codelite.project.postBuild(cfg)
 		test.capture [[
       <PostBuild>
-        <Command Enabled="yes">@echo test</Command>
+        <Command Enabled="yes">@echo "test"</Command>
       </PostBuild>
 		]]
 	end

--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -748,7 +748,7 @@
 		_p('%s: %s', file.buildoutputs[1], dependencies)
 
 		if file.buildmessage then
-			_p('\t@echo %s', file.buildmessage)
+			_p('\t@echo %s', p.quote(file.buildmessage))
 		end
 
 		if file.buildcommands then

--- a/modules/gmake2/gmake2_utility.lua
+++ b/modules/gmake2/gmake2_utility.lua
@@ -370,7 +370,7 @@
 		_p('%s: %s', outputs, dependencies)
 
 		if file.buildmessage then
-			_p('\t@echo %s', file.buildmessage)
+			_p('\t@echo %s', p.quote(file.buildmessage))
 		end
 
 		if file.buildcommands then

--- a/modules/gmake2/tests/test_gmake2_file_rules.lua
+++ b/modules/gmake2/tests/test_gmake2_file_rules.lua
@@ -93,10 +93,10 @@
 # #############################################
 
 $(OBJDIR)/hello.o: src/greetings/hello.cpp
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/hello1.o: src/hello.cpp
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 
 		]]
@@ -115,10 +115,10 @@ $(OBJDIR)/hello1.o: src/hello.cpp
 # #############################################
 
 $(OBJDIR)/hello.o: src/hello.c
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/test.o: src/test.cpp
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 
 		]]
@@ -138,10 +138,10 @@ $(OBJDIR)/test.o: src/test.cpp
 # #############################################
 
 $(OBJDIR)/hello.o: src/hello.c
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/test.o: src/test.c
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 		]]
 	end
@@ -160,17 +160,17 @@ $(OBJDIR)/test.o: src/test.c
 # #############################################
 
 $(OBJDIR)/test.o: src/test.c
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 
 ifeq ($(config),debug)
 $(OBJDIR)/hello.o: src/hello.c
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 
 else ifeq ($(config),release)
 $(OBJDIR)/hello.o: src/hello.c
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 
 endif
@@ -198,19 +198,51 @@ endif
 
 ifeq ($(config),debug)
 obj/Debug/hello.obj: hello.x
-	@echo Compiling hello.x
+	@echo "Compiling hello.x"
 	$(SILENT) cxc -c "hello.x" -o "obj/Debug/hello.xo"
 	$(SILENT) c2o -c "obj/Debug/hello.xo" -o "obj/Debug/hello.obj"
 
 else ifeq ($(config),release)
 obj/Release/hello.obj: hello.x
-	@echo Compiling hello.x
+	@echo "Compiling hello.x"
 	$(SILENT) cxc -c "hello.x" -o "obj/Release/hello.xo"
 	$(SILENT) c2o -c "obj/Release/hello.xo" -o "obj/Release/hello.obj"
 
 endif
 		]]
 	end
+
+--
+-- If a custom build rule is supplied, it should be used.
+--
+
+	function suite.customBuildRuleWithEscaping()
+		files { "hello.x" }
+		filter "files:**.x"
+			buildmessage '"Compiling %{file.name}"'
+			buildcommands {
+				'cxc -c "%{file.path}" -o "%{cfg.objdir}/%{file.basename}.xo"',
+			}
+			buildoutputs { "%{cfg.objdir}/%{file.basename}.obj" }
+		prepare()
+		test.capture [[
+# File Rules
+# #############################################
+
+ifeq ($(config),debug)
+obj/Debug/hello.obj: hello.x
+	@echo "\"Compiling hello.x\""
+	$(SILENT) cxc -c "hello.x" -o "obj/Debug/hello.xo"
+
+else ifeq ($(config),release)
+obj/Release/hello.obj: hello.x
+	@echo "\"Compiling hello.x\""
+	$(SILENT) cxc -c "hello.x" -o "obj/Release/hello.xo"
+
+endif
+		]]
+	end
+
 
 	function suite.customBuildRuleWithAdditionalInputs()
 		files { "hello.x" }
@@ -229,13 +261,13 @@ endif
 
 ifeq ($(config),debug)
 obj/Debug/hello.obj: hello.x hello.x.inc hello.x.inc2
-	@echo Compiling hello.x
+	@echo "Compiling hello.x"
 	$(SILENT) cxc -c "hello.x" -o "obj/Debug/hello.xo"
 	$(SILENT) c2o -c "obj/Debug/hello.xo" -o "obj/Debug/hello.obj"
 
 else ifeq ($(config),release)
 obj/Release/hello.obj: hello.x hello.x.inc hello.x.inc2
-	@echo Compiling hello.x
+	@echo "Compiling hello.x"
 	$(SILENT) cxc -c "hello.x" -o "obj/Release/hello.xo"
 	$(SILENT) c2o -c "obj/Release/hello.xo" -o "obj/Release/hello.obj"
 
@@ -259,14 +291,14 @@ endif
 
 ifeq ($(config),debug)
 obj/Debug/hello.obj: hello.x
-	@echo Compiling hello.x
+	@echo "Compiling hello.x"
 	$(SILENT) cxc -c "hello.x" -o "obj/Debug/hello.xo"
 	$(SILENT) c2o -c "obj/Debug/hello.xo" -o "obj/Debug/hello.obj"
 obj/Debug/hello.other obj/Debug/hello.another: obj/Debug/hello.obj
 
 else ifeq ($(config),release)
 obj/Release/hello.obj: hello.x
-	@echo Compiling hello.x
+	@echo "Compiling hello.x"
 	$(SILENT) cxc -c "hello.x" -o "obj/Release/hello.xo"
 	$(SILENT) c2o -c "obj/Release/hello.xo" -o "obj/Release/hello.obj"
 obj/Release/hello.other obj/Release/hello.another: obj/Release/hello.obj
@@ -296,10 +328,10 @@ endif
 # #############################################
 
 test.obj: test.rule
-	@echo Rule-ing test.rule
+	@echo "Rule-ing test.rule"
 	$(SILENT) dorule -p       "test.rule"
 test2.obj: test2.rule
-	@echo Rule-ing test2.rule
+	@echo "Rule-ing test2.rule"
 	$(SILENT) dorule -p -p2      "test2.rule"
 		]]
 	end
@@ -335,16 +367,16 @@ test2.obj: test2.rule
 # #############################################
 
 test.obj: test.rule
-	@echo Rule-ing test.rule
+	@echo "Rule-ing test.rule"
 	$(SILENT) dorule   testValue1\ testValue2     "test.rule"
 test2.obj: test2.rule
-	@echo Rule-ing test2.rule
+	@echo "Rule-ing test2.rule"
 	$(SILENT) dorule    -StestValue1\ -StestValue2    "test2.rule"
 test3.obj: test3.rule
-	@echo Rule-ing test3.rule
+	@echo "Rule-ing test3.rule"
 	$(SILENT) dorule     testValue1,testValue2   "test3.rule"
 test4.obj: test4.rule
-	@echo Rule-ing test4.rule
+	@echo "Rule-ing test4.rule"
 	$(SILENT) dorule      -OtestValue1,testValue2  "test4.rule"
 		]]
 	end
@@ -370,10 +402,10 @@ test4.obj: test4.rule
 # #############################################
 
 test.obj: test.rule
-	@echo Rule-ing test.rule
+	@echo "Rule-ing test.rule"
 	$(SILENT) dorule       S0 "test.rule"
 test2.obj: test2.rule
-	@echo Rule-ing test2.rule
+	@echo "Rule-ing test2.rule"
 	$(SILENT) dorule       S1 "test2.rule"
 		]]
 	end

--- a/modules/gmake2/tests/test_gmake2_pch.lua
+++ b/modules/gmake2/tests/test_gmake2_pch.lua
@@ -69,10 +69,10 @@
 # #############################################
 
 $(OBJDIR)/a.o: a.cpp
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/b.o: b.cpp
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 ]]
 	end
@@ -193,10 +193,10 @@ PCH = ../../../../src/host/premake.h
 # #############################################
 
 $(OBJDIR)/a.o: a.cpp
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/b.o: b.cpp
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 ]]
 	end
@@ -215,10 +215,10 @@ $(OBJDIR)/b.o: b.cpp
 # #############################################
 
 $(OBJDIR)/a.o: a.cpp
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/b.o: b.cpp
-	@echo $(notdir $<)
+	@echo "$(notdir $<)"
 	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 ]]
 	end

--- a/src/base/premake.lua
+++ b/src/base/premake.lua
@@ -321,7 +321,16 @@ end
 		end
 	end
 
+---
+-- Wrap the provided value in double quotes
+-- escaping backslash and double quote
+---
 
+	function premake.quote(s)
+		s = s:gsub('\\', '\\\\')
+		s = s:gsub('"', '\\"')
+		return '"' .. s .. '"'
+	end
 
 ---
 -- Wrap the provided value in double quotes if it contains spaces, or
@@ -334,7 +343,7 @@ end
 			q = value:find("$%(.-%)", 1)
 		end
 		if q then
-			value = '"' .. value .. '"'
+			return p.quote(value)
 		end
 		return value
 	end


### PR DESCRIPTION
**What does this PR do?**

Fix escaping for `buildmessage` for gmake2 and codelite

**How does this PR change Premake's behavior?**

Escape double quote and backslash in `quoted`

**Anything else we should know?**

Tested with https://github.com/Jarod42/premake-sample-projects/actions with branch custom_rule_check_quote_in_message

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
