### PR TITLE
Add some missing flags for msc toolset

### DIFF
--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -301,10 +301,18 @@
 		test.contains("-I/usr/local/include", msc.getincludedirs(cfg, cfg.includedirs, cfg.externalincludedirs))
 	end
 
+	function suite.cflags_onVs2008ExternalIncludeDirs()
+		p.action.set("vs2008")
+		externalincludedirs { "/usr/local/include" }
+		prepare()
+		test.contains("-I/usr/local/include", msc.getincludedirs(cfg, cfg.includedirs, cfg.externalincludedirs))
+	end
+
 	function suite.cflags_onVs2022ExternalIncludeDirs()
 		p.action.set("vs2022")
 		externalincludedirs { "/usr/local/include" }
 		prepare()
+		test.contains("/external:W3", msc.getsharedflags(cfg))
 		test.contains("/external:I/usr/local/include", msc.getincludedirs(cfg, cfg.includedirs, cfg.externalincludedirs))
 	end
 
@@ -318,10 +326,18 @@ function suite.cflags_onIncludeDirsAfter()
 	test.contains("-I/usr/local/include", msc.getincludedirs(cfg, cfg.includedirs, cfg.externalincludedirs, cfg.frameworkdirs, cfg.includedirsafter))
 end
 
+function suite.cflags_onVs2008IncludeDirsAfter()
+	p.action.set("vs2008")
+	includedirsafter { "/usr/local/include" }
+	prepare()
+	test.contains("-I/usr/local/include", msc.getincludedirs(cfg, cfg.includedirs, cfg.externalincludedirs, cfg.frameworkdirs, cfg.includedirsafter))
+end
+
 function suite.cflags_onVs2022IncludeDirsAfter()
 	p.action.set("vs2022")
 	includedirsafter { "/usr/local/include" }
 	prepare()
+	test.contains("/external:W3", msc.getsharedflags(cfg))
 	test.contains("/external:I/usr/local/include", msc.getincludedirs(cfg, cfg.includedirs, cfg.externalincludedirs, cfg.frameworkdirs, cfg.includedirsafter))
 end
 
@@ -347,6 +363,65 @@ end
 		test.contains('/FIinclude/sys.h', msc.getforceincludes(cfg))
 	end
 
+--
+-- Check handling of cdialect.
+--
+
+	function suite.cdialectC11()
+		cdialect "C11"
+		prepare()
+		test.contains('/std:c11', msc.getcflags(cfg))
+	end
+
+	function suite.cdialectC17()
+		cdialect "C17"
+		prepare()
+		test.contains('/std:c17', msc.getcflags(cfg))
+	end
+
+--
+-- Check handling of cppdialect.
+--
+
+	function suite.cppdialectCpp14()
+		cppdialect "C++14"
+		prepare()
+		test.contains('/std:c++14', msc.getcxxflags(cfg))
+	end
+
+	function suite.cppdialectCpp17()
+		cppdialect "C++17"
+		prepare()
+		test.contains('/std:c++17', msc.getcxxflags(cfg))
+	end
+
+	function suite.cppdialectCpp20()
+		cppdialect "C++20"
+		prepare()
+		test.contains('/std:c++20', msc.getcxxflags(cfg))
+	end
+
+	function suite.cppdialectCppLatest()
+		cppdialect "C++latest"
+		prepare()
+		test.contains('/std:c++latest', msc.getcxxflags(cfg))
+	end
+
+--
+-- Check handling of compileas.
+--
+
+	function suite.compileasC()
+		compileas "C"
+		prepare()
+		test.contains('/TC', msc.getsharedflags(cfg))
+	end
+
+	function suite.compileasCPP()
+		compileas "C++"
+		prepare()
+		test.contains('/TP', msc.getsharedflags(cfg))
+	end
 
 --
 -- Check handling of floating point modifiers.


### PR DESCRIPTION
**What does this PR do?**

For msc toolset:
- Add some missing flags (compileas/c(pp)dialect).
- Fix option dependency (D9007: '/external:I' requires '/external:W').
- Fix toolset version comparison (`"msc-v142" < "msc-v80"`!) (so vs2005/vs2008) (for external warnings).

**How does this PR change Premake's behavior?**

Just change msc toolset,
so indirectly affects Codelite (and extern modules such as Code::Blocks, ninja) when using that toolset

**Anything else we should know?**

One of the fix needed to make ninja works with msvc in [my testing repository](https://github.com/Jarod42/premake-sample-projects)

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
