### PR TITLE
Exports correct tooling in gmake(2) if GCC is specified

### DIFF
--- a/modules/gmake/tests/cpp/test_tools.lua
+++ b/modules/gmake/tests/cpp/test_tools.lua
@@ -30,6 +30,15 @@
 	function suite.usesCorrectTools()
 		make.cppTools(cfg, p.tools.gcc)
 		test.capture [[
+  ifeq ($(origin CC), default)
+    CC = gcc
+  endif
+  ifeq ($(origin CXX), default)
+    CXX = g++
+  endif
+  ifeq ($(origin AR), default)
+    AR = ar
+  endif
   RESCOMP = windres
 		]]
 	end

--- a/modules/gmake2/tests/test_gmake2_tools.lua
+++ b/modules/gmake2/tests/test_gmake2_tools.lua
@@ -31,6 +31,15 @@
 	function suite.usesCorrectTools()
 		gmake2.cpp.tools(cfg, p.tools.gcc)
 		test.capture [[
+ifeq ($(origin CC), default)
+  CC = gcc
+endif
+ifeq ($(origin CXX), default)
+  CXX = g++
+endif
+ifeq ($(origin AR), default)
+  AR = ar
+endif
 RESCOMP = windres
 		]]
 	end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -644,8 +644,9 @@
 	}
 
 	function gcc.gettoolname(cfg, tool)
-		if (cfg.gccprefix and gcc.tools[tool]) or tool == "rc" then
-			return (cfg.gccprefix or "") .. gcc.tools[tool]
+		local value = gcc.tools[tool]
+		if type(value) == "function" then
+			value = value(cfg)
 		end
-		return nil
+		return (cfg.gccprefix or "") .. value
 	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -33,9 +33,9 @@
 
 	function suite.tools_onDefaults()
 		prepare()
-		test.isnil(gcc.gettoolname(cfg, "cc"))
-		test.isnil(gcc.gettoolname(cfg, "cxx"))
-		test.isnil(gcc.gettoolname(cfg, "ar"))
+		test.isequal("gcc", gcc.gettoolname(cfg, "cc"))
+		test.isequal("g++", gcc.gettoolname(cfg, "cxx"))
+		test.isequal("ar", gcc.gettoolname(cfg, "ar"))
 		test.isequal("windres", gcc.gettoolname(cfg, "rc"))
 	end
 


### PR DESCRIPTION
**What does this PR do?**

When using gmake or gmake2 exporter and GCC toolchain, the CC/CXX/AR variables used the environment default rather than being set to GCC tooling.  This forces the Makefile to use `gcc`, `g++`, and `ar`.

**How does this PR change Premake's behavior?**

See above

**Anything else we should know?**

Closes #266 #1860 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
