### PR TITLE
Added "see also" for `files` for common use case.

### DIFF
--- a/website/docs/conformancemode.md
+++ b/website/docs/conformancemode.md
@@ -24,6 +24,7 @@ Premake 5.0.0 beta 1 or later.
 conformancemode(true)   -- better for cross-platform projects
 conformancemode(false)  -- has access to more platform-specific features
 
--- Parentheses are required in this case because Lua only supports omitting them if the parameter is a single string or table.
+-- Parentheses are required in this case because Lua only supports 
+-- omitting them if the parameter is a single string or table.
 ```
 

--- a/website/docs/conformancemode.md
+++ b/website/docs/conformancemode.md
@@ -1,12 +1,14 @@
-conformancemode - This page was auto-generated. Feel free to help us improve the documentation by creating a pull request.
+This function sets a boolean flag that controls whether or not the generated projects should adhere ("conform") to a *stricter* interpretation of the language standard or not. 
 
 ```lua
-conformancemode (value)
+conformancemode(is_strict)
 ```
 
 ### Parameters ###
 
-`value` - needs documentation.
+If `is_strict` is true (and applicable to the generated project's capabilities), the generated project will use stricter language standard rules (e.g. C and C++ ISO standards) when building the project. This will increases the chances of the build system and compiler reporting problems with the code you write and build that may not be as portable between compilers or target systems. However, it may also decrease how many platform-specific build system and compiler features are available to you.
+
+On the other hand, if `is_strict` is false then the opposite tradeoff will apply: more features/permissiveness, but less cross-platform compatibility.
 
 ## Applies To ###
 
@@ -19,6 +21,9 @@ Premake 5.0.0 beta 1 or later.
 ### Examples ###
 
 ```lua
-conformancemode (value)
+conformancemode(true)   -- better for cross-platform projects
+conformancemode(false)  -- has access to more platform-specific features
+
+-- Parentheses are required in this case because Lua only supports omitting them if the parameter is a single string or table.
 ```
 

--- a/website/docs/files.md
+++ b/website/docs/files.md
@@ -50,3 +50,4 @@ filter "system:MacOSX"
 * [Adding Source Files](Adding-Source-Files.md)
 * [Removing Values](Removing-Values.md)
 * [vpaths](vpaths.md)
+* [includedirs](https://premake.github.io/docs/includedirs/) (Whereas `files` is used to determine which files are included in a generated project's view of what files are associated with that project, `includedirs` is used to determine *where to automatically search for source files* when including/importing them. Being aware of this distinction is important if you want to use a non-standard project folder structure.) 


### PR DESCRIPTION
**What does this PR do?**

I was initially confused about whether `files` included its files in the search path or not (I assumed yes at first), but then found that you have to use `includedirs` to do that.

So, I added a comment here for that, so people will figure this out more easily.

**How does this PR change Premake's behavior?**

It doesn't. This is just a documentation suggestion.

**Anything else we should know?**

No.

**Did you check all the boxes?**

- [ Y] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ N/A] Add unit tests showing fix or feature works; all tests pass
- [ N/A] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ N/A] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [ Y] Minimize the number of commits
- [ Y] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes


