### PR TITLE
Add unistd.h to libzip to prevent build failure with Xcode 14.3

### DIFF
--- a/contrib/libzip/mkstemp.c
+++ b/contrib/libzip/mkstemp.c
@@ -43,6 +43,7 @@
 #endif
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #ifndef O_BINARY
 #define O_BINARY 0

--- a/contrib/libzip/zip_close.c
+++ b/contrib/libzip/zip_close.c
@@ -42,9 +42,9 @@
 #include <strings.h>
 #endif
 #include <errno.h>
-#ifdef HAVE_UNISTD_H
+
 #include <unistd.h>
-#endif
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #ifdef _WIN32

--- a/contrib/libzip/zip_fdopen.c
+++ b/contrib/libzip/zip_fdopen.c
@@ -35,6 +35,8 @@
 
 #include "zipint.h"
 
+#include <unistd.h>
+
 
 
 ZIP_EXTERN struct zip *


### PR DESCRIPTION
**What does this PR do?**

Without this PR, Premake will fail to build using Xcode 14.3. This PR adds `unistd.h` to three files in libzip which will allow the build to succeed. 

**How does this PR change Premake's behavior?**
Allows the build to succeed. 

**Are there any breaking changes? Will any existing behavior change?**
Not that I'm aware of.

**Anything else we should know?**

From my understanding, `unistd.h` is for posix-compliant OSes, so ideally I should ifdef these changes so they are not added to non-posix OSes. 

`zip_close.c` has the check `#ifdef HAVE_UNISTD_H` which I thought would be appropriate, but building still fails when using this. 

If anyone can suggest a better define, let me know and I'll add it. 


