### PR TITLE
Add address sanitizer flags

### DIFF
--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -355,12 +355,12 @@
 	end
 
 --
--- If the AddressSanitizer flag is set, add the EnableASAN element.
+-- If the sanitizer flags are set, add the correct elements.
 --
 
-function suite.onAddressSanitizer()
+function suite.onSanitizeAddress()
 	p.action.set("vs2022")
-	flags "AddressSanitizer"
+	sanitize { "Address" }
 	prepare()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -373,9 +373,9 @@ function suite.onAddressSanitizer()
 	]]
 end
 
-function suite.onAddressSanitizer_BeforeVS2022()
+function suite.onSanitizeAddress_BeforeVS2022()
 	p.action.set("vs2019")
-	flags "AddressSanitizer"
+	sanitize { "Address" }
 	prepare()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -387,13 +387,9 @@ function suite.onAddressSanitizer_BeforeVS2022()
 	]]
 end
 
---
--- If the Fuzzer flag is set, add the EnableFuzzer element.
---
-
-function suite.onFuzzer()
+function suite.onSanitizeFuzzer()
 	p.action.set("vs2022")
-	flags "Fuzzer"
+	sanitize { "Fuzzer" }
 	prepare()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -406,9 +402,9 @@ function suite.onFuzzer()
 	]]
 end
 
-function suite.onFuzzer_BeforeVS2022()
+function suite.onSanitizeFuzzer_BeforeVS2022()
 	p.action.set("vs2019")
-	flags "Fuzzer"
+	sanitize { "Fuzzer" }
 	prepare()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -416,6 +412,22 @@ function suite.onFuzzer_BeforeVS2022()
 	<UseDebugLibraries>false</UseDebugLibraries>
 	<CharacterSet>Unicode</CharacterSet>
 	<PlatformToolset>v142</PlatformToolset>
+</PropertyGroup>
+	]]
+end
+
+function suite.onSanitizeAddressFuzzer()
+	p.action.set("vs2022")
+	sanitize { "Address", "Fuzzer" }
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v143</PlatformToolset>
+	<EnableASAN>true</EnableASAN>
+	<EnableFuzzer>true</EnableFuzzer>
 </PropertyGroup>
 	]]
 end

--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -156,7 +156,7 @@
 	<CLRSupport>Pure</CLRSupport>
 		]]
 	end
-	
+
 	function suite.clrSupport_onClrNetCore()
 		clr "NetCore"
 		prepare()
@@ -353,3 +353,69 @@
 </PropertyGroup>
 		]]
 	end
+
+--
+-- If the AddressSanitizer flag is set, add the EnableASAN element.
+--
+
+function suite.onAddressSanitizer()
+	p.action.set("vs2022")
+	flags "AddressSanitizer"
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v143</PlatformToolset>
+	<EnableASAN>true</EnableASAN>
+</PropertyGroup>
+	]]
+end
+
+function suite.onAddressSanitizer_BeforeVS2022()
+	p.action.set("vs2019")
+	flags "AddressSanitizer"
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v142</PlatformToolset>
+</PropertyGroup>
+	]]
+end
+
+--
+-- If the Fuzzer flag is set, add the EnableFuzzer element.
+--
+
+function suite.onFuzzer()
+	p.action.set("vs2022")
+	flags "Fuzzer"
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v143</PlatformToolset>
+	<EnableFuzzer>true</EnableFuzzer>
+</PropertyGroup>
+	]]
+end
+
+function suite.onFuzzer_BeforeVS2022()
+	p.action.set("vs2019")
+	flags "Fuzzer"
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v142</PlatformToolset>
+</PropertyGroup>
+	]]
+end

--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -359,7 +359,7 @@
 --
 
 function suite.onSanitizeAddress()
-	p.action.set("vs2022")
+	p.action.set("vs2019")
 	sanitize { "Address" }
 	prepare()
 	test.capture [[
@@ -367,14 +367,14 @@ function suite.onSanitizeAddress()
 	<ConfigurationType>Application</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
 	<CharacterSet>Unicode</CharacterSet>
-	<PlatformToolset>v143</PlatformToolset>
+	<PlatformToolset>v142</PlatformToolset>
 	<EnableASAN>true</EnableASAN>
 </PropertyGroup>
 	]]
 end
 
-function suite.onSanitizeAddress_BeforeVS2022()
-	p.action.set("vs2019")
+function suite.onSanitizeAddress_BeforeVS2019()
+	p.action.set("vs2017")
 	sanitize { "Address" }
 	prepare()
 	test.capture [[
@@ -382,27 +382,12 @@ function suite.onSanitizeAddress_BeforeVS2022()
 	<ConfigurationType>Application</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
 	<CharacterSet>Unicode</CharacterSet>
-	<PlatformToolset>v142</PlatformToolset>
+	<PlatformToolset>v141</PlatformToolset>
 </PropertyGroup>
 	]]
 end
 
 function suite.onSanitizeFuzzer()
-	p.action.set("vs2022")
-	sanitize { "Fuzzer" }
-	prepare()
-	test.capture [[
-<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-	<ConfigurationType>Application</ConfigurationType>
-	<UseDebugLibraries>false</UseDebugLibraries>
-	<CharacterSet>Unicode</CharacterSet>
-	<PlatformToolset>v143</PlatformToolset>
-	<EnableFuzzer>true</EnableFuzzer>
-</PropertyGroup>
-	]]
-end
-
-function suite.onSanitizeFuzzer_BeforeVS2022()
 	p.action.set("vs2019")
 	sanitize { "Fuzzer" }
 	prepare()
@@ -412,12 +397,27 @@ function suite.onSanitizeFuzzer_BeforeVS2022()
 	<UseDebugLibraries>false</UseDebugLibraries>
 	<CharacterSet>Unicode</CharacterSet>
 	<PlatformToolset>v142</PlatformToolset>
+	<EnableFuzzer>true</EnableFuzzer>
+</PropertyGroup>
+	]]
+end
+
+function suite.onSanitizeFuzzer_BeforeVS2019()
+	p.action.set("vs2017")
+	sanitize { "Fuzzer" }
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v141</PlatformToolset>
 </PropertyGroup>
 	]]
 end
 
 function suite.onSanitizeAddressFuzzer()
-	p.action.set("vs2022")
+	p.action.set("vs2019")
 	sanitize { "Address", "Fuzzer" }
 	prepare()
 	test.capture [[
@@ -425,7 +425,7 @@ function suite.onSanitizeAddressFuzzer()
 	<ConfigurationType>Application</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
 	<CharacterSet>Unicode</CharacterSet>
-	<PlatformToolset>v143</PlatformToolset>
+	<PlatformToolset>v142</PlatformToolset>
 	<EnableASAN>true</EnableASAN>
 	<EnableFuzzer>true</EnableFuzzer>
 </PropertyGroup>

--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -388,6 +388,21 @@ function suite.onSanitizeAddress_BeforeVS2019()
 end
 
 function suite.onSanitizeFuzzer()
+	p.action.set("vs2022")
+	sanitize { "Fuzzer" }
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v143</PlatformToolset>
+	<EnableFuzzer>true</EnableFuzzer>
+</PropertyGroup>
+	]]
+end
+
+function suite.onSanitizeFuzzer_BeforeVS2022()
 	p.action.set("vs2019")
 	sanitize { "Fuzzer" }
 	prepare()
@@ -397,26 +412,27 @@ function suite.onSanitizeFuzzer()
 	<UseDebugLibraries>false</UseDebugLibraries>
 	<CharacterSet>Unicode</CharacterSet>
 	<PlatformToolset>v142</PlatformToolset>
-	<EnableFuzzer>true</EnableFuzzer>
 </PropertyGroup>
 	]]
 end
 
-function suite.onSanitizeFuzzer_BeforeVS2019()
-	p.action.set("vs2017")
-	sanitize { "Fuzzer" }
+function suite.onSanitizeAddressFuzzer()
+	p.action.set("vs2022")
+	sanitize { "Address", "Fuzzer" }
 	prepare()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
 	<ConfigurationType>Application</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
 	<CharacterSet>Unicode</CharacterSet>
-	<PlatformToolset>v141</PlatformToolset>
+	<PlatformToolset>v143</PlatformToolset>
+	<EnableASAN>true</EnableASAN>
+	<EnableFuzzer>true</EnableFuzzer>
 </PropertyGroup>
 	]]
 end
 
-function suite.onSanitizeAddressFuzzer()
+function suite.onSanitizeAddressFuzzer_BeforeVS2022()
 	p.action.set("vs2019")
 	sanitize { "Address", "Fuzzer" }
 	prepare()
@@ -427,7 +443,6 @@ function suite.onSanitizeAddressFuzzer()
 	<CharacterSet>Unicode</CharacterSet>
 	<PlatformToolset>v142</PlatformToolset>
 	<EnableASAN>true</EnableASAN>
-	<EnableFuzzer>true</EnableFuzzer>
 </PropertyGroup>
 	]]
 end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -195,6 +195,7 @@
 				m.clrSupport,
 				m.characterSet,
 				m.platformToolset,
+				m.sanitizers,
 				m.toolsVersion,
 				m.wholeProgramOptimization,
 				m.nmakeOutDirs,
@@ -2503,6 +2504,17 @@
 				end
 			else
 				m.element("PlatformToolset", nil, version)
+			end
+		end
+	end
+
+	function m.sanitizers(cfg)
+		if _ACTION >= "vs2022" then
+			if cfg.flags.AddressSanitizer then
+				m.element("EnableASAN", nil, "true")
+			end
+			if cfg.flags.Fuzzer then
+				m.element("EnableFuzzer", nil, "true")
 			end
 		end
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2509,11 +2509,11 @@
 	end
 
 	function m.sanitizers(cfg)
-		if _ACTION >= "vs2022" then
-			if cfg.flags.AddressSanitizer then
+		if _ACTION >= "vs2022" and cfg.sanitize then
+			if table.contains(cfg.sanitize, "Address") then
 				m.element("EnableASAN", nil, "true")
 			end
-			if cfg.flags.Fuzzer then
+			if table.contains(cfg.sanitize, "Fuzzer") then
 				m.element("EnableFuzzer", nil, "true")
 			end
 		end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2509,7 +2509,7 @@
 	end
 
 	function m.sanitizers(cfg)
-		if _ACTION >= "vs2022" and cfg.sanitize then
+		if _ACTION >= "vs2019" and cfg.sanitize then
 			if table.contains(cfg.sanitize, "Address") then
 				m.element("EnableASAN", nil, "true")
 			end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2513,6 +2513,8 @@
 			if table.contains(cfg.sanitize, "Address") then
 				m.element("EnableASAN", nil, "true")
 			end
+		end
+		if _ACTION >= "vs2022" and cfg.sanitize then
 			if table.contains(cfg.sanitize, "Fuzzer") then
 				m.element("EnableFuzzer", nil, "true")
 			end

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -190,7 +190,7 @@
 			"HeaderUnit"
 		}
 	}
- 
+
 	api.register {
 		name = "allmodulespublic",
 		scope = "config",
@@ -489,7 +489,6 @@
 		scope = "config",
 		kind  = "list:string",
 		allowed = {
-			"AddressSanitizer",
 			"Component",           -- DEPRECATED
 			"DebugEnvsDontMerge",
 			"DebugEnvsInherit",
@@ -501,7 +500,6 @@
 			"FatalLinkWarnings",
 			"FloatFast",           -- DEPRECATED
 			"FloatStrict",         -- DEPRECATED
-			"Fuzzer",              -- Visual Studio 2022+ only
 			"LinkTimeOptimization",
 			"Managed",             -- DEPRECATED
 			"Maps",
@@ -1118,6 +1116,16 @@
 		name = "rules",
 		scope = "project",
 		kind = "list:string",
+	}
+
+	api.register {
+		name = "sanitize",
+		scope = "config",
+		kind = "list:string",
+		allowed = {
+			"Address",
+			"Fuzzer",              -- Visual Studio 2022+ only
+		}
 	}
 
 	api.register {

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -489,6 +489,7 @@
 		scope = "config",
 		kind  = "list:string",
 		allowed = {
+			"AddressSanitizer",
 			"Component",           -- DEPRECATED
 			"DebugEnvsDontMerge",
 			"DebugEnvsInherit",
@@ -500,6 +501,7 @@
 			"FatalLinkWarnings",
 			"FloatFast",           -- DEPRECATED
 			"FloatStrict",         -- DEPRECATED
+			"Fuzzer",              -- Visual Studio 2022+ only
 			"LinkTimeOptimization",
 			"Managed",             -- DEPRECATED
 			"Maps",

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -115,6 +115,9 @@
 --
 
 	clang.cxxflags = table.merge(gcc.cxxflags, {
+		sanitize = {
+			Fuzzer = "-fsanitize=fuzzer",
+		},
 	})
 
 	function clang.getcxxflags(cfg)

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -203,7 +203,6 @@
 			Off = "-fno-exceptions"
 		},
 		flags = {
-			AddressSanitizer = "-fsanitize=address",
 			NoBufferSecurityCheck = "-fno-stack-protector",
 		},
 		cppdialect = {
@@ -229,6 +228,9 @@
 		},
 		rtti = {
 			Off = "-fno-rtti"
+		},
+		sanitize = {
+			Address = "-fsanitize=address",
 		},
 		visibility = {
 			Default = "-fvisibility=default",

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -203,6 +203,7 @@
 			Off = "-fno-exceptions"
 		},
 		flags = {
+			AddressSanitizer = "-fsanitize=address",
 			NoBufferSecurityCheck = "-fno-stack-protector",
 		},
 		cppdialect = {

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -154,6 +154,10 @@
 --
 
 	msc.cxxflags = {
+		flags = {
+			AddressSanitizer = "/fsanitize=address",
+			Fuzzer = "/fsanitize=fuzzer",
+		},
 		exceptionhandling = {
 			Default = "/EHsc",
 			On = "/EHsc",

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -154,10 +154,6 @@
 --
 
 	msc.cxxflags = {
-		flags = {
-			AddressSanitizer = "/fsanitize=address",
-			Fuzzer = "/fsanitize=fuzzer",
-		},
 		exceptionhandling = {
 			Default = "/EHsc",
 			On = "/EHsc",
@@ -165,6 +161,10 @@
 		},
 		rtti = {
 			Off = "/GR-"
+		},
+		sanitize = {
+			Address = "/fsanitize=address",
+			Fuzzer = "/fsanitize=fuzzer",
 		}
 	}
 

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -37,7 +37,7 @@
 		prepare()
 		test.contains({ "-mmacosx-version-min=10.9" }, clang.getcflags(cfg))
 	end
-	
+
 	function suite.cxxflags_macosx_systemversion()
 		system "MacOSX"
 		systemversion "10.9"
@@ -50,7 +50,7 @@
 		prepare()
 		test.excludes({ "-mmacosx-version-min=10.9" }, clang.getcxxflags(cfg))
 	end
-	
+
 --
 -- Check iOS deployment target flags
 --
@@ -61,7 +61,7 @@
 		prepare()
 		test.contains({ "-miphoneos-version-min=12.1" }, clang.getcflags(cfg))
 	end
-	
+
 	function suite.cxxflags_ios_systemversion()
 		system "iOS"
 		systemversion "5.0"
@@ -85,3 +85,12 @@
 		test.excludes("-fopenmp", clang.getcflags(cfg))
 	end
 
+--
+-- Check the translation of CXXFLAGS.
+--
+
+function suite.cxxflags_onSanitizeFuzzer()
+	sanitize { "Fuzzer" }
+	prepare()
+	test.contains({ "-fsanitize=fuzzer" }, gcc.getcxxflags(cfg))
+end

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -92,5 +92,5 @@
 function suite.cxxflags_onSanitizeFuzzer()
 	sanitize { "Fuzzer" }
 	prepare()
-	test.contains({ "-fsanitize=fuzzer" }, gcc.getcxxflags(cfg))
+	test.contains({ "-fsanitize=fuzzer" }, clang.getcxxflags(cfg))
 end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -368,8 +368,8 @@
 		test.contains({ "-fno-stack-protector" }, gcc.getcxxflags(cfg))
 	end
 
-	function suite.cxxflags_onAddressSanitizer()
-		flags { "AddressSanitizer" }
+	function suite.cxxflags_onSanitizeAddress()
+		sanitize { "Address" }
 		prepare()
 		test.contains({ "-fsanitize=address" }, gcc.getcxxflags(cfg))
 	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -356,16 +356,22 @@
 -- Check the translation of CXXFLAGS.
 --
 
-	function suite.cflags_onNoExceptions()
+	function suite.cxxflags_onNoExceptions()
 		exceptionhandling "Off"
 		prepare()
 		test.contains({ "-fno-exceptions" }, gcc.getcxxflags(cfg))
 	end
 
-	function suite.cflags_onNoBufferSecurityCheck()
+	function suite.cxxflags_onNoBufferSecurityCheck()
 		flags { "NoBufferSecurityCheck" }
 		prepare()
 		test.contains({ "-fno-stack-protector" }, gcc.getcxxflags(cfg))
+	end
+
+	function suite.cxxflags_onAddressSanitizer()
+		flags { "AddressSanitizer" }
+		prepare()
+		test.contains({ "-fsanitize=address" }, gcc.getcxxflags(cfg))
 	end
 
 --

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -441,15 +441,22 @@
 		test.contains("/GR-", msc.getcxxflags(cfg))
 	end
 
-	function suite.cxxflags_onAddressSanitizer()
-		flags { "AddressSanitizer" }
+	function suite.cxxflags_onSanitizeAddress()
+		sanitize { "Address" }
 		prepare()
 		test.contains("/fsanitize=address", msc.getcxxflags(cfg))
 	end
 
-	function suite.cxxflags_onFuzzer()
-		flags { "Fuzzer" }
+	function suite.cxxflags_onSanitizeFuzzer()
+		sanitize { "Fuzzer" }
 		prepare()
+		test.contains("/fsanitize=fuzzer", msc.getcxxflags(cfg))
+	end
+
+	function suite.cxxflags_onSanitizeAddressFuzzer()
+		sanitize { "Address", "Fuzzer" }
+		prepare()
+		test.contains("/fsanitize=address", msc.getcxxflags(cfg))
 		test.contains("/fsanitize=fuzzer", msc.getcxxflags(cfg))
 	end
 

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -441,6 +441,18 @@
 		test.contains("/GR-", msc.getcxxflags(cfg))
 	end
 
+	function suite.cxxflags_onAddressSanitizer()
+		flags { "AddressSanitizer" }
+		prepare()
+		test.contains("/fsanitize=address", msc.getcxxflags(cfg))
+	end
+
+	function suite.cxxflags_onFuzzer()
+		flags { "Fuzzer" }
+		prepare()
+		test.contains("/fsanitize=fuzzer", msc.getcxxflags(cfg))
+	end
+
 
 --
 -- Check handling of additional linker options.
@@ -573,9 +585,9 @@
 	end
 
 
-	--
-	-- Check handling of Run-Time Library flags.
-	--
+--
+-- Check handling of Run-Time Library flags.
+--
 
 	function suite.cflags_onStaticRuntime()
 		staticruntime "On"

--- a/website/docs/Project-API.md
+++ b/website/docs/Project-API.md
@@ -150,6 +150,7 @@
 | [rule](rule.md)                                           |  |
 | [rules](rules.md)                                         |  |
 | [runtime](runtime.md)                                     |  |
+| [sanitize](sanitize.md)                                   | Enable `fsanitize` compiler options |
 | [sharedlibtype](sharedlibtype.md)                         |  |
 | [startproject](startproject.md)                           |  |
 | [strictaliasing](strictaliasing.md)                       |  |

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -10,8 +10,6 @@ flags { "flag_list" }
 
 | Flag                  | Description                                                         | Notes |
 |-----------------------|---------------------------------------------------------------------|----------------|
-| AddressSanitizer      | Enables compiler support for AddressSanitizer. | Visual Studio support starts with 2022. |
-| Fuzzer                | Enables support for LibFuzzer, a coverage-guided fuzzing library. | Visual Studio 2022+ only. |
 | ExcludeFromBuild      | Exclude a source code file from the build, for the current configuration. |
 | FatalCompileWarnings  | Treat compiler warnings as errors.                                  |
 | FatalLinkWarnings     | Treat linker warnings as errors.                                    |

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -10,6 +10,8 @@ flags { "flag_list" }
 
 | Flag                  | Description                                                         | Notes |
 |-----------------------|---------------------------------------------------------------------|----------------|
+| AddressSanitizer      | Enables compiler support for AddressSanitizer. | Visual Studio support starts with 2022. |
+| Fuzzer                | Enables support for LibFuzzer, a coverage-guided fuzzing library. | Visual Studio 2022+ only. |
 | ExcludeFromBuild      | Exclude a source code file from the build, for the current configuration. |
 | FatalCompileWarnings  | Treat compiler warnings as errors.                                  |
 | FatalLinkWarnings     | Treat linker warnings as errors.                                    |

--- a/website/docs/sanitize.md
+++ b/website/docs/sanitize.md
@@ -10,8 +10,8 @@ sanitize { "value_list" }
 
 | Value       | Description                                            |
 |-------------|--------------------------------------------------------|
-| Address     | Enables compiler support for AddressSanitizer. | Visual Studio support starts with 2022. |
-| Fuzzer      | Enables support for LibFuzzer, a coverage-guided fuzzing library. | Visual Studio 2022+ & Clang only. |
+| Address     | Enables compiler support for AddressSanitizer. | Visual Studio support starts with 2019 16.9 |
+| Fuzzer      | Enables support for LibFuzzer, a coverage-guided fuzzing library. | Visual Studio support starts with 2019 16.9 |
 
 ### Applies To ###
 

--- a/website/docs/sanitize.md
+++ b/website/docs/sanitize.md
@@ -1,0 +1,28 @@
+Enables various `fsanitize` options for compilers.
+
+```lua
+sanitize { "value_list" }
+```
+
+### Parameters ###
+
+`value_list` specifies the desired `fsanitize` options to enable.
+
+| Value       | Description                                            |
+|-------------|--------------------------------------------------------|
+| Address     | Enables compiler support for AddressSanitizer. | Visual Studio support starts with 2022. |
+| Fuzzer      | Enables support for LibFuzzer, a coverage-guided fuzzing library. | Visual Studio 2022+ only. |
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0 or later.
+
+### Examples ###
+
+```lua
+sanitize { "Address", "Fuzzer" }
+```

--- a/website/docs/sanitize.md
+++ b/website/docs/sanitize.md
@@ -11,7 +11,7 @@ sanitize { "value_list" }
 | Value       | Description                                            |
 |-------------|--------------------------------------------------------|
 | Address     | Enables compiler support for AddressSanitizer. | Visual Studio support starts with 2022. |
-| Fuzzer      | Enables support for LibFuzzer, a coverage-guided fuzzing library. | Visual Studio 2022+ only. |
+| Fuzzer      | Enables support for LibFuzzer, a coverage-guided fuzzing library. | Visual Studio 2022+ & Clang only. |
 
 ### Applies To ###
 


### PR DESCRIPTION
**What does this PR do?**

Resolves #1595

1. Implement support for `fsanitize=address` in gcc, clang, msc, and Visual Studio backends.
2. Implement support for `fsanitize=fuzzer` in msc, Visual Studio, and clang backends.

**How does this PR change Premake's behavior?**

Existing behavior should be unaffected.

**Anything else we should know?**

There are a number of other `fsanitize` options that are supported by gcc/clang, but not by msc or visual studio. I did not add support for these, but can if it is desired.

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
    * **I did make a couple unnecessary format changes, but only in files I was already modifying and nothing major.**
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
