### PR TITLE
Add support to `undefines` for Codelite.

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -204,8 +204,9 @@
 		local toolset = m.getcompiler(cfg)
 		local externalincludedirs = toolset.getincludedirs(cfg, {}, cfg.externalincludedirs, cfg.frameworkdirs, cfg.includedirsafter)
 		local forceincludes = toolset.getforceincludes(cfg)
-		local cxxflags = table.concat(table.join(externalincludedirs, toolset.getcxxflags(cfg), forceincludes, cfg.buildoptions), ";")
-		local cflags   = table.concat(table.join(externalincludedirs, toolset.getcflags(cfg), forceincludes, cfg.buildoptions), ";")
+		local defines = iif(#cfg.undefines > 0, table.join(toolset.getdefines(cfg.defines), toolset.getundefines(cfg.undefines)), {})
+		local cxxflags = table.concat(table.join(externalincludedirs, toolset.getcxxflags(cfg), forceincludes, cfg.buildoptions, defines), ";")
+		local cflags   = table.concat(table.join(externalincludedirs, toolset.getcflags(cfg), forceincludes, cfg.buildoptions, defines), ";")
 		local asmflags = ""
 		local pch      = p.tools.gcc.getpch(cfg)
 		local usepch   = "yes"
@@ -219,8 +220,12 @@
 		for _, includedir in ipairs(cfg.includedirs) do
 			_x(4, '<IncludePath Value="%s"/>', project.getrelative(cfg.project, includedir))
 		end
-		for _, define in ipairs(cfg.defines) do
-			_p(4, '<Preprocessor Value="%s"/>', p.esc(define):gsub(' ', '\\ '))
+		-- undefines should be placed *after* defines/buildoptions
+		-- Codelite places preprocessors after buildoptions...
+		if #cfg.undefines == 0 then
+			for _, define in ipairs(cfg.defines) do
+				_p(4, '<Preprocessor Value="%s"/>', p.esc(define):gsub(' ', '\\ '))
+			end
 		end
 		_p(3, '</Compiler>')
 	end

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -111,6 +111,17 @@
 		]]
 	end
 
+	function suite.OnProjectCfg_Undefines()
+		defines { "TEST" }
+		undefines { "UNDEF" }
+		prepare()
+		codelite.project.compiler(cfg)
+		test.capture [[
+      <Compiler Options="-DTEST;-UUNDEF" C_Options="-DTEST;-UUNDEF" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
+      </Compiler>
+		]]
+	end
+
 	function suite.OnProjectCfg_Pch()
 		  pchheader "pch.h"
 		prepare()


### PR DESCRIPTION
**What does this PR do?**

Add support to `undefines` for Codelite.

**How does this PR change Premake's behavior?**

Only Codelite generator

**Anything else we should know?**

Also tested in my testing repo: https://github.com/Jarod42/premake-sample-projects/tree/master/projects/project-undefines


**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
