### PR TITLE
6.x - Fix vstudio exporter

### DIFF
--- a/modules/exporters/vstudio/src/vcxproj.filters.lua
+++ b/modules/exporters/vstudio/src/vcxproj.filters.lua
@@ -38,7 +38,7 @@ filters.elements = {
 ---
 
 function filters.export(prj)
-	if tree.hasBranches(prj.virtualSourceTree) then
+	if tree.hasBranches(prj.sourceTree) then
 		local exportPath = prj.exportPath .. '.filters'
 		return premake.export(prj, exportPath, function ()
 			export.eol('\r\n')


### PR DESCRIPTION
**What does this PR do?**

Fixes the vstudio exporter. When I ran it by default I got an error:

```
Configuring...
Exporting Premake...
Error: C:/Dev/premake-core/core/modules/tree/tree.lua:100: attempt to index a nil value (local 'self')
stack traceback:
        ...e-core/modules/exporters/vstudio/src/vcxproj.filters.lua:41: in field 'export'
        ...v/premake-core/modules/exporters/vstudio/src/vcxproj.lua:266: in field 'export'
        C:/Dev/premake-core/modules/exporters/vstudio/vstudio.lua:282: in function 'vstudio.exportProject'
        C:/Dev/premake-core/modules/exporters/vstudio/vstudio.lua:271: in function 'vstudio.exportWorkspace'
        C:/Dev/premake-core/modules/exporters/vstudio/vstudio.lua:54: in function 'vstudio.export'
        C:/Dev/premake-core/modules/exporters/vstudio/_register.lua:9: in field 'execute'
        C:/Dev/premake-core/core/modules/options/options.lua:90: in function 'options.execute'
        C:/Dev/premake-core/core/modules/main/main.lua:67: in function 'main.executeCommandLineOptions'
        C:/Dev/premake-core/core/modules/premake/premake.lua:57: in function 'premake.callArray'
        C:/Dev/premake-core/core/modules/main/main.lua:88: in function 'main.run'
        C:/Dev/premake-core/core/host/src/_premake_main.lua:20: in function '_premake_main'
```

It seems like the `virtualSourceTree` property should actually have been `sourceTree`. I'm not 100% confident but after this change I was able to generate a solution and build it.

**How does this PR change Premake's behavior?**

Fixes the vstudio exporter.

**Anything else we should know?**

I'm not 100% certain on the changes. All I know is I couldn't generate a project before and after making this change I can so it seems correct, but please let me know if this is wrong for some reason.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
