### PR TITLE
Update defaultplatform.md

### DIFF
--- a/website/docs/defaultplatform.md
+++ b/website/docs/defaultplatform.md
@@ -1,16 +1,18 @@
-defaultplatform
+Specifies the default build platform for a workspace.
 
 ```lua
-defaultplatform "value"
+defaultplatform ("platform_name")
 ```
 
+If `platform_name` has not been defined using [`platforms`](platforms.md) the default platform will not change from the generic one i.e. the first one passed to [`platforms`](platforms.md).
+ 
 ### Parameters ###
 
-`value` - needs documentation.
+`platform_name` - Is the name of the platform you want to use as default. 
 
 ### Applies To ###
 
-The `project` scope.
+The `workspace` scope.
 
 ### Availability ###
 
@@ -19,6 +21,28 @@ Premake 5.0.0 alpha 12 or later.
 ### Examples ###
 
 ```lua
-defaultplatform "value"
-```
+workspace "MyWorkspace"
+  configurations { "Debug", "Release" }
+  platforms { "Static32", "Shared32", "Static64", "Shared64" }
+  defaultplatform "Shared64" -- Default platform from "Static32" to "Shared64"
 
+  filter "platforms:Static32"
+    kind "StaticLib"
+    architecture "x32"
+
+  filter "platforms:Static64"
+    kind "StaticLib"
+    architecture "x64"
+
+  filter "platforms:Shared32"
+    kind "SharedLib"
+    architecture "x32"
+
+  filter "platforms:Shared64"
+    kind "SharedLib"
+    architecture "x64"
+	
+```
+### See Also ###
+
+* [platforms](platforms.md)

--- a/website/docs/platforms.md
+++ b/website/docs/platforms.md
@@ -49,3 +49,4 @@ workspace "MyWorkspace"
 
 * [Configurations and Platforms](Configurations-and-Platforms.md)
 * [configurations](configurations.md)
+* [defaultplatform](defaultplatform.md)


### PR DESCRIPTION
**What does this PR do?**

This PR adds the documentation for defaultplatform as there was only the automatically generated empty one.

**How does this PR change Premake's behavior?**

It doesn't.

**Anything else we should know?**

I tested the behaviour of defaultplatform extensively only with the gmake2 as the Makefile was giving problems.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass - Does not apply
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged) - Does not apply
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions) - Does not apply
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
