### PR TITLE
`sanitize { "Address" }` should set link flags too for gcc/clang.

### DIFF
--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -241,6 +241,9 @@
 				if cfg.system == p.WINDOWS then return "-mwindows" end
 			end,
 		},
+		sanitize = {
+			Address = "-fsanitize=address",
+		},
 		system = {
 			wii = "$(MACHDEP)",
 		}

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -453,6 +453,9 @@
 				if cfg.system == p.WINDOWS then return "-mwindows" end
 			end,
 		},
+		sanitize = {
+			Address = "-fsanitize=address",
+		},
 		system = {
 			wii = "$(MACHDEP)",
 		},

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -89,6 +89,13 @@
 -- Check the translation of CXXFLAGS.
 --
 
+function suite.onSanitizeAddress()
+	sanitize { "Address" }
+	prepare()
+	test.contains({ "-fsanitize=address" }, clang.getcxxflags(cfg))
+	test.contains({ "-fsanitize=address" }, clang.getldflags(cfg))
+end
+
 function suite.cxxflags_onSanitizeFuzzer()
 	sanitize { "Fuzzer" }
 	prepare()

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -372,6 +372,7 @@
 		sanitize { "Address" }
 		prepare()
 		test.contains({ "-fsanitize=address" }, gcc.getcxxflags(cfg))
+		test.contains({ "-fsanitize=address" }, gcc.getldflags(cfg))
 	end
 
 --


### PR DESCRIPTION
**What does this PR do?**

`sanitize { "Address" }`  set also ldflags for gcc/clang

**How does this PR change Premake's behavior?**

Fix generator using ldflags for gcc/clang for that option.

**Anything else we should know?**

Tested with [my testing repo](https://github.com/Jarod42/premake-sample-projects/tree/satinize_address_fix)
in particular [that git-action](https://github.com/Jarod42/premake-sample-projects/actions/runs/4015360228)

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

