### PR TITLE
Handle entrypoint for msc.

### DIFF
--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -305,6 +305,17 @@
 	function msc.getldflags(cfg)
 		local map = iif(cfg.kind ~= p.STATICLIB, msc.linkerFlags, msc.librarianFlags)
 		local flags = config.mapFlags(cfg, map)
+
+		if cfg.entrypoint then
+			-- /ENTRY requires that /SUBSYSTEM is set.
+			if cfg.kind == "ConsoleApp" then
+				table.insert(flags, "/SUBSYSTEM:CONSOLE")
+			elseif cfg.kind ~= "WindowedApp" then -- already set by above map
+				table.insert(flags, "/SUBSYSTEM:NATIVE") -- fallback
+			end
+			table.insert(flags, '/ENTRY:' .. cfg.entrypoint)
+		end
+
 		table.insert(flags, 1, "/NOLOGO")
 
 		-- Ignore default libraries

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -460,6 +460,30 @@
 		test.contains("/fsanitize=fuzzer", msc.getcxxflags(cfg))
 	end
 
+--
+-- Check entrypoint linker options.
+--
+
+	function suite.ldflags_entrypoint_windows()
+		kind "WindowedApp"
+		entrypoint "main2"
+		prepare()
+		test.contains("/SUBSYSTEM:WINDOWS", msc.getldflags(cfg))
+		test.contains("/ENTRY:main2", msc.getldflags(cfg))
+	end
+	function suite.ldflags_entrypoint_console()
+		kind "ConsoleApp"
+		entrypoint "main2"
+		prepare()
+		test.contains("/SUBSYSTEM:CONSOLE", msc.getldflags(cfg))
+		test.contains("/ENTRY:main2", msc.getldflags(cfg))
+	end
+	function suite.ldflags_entrypoint_other()
+		entrypoint "main2"
+		prepare()
+		test.contains("/SUBSYSTEM:NATIVE", msc.getldflags(cfg))
+		test.contains("/ENTRY:main2", msc.getldflags(cfg))
+	end
 
 --
 -- Check handling of additional linker options.


### PR DESCRIPTION
**What does this PR do?**

Handle entrypoint for msc (for no vs* action).

**How does this PR change Premake's behavior?**

Just change msc toolset for `entrypoint "somefunc"`

**Anything else we should know?**

Tested locally (not on https://github.com/Jarod42/premake-sample-projects as usual #2003 (`--cc=msc`) would be required there to test it properly.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

