### PR TITLE
Changes target of HTTP tests to hopefully resolve test issues in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Makefile
 .cproject
 .settings
 .buildpath
+*.vs
 
 *.bbprojectsettings
 Scratchpad.txt

--- a/tests/base/test_http.lua
+++ b/tests/base/test_http.lua
@@ -31,7 +31,7 @@ if http.get ~= nil and _OPTIONS["test-all"] then
 	end
 
 	function suite.http_get()
-		local result, err = safe_http_get("http://httpbin.org/user-agent")
+		local result, err = safe_http_get("http://httpbingo.org/user-agent")
 		if result then
 			p.out(result)
 			test.capture(
@@ -45,7 +45,7 @@ if http.get ~= nil and _OPTIONS["test-all"] then
 	function suite.https_get()
 		-- sslverifypeer = 0, so we can test from within companies like here at Blizzard where all HTTPS traffic goes through
 		-- some strange black box that re-signs all traffic with a custom ssl certificate.
-		local result, err = safe_http_get("https://httpbin.org/user-agent", { sslverifypeer = 0 })
+		local result, err = safe_http_get("https://httpbingo.org/user-agent", { sslverifypeer = 0 })
 		if result then
 			p.out(result)
 			test.capture(
@@ -57,7 +57,7 @@ if http.get ~= nil and _OPTIONS["test-all"] then
 	end
 
 	function suite.https_get_verify_peer()
-		local result, err = safe_http_get("https://httpbin.org/user-agent")
+		local result, err = safe_http_get("https://httpbingo.org/user-agent")
 		if result then
 			p.out(result)
 			test.capture(
@@ -69,7 +69,7 @@ if http.get ~= nil and _OPTIONS["test-all"] then
 	end
 
 	function suite.http_responsecode()
-		local result, err, responseCode = safe_http_get("http://httpbin.org/status/418")
+		local result, err, responseCode = safe_http_get("http://httpbingo.org/status/418")
 		test.isequal(418, responseCode)
 	end
 
@@ -78,7 +78,7 @@ if http.get ~= nil and _OPTIONS["test-all"] then
 
 	--[[
 	function suite.http_redirect()
-		local result, err, responseCode = safe_http_get("http://httpbin.org/redirect/3")
+		local result, err, responseCode = safe_http_get("http://httpbingo.org/redirect/3")
 		if result then
 			test.isequal(200, responseCode)
 		else
@@ -88,7 +88,7 @@ if http.get ~= nil and _OPTIONS["test-all"] then
 	]]
 
 	function suite.http_headers()
-		local result, err, responseCode = safe_http_get("http://httpbin.org/headers", {
+		local result, err, responseCode = safe_http_get("http://httpbingo.org/headers", {
 			headers = { 'X-Premake: premake' }
 		})
 


### PR DESCRIPTION
**What does this PR do?**

Changes target of HTTP tests to http://httpbingo.org/ instead of https://httpbin.org/

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
