### PR TITLE
Allow adding any property to a VisualStudio project

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -216,6 +216,13 @@
 		}
 	}
 
+	p.api.register {
+		name = "vsprops",
+		scope = "config",
+		kind = "list:table",
+		tokens = true,
+	}
+
 --
 -- Decide when the full module should be loaded.
 --

--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -6,6 +6,7 @@ return {
 	"dotnet2005/test_nuget_framework_folders.lua",
 
 	-- Visual Studio 2005+ C# projects
+	"cs2005/test_additional_props.lua",
 	"cs2005/test_assembly_refs.lua",
 	"cs2005/test_build_events.lua",
 	"cs2005/test_common_props.lua",

--- a/modules/vstudio/tests/cs2005/test_additional_props.lua
+++ b/modules/vstudio/tests/cs2005/test_additional_props.lua
@@ -1,0 +1,84 @@
+--
+-- tests/actions/vstudio/cs2005/test_additional_props.lua
+-- Test the compiler flags of a Visual Studio 2005+ C# project.
+-- Copyright (c) 2012-2023 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("vstudio_cs2005_additional_props")
+	local dn2005 = p.vstudio.dotnetbase
+	local project = p.project
+
+
+--
+-- Setup and teardown
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2005")
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare()
+		local cfg = test.getconfig(prj, "Debug")
+		dn2005.additionalProps(cfg)
+	end
+
+
+--
+-- Check handling of AdditionialProps.
+-- Elements specified at a time are sorted by name before placement.
+--
+
+	function suite.propsAreSorted()
+		vsprops {
+			Zzz = "zzz",
+			Aaa = "aaa",
+			Nullable = "enable",
+		}
+		prepare()
+		test.capture [[
+		<Aaa>aaa</Aaa>
+		<Nullable>enable</Nullable>
+		<Zzz>zzz</Zzz>
+		]]
+	end
+
+
+--
+-- Check handling of AdditionialProps.
+-- Element groups set multiple times are placed in the order in which they are set.
+--
+
+	function suite.multipleSetPropsAreNotSorted()
+		vsprops {
+			Zzz = "zzz",
+		}
+		vsprops {
+			Aaa = "aaa",
+		}
+		vsprops {
+			Nullable = "enable",
+		}
+		prepare()
+		test.capture [[
+		<Zzz>zzz</Zzz>
+		<Aaa>aaa</Aaa>
+		<Nullable>enable</Nullable>
+		]]
+	end
+
+
+	function suite.xmlEscape()
+		vsprops {
+			ValueRequiringEscape = "if (age > 3 && age < 8)",
+		}
+		prepare()
+		test.capture [[
+		<ValueRequiringEscape>if (age &gt; 3 &amp;&amp; age &lt; 8)</ValueRequiringEscape>
+		]]
+	end
+
+

--- a/modules/vstudio/tests/vc2010/test_globals.lua
+++ b/modules/vstudio/tests/vc2010/test_globals.lua
@@ -495,6 +495,45 @@ end
 	end
 
 
+	function suite.additionalProps()
+		p.action.set("vs2022")
+
+		vsprops {
+			-- https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/#2-set-agility-sdk-parameters
+			Microsoft_Direct3D_D3D12_D3D12SDKPath = "custom_path",
+			ValueRequiringEscape = "if (age > 3 && age < 8)",
+		}
+		filter "Debug"
+			vsprops {
+				CustomParam = "DebugParam",
+			}
+		filter "Release"
+			vsprops {
+				CustomParam = "ReleaseParam",
+			}
+		filter {}
+		prepare()
+		test.capture [[
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
+	<Keyword>Win32Proj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Globals">
+	<Microsoft_Direct3D_D3D12_D3D12SDKPath>custom_path</Microsoft_Direct3D_D3D12_D3D12SDKPath>
+	<ValueRequiringEscape>if (age &gt; 3 &amp;&amp; age &lt; 8)</ValueRequiringEscape>
+	<CustomParam>DebugParam</CustomParam>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Globals">
+	<Microsoft_Direct3D_D3D12_D3D12SDKPath>custom_path</Microsoft_Direct3D_D3D12_D3D12SDKPath>
+	<ValueRequiringEscape>if (age &gt; 3 &amp;&amp; age &lt; 8)</ValueRequiringEscape>
+	<CustomParam>ReleaseParam</CustomParam>
+</PropertyGroup>
+		]]
+	end
+
+
 	function suite.disableFastUpToDateCheck()
 		fastuptodate "Off"
 		prepare()

--- a/modules/vstudio/vs2005_csproj.lua
+++ b/modules/vstudio/vs2005_csproj.lua
@@ -81,7 +81,8 @@
 			dotnetbase.debugProps,
 			dotnetbase.outputProps,
 			dotnetbase.compilerProps,
-			dotnetbase.NoWarn
+			dotnetbase.additionalProps,
+			dotnetbase.NoWarn,
 		}
 	end
 

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -8,6 +8,7 @@
 	p.vstudio.dotnetbase = {}
 
 	local vstudio = p.vstudio
+	local vs2005 = p.vstudio.vs2005
 	local dotnetbase  = p.vstudio.dotnetbase
 	local project = p.project
 	local config = p.config
@@ -241,6 +242,17 @@
 		end
 	end
 
+--
+-- Write out the additional props.
+--
+
+	function dotnetbase.additionalProps(cfg)
+		for i = 1, #cfg.vsprops do
+			for key, value in spairs(cfg.vsprops[i]) do
+				_p(2, '<%s>%s</%s>', key, vs2005.esc(value), key)
+			end
+		end
+	end
 
 --
 -- Write the compiler flags for a particular configuration.
@@ -739,6 +751,7 @@
 			_p(2,'<LangVersion>%s</LangVersion>', cfg.csversion)
 		end
 	end
+
 
 	function dotnetbase.targetFrameworkProfile(cfg)
 		if _ACTION == "vs2010" then

--- a/modules/vstudio/vs2005_fsproj.lua
+++ b/modules/vstudio/vs2005_fsproj.lua
@@ -52,6 +52,7 @@
 			dotnetbase.debugProps,
 			dotnetbase.outputProps,
 			dotnetbase.compilerProps,
+			dotnetbase.additionalProps,
 			dotnetbase.NoWarn,
 			fs2005.tailCalls
 		}

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -8,6 +8,7 @@
 	p.vstudio.vc2010 = {}
 
 	local vstudio = p.vstudio
+	local vs2010 = p.vstudio.vs2010
 	local project = p.project
 	local config = p.config
 	local fileconfig = p.fileconfig
@@ -148,6 +149,7 @@
 		return {
 			m.windowsTargetPlatformVersion,
 			m.xpDeprecationWarning,
+			m.additionalProps,
 		}
 	end
 
@@ -1356,8 +1358,8 @@
 								if value and #value > 0 then
 									m.element(prop.name, m.configPair(cfg), '%s', value)
 								end
-								end
 							end
+						end
 						if #m.conditionalElements > 0 then
 							m.emitConditionalElements(prj)
 						end
@@ -2906,6 +2908,15 @@
 	function m.xpDeprecationWarning(prj, cfg)
 		if cfg.toolset == "msc-v141_xp" then
 			m.element("XPDeprecationWarning", nil, "false")
+		end
+	end
+
+
+	function m.additionalProps(prj, cfg)
+		for i = 1, #cfg.vsprops do
+			for key, value in spairs(cfg.vsprops[i]) do
+				m.element(key, nil, vs2010.esc(value))
+			end
 		end
 	end
 

--- a/website/docs/vsprops.md
+++ b/website/docs/vsprops.md
@@ -1,0 +1,51 @@
+Add any property to your visual studio project
+This allows you to set properties that premake does not support without extending it
+
+Values set at one time are sorted alphabetically
+If you want to output groups of values in any order, set multiple times.
+
+```lua
+	vsprops {
+		Name1 = "value1",
+		Name2 = "value2",
+	}
+	vsprops {
+		Name3 = "value3",
+	}
+```
+
+### Parameters ###
+
+Name and value are strings
+
+### Availability ###
+
+Premake 5.0-beta3 or later.
+
+### Applies To ###
+
+The `config` scope.
+
+### Examples ###
+
+```lua
+	language "C#"
+	vsprops {
+		-- https://devblogs.microsoft.com/visualstudio/vs-toolbox-accelerate-your-builds-of-sdk-style-net-projects/
+		AccelerateBuildsInVisualStudio = "true",
+		-- https://learn.microsoft.com/en-us/visualstudio/ide/how-to-change-the-build-output-directory?view=vs-2022
+		AppendTargetFrameworkToOutputPath = "false",
+		-- https://learn.microsoft.com/en-us/dotnet/csharp/tutorials/nullable-reference-types
+		Nullable = "enable",
+	}
+```
+```lua
+	language "C++"
+	nuget {
+		"Microsoft.Direct3D.D3D12:1.608.2"
+	}
+	vsprops {
+		-- https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/#2-set-agility-sdk-parameters
+		Microsoft_Direct3D_D3D12_D3D12SDKPath = "custom_path",
+	}
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -290,6 +290,7 @@ module.exports = {
 						'versionlevel',
 						'visibility',
 						'vpaths',
+						'vsprops',
 						'warnings',
 						'workspace',
 						'xcodebuildresources',


### PR DESCRIPTION

**What does this PR do?**

At #2025 I was able to use the nuget package from Microsoft.Direct3D.D3D12.

But to parameterize this package, we need to set properties such as [Microsoft_Direct3D_D3D12_D3D12SDKPath and Microsoft_Direct3D_D3D12_SkipLibraryCopy](https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/#2-set-agility-sdk-parameters) etc.

Also in charp, we need to set properties for [nullable](https://learn.microsoft.com/en-us/dotnet/csharp/tutorials/nullable-reference-types#create-the-application-and-enable-nullable-reference-types) and [other settings](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#publish-related-properties).

Instead of creating dedicated functions for each of these settings, I would like to create a single function that can set any property.


**How does this PR change Premake's behavior?**

Add a `props` command to allow setting arbitrary properties

**Anything else we should know?**

no

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*

