### PR TITLE
Allow to specify "--cc=msc" as command line.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1783,6 +1783,7 @@
 			{ "clang", "Clang (clang)" },
 			{ "gcc", "GNU GCC (gcc/g++)" },
 			{ "mingw", "MinGW GCC (gcc/g++)" },
+			{ "msc", "Microsoft compiler" }
 		}
 	}
 


### PR DESCRIPTION
**What does this PR do?**

Allow to specify "--cc=msc" as command line (in addition to gcc/clang).

**How does this PR change Premake's behavior?**

Just the command line to specify `cc`

**Anything else we should know?**

Tested on https://github.com/Jarod42/premake-sample-projects/tree/windows_ninja
(More specifically that [action run](https://github.com/Jarod42/premake-sample-projects/actions/runs/3531954496)).

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
