### PR TITLE
Add newoption.catagory to documentation, mark os.is as deprecated

### DIFF
--- a/website/docs/newoption.md
+++ b/website/docs/newoption.md
@@ -10,11 +10,12 @@ newoption { description }
 
 | Field       | Description                                                                        |
 |-------------|------------------------------------------------------------------------------------|
-| trigger     | What the user would type on the command line to select the option, e.g. "--name". |
+| trigger     | What the user would type on the command line to select the option, e.g. `--name`. |
 | description | A short description of the option, to be displayed in the help text. |
 | value       | Optional. If the option needs a value, provides a hint to the user what type of data is expected. |
 | allowed     | Optional. A list of key-value pairs listing the allowed values for the option. |
 | default     | Optional. Sets the default for this option if not specified on the commandline. |
+| category    | Optional. Places the option under a separate header when the user passes `--help` |
 
 
 ### Availability ###
@@ -32,6 +33,7 @@ newoption {
    value       = "API",
    description = "Choose a particular 3D API for rendering",
    default     = "opengl",
+   category    = "Build Options",
    allowed = {
       { "opengl",    "OpenGL" },
       { "direct3d",  "Direct3D (Windows only)" },

--- a/website/docs/os.is.md
+++ b/website/docs/os.is.md
@@ -1,3 +1,7 @@
+:::caution
+**This function has been deprecated.** Use [os.target()](os.target.md) or [os.host()](os.host.md) instead.
+:::
+
 Checks the current operating system identifier against a particular value.
 
 ```lua


### PR DESCRIPTION
**What does this PR do?**

Closes #1859 

Adds a description of the `category` option when using `newoption`.

Also marks `os.is()` as deprecated which is mentioned in the same issue.

**How does this PR change Premake's behavior?**

No. Should only be docs changes.

**Anything else we should know?**

Nope.

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
