### PR TITLE
Adds "uses" and "block" APIs

### DIFF
--- a/core/modules/dom/dom.lua
+++ b/core/modules/dom/dom.lua
@@ -1,5 +1,6 @@
 local dom = {}
 
+dom.Block = doFile('./src/block.lua', dom)
 dom.Config = doFile('./src/config.lua', dom)
 dom.Project = doFile('./src/project.lua', dom)
 dom.Root = doFile('./src/root.lua', dom)

--- a/core/modules/dom/src/block.lua
+++ b/core/modules/dom/src/block.lua
@@ -1,0 +1,54 @@
+local State = require('state')
+local Type = require('type')
+
+local dom = select(1, ...)
+
+local Block = Type.declare('Block', State)
+
+
+---
+-- Instantiate a new block configuration helper.
+--
+-- @param state
+--    The block configuration state.
+-- @returns
+--    The new block helper instance.
+---
+
+function Block.new(state)
+    local blk = Type.assign(Block, state)
+
+    local name = state.blocks[1]
+    blk.name = name
+
+    return blk
+end
+
+
+---
+-- Retrieve the configurations contained by this block.
+--
+-- @param createCallback
+--    A function with signature `(workspace, build, platform)` which will be called for
+--    each build/platform pair found in the block.  Return a new `dom.Config` to represent
+--    the configuration, or `nil` to ignore it.
+-- @returns
+--    An array of `dom.Config`.
+---
+
+function Block.fetchConfigs(self, createCallback)
+    local configs = {}
+
+    local selectors = dom.Config.fetchConfigPlatformPairs(self)
+    for i = 1, #selectors do
+        local selector = selectors[i]
+        local cfg = createCallback(self, selector.configurations, selector.platforms)
+        configs[i] = cfg
+        configs[cfg.name] = cfg
+    end
+
+    return configs
+end
+
+
+return Block

--- a/core/modules/dom/src/config.lua
+++ b/core/modules/dom/src/config.lua
@@ -25,9 +25,9 @@ end
 
 
 ---
--- Given a container state (i.e. workspace or project), returns a list of build
--- configuration and platform pairs for that state, as an array of query selectors
--- suitable for passing to `State.selectAny()`, ex.
+-- Given a container state (i.e. workspace, project, or block), returns a list
+-- of build configuration and platform pairs for that state, as an array of
+-- query selectors suitable for passing to `State.selectAny()`, ex.
 --
 --     { configurations = 'Debug', platforms = 'x86_64' }
 ---

--- a/core/modules/dom/src/project.lua
+++ b/core/modules/dom/src/project.lua
@@ -112,6 +112,32 @@ end
 
 
 ---
+-- Retrieve the blocks contained by this project.
+--
+-- @param createCallback
+--    A function with the signature `(project, blockName)` which will be called for
+--    each block name found in the workspace. Return a new `dom.Block` to represent
+--    the project, or `nil` to ignore it.
+-- @returns
+--    A table of projects, keyed by integer index and block name.
+---
+
+function Project.fetchBlocks(self, createCallback)
+	local blocks = {}
+
+	local names = self.blocks
+	for i = 1, #names do
+		local name = names[i]
+		local block = createCallback(self, name)
+		blocks[i] = block
+		blocks[name] = block
+	end
+
+	return blocks
+end
+
+
+---
 -- Convert absolute paths to project relative.
 ---
 

--- a/core/modules/dom/tests/dom_block_tests.lua
+++ b/core/modules/dom/tests/dom_block_tests.lua
@@ -1,0 +1,26 @@
+local premake = require('premake')
+local dom = require('dom')
+
+local DomBlockTests = test.declare('DomBlockTests', 'dom')
+
+local _blk
+
+
+---
+-- Sets up the DOM Block Tests.
+---
+function DomBlockTests.setup()
+    block('MyBlock', function()
+        
+    end)
+
+    _blk = dom.Block.new(dom.Root.new():select({ blocks = 'MyBlock' }))
+end
+
+
+---
+-- Tests to make sure the name of the Block element is set correctly.
+---
+function DomBlockTests.new_setsName()
+    test.isEqual('MyBlock', _blk.name)
+end

--- a/core/modules/main/core_fields.lua
+++ b/core/modules/main/core_fields.lua
@@ -26,6 +26,12 @@ Field.register({
 })
 
 Field.register({
+	name = 'blocks',
+	kind = 'set:string',
+	isScope = true
+})
+
+Field.register({
 	name = 'configurations',
 	kind = 'set:string',
 	isScope = true
@@ -115,6 +121,11 @@ Field.register({
 		'Wii',
 		'Windows',
 	}
+})
+
+Field.register({
+	name = 'uses',
+	kind = 'set:string'
 })
 
 Field.register({

--- a/core/modules/scripting/scripting.lua
+++ b/core/modules/scripting/scripting.lua
@@ -53,6 +53,17 @@ function when(clauses, fn)
 end
 
 
+function block(name, fn)
+	blocks(name)
+	when({ blocks = name }, function()
+		baseDir(_SCRIPT_DIR)
+		if fn ~= nil then
+			fn()
+		end
+	end)
+end
+
+
 function project(name, fn)
 	projects(name)
 	when({ projects = name }, function()


### PR DESCRIPTION
**What does this PR do?**

Adds the `uses` and `block` APIs.  `uses` accepts a set of strings and `block` is a scoped API that accepts a name and a function.  The goal of the API is to provide easy configuration reusability.  The planned API behaviors are as follows:

* A `block` provides a reusable set of definitions, such as `links` and `includeDirs`.  These will allow both the project owning the block and external projects to consume the block.
* A `block` is consumed via the `uses` API.  By using a block, the consumer will link against the project and inherit its linked projects, library directories, include directories, defines, and more.
* When a `block` is consumed by `uses`, it will also inherit downstream dependencies.  That is to say if block `A` uses block `B` and block `B` uses block `C`, block `A` will inherit from block `C` as well.

**How does this PR change Premake's behavior?**

No breaking behavior.

**Anything else we should know?**

Addresses concerns brought up in #1346

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
