### PR TITLE
XCUITest type added (similar to XCTest)

### DIFF
--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -241,6 +241,7 @@
 			OSXBundle    = "com.apple.product-type.bundle",
 			OSXFramework = "com.apple.product-type.framework",
 			XCTest       = "com.apple.product-type.bundle.unit-test",
+			XCUITest	 = "com.apple.product-type.bundle.ui-testing",
 		}
 		return types[iif(node.cfg.kind == "SharedLib" and node.cfg.sharedlibtype, node.cfg.sharedlibtype, node.cfg.kind)]
 	end
@@ -264,6 +265,7 @@
 			OSXBundle    = "wrapper.cfbundle",
 			OSXFramework = "wrapper.framework",
 			XCTest       = "wrapper.cfbundle",
+			XCUITest     = "wrapper.cfbundle",
 		}
 		return types[iif(node.cfg.kind == "SharedLib" and node.cfg.sharedlibtype, node.cfg.sharedlibtype, node.cfg.kind)]
 	end

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1271,6 +1271,7 @@
 				OSXBundle    = "bundle",
 				OSXFramework = "framework",
 				XCTest       = "xctest",
+				XCUITest	 = "xctest",
 			}
 			local ext = cfg.buildtarget.extension:sub(2)
 			if ext ~= exts[iif(cfg.kind == "SharedLib" and cfg.sharedlibtype, cfg.sharedlibtype, cfg.kind)] then

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1921,6 +1921,10 @@
 		targetprefix ""
 		targetextension ".xctest"
 
+	filter { "system:darwin", "kind:SharedLib", "sharedlibtype:XCUITest" }
+		targetprefix ""
+		targetextension ".xctest"
+
 	-- Windows and friends.
 
 	filter { "system:Windows or language:C# or language:F#", "kind:ConsoleApp or WindowedApp" }

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -750,6 +750,7 @@
 			"OSXBundle",
 			"OSXFramework",
 			"XCTest",
+			"XCUITest",
 		},
 	}
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -406,6 +406,8 @@
 				return "-bundle"
 			elseif cfg.sharedlibtype == "XCTest" then
 				return "-bundle"
+			elseif cfg.sharedlibtype == "XCUITest" then
+				return "-bundle"
 			elseif cfg.sharedlibtype == "OSXFramework" then
 				return "-framework"
 			else

--- a/tests/config/test_targetinfo.lua
+++ b/tests/config/test_targetinfo.lua
@@ -243,6 +243,13 @@
 		test.isequal("bin/Debug/MyProject.xctest/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
 	end
 
+	function suite.bundlepathSet_onMacSharedLibXCUITest()
+		kind "SharedLib"
+		sharedlibtype "XCUITest"
+		system "macosx"
+		i = prepare()
+		test.isequal("bin/Debug/MyProject.xctest/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
+	end
 
 --
 -- Bundle path should be set for macOS/iOS framework.

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -409,6 +409,14 @@
 		test.contains({ "-Wl,-x", "-bundle" }, gcc.getldflags(cfg))
 	end
 
+	function suite.ldflags_onMacOSXXCUITest()
+		system "MacOSX"
+		kind "SharedLib"
+		sharedlibtype "XCUITest"
+		prepare()
+		test.contains({ "-Wl,-x", "-bundle" }, gcc.getldflags(cfg))
+	end
+
 	function suite.ldflags_onMacOSXFramework()
 		system "MacOSX"
 		kind "SharedLib"

--- a/website/docs/sharedlibtype.md
+++ b/website/docs/sharedlibtype.md
@@ -10,6 +10,7 @@ sharedlibtype "value"
 * `OSXBundle` - needs documentation.
 * `OSXFramework` - needs documentation.
 * `XCTest` - needs documentation.
+* `XCUITest`- needs documentation.
 
 ### Applies To ###
 


### PR DESCRIPTION
This PR adds the support for the XCUITest type for XCode projects. It is very similar to XCTest, with most things being the same, but it's a different `productType` than the XCTest.

Don't expect any breaking change, because this is an addition. And I have also added tests.