### PR TITLE
Added support for CopyFileToFolders via Copy buildaction

### DIFF
--- a/modules/vstudio/tests/vc2010/test_files.lua
+++ b/modules/vstudio/tests/vc2010/test_files.lua
@@ -107,11 +107,13 @@
 -- Check handling of buildaction.
 --
 	function suite.customBuildTool_onBuildAction()
-		files { "test.x", "test2.cpp", "test3.cpp" }
+		files { "test.x", "test2.cpp", "test3.cpp", "test4.dll" }
 		filter "files:**.x"
 			buildaction "FxCompile"
 		filter "files:test2.cpp"
 			buildaction "None"
+		filter { "files:test4.dll" }
+			buildaction "Copy"
 		prepare()
 		test.capture [[
 <ItemGroup>
@@ -122,6 +124,12 @@
 </ItemGroup>
 <ItemGroup>
 	<None Include="test2.cpp" />
+</ItemGroup>
+<ItemGroup>
+	<CopyFileToFolders Include="test4.dll">
+		<DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">bin\Debug</DestinationFolders>
+		<DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">bin\Release</DestinationFolders>
+	</CopyFileToFolders>
 </ItemGroup>
 		]]
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1086,6 +1086,28 @@
 	}
 
 ---
+-- Copy group
+---
+
+	m.categories.Copy = {
+		name = "Copy",
+		priority = 13,
+
+		emitFiles = function(prj, group)
+			local fileCfgFunc = {
+				m.excludedFromBuild,
+				m.destinationFolders
+			}
+
+			m.emitFiles(prj, group, "CopyFileToFolders", nil, fileCfgFunc)
+		end,
+
+		emitFilter = function(prj, group)
+			m.filterGroup(prj, group, "CopyFileToFolders")
+		end
+	}
+
+---
 -- Categorize files into groups.
 ---
 	function m.categorizeSources(prj)
@@ -1832,6 +1854,13 @@
 			end
 
 			m.element("DebugInformationFormat", nil, value)
+		end
+	end
+
+
+	function m.destinationFolders(filecfg, condition)
+		if filecfg then
+			m.element("DestinationFolders", condition, vstudio.path(filecfg.config, filecfg.config.buildtarget.directory))
 		end
 	end
 

--- a/website/docs/buildaction.md
+++ b/website/docs/buildaction.md
@@ -8,6 +8,21 @@ buildaction ("action")
 
 For C/C++, `action` is the name of the MSBuild action as defined by the vcxproj format; eg: `ClCompile`, `FxCompile`, `None`, etc, and may refer to any such action available to MSBuild.
 
+| Action          | Description                                                                      |
+|-----------------|----------------------------------------------------------------------------------|
+| ClInclude       | Treat the file as an include file.                                               |
+| ClCompile       | Treat the file as source code; compile and link it.                              |
+| FxCompile       | Treat the file as HLSL shader source code; compile and link it.                  |
+| None            | Do nothing with this file.                                                       |
+| ResourceCompile | Copy/embed the file with the project resources.                                  |
+| CustomBuild     | Treat the file as custom build code; compile and optionally link it.             |
+| Midl            | Treat the file as MIDL source code; compile and link it.                         |
+| Masm            | Treat the file as MASM source code; compile and link it.                         |
+| Image           | Treat the file as an Image.                                                      |
+| Natvis          | Treat the file as Natvis source; use it for custom data layouts while debugging. |
+| AppxManifest    | Treat the file as AppX Manifest; required for UWP applications.                  |
+| Copy            | Copy the file to the target directory.                                           |
+
 For C# projects, `buildaction` behaviour is special to support legacy implementation.
 In C#, `action` is one of
 


### PR DESCRIPTION
- Added full table of supported C++ values for buildaction

**What does this PR do?**

Adds support for the `buildaction "Copy"` in VS C++ projects.

**How does this PR change Premake's behavior?**

Using `buildaction "Copy"` in a VS C++ project will now copy the files to the output target.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
