### PR TITLE
Strip linking decorators for sibling projects

### DIFF
--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -262,10 +262,20 @@
 			local link = cfg.links[i]
 			local item
 
+			-- Strip linking decorators from link, to determine if the link
+			-- is a "sibling" project.
+			local endswith = function(s, ptrn)
+				return ptrn == string.sub(s, -string.len(ptrn))
+			end
+			local name = link
+			if endswith(name, ":static") or endswith(name, ":shared") then
+				name = string.sub(name, 0, -8)
+			end
+
 			-- Sort the links into "sibling" (is another project in this same
 			-- workspace) and "system" (is not part of this workspace) libraries.
 
-			local prj = p.workspace.findproject(cfg.workspace, link)
+			local prj = p.workspace.findproject(cfg.workspace, name)
 			if prj and kind ~= "system" then
 
 				-- Sibling; is there a matching configuration in this project that

--- a/tests/config/test_links.lua
+++ b/tests/config/test_links.lua
@@ -222,3 +222,45 @@
 		local r = prepare("all", "fullpath")
 		test.isequal({ "bin/Debug/MyProject2.lib" }, r)
 	end
+
+--
+-- Linking decorators need to be passed through
+--
+
+	function suite.canLink_StaticDecoratorSystemLib()
+		links { "SystemLibrary:static" }
+		local r = prepare("all", "fullpath")
+		test.isequal({ "SystemLibrary:static" }, r)
+	end
+
+	function suite.canLink_SharedDecoratorSystemLib()
+		links { "SystemLibrary:shared" }
+		local r = prepare("all", "fullpath")
+		test.isequal({ "SystemLibrary:shared" }, r)
+	end
+
+--
+-- Linking decorators need to be stripped for sibling projects
+--
+
+	function suite.canLink_StaticDecoratorSiblingLib()
+		links { "SiblingLibrary:static" }
+
+		project "SiblingLibrary"
+		kind "StaticLib"
+		language "C++"
+
+		local r = prepare("all", "fullpath")
+		test.isequal({ "bin/Debug/SiblingLibrary.lib" }, r)
+	end
+
+	function suite.canLink_SharedDecoratorSiblingLib()
+		links { "SiblingLibrary:shared" }
+
+		project "SiblingLibrary"
+		kind "SharedLib"
+		language "C++"
+
+		local r = prepare("all", "fullpath")
+		test.isequal({ "bin/Debug/SiblingLibrary.lib" }, r)
+	end


### PR DESCRIPTION
- Added unit tests for linking decorators

**What does this PR do?**

Fixes #1685 by ignoring the linking decorators for sibling projects.

**How does this PR change Premake's behavior?**

Specifying a linking decorator on a sibling project will result in it treating it as a sibling project not a system library.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
