### PR TITLE
Fix nil indexing for codelite

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -428,6 +428,9 @@
 		p.tree.traverse(tr, {
 			onleaf = function(node, depth)
 				local filecfg = p.fileconfig.getconfig(node, cfg)
+				if not filecfg then
+					return
+				end
 				local prj = cfg.project
 				local rule = p.global.getRuleForFile(node.name, prj.rules)
 


### PR DESCRIPTION
**What does this PR do?**

Fix "attempt to index a nil value".
It happens with https://github.com/Jarod42/premake-sample-projects/projects-qt/project-qt with `objdir` removed.

**How does this PR change Premake's behavior?**

Just Codelite generator.

**Anything else we should know?**

No.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
