### PR TITLE
Add VS2022 to list of valid kinds for Android Packaging

### DIFF
--- a/modules/android/_preload.lua
+++ b/modules/android/_preload.lua
@@ -23,6 +23,7 @@
 	premake.action._list["vs2015"].valid_kinds = table.join(premake.action._list["vs2015"].valid_kinds, { p.PACKAGING })
 	premake.action._list["vs2017"].valid_kinds = table.join(premake.action._list["vs2017"].valid_kinds, { p.PACKAGING })
 	premake.action._list["vs2019"].valid_kinds = table.join(premake.action._list["vs2019"].valid_kinds, { p.PACKAGING })
+	premake.action._list["vs2022"].valid_kinds = table.join(premake.action._list["vs2022"].valid_kinds, { p.PACKAGING })
 	
 	local osoption = p.option.get("os")
 	if osoption ~= nil then


### PR DESCRIPTION
**What does this PR do?**

Adds VS2022 to the list of valid kinds for Android

**How does this PR change Premake's behavior?**

Removes the warning that happens when trying to add a project of type packaging in VS2022

**Anything else we should know?**

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
