### PR TITLE
Fixes for using debugger under Linux

### DIFF
--- a/binmodules/luasocket/premake5.lua
+++ b/binmodules/luasocket/premake5.lua
@@ -44,6 +44,9 @@ project "luasocket"
 		
 		defines { "LUASOCKET_API=__attribute__((visibility(\"default\")))" }
 		
+		-- Do not prepend with "lib" prefix.
+		targetprefix ""
+
 	filter "configurations:Release"
 		targetdir "../../bin/release"
 

--- a/src/host/buffered_io.c
+++ b/src/host/buffered_io.c
@@ -9,14 +9,14 @@
 #include "premake.h"
 #include "buffered_io.h"
 
-void buffer_init(Buffer* b)
+void premake_buffer_init(Buffer* b)
 {
 	b->capacity = 0;
 	b->length = 0;
 	b->data = NULL;
 }
 
-void buffer_destroy(Buffer* b)
+void premake_buffer_destroy(Buffer* b)
 {
 	free(b->data);
 	b->capacity = 0;
@@ -24,7 +24,7 @@ void buffer_destroy(Buffer* b)
 	b->data = NULL;
 }
 
-void buffer_puts(Buffer* b, const void* ptr, size_t len)
+void premake_buffer_puts(Buffer* b, const void* ptr, size_t len)
 {
 	char* data;
 
@@ -53,7 +53,7 @@ void buffer_puts(Buffer* b, const void* ptr, size_t len)
 	b->length += len;
 }
 
-void buffer_printf(Buffer* b, const char *fmt, ...)
+void premake_buffer_printf(Buffer* b, const char *fmt, ...)
 {
 	char text[2048];
 	int len;
@@ -61,7 +61,7 @@ void buffer_printf(Buffer* b, const char *fmt, ...)
 	va_start(args, fmt);
 	len = vsnprintf(text, sizeof(text) - 1, fmt, args);
 	va_end(args);
-	buffer_puts(b, text, len);
+	premake_buffer_puts(b, text, len);
 }
 
 // -- Lua wrappers ----------------------------------------
@@ -69,7 +69,7 @@ void buffer_printf(Buffer* b, const char *fmt, ...)
 int buffered_new(lua_State* L)
 {
 	Buffer* b = (Buffer*)malloc(sizeof(Buffer));
-	buffer_init(b);
+	premake_buffer_init(b);
 	lua_pushlightuserdata(L, b);
 	return 1;
 }
@@ -80,7 +80,7 @@ int buffered_write(lua_State* L)
 	const char *s = luaL_checklstring(L, 2, &len);
 	Buffer* b = (Buffer*)lua_touserdata(L, 1);
 
-	buffer_puts(b, s, len);
+	premake_buffer_puts(b, s, len);
 	return 0;
 }
 
@@ -91,15 +91,15 @@ int buffered_writeln(lua_State* L)
 	Buffer* b = (Buffer*)lua_touserdata(L, 1);
 
 	if (s != NULL)
-		buffer_puts(b, s, len);
-	buffer_puts(b, "\r\n", 2);
+		premake_buffer_puts(b, s, len);
+	premake_buffer_puts(b, "\r\n", 2);
 	return 0;
 }
 
 int buffered_close(lua_State* L)
 {
 	Buffer* b = (Buffer*)lua_touserdata(L, 1);
-	buffer_destroy(b);
+	premake_buffer_destroy(b);
 	free(b);
 	return 0;
 }

--- a/src/host/buffered_io.h
+++ b/src/host/buffered_io.h
@@ -15,10 +15,10 @@ typedef struct struct_Buffer
 	char*  data;
 } Buffer;
 
-void buffer_init(Buffer* b);
-void buffer_destroy(Buffer* b);
+void premake_buffer_init(Buffer* b);
+void premake_buffer_destroy(Buffer* b);
 
-void buffer_puts(Buffer* b, const void* ptr, size_t len);
-void buffer_printf(Buffer* b, const char* s, ...);
+void premake_buffer_puts(Buffer* b, const void* ptr, size_t len);
+void premake_buffer_printf(Buffer* b, const char* s, ...);
 
 #endif

--- a/src/host/curl_utils.c
+++ b/src/host/curl_utils.c
@@ -35,7 +35,7 @@ int curlProgressCallback(curl_state* state, double dltotal, double dlnow, double
 size_t curlWriteCallback(char *ptr, size_t size, size_t nmemb, curl_state* state)
 {
 	size_t length = size * nmemb;
-	buffer_puts(&state->S, ptr, length);
+	premake_buffer_puts(&state->S, ptr, length);
 	return length;
 }
 
@@ -74,7 +74,7 @@ CURL* curlRequest(lua_State* L, curl_state* state, int optionsIndex, int progres
 	state->RefIndex = 0;
 	state->errorBuffer[0] = '\0';
 	state->headers = NULL;
-	buffer_init(&state->S);
+	premake_buffer_init(&state->S);
 
 	curl_init();
 	curl = curl_easy_init();

--- a/src/host/http_download.c
+++ b/src/host/http_download.c
@@ -68,7 +68,7 @@ int http_download(lua_State* L)
 		lua_pushstring(L, "OK");
 	}
 
-	buffer_destroy(&state.S);
+	premake_buffer_destroy(&state.S);
 	lua_pushnumber(L, (lua_Number)responseCode);
 	return 2;
 }

--- a/src/host/http_get.c
+++ b/src/host/http_get.c
@@ -51,7 +51,7 @@ int http_get(lua_State* L)
 		lua_pushstring(L, "OK");
 	}
 
-	buffer_destroy(&state.S);
+	premake_buffer_destroy(&state.S);
 	lua_pushnumber(L, (lua_Number)responseCode);
 	return 3;
 }

--- a/src/host/http_post.c
+++ b/src/host/http_post.c
@@ -49,7 +49,7 @@ int http_post(lua_State* L)
 		lua_pushstring(L, "OK");
 	}
 
-	buffer_destroy(&state.S);
+	premake_buffer_destroy(&state.S);
 	lua_pushnumber(L, (lua_Number)responseCode);
 	return 3;
 }


### PR DESCRIPTION
This PR fixes using `--debugger` option under Linux. Currently it can't be used at all for the reasons explained in the commit messages.

It's a bit surprising that it was so broken, but without these fixes following [the instructions for debugging](https://premake.github.io/docs/Debugging-Scripts/) simply doesn't work currently.