### PR TITLE
Android projects use IncludePath instead of ExternalIncludePath

### DIFF
--- a/modules/android/tests/test_android_project.lua
+++ b/modules/android/tests/test_android_project.lua
@@ -26,6 +26,11 @@
 		vc2010.globals(prj)
 	end
 
+	local function prepareOutputProperties()
+		local cfg = test.getconfig(prj, "Debug")
+		vc2010.outputProperties(cfg)
+	end
+
 	function suite.minVisualStudioVersion_14()
 		prepareGlobals()
 		test.capture [[
@@ -146,5 +151,19 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<Optimization>Disabled</Optimization>
 	<CppLanguageStandard>c++1z</CppLanguageStandard>
+]]
+	end
+
+	function suite.externalIncludeDirs()
+		externalincludedirs { "externalincludedirs" }
+		prepareOutputProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Android'">
+	<LinkIncremental>true</LinkIncremental>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>
+	</TargetExt>
+	<IncludePath>externalincludedirs;$(IncludePath)</IncludePath>
 ]]
 	end

--- a/modules/android/vsandroid_vcxproj.lua
+++ b/modules/android/vsandroid_vcxproj.lua
@@ -640,3 +640,18 @@ end)
 			return oldfn(cfg)
 		end
 	end)
+	
+--
+-- Disable usage of ExternalIncludePath, Android project format ignores it.
+--
+
+	p.override(vc2010, "includePath", function(oldfn, cfg)
+		if cfg.system == p.ANDROID then
+			local dirs = vstudio.path(cfg, cfg.externalincludedirs)
+			if #dirs > 0 then
+				vc2010.element("IncludePath", nil, "%s;$(IncludePath)", table.concat(dirs, ";"))
+			end
+		else
+			oldfn(cfg)
+		end
+	end)


### PR DESCRIPTION
**What does this PR do?**

Changes Android projects so they use `IncludePath` instead of `ExternalIncludePath` as this appears to be ignored resulting in projects failing to build that worked in VS2019.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
