### PR TITLE
Require unistd.h for macosx in libzip

### DIFF
--- a/contrib/libzip/premake5.lua
+++ b/contrib/libzip/premake5.lua
@@ -21,3 +21,4 @@ project "zip-lib"
 
 	filter "system:macosx"
 		defines { "HAVE_SSIZE_T_LIBZIP" }
+		forceincludes { "unistd.h" }


### PR DESCRIPTION
**What does this PR do?**

Resolves implicit symbol in libzip and closes #2092 

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
