### PR TITLE
wrap OBJDIR creation in prevent gmake warning

### DIFF
--- a/modules/gmake2/gmake2.lua
+++ b/modules/gmake2/gmake2.lua
@@ -129,10 +129,12 @@
 		_p('endif')
 	end
 
-	function gmake2.mkdirRules(dirname)
+	function gmake2.mkdirRules(dirname, before, after)
+		if before then _p(before) end
 		_p('%s:', dirname)
 		_p('\t@echo Creating %s', dirname)
 		gmake2.mkdir(dirname)
+		if after then _p(after) end
 		_p('')
 	end
 
@@ -327,7 +329,9 @@
 
 
 	function gmake2.objDirRules(cfg, toolset)
-		gmake2.mkdirRules("$(OBJDIR)")
+		local before = 'ifneq ($(OBJDIR),$(TARGETDIR))'
+		local after = 'endif'
+		gmake2.mkdirRules("$(OBJDIR)", before, after)
 	end
 
 


### PR DESCRIPTION
## Wrap OBJDIR creation in conditional to prevent defining two rules with the same name

**What does this PR do?**

Make doesn't want you to create two rules with the same name and will emit a warning if you do (unless they are double colon rules which have some caveats?).

If you set the `targetdir` and `objdir` to the same location in Premake two rules are produced with the same name, as described in #726, causing make to complain.

**How does this PR change Premake's behavior?**

Wraps the `OBJDIR` rule in a conditional so it is not run if `OBJDIR` and `TARGETDIR` are the same.

closes #726

**Anything else we should know?**

I'm not an expert on makefiles but in my research I saw two possible solutions to this issue.

1. Change the rules to [double colon rules](https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html) which did work but possibly has some caveats.

2. Wrap a conditional around one of the rules. Apparently make has the concept of *immediate* and *deferred* contexts which I looked into a bit but seems to not be an issue for this case. I was reading about the concepts [here](https://www.gnu.org/software/make/manual/html_node/Reading-Makefiles.html#index-ifeq_002c-expansion).

I selected option 2 because as far as I could tell I didn't have any relevant caveats and seemed the least surprising for someone reading the makefile / Lua code.

Tests were not included because the warning was only visible when you run the makefile and I wasn't sure how / if it was worthing testing that.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
