### PR TITLE
Fix for premake-qt

### DIFF
--- a/modules/gmake2/gmake2_utility.lua
+++ b/modules/gmake2/gmake2_utility.lua
@@ -99,27 +99,19 @@
 
 		-- process custom build commands.
 		if fileconfig.hasCustomBuildRule(filecfg) then
-			local env = table.shallowcopy(filecfg.environ)
-			env.PathVars = {
-				["file.basename"] = { absolute = false, token = node.basename },
-				["file.abspath"]  = { absolute = true,  token = node.abspath },
-				["file.relpath"]  = { absolute = false, token = node.relpath },
-				["file.name"]     = { absolute = false, token = node.name },
-				["file.path"]     = { absolute = true,  token = node.path },
-			}
-
-			local shadowContext = p.context.extent(filecfg, env)
-
-			local buildoutputs = p.project.getrelative(cfg.project, shadowContext.buildoutputs)
+			local buildoutputs = p.project.getrelative(cfg.project, filecfg.buildoutputs)
 			if buildoutputs and #buildoutputs > 0 then
 				local file = {
 					buildoutputs  = buildoutputs,
 					source        = node.relpath,
-					buildmessage  = shadowContext.buildmessage,
-					buildcommands = shadowContext.buildcommands,
-					buildinputs   = p.project.getrelative(cfg.project, shadowContext.buildinputs)
+					buildmessage  = filecfg.buildmessage,
+					buildcommands = filecfg.buildcommands,
+					buildinputs   = p.project.getrelative(cfg.project, filecfg.buildinputs)
 				}
-				table.insert(cfg._gmake.fileRules, file)
+				local cmp = function(lhs, rhs) return lhs.buildoutputs[1] == rhs.buildoutputs[1] end
+				if table.indexof(cfg._gmake.fileRules, file, cmp) == nil then
+					table.insert(cfg._gmake.fileRules, file)
+				end
 
 				for _, output in ipairs(buildoutputs) do
 					utility.addGeneratedFile(cfg, node, output)
@@ -158,7 +150,9 @@
 		local kind = "CUSTOM"
 
 		local fileset = cfg._gmake.filesets[kind] or {}
-		table.insert(fileset, filename)
+		if not table.contains(fileset, filename) then
+			table.insert(fileset, filename)
+		end
 		cfg._gmake.filesets[kind] = fileset
 
 		-- recursively setup rules.
@@ -195,7 +189,10 @@
 					buildcommands = buildcommands,
 					buildinputs   = buildinputs
 				}
-				table.insert(cfg._gmake.fileRules, file)
+				local cmp = function(lhs, rhs) return lhs.buildoutputs[1] == rhs.buildoutputs[1] end
+				if table.indexof(cfg._gmake.fileRules, file, cmp) == nil then
+					table.insert(cfg._gmake.fileRules, file)
+				end
 
 				for _, output in ipairs(buildoutputs) do
 					utility.addGeneratedFile(cfg, node, output)

--- a/src/base/table.lua
+++ b/src/base/table.lua
@@ -196,9 +196,10 @@
 -- or nil if the object could not be found.
 --
 
-	function table.indexof(tbl, obj)
+	function table.indexof(tbl, obj, cmp)
+		cmp = cmp or function(lhs, rhs) return lhs == rhs end
 		for k, v in ipairs(tbl) do
-			if v == obj then
+			if cmp(v, obj) then
 				return k
 			end
 		end

--- a/tests/base/test_table.lua
+++ b/tests/base/test_table.lua
@@ -54,6 +54,10 @@
 		test.isequal(2, idx)
 	end
 
+	function suite.indexof_returnsIndexOfValueFoundWithCmp()
+		local idx = table.indexof({ "a", "bb", "ccc" }, "aa", function(lhs, rhs) return #lhs == #rhs end)
+		test.isequal(2, idx)
+	end
 
 --
 -- table.isempty() tests

--- a/website/docs/table.indexof.md
+++ b/website/docs/table.indexof.md
@@ -1,13 +1,13 @@
 Returns the key or index of a value within a table.
 
 ```lua
-table.indexof(arr, value)
+table.indexof(arr, value, cmp)
 ```
 
 ### Parameters ###
 
 `arr` is a table containing indexed elements. `value` is the value for which to search.
-
+`cmp` is a predicate to compare elements, default to `function(lhs, rhs) return lhs == rhs end`
 
 ### Return Value ###
 


### PR DESCRIPTION
**What does this PR do?**

closes #1916
Fix for premake-qt for gmake2
- `shadowContext` is wrong (case typo of `PathVars` BTW).
- Remove duplicated generated `node` entries.

**How does this PR change Premake's behavior?**

gmake2 generator fixed.
modify `table.indexof` to allow to have predicate too.

**Anything else we should know?**

Tested with https://github.com/Jarod42/premake-sample-projects/actions/runs/4563673420

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
