### PR TITLE
Add AntTarget to vsandroid project file

### DIFF
--- a/modules/android/vsandroid_vcxproj.lua
+++ b/modules/android/vsandroid_vcxproj.lua
@@ -447,6 +447,7 @@
 		else
 			vc2010.element("AndroidAppLibName", nil, "$(RootNamespace)")
 		end
+		vc2010.element("AntTarget", nil, iif(premake.config.isDebugBuild(cfg), "debug", "release"))
 		p.pop('</AntPackage>')
 	end
 


### PR DESCRIPTION
**What does this PR do?**

Adds AntTarget to .androidproj files

**How does this PR change Premake's behavior?**

All the android builds used to be built targeting the debug mode, which adds android:debuggable=true, generates a different BuildConfig.java (Debug=true), etc.
This is unacceptable for release builds.

**Anything else we should know?**

I'm not sure when did VS add this option but I don't think adding this on older VS versions would hurt anything.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass (There are no tests on AndroidAppLibName or many other elements on the android module and I don't know how to implement them)
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
