### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/contrib/curl/lib/strerror.c
+++ b/contrib/curl/lib/strerror.c
@@ -187,8 +187,10 @@ curl_easy_strerror(CURLcode error)
   case CURLE_TELNET_OPTION_SYNTAX :
     return "Malformed telnet option";
 
+#if LIBCURL_VERSION_NUM < 0x073e00
   case CURLE_PEER_FAILED_VERIFICATION:
     return "SSL peer certificate or SSH remote key was not OK";
+#endif
 
   case CURLE_GOT_NOTHING:
     return "Server returned nothing (no headers, no data)";
@@ -214,9 +216,11 @@ curl_easy_strerror(CURLcode error)
   case CURLE_SSL_CIPHER:
     return "Couldn't use specified SSL cipher";
 
+#if LIBCURL_VERSION_NUM >= 0x073e00
   case CURLE_SSL_CACERT:
     return "Peer certificate cannot be authenticated with given CA "
       "certificates";
+#endif
 
   case CURLE_SSL_CACERT_BADFILE:
     return "Problem with the SSL CA cert (path? access rights?)";


### PR DESCRIPTION
**What does this PR do?**
Fixes building on OpenBSD

**How does this PR change Premake's behavior?**
It fixes building on OpenBSD

**Anything else we should know?**
Curl piece works

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
- [x] Fix building on OpenBSD

I will write a port on OpenBSD this weekend for premake5. maybe

Also worth noting:

```
os_match.c(obj/Release/Premake5/os_match.o:(os_matchstart)): warning: strcpy() is almost always misused, please use strlcpy()
function function> os_uuid.c(obj/Release/Premake5/os_uuid.o:(os_uuid)): warning: sprintf() is often misused, please use snprintf()
function function function function> path_getabsolute.c(obj/Release/Premake5/path_getabsolute.o:(do_getabsolute)): warning: strcat() is almost always misused, please use strlcat()
function function function function function function> lmathlib.c(lmathlib.o:(math_random) in archive bin/Release/liblua-lib.a): warning: random() may return deterministic values, is that what you want?
```

You can peek the first 3 cases for yourself if that matters. PS: Should use internal Curl in anyway?