### PR TITLE
Fix .NET 5.0+ C++ projects being generated with the wrong framework tag on MSVC

### DIFF
--- a/modules/vstudio/tests/vc2010/test_globals.lua
+++ b/modules/vstudio/tests/vc2010/test_globals.lua
@@ -61,7 +61,7 @@
 
 
 --
--- Ensure custom target framework version correct for Managed C++ projects.
+-- Ensure custom target framework version correct for Managed C++ projects on .NET Framework.
 --
 
 	function suite.frameworkVersionIsCorrect_onSpecificVersion()
@@ -92,6 +92,24 @@
 </PropertyGroup>
 		]]
 	end
+
+--
+-- Ensure custom target framework version correct for Managed C++ projects on .NET 5.0+.
+--
+
+function suite.frameworkVersionIsCorrectNetCore_onSpecificVersion()
+	clr "NetCore"
+	dotnetframework "net5.0"
+	prepare()
+	test.capture [[
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<TargetFramework>net5.0</TargetFramework>
+	<Keyword>ManagedCProj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
+	]]
+end
 
 --
 -- Omit Keyword and RootNamespace for non-Windows projects.

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -12,6 +12,7 @@
 	local config = p.config
 	local fileconfig = p.fileconfig
 	local tree = p.tree
+	local dotnetbase = p.vstudio.dotnetbase
 
 	local m = p.vstudio.vc2010
 
@@ -115,7 +116,11 @@
 		local tools = string.format(' ToolsVersion="%s"', action.vstudio.toolsVersion)
 
 		local framework = prj.dotnetframework or action.vstudio.targetFramework or "4.0"
-		p.w('<TargetFramework>%s</TargetFramework>', framework)
+		if framework and dotnetbase.isNewFormatProject(prj) then
+			p.w('<TargetFramework>%s</TargetFramework>', framework)
+		else
+			p.w('<TargetFrameworkVersion>v%s</TargetFrameworkVersion>', framework)
+		end
 	end
 
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -107,7 +107,7 @@
 
 
 --
--- Write out the TargetFrameworkVersion property.
+-- Write out the TargetFramework property.
 --
 
 	function m.targetFramework(prj)
@@ -115,7 +115,7 @@
 		local tools = string.format(' ToolsVersion="%s"', action.vstudio.toolsVersion)
 
 		local framework = prj.dotnetframework or action.vstudio.targetFramework or "4.0"
-		p.w('<TargetFrameworkVersion>v%s</TargetFrameworkVersion>', framework)
+		p.w('<TargetFramework>%s</TargetFramework>', framework)
 	end
 
 


### PR DESCRIPTION
**What does this PR do?**

Fixes #1559 and provides a new test case to check if .NET 5.0+ C++ projects are generated correctly on MSVC.
Closes #1559 

**How does this PR change Premake's behavior?**

Generation of .NET 5.0+ C++ projects will now emit the correct target framework tag and version. For instance:
`<TargetFramework>net5.0</TargetFramework>`
instead of
`<TargetFrameworkVersion>vnet5.0</TargetFrameworkVersion>`

**Anything else we should know?**

None