### PR TITLE
Update debugdir.md docs to clarify feature support

### DIFF
--- a/website/docs/debugdir.md
+++ b/website/docs/debugdir.md
@@ -4,7 +4,7 @@ Sets the working directory for the integrated debugger.
 debugdir "path"
 ```
 
-Note that this settings is not implemented for Xcode 3, which requires a per-user configuration file in order to make it work.
+Note that this settings is not implemented for Xcode, which requires a per-user configuration file in order to make it work.
 
 In Visual Studio, this file can be overridden by a per-user configuration file (such as `ProjectName.vcproj.MYDOMAIN-MYUSERNAME.user`). Removing this file (which is done by Premake's clean action) will restore the default settings.
 


### PR DESCRIPTION
Doc suggested `debugdir` was not implemented in Xcode 3, but was implemented in other versions. However from testing & looking at the code it is not implemented for any Xcode version.

**What does this PR do?**

Updates docs to clarify feature support.

**How does this PR change Premake's behavior?**

Nope.

**Anything else we should know?**

Nope.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [NA] Add unit tests showing fix or feature works; all tests pass
- [NA] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [NA] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
