### PR TITLE
Change to minimize differences after Codelite re-save the file

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -96,7 +96,7 @@
 		_p('<?xml version="1.0" encoding="UTF-8"?>')
 
 		local type = m.internalTypeMap[prj.kind] or ""
-		_x('<CodeLite_Project Name="%s" InternalType="%s">', prj.name, type)
+		_x('<CodeLite_Project Name="%s" InternalType="%s" Version="11000">', prj.name, type)
 	end
 
 	function m.plugins(prj)
@@ -105,7 +105,7 @@
 			-- <Plugin Name="qmake">
 --		_p(1, '</Plugins>')
 
-		_p(1, '<Plugins/>')
+		-- _p(1, '<Plugins/>')
 	end
 
 	function m.description(prj)
@@ -124,10 +124,10 @@
 		tree.traverse(tr, {
 			-- folders are handled at the internal nodes
 			onbranchenter = function(node, depth)
-				_p(depth, '<VirtualDirectory Name="%s">', node.name)
+				_p(1 + depth, '<VirtualDirectory Name="%s">', node.name)
 			end,
 			onbranchexit = function(node, depth)
-				_p(depth, '</VirtualDirectory>')
+				_p(1 + depth, '</VirtualDirectory>')
 			end,
 			-- source files are handled at the leaves
 			onleaf = function(node, depth)
@@ -141,9 +141,9 @@
 				end
 
 				if #excludesFromBuild > 0 then
-					_p(depth, '<File Name="%s" ExcludeProjConfig="%s" />', node.relpath, table.concat(excludesFromBuild, ';'))
+					_p(1 + depth, '<File Name="%s" ExcludeProjConfig="%s" />', node.relpath, table.concat(excludesFromBuild, ';'))
 				else
-					_p(depth, '<File Name="%s"/>', node.relpath)
+					_p(1 + depth, '<File Name="%s"/>', node.relpath)
 				end
 			end,
 		}, true)
@@ -214,7 +214,7 @@
 			usepch = "no"
 		end
 
-		_x(3, '<Compiler Options="%s" C_Options="%s" Assembler="%s" Required="yes" PreCompiledHeader="%s" PCHInCommandLine="%s" PCHFlagsPolicy="1" PCHFlags="">', cxxflags, cflags, asmflags, pch, usepch)
+		_x(3, '<Compiler Options="%s" C_Options="%s" Assembler="%s" Required="yes" PreCompiledHeader="%s" PCHInCommandLine="%s" PCHFlags="" PCHFlagsPolicy="1">', cxxflags, cflags, asmflags, pch, usepch)
 
 		for _, includedir in ipairs(cfg.includedirs) do
 			_x(4, '<IncludePath Value="%s"/>', project.getrelative(cfg.project, includedir))
@@ -234,7 +234,7 @@
 		local toolset = m.getcompiler(cfg)
 		local flags   = table.join(toolset.getldflags(cfg), toolset.getincludedirs(cfg, {}, nil, cfg.frameworkdirs), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), cfg.linkoptions, toolset.getlinks(cfg))
 
-		_x(3, '<Linker Required="yes" Options="%s">', table.concat(flags, ";"))
+		_x(3, '<Linker Options="%s" Required="yes">', table.concat(flags, ";"))
 
 		for _, libdir in ipairs(cfg.libdirs) do
 			_p(4, '<LibraryPath Value="%s"/>', project.getrelative(cfg.project, libdir))
@@ -283,6 +283,7 @@
 
 		_x(3, '<General OutputFile="%s" IntermediateDirectory="%s" Command="%s" CommandArguments="%s" UseSeparateDebugArgs="%s" DebugArguments="%s" WorkingDirectory="%s" PauseExecWhenProcTerminates="%s" IsGUIProgram="%s" IsEnabled="%s"/>',
 			targetname, objdir, command, cmdargs, useseparatedebugargs, debugargs, workingdir, pauseexec, isguiprogram, isenabled)
+		_x(3, '<BuildSystem Name="Default"/>')
 	end
 
 	function m.environment(cfg)
@@ -334,6 +335,8 @@
 			end
 			p.escaper(codelite.esc)
 			_p(3, '</PreBuild>')
+		else
+			_p(3, '<PreBuild/>')
 		end
 	end
 
@@ -351,12 +354,23 @@
 			end
 			p.escaper(codelite.esc)
 			_p(3, '</PostBuild>')
+		else
+			_p(3, '<PostBuild/>')
 		end
 	end
 
 	function m.customBuild(cfg)
 		if not configuration_iscustombuild(cfg) then
-			_p(3, '<CustomBuild Enabled="no"/>')
+			_p(3, '<CustomBuild Enabled="no">')
+			_p(4, '<RebuildCommand/>')
+			_p(4, '<CleanCommand/>')
+			_p(4, '<BuildCommand/>')
+			_p(4, '<PreprocessFileCommand/>')
+			_p(4, '<SingleFileCommand/>')
+			_p(4, '<MakefileGenerationCommand/>')
+			_p(4, '<ThirdPartyToolName/>')
+			_p(4, '<WorkingDirectory/>')
+			_p(3, '</CustomBuild>')
 			return
 		end
 
@@ -365,14 +379,14 @@
 		local rebuild = table.implode(cfg.rebuildcommands,"","","")
 
 		_p(3, '<CustomBuild Enabled="yes">')
-		_x(4, '<BuildCommand>%s</BuildCommand>', build)
-		_x(4, '<CleanCommand>%s</CleanCommand>', clean)
 		_x(4, '<RebuildCommand>%s</RebuildCommand>', rebuild)
-		_p(4, '<PreprocessFileCommand></PreprocessFileCommand>')
-		_p(4, '<SingleFileCommand></SingleFileCommand>')
-		_p(4, '<MakefileGenerationCommand></MakefileGenerationCommand>')
-		_p(4, '<ThirdPartyToolName></ThirdPartyToolName>')
-		_p(4, '<WorkingDirectory></WorkingDirectory>')
+		_x(4, '<CleanCommand>%s</CleanCommand>', clean)
+		_x(4, '<BuildCommand>%s</BuildCommand>', build)
+		_p(4, '<PreprocessFileCommand/>')
+		_p(4, '<SingleFileCommand/>')
+		_p(4, '<MakefileGenerationCommand/>')
+		_p(4, '<ThirdPartyToolName/>')
+		_p(4, '<WorkingDirectory/>')
 		_p(3, '</CustomBuild>')
 	end
 
@@ -534,4 +548,5 @@
 		p.callArray(m.elements.project, prj)
 
 		_p('</CodeLite_Project>')
+		_p('')
 	end

--- a/modules/codelite/codelite_workspace.lua
+++ b/modules/codelite/codelite_workspace.lua
@@ -30,7 +30,7 @@
 
 		local tagsdb = ""
 --		local tagsdb = "./" .. wks.name .. ".tags"
-		p.push('<CodeLite_Workspace Name="%s" Database="%s" SWTLW="No">', wks.name, tagsdb)
+		p.push('<CodeLite_Workspace Name="%s" Database="%s" Version="10000">', wks.name, tagsdb)
 
 		--
 		-- Project list
@@ -102,4 +102,5 @@
 		p.pop('</BuildMatrix>')
 
 		p.pop('</CodeLite_Workspace>')
+		p.w('')
 	end

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -40,7 +40,7 @@
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlagsPolicy="1" PCHFlags="">
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
       </Compiler>
 		]]
 	end
@@ -59,7 +59,7 @@
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="-O0;-fPIC;-g;-std=c++11;-fno-exceptions;-fno-stack-protector;-fno-rtti;-include forced_include1.h;-include forced_include2.h;-opt1;-opt2" C_Options="-O0;-fPIC;-g;-include forced_include1.h;-include forced_include2.h;-opt1;-opt2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlagsPolicy="1" PCHFlags="">
+      <Compiler Options="-O0;-fPIC;-g;-std=c++11;-fno-exceptions;-fno-stack-protector;-fno-rtti;-include forced_include1.h;-include forced_include2.h;-opt1;-opt2" C_Options="-O0;-fPIC;-g;-include forced_include1.h;-include forced_include2.h;-opt1;-opt2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
       </Compiler>
 		]]
 	end
@@ -69,7 +69,7 @@
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlagsPolicy="1" PCHFlags="">
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
         <IncludePath Value="dir"/>
         <IncludePath Value="dir2"/>
       </Compiler>
@@ -81,7 +81,7 @@
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="-isystem sysdir;-isystem sysdir2" C_Options="-isystem sysdir;-isystem sysdir2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlagsPolicy="1" PCHFlags="">
+      <Compiler Options="-isystem sysdir;-isystem sysdir2" C_Options="-isystem sysdir;-isystem sysdir2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
       </Compiler>
 		]]
 	end
@@ -92,7 +92,7 @@
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlagsPolicy="1" PCHFlags="">
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
         <Preprocessor Value="TEST"/>
         <Preprocessor Value="DEF"/>
         <Preprocessor Value="VAL=1"/>
@@ -106,7 +106,7 @@
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="pch.h" PCHInCommandLine="yes" PCHFlagsPolicy="1" PCHFlags="">
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="pch.h" PCHInCommandLine="yes" PCHFlags="" PCHFlagsPolicy="1">
       </Compiler>
 		]]
 	end
@@ -124,7 +124,7 @@
 		prepare()
 		codelite.project.linker(cfg)
 		test.capture [[
-      <Linker Required="yes" Options="">
+      <Linker Options="" Required="yes">
       </Linker>
 		]]
 	end
@@ -134,7 +134,7 @@
 		prepare()
 		codelite.project.linker(cfg)
 		test.capture [[
-      <Linker Required="yes" Options="">
+      <Linker Options="" Required="yes">
         <LibraryPath Value="test"/>
         <LibraryPath Value="test2"/>
       </Linker>
@@ -146,7 +146,7 @@
 		prepare()
 		codelite.project.linker(cfg)
 		test.capture [[
-      <Linker Required="yes" Options="-la;-lb">
+      <Linker Options="-la;-lb" Required="yes">
       </Linker>
 		]]
 	end
@@ -377,7 +377,7 @@ cmd2</StartupCommands>
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="-funsigned-char" C_Options="-funsigned-char" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlagsPolicy="1" PCHFlags="">
+      <Compiler Options="-funsigned-char" C_Options="-funsigned-char" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
       </Compiler>
 		]]
 	end
@@ -388,7 +388,7 @@ cmd2</StartupCommands>
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="-fno-unsigned-char" C_Options="-fno-unsigned-char" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlagsPolicy="1" PCHFlags="">
+      <Compiler Options="-fno-unsigned-char" C_Options="-fno-unsigned-char" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
       </Compiler>
 		]]
 	end

--- a/modules/codelite/tests/test_codelite_project.lua
+++ b/modules/codelite/tests/test_codelite_project.lua
@@ -33,7 +33,7 @@
 		codelite.project.header(prj)
 		test.capture [[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Project Name="MyProject" InternalType="Console">
+<CodeLite_Project Name="MyProject" InternalType="Console" Version="11000">
 		]]
 	end
 	function suite.OnProject_Header_Windowed()
@@ -42,7 +42,7 @@
 		codelite.project.header(prj)
 		test.capture [[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Project Name="MyProject" InternalType="Console">
+<CodeLite_Project Name="MyProject" InternalType="Console" Version="11000">
 		]]
 	end
 	function suite.OnProject_Header_Shared()
@@ -51,7 +51,7 @@
 		codelite.project.header(prj)
 		test.capture [[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Project Name="MyProject" InternalType="Library">
+<CodeLite_Project Name="MyProject" InternalType="Library" Version="11000">
 		]]
 	end
 
@@ -59,7 +59,6 @@
 		prepare()
 		codelite.project.plugins(prj)
 		test.capture [[
-  <Plugins/>
 		]]
 	end
 
@@ -106,5 +105,16 @@
 		codelite.project.files(prj)
 		test.capture [[
   <VirtualDirectory Name="MyProject"/>
+		]]
+	end
+
+	function suite.OnProject_SourceFiles()
+		files { "a.cpp" }
+		prepare()
+		codelite.project.files(prj)
+		test.capture [[
+  <VirtualDirectory Name="MyProject">
+    <File Name="a.cpp"/>
+  </VirtualDirectory>
 		]]
 	end

--- a/modules/codelite/tests/test_codelite_workspace.lua
+++ b/modules/codelite/tests/test_codelite_workspace.lua
@@ -38,7 +38,7 @@
 		prepare()
 		test.capture [[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+<CodeLite_Workspace Name="MyWorkspace" Database="" Version="10000">
   <BuildMatrix>
     <WorkspaceConfiguration Name="Debug" Selected="yes">
     </WorkspaceConfiguration>
@@ -53,7 +53,7 @@
 		prepare()
 		test.capture [[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+<CodeLite_Workspace Name="MyWorkspace" Database="" Version="10000">
   <Project Name="MyProject" Path="MyProject.project"/>
   <BuildMatrix>
     <WorkspaceConfiguration Name="Debug" Selected="yes">
@@ -72,7 +72,7 @@
 		prepare()
 		test.capture [[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+<CodeLite_Workspace Name="MyWorkspace" Database="" Version="10000">
   <Project Name="MyProject" Path="MyProject.project"/>
   <Project Name="MyProject2" Path="MyProject2.project"/>
   <BuildMatrix>
@@ -99,7 +99,7 @@
 		prepare()
 		test.capture([[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+<CodeLite_Workspace Name="MyWorkspace" Database="" Version="10000">
   <Project Name="MyProject" Path="MyProject/MyProject.project"/>
   <BuildMatrix>
     <WorkspaceConfiguration Name="Debug" Selected="yes">
@@ -118,7 +118,7 @@
 		prepare()
 		test.capture([[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+<CodeLite_Workspace Name="MyWorkspace" Database="" Version="10000">
   <Project Name="MyProject" Path="../MyProject/MyProject.project"/>
   <BuildMatrix>
     <WorkspaceConfiguration Name="Debug" Selected="yes">
@@ -139,7 +139,7 @@
 		prepare()
 		test.capture([[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+<CodeLite_Workspace Name="MyWorkspace" Database="" Version="10000">
   <Project Name="MyProject" Path="MyProject.project" Active="Yes"/>
   <BuildMatrix>
     <WorkspaceConfiguration Name="Debug" Selected="yes">
@@ -164,7 +164,7 @@
     prepare()
     test.capture([[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+<CodeLite_Workspace Name="MyWorkspace" Database="" Version="10000">
   <VirtualDirectory Name="My">
     <VirtualDirectory Name="Nested">
       <VirtualDirectory Name="Group">
@@ -203,7 +203,7 @@
 		prepare()
 		test.capture [[
 <?xml version="1.0" encoding="UTF-8"?>
-<CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
+<CodeLite_Workspace Name="MyWorkspace" Database="" Version="10000">
   <Project Name="MyProject" Path="MyProject.project"/>
   <BuildMatrix>
     <WorkspaceConfiguration Name="x86_64-Debug" Selected="yes">


### PR DESCRIPTION
**What does this PR do?**

Change to minimize differences after Codelite re-save the file
- Version in header
- indentation of VirtualDirectory node
- order of pch and linker attributes
- order of custom build nodes
- Handle empty nodes (add PreBuild/PostNuild, remove Plugins)
- Add EOL at EOF.


**How does this PR change Premake's behavior?**

No behavior changes.

**Anything else we should know?**

No.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
