### PR TITLE
Use admonitions in documentation for things marked as deprecated

### DIFF
--- a/website/docs/Tokens.md
+++ b/website/docs/Tokens.md
@@ -76,7 +76,7 @@ Command tokens represent a system level command in a platform-neutral way.
 
 ```lua
 postbuildcommands {
-	"{COPY} file1.txt file2.txt"
+	"{COPYFILE} file1.txt file2.txt"
 }
 ```
 
@@ -108,8 +108,13 @@ The available tokens, and their replacements:
 | {RMDIR}    | rmdir /S /Q {args}                          | rm -rf {args}   |
 | {TOUCH}    | type nul >> {arg} && copy /b {arg}+,, {arg} | touch {args}    |
 
-Note that this token exists but is deprecated in favor of {COPYDIR} and {COPYFILE}
-| {COPY}   | xcopy /Q /E /Y /I {args}                    | cp -rf {args}   |
+:::caution
+The following tokens are deprecated:
+:::
+
+| Token      | DOS                                         | Posix           | Remarks                             |
+|------------|---------------------------------------------|-----------------|-------------------------------------|
+| {COPY}     | xcopy /Q /E /Y /I {args}                    | cp -rf {args}   | Use {COPYDIR} or {COPYFILE} instead |
 
 ## Tokens and Filters
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -1,10 +1,12 @@
+:::caution
+**This function has been deprecated in Premake 5.0 beta1.** Use the new [filter()](filter.md) function instead; you will get more granular matching and much better performance. `configuration()` will be not supported in Premake 6.
+:::
+
 Limits the subsequent build settings to a particular environment.
 
 ```lua
 configuration { "keywords" }
 ```
-
-**This function has been deprecated in Premake 5.0 beta1.** Use the new [filter()](filter.md) function instead; you will get more granular matching and much better performance. `configuration()` will be not supported in Premake 6.
 
 ### Parameters ###
 

--- a/website/docs/framework.md
+++ b/website/docs/framework.md
@@ -1,3 +1,7 @@
+:::caution
+**This API is deprecated since 5.0**, please use [dotnetframework](dotnetframework.md) instead.
+:::
+
 Selects a .NET framework version.
 
 ```lua
@@ -32,10 +36,6 @@ Use the .NET 3.0 Framework.
 ```lua
 framework "3.0"
 ```
-
-### Remarks ###
-
-This API is deprecated since 5.0, please use [dotnetframework](dotnetframework.md) instead.
 
 ### See Also ###
 

--- a/website/docs/newaction.md
+++ b/website/docs/newaction.md
@@ -14,14 +14,12 @@ newaction { description }
 | shortname   | A short summary for the help text, e.g. "Visual Studio 2013".                      |
 | description | A description of the action's result, e.g. "Generate Visual Studio 2013 project files". |
 | execute     | A function to be executed when the action is fired.                                |
-| os          | Deprecated, use targetos instead. |
 | targetos    | If the toolset targets a specific OS, the [identifier](system.md) for that OS. |
 | valid_kinds | The list of [project kinds](kind.md) supported by the action. |
 | valid_languages | The list of [languages](language.md) supported by the action. |
 | valid_tools | The list of [tools](toolset.md) supported by the action. |
 | toolset | Default [tools](toolset.md). |
 | onStart     | A callback marking the start of action processing. |
-| onSolution | Deprecated, use onWorkspace instead. |
 | onWorkspace | A callback for each workspace specified in the user script. |
 | onProject   | A callback for each project specified in the user script. |
 | onRule      | A callback for each rule specified in the user script. |
@@ -40,6 +38,14 @@ The callbacks will fire in this order:
 4. `execute()`
 5. `onEnd()`
 
+:::caution
+The following fields have been deprecated:
+:::
+
+| Field       | Description                                                                        |
+|-------------|------------------------------------------------------------------------------------|
+| os          | Deprecated, use targetos instead. |
+| onSolution  | Deprecated, use onWorkspace instead. |
 
 ### Availability ###
 

--- a/website/docs/sysincludedirs.md
+++ b/website/docs/sysincludedirs.md
@@ -1,10 +1,13 @@
+:::caution
+**This function has been deprecated in Premake 5.0 beta2.** Use the new [externalincludedirs](externalincludedirs.md) function instead. `sysincludedirs` will be not supported in Premake 6.
+:::
+
 Alias of [externalincludedirs](externalincludedirs.md).
 
 ```lua
 sysincludedirs { "paths" }
 ```
 
-**This function has been deprecated in Premake 5.0 beta2.** Use the new [externalincludedirs](externalincludedirs.md) function instead. `sysincludedirs` will be not supported in Premake 6.
 
 ### Parameters ###
 


### PR DESCRIPTION
**What does this PR do?**

Wraps deprecation notices in *caution* [admonitions](https://premake.github.io/docs/Style-Guide/#admonitions) and moves them to the top for clarity.

When individual items in a table have been deprecated, those items are extracted to a table below with a *caution* admonition above. IMHO this makes it less likely someone will neglect to fully read the documentation and end up using a deprecated parameter.

**How does this PR change Premake's behavior?**

No, just documentation.

**Anything else we should know?**

Follow on from suggestions made during #1954  

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
