### PR TITLE
vstudio: add usestandardpreprocessor option

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -175,6 +175,16 @@
 		kind = "boolean"
 	}
 
+	p.api.register {
+		name = "usestandardpreprocessor",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"On",
+			"Off"
+		}
+	}
+
 
 --
 -- Decide when the full module should be loaded.

--- a/modules/vstudio/tests/vc2019/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_compile_settings.lua
@@ -106,3 +106,27 @@
 	<ScanSourceForModuleDependencies>false</ScanSourceForModuleDependencies>
 		]]
 	end
+
+	function suite.UseStandardPreprocessorOn()
+		usestandardpreprocessor 'On'
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<UseStandardPreprocessor>true</UseStandardPreprocessor>
+		]]
+	end
+
+	function suite.UseStandardPreprocessorOff()
+		usestandardpreprocessor 'Off'
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<UseStandardPreprocessor>false</UseStandardPreprocessor>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -400,6 +400,7 @@
 			m.externalWarningLevel,
 			m.externalAngleBrackets,
 			m.scanSourceForModuleDependencies,
+			m.useStandardPreprocessor,
 		}
 
 		if cfg.kind == p.STATICLIB then
@@ -2951,6 +2952,16 @@
 				else
 					m.element("ScanSourceForModuleDependencies", nil, "false")
 				end
+			end
+		end
+	end
+
+	function m.useStandardPreprocessor(cfg)
+		if _ACTION >= "vs2019" and cfg.usestandardpreprocessor ~= nil then
+			if cfg.usestandardpreprocessor == 'On' then
+				m.element("UseStandardPreprocessor", nil, "true")
+			else
+				m.element("UseStandardPreprocessor", nil, "false")
 			end
 		end
 	end

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -134,6 +134,10 @@
 		openmp = {
 			On = "/openmp",
 			Off = "/openmp-"
+		},
+		usestandardpreprocessor = {
+			On = "/Zc:preprocessor",
+			Off = "/Zc:preprocessor-"
 		}
 
 	}

--- a/website/docs/usestandardpreprocessor.md
+++ b/website/docs/usestandardpreprocessor.md
@@ -1,0 +1,26 @@
+Enables a token-based preprocessor conforming to C99, C++11, and later standards.
+
+```lua
+usestandardpreprocessor 'value'
+```
+
+### Parameters ###
+
+`value` is one of:
+
+| Action      | Description                           |
+|-------------|---------------------------------------|
+| Off         | Do not use the conforming processor.  |
+| On          | Enable the conforming processor.      |
+
+### Applies To ###
+
+Visual Studio 2019 or later.
+
+### Availability ###
+
+Premake 5.0 or later.
+
+### See Also ###
+
+ * [Microsoft's documentation](https://docs.microsoft.com/en-us/cpp/build/reference/zc-preprocessor)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -277,6 +277,7 @@ module.exports = {
 						'undefines',
 						'unsignedchar',
 						'usefullpaths',
+						'usestandardpreprocessor',
 						'usingdirs',
 						'uuid',
 						'vectorextensions',


### PR DESCRIPTION
**What does this PR do?**

Adds the `usestandardpreprocessor` option for Visual Studio. Tells msbuild to use a standard-conforming preprocessor.

**How does this PR change Premake's behavior?**

Doesn't really change much, just adds another config option.

**Anything else we should know?**

Nope

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
