### PR TITLE
os.translateCommandsAndPaths

### DIFF
--- a/modules/vstudio/vs2010_rules_props.lua
+++ b/modules/vstudio/vs2010_rules_props.lua
@@ -150,7 +150,7 @@
 
 		-- write out the result.
 		if buildcommands and #buildcommands > 0 then
-			local cmds = os.translateCommands(buildcommands, p.WINDOWS)
+			local cmds = os.translateCommandsAndPaths(buildcommands, r.basedir, r.location, p.WINDOWS)
 			cmds = table.concat(cmds, p.eol())
 			p.x('<CommandLineTemplate>%s</CommandLineTemplate>', cmds)
 		end

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1061,7 +1061,7 @@
 
 			if #commands > 0 then
 				table.insert(commands, 1, 'set -e') -- Tells the shell to exit when any command fails
-				commands = os.translateCommands(commands, p.MACOSX)
+				commands = os.translateCommandsAndPaths(commands, tr.project.basedir, tr.project.location, p.MACOSX)
 				if not wrapperWritten then
 					_p('/* Begin PBXShellScriptBuildPhase section */')
 					wrapperWritten = true

--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -735,12 +735,12 @@
 -- Translate decorated command paths into their OS equivalents.
 ---
 	function os.translateCommandsAndPaths(cmds, basedir, location, map)
-		local translatedBaseDir = path.getrelative(location, basedir)
-
 		map = map or os.target()
+		location = path.getabsolute(location)
+		basedir = path.getabsolute(basedir)
 
 		local translateFunction = function(value)
-			local result = path.join(translatedBaseDir, value)
+			local result = path.getrelative(location, path.join(basedir, value))
 			result = os.translateCommandAndPath(result, map)
 			if value:endswith('/') or value:endswith('\\') or -- if original path ends with a slash then ensure the same
 			   value:endswith('/"') or value:endswith('\\"') then

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -408,6 +408,9 @@
 		test.isequal('cmdtool "../foo/path1" "../foo/path2/"', os.translateCommandsAndPaths("cmdtool %[path1] %[path2/]", '../foo', '.', 'osx'))
 	end
 
+	function suite.translateCommandsAndPaths_RelativePath()
+		test.isequal('cmdtool "path1" "../bar/path2/"', os.translateCommandsAndPaths("cmdtool %[../foo/path1] %[path2/]", './bar', './foo', 'osx'))
+	end
 
 --
 -- Helpers

--- a/website/docs/Custom-Build-Commands.md
+++ b/website/docs/Custom-Build-Commands.md
@@ -14,7 +14,7 @@ These are the simplest to setup and use: pass one or more command lines to the [
 ```lua
 -- copy a file from the objects directory to the target directory
 postbuildcommands {
-  "{COPY} %{cfg.objdir}/output.map %{cfg.targetdir}"
+  "{COPYFILE} %[%{!cfg.objdir}/output.map] %[%{!cfg.targetdir}]"
 }
 ```
 
@@ -29,11 +29,11 @@ Here is an example which compiles all Lua files in a project to C:
 ```lua
 filter 'files:**.lua'
    -- A message to display while this build step is running (optional)
-   buildmessage 'Compiling %{file.relpath}'
+   buildmessage 'Compiling %[%{file.relpath}]'
 
    -- One or more commands to run (required)
    buildcommands {
-      'luac -o "%{cfg.objdir}/%{file.basename}.out" "%{file.relpath}"'
+      'luac -o "%[%{!cfg.objdir}/%{file.basename}.out]" "%[%{!file.relpath}]"'
    }
 
    -- One or more outputs resulting from the build (required)

--- a/website/docs/Custom-Rules.md
+++ b/website/docs/Custom-Rules.md
@@ -53,7 +53,7 @@ rule "MyCustomRule"
   }
 ```
 
-Properties may then be used in the rule commands by enclosing the name in square brackets. This, again, is a Visual Studio convention; we may switch it up if support for additional exporters becomes available.
+Properties may then be used in the rule commands by enclosing the name in square brackets. This, again, is a Visual Studio convention; we may switch it up if support for additional exporters becomes available. You might find in [Tokens](Tokens.md) some portable tokens for replacement.
 
 ```lua
 buildcommand 'MyCustomCC.exe -c "%(FullPath)" -o "%(IntDir)/%(Filename).obj" [StripDebugInfo]

--- a/website/docs/Tokens.md
+++ b/website/docs/Tokens.md
@@ -16,7 +16,7 @@ Value tokens are expressions wrapped in a `%{}` sequence. Tokens have access to 
 %{cfg.targetdir}
 ```
 
-The contents of the %{} are run through loadstring() and executed at token-replacement time, so more complex replacements can be used. You can access any global value.
+The contents of the %{} are run through `loadstring()` and executed at token-replacement time, so more complex replacements can be used. You can access any global value.
 
 ```lua
 %{wks.name:gsub(' ', '_')}
@@ -70,13 +70,15 @@ file.extension -- (including '.'; eg ".cpp")
 [target].suffix
 ```
 
+The paths are expanded relative to premake script, to obtain absolute paths, you have to add `!` as in `%{!file.path}`.
+
 ## Command Tokens
 
 Command tokens represent a system level command in a platform-neutral way.
 
 ```lua
 postbuildcommands {
-	"{COPYFILE} file1.txt file2.txt"
+	"{COPYFILE} %[file1.txt] %[file2.txt]"
 }
 ```
 
@@ -115,6 +117,20 @@ The following tokens are deprecated:
 | Token      | DOS                                         | Posix           | Remarks                             |
 |------------|---------------------------------------------|-----------------|-------------------------------------|
 | {COPY}     | xcopy /Q /E /Y /I {args}                    | cp -rf {args}   | Use {COPYDIR} or {COPYFILE} instead |
+
+### Path in commands
+
+Paths in Premake should be relative to premake script in which they appears.
+
+When you specify a path inside a commands, you have to wrap path insice `%[]` to allow correct trnasformation for the generator.
+
+i.e.
+
+```lua
+buildcommands {
+	"{COPYFILE} %[%{!file.abspath}] %[%{!sln.location}/%{file.basename}]"
+}
+```
 
 ## Tokens and Filters
 

--- a/website/docs/buildcommands.md
+++ b/website/docs/buildcommands.md
@@ -23,11 +23,11 @@ Use [per-file custom build commands](Custom-Build-Commands.md) to compile all Lu
 ```lua
 filter 'files:**.lua'
    -- A message to display while this build step is running (optional)
-   buildmessage 'Compiling %{file.relpath}'
+   buildmessage 'Compiling %[%{file.relpath}]'
 
    -- One or more commands to run (required)
    buildcommands {
-      'luac -o "%{cfg.objdir}/%{file.basename}.out" "%{file.relpath}"'
+      'luac -o "%[%{!cfg.objdir}/%{file.basename}.out]" "%[%{file.relpath}]"'
    }
 
    -- One or more outputs resulting from the build (required)
@@ -56,6 +56,7 @@ project "MyProject"
 
 ## See Also ##
 
+* [Tokens](Tokens.md)
 * [Custom Build Commands](Custom-Build-Commands.md)
 * [Makefile Projects](Makefile-Projects.md)
 * [buildinputs](buildinputs.md)

--- a/website/docs/postbuildcommands.md
+++ b/website/docs/postbuildcommands.md
@@ -6,7 +6,7 @@ postbuildcommands { "commands" }
 
 ### Parameters ###
 
-`commands` is one or more shell commands. These commands will be passed to the shell exactly as entered, including path separators and the like.
+`commands` is one or more shell commands.
 
 ### Applies To ###
 
@@ -19,14 +19,11 @@ Premake 4.4 or later.
 ### Examples ###
 
 ```lua
-filter { "system:windows" }
-   postbuildcommands { "copy default.config bin\\project.config" }
-
-filter { "not system:windows" }
-   postbuildcommands { "cp default.config bin/project.config" }
+postbuildcommands { "{COPYFILE} %[default.config] %[bin/project.config]" }
 ```
 
 ### See Also ###
+ * [Tokens](Tokens.md)
  * [Custom Build Commands](Custom-Build-Commands.md)
  * [Tokens](Tokens.md)
  * [prebuildcommands](prebuildcommands.md)

--- a/website/docs/postbuildmessage.md
+++ b/website/docs/postbuildmessage.md
@@ -21,12 +21,13 @@ Premake 5.0 or later.
 
 ```lua
 project "MyProject"
-   postbuildcommands { "copy dependencies/*.lib bin" }
+   postbuildcommands { "{COPYFILE} %[dependencies/*.lib] %[bin]" }
    postbuildmessage "Copying dependencies..."
 ```
 
 ### See Also ###
 
+* [Tokens](Tokens.md)
 * [postbuildcommands](postbuildcommands.md)
 * [prebuildmessage](prebuildmessage.md)
 * [prelinkmessage](prelinkmessage.md)

--- a/website/docs/prebuildcommands.md
+++ b/website/docs/prebuildcommands.md
@@ -6,7 +6,7 @@ prebuildcommands { "commands" }
 
 ### Parameters ###
 
-`commands` is one or more shell commands. These commands will be passed to the shell exactly as entered, including path separators and the like.
+`commands` is one or more shell commands.
 
 ### Applies To ###
 
@@ -19,14 +19,11 @@ Premake 4.4 or later.
 ### Examples ###
 
 ```lua
-filter { "system:windows" }
-   prebuildcommands { "copy default.config bin\\project.config" }
-
-filter { "not system:windows" }
-   prebuildcommands { "cp default.config bin/project.config" }
+prebuildcommands { "{COPYFILE} %[default.config] %[bin/project.config]" }
 ```
 
 ### See Also ###
 
+ * [Tokens](Tokens.md)
  * [postbuildcommands](postbuildcommands.md)
  * [prelinkcommands](prelinkcommands.md)

--- a/website/docs/prebuildmessage.md
+++ b/website/docs/prebuildmessage.md
@@ -20,12 +20,13 @@ Premake 4.4 or later.
 
 ```lua
 project "MyProject"
-   prebuildcommands { "copy dependencies/*.lib bin" }
+   prebuildcommands { "{COPYFILE} %[dependencies/*.lib] %[bin]" }
    prebuildmessage "Copying dependencies..."
 ```
 
 ### See Also ###
 
+* [Tokens](Tokens.md)
 * [prebuildcommands](prebuildcommands.md)
 * [postbuildmessage](postbuildmessage.md)
 * [prelinkmessage](prelinkmessage.md)

--- a/website/docs/prelinkcommands.md
+++ b/website/docs/prelinkcommands.md
@@ -6,7 +6,7 @@ prelinkcommands { "commands" }
 
 ### Parameters ###
 
-`commands` is one or more shell commands. These commands will be passed to the shell exactly as entered, including path separators and the like.
+`commands` is one or more shell commands.
 
 ### Applies To ###
 
@@ -19,14 +19,11 @@ Premake 4.4 or later.
 ### Examples ###
 
 ```lua
-filter { "system:windows" }
-   prelinkcommands { "copy default.config bin\\project.config" }
-
-filter { "not system:windows" }
-   prelinkcommands { "cp default.config bin/project.config" }
+prelinkcommands { "{COPY} %[default.config] %[bin/project.config]" }
 ```
 
 ### See Also ###
 
+ * [Tokens](Tokens.md)
  * [prebuildcommands](prebuildcommands.md)
  * [postbuildcommands](postbuildcommands.md)

--- a/website/docs/prelinkmessage.md
+++ b/website/docs/prelinkmessage.md
@@ -20,12 +20,13 @@ Premake 4.4 or later.
 
 ```lua
 project "MyProject"
-   prelinkcommands { "copy dependencies/*.lib bin" }
+   prelinkcommands { "{COPYFILE} %[dependencies/*.lib] %[bin]" }
    prelinkmessage "Copying dependencies..."
 ```
 
 ## See Also ##
 
+* [Tokens](Tokens.md)
 * [prelinkcommands](prelinkcommands.md)
 * [prebuildmessage](prebuildmessage.md)
 * [postbuildmessage](postbuildmessage.md)


### PR DESCRIPTION
**What does this PR do?**

Improve `os.translateCommandsAndPaths`.
Fix msvc rule with `%[path]`.
Fix xcode4 with `%[path]`.

**How does this PR change Premake's behavior?**

For usage of `'%[path]'`

**Anything else we should know?**

Add any other context about your changes here.
Tested in [my testing repo repo](https://github.com/Jarod42/premake-sample-projects/tree/translateCommandsAndPaths)

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

