### PR TITLE
Fix spelling error in the help message

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1878,7 +1878,7 @@
 	if http ~= nil then
 		newoption {
 			trigger = "insecure",
-			description = "forfit SSH certification checks."
+			description = "Forfeit SSH certification checks."
 		}
 	end
 


### PR DESCRIPTION
Sorry for this trivial PR, but I've just installed premake5 for testing it and couldn't help noticing this typo in the help message and thought that fixing it would improve the first impression.