### PR TITLE
Fix `compileas "C"` and `"C++"` for gcc (shared with clang).

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -134,6 +134,8 @@
 			Off = "-fno-omit-frame-pointer"
 		},
 		compileas = {
+			["C"] = "-x c",
+			["C++"] = "-x c++",
 			["Objective-C"] = "-x objective-c",
 			["Objective-C++"] = "-x objective-c++",
 		}

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -1099,3 +1099,36 @@
 		test.excludes({ "-fvisibility-inlines-hidden" }, gcc.getcflags(cfg))
 		test.contains({ "-fvisibility-inlines-hidden" }, gcc.getcxxflags(cfg))
 	end
+
+--
+-- Test compileas.
+--
+
+	function suite.cxxflags_compileasC()
+		compileas "C"
+		prepare()
+		test.contains({ "-x c" }, gcc.getcflags(cfg))
+		test.contains({ "-x c" }, gcc.getcxxflags(cfg))
+	end
+
+	function suite.cxxflags_compileasCPP()
+		compileas "C++"
+		prepare()
+		test.contains({ "-x c++" }, gcc.getcflags(cfg))
+		test.contains({ "-x c++" }, gcc.getcxxflags(cfg))
+	end
+
+	function suite.cxxflags_compileasObjC()
+		compileas "Objective-C"
+		prepare()
+		test.contains({ "-x objective-c" }, gcc.getcflags(cfg))
+		test.contains({ "-x objective-c" }, gcc.getcxxflags(cfg))
+	end
+
+	function suite.cxxflags_compileasObjCPP()
+		compileas "Objective-C++"
+
+		prepare()
+		test.contains({ "-x objective-c++" }, gcc.getcflags(cfg))
+		test.contains({ "-x objective-c++" }, gcc.getcxxflags(cfg))
+	end


### PR DESCRIPTION
**What does this PR do?**

Fix `compileas "C"` and `compileas "C++"` for gcc (shared with clang).

**How does this PR change Premake's behavior?**

All of `gcc.getcflags(cfg))` and `gcc.getcxxflags(cfg)` now provide flags to respect provided option.

**Anything else we should know?**

No

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
