### PR TITLE
[Codelite] Fix custom build with missing directory

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -401,7 +401,7 @@
 				buildmessage = "\t@{ECHO} " .. p.quote(config.buildmessage) .. "\n"
 			end
 			local commands = table.implode(config.buildcommands,"\t","\n","")
-			table.insert(makefilerules, os.translateCommandsAndPaths(outputs .. ": " .. filename .. inputs .. "\n" .. buildmessage .. commands, cfg.project.basedir, cfg.project.location))
+			table.insert(makefilerules, os.translateCommandsAndPaths(outputs .. ": " .. filename .. inputs .. "\n" .. buildmessage .. "\t@$(MakeDirCommand) $(@D)\n" .. commands, cfg.project.basedir, cfg.project.location))
 			table.insertflat(dependencies, outputs)
 			return true
 		end

--- a/modules/codelite/tests/test_codelite_additional_rules.lua
+++ b/modules/codelite/tests/test_codelite_additional_rules.lua
@@ -112,10 +112,12 @@
         <CustomPreBuild>test.obj test2.obj
 test.obj: test.rule
 	@echo "Rule-ing test.rule"
+	@$(MakeDirCommand) $(@D)
 	dorule -p       "test.rule"
 
 test2.obj: test2.rule
 	@echo "Rule-ing test2.rule"
+	@$(MakeDirCommand) $(@D)
 	dorule -p -p2      "test2.rule"
 </CustomPreBuild>
       </AdditionalRules>
@@ -157,18 +159,22 @@ test2.obj: test2.rule
         <CustomPreBuild>test.obj test2.obj test3.obj test4.obj
 test.obj: test.rule
 	@echo "Rule-ing test.rule"
+	@$(MakeDirCommand) $(@D)
 	dorule   testValue1 testValue2     "test.rule"
 
 test2.obj: test2.rule
 	@echo "Rule-ing test2.rule"
+	@$(MakeDirCommand) $(@D)
 	dorule    -StestValue1 -StestValue2    "test2.rule"
 
 test3.obj: test3.rule
 	@echo "Rule-ing test3.rule"
+	@$(MakeDirCommand) $(@D)
 	dorule     testValue1,testValue2   "test3.rule"
 
 test4.obj: test4.rule
 	@echo "Rule-ing test4.rule"
+	@$(MakeDirCommand) $(@D)
 	dorule      -OtestValue1,testValue2  "test4.rule"
 </CustomPreBuild>
       </AdditionalRules>
@@ -198,10 +204,12 @@ test4.obj: test4.rule
         <CustomPreBuild>test.obj test2.obj
 test.obj: test.rule
 	@echo "Rule-ing test.rule"
+	@$(MakeDirCommand) $(@D)
 	dorule       S0 "test.rule"
 
 test2.obj: test2.rule
 	@echo "Rule-ing test2.rule"
+	@$(MakeDirCommand) $(@D)
 	dorule       S1 "test2.rule"
 </CustomPreBuild>
       </AdditionalRules>
@@ -222,6 +230,7 @@ test2.obj: test2.rule
         <CustomPreBuild>toto.c
 toto.c: toto.txt extra_dependency
 	@echo "Some message"
+	@$(MakeDirCommand) $(@D)
 	test
 	test toto.c
 </CustomPreBuild>
@@ -242,6 +251,7 @@ toto.c: toto.txt extra_dependency
         <CustomPreBuild>toto.c
 toto.c: toto.txt extra_dependency
 	@echo "\"Some message\""
+	@$(MakeDirCommand) $(@D)
 	test
 	test toto.c
 </CustomPreBuild>
@@ -263,11 +273,13 @@ toto.c: toto.txt extra_dependency
         <CustomPreBuild>bar.c foo.c
 bar.c: bar.txt bar.h extra_dependency
 	@echo "Some message"
+	@$(MakeDirCommand) $(@D)
 	test
 	test bar
 
 foo.c: foo.txt foo.h extra_dependency
 	@echo "Some message"
+	@$(MakeDirCommand) $(@D)
 	test
 	test foo
 </CustomPreBuild>


### PR DESCRIPTION
**What does this PR do?**

Fix custom build for codelite when generated files which are in new/missing directory

**How does this PR change Premake's behavior?**

Only change Codelite generation.

**Anything else we should know?**

Tested in my test repository with https://github.com/Jarod42/premake-sample-projects/actions/runs/3006214377

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
