### PR TITLE
Allow to select shell in command line for token replacement.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1878,6 +1878,17 @@
 
 	newoption
 	{
+		trigger     = "shell",
+		value       = "VALUE",
+		description = "Select shell (for command token substitution)",
+		allowed = {
+			{ "cmd", "Windows command shell" },
+			{ "posix", "For posix shells" },
+		}
+	}
+
+	newoption
+	{
 		trigger     = "scripts",
 		value       = "PATH",
 		description = "Search for additional scripts on the given path"

--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -258,6 +258,13 @@
 		return table.contains(tags, id:lower())
 	end
 
+--
+-- Retrieve the current target shell ID string.
+--
+
+	function os.shell()
+		return _OPTIONS.shell or iif(os.target() == "windows", "cmd", "posix")
+	end
 
 ---
 -- Determine if a directory exists on the file system, and that it is a
@@ -599,7 +606,7 @@
 ---
 
 	os.commandTokens = {
-		_ = {
+		posix = {
 			chdir = function(v)
 				return "cd " .. path.normalize(v)
 			end,
@@ -631,7 +638,7 @@
 				return "touch " .. path.normalize(v)
 			end,
 		},
-		windows = {
+		cmd = {
 			chdir = function(v)
 				return "chdir " .. path.translate(path.normalize(v))
 			end,
@@ -681,9 +688,12 @@
 	}
 
 	function os.translateCommands(cmd, map)
-		map = map or os.target()
+		map = map or os.shell()
 		if type(map) == "string" then
-			map = os.commandTokens[map] or os.commandTokens["_"]
+			if map == "windows" then -- For retro compatibility
+				map = "cmd"
+			end
+			map = os.commandTokens[map] or os.commandTokens["posix"]
 		end
 
 		local processOne = function(cmd)
@@ -697,7 +707,7 @@
 
 					local token = cmd:sub(i + 1, j - 1):lower()
 					local args = cmd:sub(j + 2)
-					local func = map[token] or os.commandTokens["_"][token]
+					local func = map[token] or os.commandTokens["posix"][token]
 					if func then
 						cmd = cmd:sub(1, i -1) .. func(args)
 					end
@@ -725,7 +735,7 @@
 -- Apply os slashes for decorated command paths.
 ---
 	function os.translateCommandAndPath(dir, map)
-		if map == 'windows' then
+		if map == 'windows' or map == 'cmd' then
 			return path.translate(dir)
 		end
 		return dir
@@ -735,7 +745,7 @@
 -- Translate decorated command paths into their OS equivalents.
 ---
 	function os.translateCommandsAndPaths(cmds, basedir, location, map)
-		map = map or os.target()
+		map = map or os.shell()
 		location = path.getabsolute(location)
 		basedir = path.getabsolute(basedir)
 

--- a/website/docs/Tokens.md
+++ b/website/docs/Tokens.md
@@ -74,7 +74,7 @@ The paths are expanded relative to premake script, to obtain absolute paths, you
 
 ## Command Tokens
 
-Command tokens represent a system level command in a platform-neutral way.
+Command tokens represent a system level command in a shell-neutral way.
 
 ```lua
 postbuildcommands {
@@ -94,11 +94,11 @@ You can use command tokens anywhere you specify a command line, including:
 * [prelinkcommands](prelinkcommands.md)
 * [rebuildcommands](rebuildcommands.md)
 
-Command tokens are replaced with an appropriate command for the target platform. For Windows, path separators in the commmand arguments are converted to backslashes.
+Command tokens are replaced with an appropriate command for the target shell. For Windows, path separators in the commmand arguments are converted to backslashes.
 
 The available tokens, and their replacements:
 
-| Token      | DOS                                         | Posix           |
+| Token      | DOS/cmd                                     | Posix           |
 |------------|---------------------------------------------|-----------------|
 | {CHDIR}    | chdir {args}                                | cd {args}       |
 | {COPYFILE} | copy /B /Y {args}                           | cp -f {args}    |


### PR DESCRIPTION
**What does this PR do?**

Allow to select shell type to use for command substitution.
We can use posix shell on windows

**How does this PR change Premake's behavior?**

Token command substitution uses `shell` before `os.target()`

**Anything else we should know?**

Needed for testing repository to run ninja with msc under windows run from bash shell.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
