### PR TITLE
`externalwarnings`, `externalanglebrackets`, `externalincludedirs` was already available in vs2019

### DIFF
--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -1277,6 +1277,7 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<LanguageStandard>stdcpp14</LanguageStandard>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 </ClCompile>
 		]]
 	end
@@ -1334,6 +1335,7 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<LanguageStandard>stdcpp17</LanguageStandard>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 </ClCompile>
 		]]
 	end
@@ -1364,6 +1366,7 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<LanguageStandard>stdcpp20</LanguageStandard>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 </ClCompile>
 		]]
 	end
@@ -1379,6 +1382,7 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<LanguageStandard_C>stdc11</LanguageStandard_C>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 </ClCompile>
 		]]
 	end
@@ -1394,6 +1398,7 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<LanguageStandard_C>stdc17</LanguageStandard_C>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 </ClCompile>
 		]]
 	end
@@ -1451,6 +1456,7 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<LanguageStandard>stdcpplatest</LanguageStandard>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 </ClCompile>
 		]]
 	end
@@ -1711,6 +1717,7 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 </ClCompile>
 		]]
 	end

--- a/modules/vstudio/tests/vc2019/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_compile_settings.lua
@@ -91,6 +91,7 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 	<ScanSourceForModuleDependencies>true</ScanSourceForModuleDependencies>
 		]]
 	end
@@ -103,6 +104,7 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 	<ScanSourceForModuleDependencies>false</ScanSourceForModuleDependencies>
 		]]
 	end
@@ -115,6 +117,7 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 	<UseStandardPreprocessor>true</UseStandardPreprocessor>
 		]]
 	end
@@ -127,6 +130,7 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 	<UseStandardPreprocessor>false</UseStandardPreprocessor>
 		]]
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2249,7 +2249,7 @@
 	function m.includePath(cfg)
 		local dirs = vstudio.path(cfg, cfg.externalincludedirs)
 		if #dirs > 0 then
-			if _ACTION < "vs2022" then
+			if _ACTION < "vs2019" then
 				m.element("IncludePath", nil, "%s;$(IncludePath)", table.concat(dirs, ";"))
 			else
 				m.element("ExternalIncludePath", nil, "%s;$(ExternalIncludePath)", table.concat(dirs, ";"))
@@ -2965,7 +2965,7 @@
 
 
 	function m.externalWarningLevel(cfg)
-		if _ACTION >= "vs2022" then
+		if _ACTION >= "vs2019" then
 			local map = { Off = "TurnOffAllWarnings", High = "Level4", Extra = "Level4", Everything = "Level4" }
 			m.element("ExternalWarningLevel", nil, map[cfg.externalwarnings] or "Level3")
 		end
@@ -2973,7 +2973,7 @@
 
 
 	function m.externalWarningLevelFile(cfg, condition)
-		if _ACTION >= "vs2022" then
+		if _ACTION >= "vs2019" then
 			if cfg.externalwarnings then
 				local map = { Off = "TurnOffAllWarnings", High = "Level4", Extra = "Level4", Everything = "Level4" }
 				m.element("ExternalWarningLevel", condition, map[cfg.externalwarnings] or "Level3")
@@ -2983,7 +2983,7 @@
 
 
 	function m.externalAngleBrackets(cfg, condition)
-		if _ACTION >= "vs2022" then
+		if _ACTION >= "vs2019" then
 			if cfg.externalanglebrackets == p.OFF then
 				m.element("TreatAngleIncludeAsExternal", condition, "false")
 			elseif cfg.externalanglebrackets == p.ON then

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -264,7 +264,7 @@
 
 		for _, dir in ipairs(extdirs or {}) do
 			dir = project.getrelative(cfg.project, dir)
-			if cfg.toolset and cfg.toolset >= "msc-v143" then
+			if cfg.toolset and cfg.toolset >= "msc-v142" then
 				table.insert(result, '/external:I' ..  p.quoted(dir))
 			else
 				table.insert(result, '-I' ..  p.quoted(dir))

--- a/website/docs/externalanglebrackets.md
+++ b/website/docs/externalanglebrackets.md
@@ -20,7 +20,7 @@ Project configurations.
 ### Availability ###
 
 Premake 5.0 or later.
-Visual Studio 2022 version 17.0 or later.
+Visual Studio 2019 version or later.
 
 ### See Also ###
 

--- a/website/docs/externalwarnings.md
+++ b/website/docs/externalwarnings.md
@@ -25,7 +25,7 @@ Project configurations.
 ### Availability ###
 
 Premake 5.0 or later.
-Visual Studio 2022 version 17.0 or later.
+Visual Studio 2019 version or later.
 
 ### Examples ###
 


### PR DESCRIPTION
**What does this PR do?**

`externalwarnings`, `externalanglebrackets`, `externalincludedirs` is now handled for vs2019

**How does this PR change Premake's behavior?**

Change action vs2019 (and msc-v142) to support too the above flags.

**Anything else we should know?**

No.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
