### PR TITLE
Fix prelink step dependencies for gmake (to be done after compilation).

### DIFF
--- a/modules/gmake/gmake.lua
+++ b/modules/gmake/gmake.lua
@@ -248,7 +248,7 @@
 
 
 	function make.preLinkRules(prj)
-		_p('prelink:')
+		_p('prelink: $(OBJECTS)')
 		_p('\t$(PRELINKCMDS)')
 		_p('')
 	end


### PR DESCRIPTION
**What does this PR do?**

Fix `prelink` step for gmake generator

**How does this PR change Premake's behavior?**

Just change gmake generator.

**Anything else we should know?**

Tested successfully on my testing repo: https://github.com/Jarod42/premake-sample-projects/actions/runs/4895539865

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

