### PR TITLE
Fix support of openmp for visual studio with clang toolset.

### DIFF
--- a/modules/vstudio/tests/vc2019/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_compile_settings.lua
@@ -79,6 +79,20 @@
 		]]
 	end
 
+	function suite.openmpOnWithClang()
+		toolset "clang"
+		openmp "On"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<OpenMPSupport>true</OpenMPSupport>
+	<AdditionalOptions>/openmp %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end
+
 --
 -- Check ClCompile for ScanForModuleDependencies
 --

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1645,6 +1645,10 @@
 		elseif _ACTION >= "vs2019" and cfg.toolset and cfg.toolset == "clang" then
 			local value = iif(cfg.unsignedchar, "On", "Off")
 			table.insert(opts, p.tools.msc.shared.unsignedchar[value])
+			-- <OpenMPSupport>true</OpenMPSupport> is unfortunately ignored with clang toolset
+			if cfg.openmp == "On" then
+				table.insert(opts, 1, '/openmp')
+			end
 		end
 
 		if #opts > 0 then


### PR DESCRIPTION
**What does this PR do?**

Fix support of openmp for visual studio with clang toolset.

**How does this PR change Premake's behavior?**

only visual generator are impacted

**Anything else we should know?**

Also tested with [my testing repo](https://github.com/Jarod42/premake-sample-projects)
especially action https://github.com/Jarod42/premake-sample-projects/actions/runs/3941604370

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
