### PR TITLE
Fix missing targets file issue in some C++ nuget packages

### DIFF
--- a/modules/vstudio/tests/vc2010/test_ensure_nuget_imports.lua
+++ b/modules/vstudio/tests/vc2010/test_ensure_nuget_imports.lua
@@ -44,7 +44,7 @@
 
 if _OPTIONS["test-all"] then
 	function suite.structureIsCorrect()
-		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3" }
+		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
 		prepare()
 		test.capture [[
 <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -54,6 +54,9 @@ if _OPTIONS["test-all"] then
 	<Error Condition="!Exists('packages\boost.1.59.0-b1\build\native\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\boost.1.59.0-b1\build\native\boost.targets'))" />
 	<Error Condition="!Exists('packages\sdl2.v140.2.0.3\build\native\sdl2.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.v140.2.0.3\build\native\sdl2.v140.targets'))" />
 	<Error Condition="!Exists('packages\sdl2.v140.redist.2.0.3\build\native\sdl2.v140.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.v140.redist.2.0.3\build\native\sdl2.v140.redist.targets'))" />
+	<Error Condition="!Exists('packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
+	<Error Condition="!Exists('packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.props'))" />
+	<Error Condition="!Exists('packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.targets'))" />
 </Target>
 		]]
 	end

--- a/modules/vstudio/tests/vc2010/test_extension_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_extension_settings.lua
@@ -28,6 +28,22 @@
 		vc2010.importExtensionSettings(prj)
 	end
 
+--
+-- Writes entries only for nuget packages with props files.
+--
+
+if _OPTIONS["test-all"] then
+	function suite.importOnlyNugetPackagesWithProps()
+		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
+		prepare()
+	test.capture [[
+<ImportGroup Label="ExtensionSettings">
+	<Import Project="packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.props" Condition="Exists('packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.props')" />
+</ImportGroup>
+		]]
+	end
+end
+
 
 --
 -- Writes an empty element when no custom rules are specified.

--- a/modules/vstudio/tests/vc2010/test_extension_targets.lua
+++ b/modules/vstudio/tests/vc2010/test_extension_targets.lua
@@ -65,13 +65,15 @@
 
 if _OPTIONS["test-all"] then
 	function suite.addsImport_onEachNuGetPackage()
-		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3" }
+		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
 		prepare()
 		test.capture [[
 <ImportGroup Label="ExtensionTargets">
 	<Import Project="packages\boost.1.59.0-b1\build\native\boost.targets" Condition="Exists('packages\boost.1.59.0-b1\build\native\boost.targets')" />
 	<Import Project="packages\sdl2.v140.2.0.3\build\native\sdl2.v140.targets" Condition="Exists('packages\sdl2.v140.2.0.3\build\native\sdl2.v140.targets')" />
 	<Import Project="packages\sdl2.v140.redist.2.0.3\build\native\sdl2.v140.redist.targets" Condition="Exists('packages\sdl2.v140.redist.2.0.3\build\native\sdl2.v140.redist.targets')" />
+	<Import Project="packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets" Condition="Exists('packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" />
+	<Import Project="packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.targets" Condition="Exists('packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.targets')" />
 </ImportGroup>
 		]]
 	end

--- a/modules/vstudio/tests/vc2010/test_nuget_packages_config.lua
+++ b/modules/vstudio/tests/vc2010/test_nuget_packages_config.lua
@@ -44,7 +44,7 @@
 --
 
 	function suite.structureIsCorrect()
-		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3" }
+		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
 		prepare()
 		test.capture [[
 <?xml version="1.0" encoding="utf-8"?>
@@ -52,6 +52,8 @@
 	<package id="boost" version="1.59.0-b1" targetFramework="native" />
 	<package id="sdl2.v140" version="2.0.3" targetFramework="native" />
 	<package id="sdl2.v140.redist" version="2.0.3" targetFramework="native" />
+	<package id="WinPixEventRuntime" version="1.0.220810001" targetFramework="native" />
+	<package id="Microsoft.Direct3D.D3D12" version="1.608.2" targetFramework="native" />
 </packages>
 		]]
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2148,16 +2148,28 @@
 		end
 	end
 
-	local function nuGetTargetsFile(prj, package)
+	local function nuGetTargetsFile(prj, package, extension)
 		local packageAPIInfo = vstudio.nuget2010.packageAPIInfo(prj, package)
-		return p.vstudio.path(prj, p.filename(prj.workspace, string.format("packages\\%s.%s\\build\\native\\%s.targets", vstudio.nuget2010.packageId(package), packageAPIInfo.verbatimVersion or packageAPIInfo.version, vstudio.nuget2010.packageId(package))))
+		if not packageAPIInfo.packageEntries then
+			return nil
+		end
+		for _, entry in ipairs(packageAPIInfo.packageEntries) do
+			if path.getextension(entry) == extension then
+				local packageRootPath = p.filename(prj.workspace, string.format("packages\\%s.%s\\", vstudio.nuget2010.packageId(package), packageAPIInfo.verbatimVersion or packageAPIInfo.version))
+				return p.vstudio.path(prj, path.join(packageRootPath, entry))
+			end
+		end
+
+		return nil
 	end
 
 	function m.importNuGetTargets(prj)
 		if not vstudio.nuget2010.supportsPackageReferences(prj) then
 			for i = 1, #prj.nuget do
-				local targetsFile = nuGetTargetsFile(prj, prj.nuget[i])
-				p.x('<Import Project="%s" Condition="Exists(\'%s\')" />', targetsFile, targetsFile)
+				local targetsFile = nuGetTargetsFile(prj, prj.nuget[i], ".targets")
+				if targetsFile then
+					p.x('<Import Project="%s" Condition="Exists(\'%s\')" />', targetsFile, targetsFile)
+				end
 			end
 		end
 	end
@@ -2178,8 +2190,14 @@
 			p.pop('</PropertyGroup>')
 
 			for i = 1, #prj.nuget do
-				local targetsFile = nuGetTargetsFile(prj, prj.nuget[i])
-				p.x('<Error Condition="!Exists(\'%s\')" Text="$([System.String]::Format(\'$(ErrorText)\', \'%s\'))" />', targetsFile, targetsFile)
+				local propsFile = nuGetTargetsFile(prj, prj.nuget[i], ".props")
+				if propsFile then
+					p.x('<Error Condition="!Exists(\'%s\')" Text="$([System.String]::Format(\'$(ErrorText)\', \'%s\'))" />', propsFile, propsFile)
+				end
+				local targetsFile = nuGetTargetsFile(prj, prj.nuget[i], ".targets")
+				if targetsFile then
+					p.x('<Error Condition="!Exists(\'%s\')" Text="$([System.String]::Format(\'$(ErrorText)\', \'%s\'))" />', targetsFile, targetsFile)
+				end
 			end
 			p.pop('</Target>')
 		end
@@ -2201,6 +2219,7 @@
 		return {
 			m.importGroupSettings,
 			m.importRuleSettings,
+			m.importNuGetProps,
 			m.importBuildCustomizationsProps
 		}
 	end
@@ -2227,6 +2246,17 @@
 			local rule = p.global.getRule(prj.rules[i])
 			local loc = vstudio.path(prj, p.filename(rule, ".props"))
 			p.x('<Import Project="%s" />', loc)
+		end
+	end
+
+	function m.importNuGetProps(prj)
+		if not vstudio.nuget2010.supportsPackageReferences(prj) then
+			for i = 1, #prj.nuget do
+				local propsFile = nuGetTargetsFile(prj, prj.nuget[i], ".props")
+				if propsFile then
+					p.x('<Import Project="%s" Condition="Exists(\'%s\')" />', propsFile, propsFile)
+				end
+			end
 		end
 	end
 


### PR DESCRIPTION
**What does this PR do?**

Projects using the C++ nuget package import the targets file `packages\\{package_id}.{version}\\build\\native\\{package_id}.targets` is imported,
but there are some packages that have `.targets` files in other locations or need to import `.props` files other than `.targets`.

Example.

The targets file for the [WinPixEventRuntime](https://www.nuget.org/packages/WinPixEventRuntime) package targets file exists in
`packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets`. not
`packages\WinPixEventRuntime.1.0.220810001\build\native\WinPixEventRuntime.targets`.

[Microsoft.Direct3D.D3D12](https://www.nuget.org/packages/Microsoft.Direct3D.D3D12) package needs to import
`packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.props` file as well as
`packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.targets` file.

**How does this PR change Premake's behavior?**

* Create `packageAPIInfo.packageEntries` variable for package nuget even when it is not a C# project
* In a project using the nuget package, look for `.props` and `.targets` files in the `packageAPIInfo.packageEntries` variable and import them.

**Anything else we should know?**

May slow down project generation to search for targets and props files.

Closes #1497

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
