### PR TITLE
Improve error message of `include`

### DIFF
--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -238,7 +238,15 @@
 --
 
 	function premake.findProjectScript(fname)
-		return os.locate(fname, fname .. ".lua", path.join(fname, "premake5.lua"), path.join(fname, "premake4.lua"))
+		local with_ext = fname .. ".lua"
+		local p5 = path.join(fname, "premake5.lua")
+		local p4 = path.join(fname, "premake4.lua")
+
+		local res = os.locate(fname, with_ext, p5, p4)
+		if res == nil then
+			premake.error("Cannot find either " .. table.implode({fname, with_ext, p5, p4}, "", "", " or "))
+		end
+		return res
 	end
 
 

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -81,10 +81,9 @@
 ---
 
 	function includeexternal(fname)
-		local fullPath = p.findProjectScript(fname)
+		fname = p.findProjectScript(fname)
 		local wasIncludingExternal = api._isIncludingExternal
 		api._isIncludingExternal = true
-		fname = fullPath or fname
 		dofile(fname)
 		api._isIncludingExternal = wasIncludingExternal
 	end

--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -48,8 +48,7 @@
 	io._includedFiles = {}
 
 	function include(fname)
-		local fullPath = premake.findProjectScript(fname)
-		fname = fullPath or fname
+		fname = premake.findProjectScript(fname)
 		if not io._includedFiles[fname] then
 			io._includedFiles[fname] = true
 			return dofile(fname)


### PR DESCRIPTION
**What does this PR do?**

Change error message for include/includeexternal from
`"Error: cannot open $name: No such file or directory"` (from `dofile`) to
`"Error: Cannot find either $name or $name.lua or $name/premake5.lua or $name/premake4.lua"`

**How does this PR change Premake's behavior?**

Error message change.

**Anything else we should know?**

Done after viewing https://stackoverflow.com/questions/75986260/include-path-not-detected-when-running-premake

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
