### PR TITLE
Slightly improve MSVS filters generation

### DIFF
--- a/modules/vstudio/tests/vc2010/test_filter_ids.lua
+++ b/modules/vstudio/tests/vc2010/test_filter_ids.lua
@@ -97,11 +97,11 @@
 		prepare()
 		test.capture [[
 <ItemGroup>
-	<Filter Include="Header Files">
-		<UniqueIdentifier>{21EB8090-0D4E-1035-B6D3-48EBA215DCB7}</UniqueIdentifier>
-	</Filter>
 	<Filter Include="Source Files">
 		<UniqueIdentifier>{E9C7FDCE-D52A-8D73-7EB0-C5296AF258F6}</UniqueIdentifier>
+	</Filter>
+	<Filter Include="Header Files">
+		<UniqueIdentifier>{21EB8090-0D4E-1035-B6D3-48EBA215DCB7}</UniqueIdentifier>
 	</Filter>
 </ItemGroup>
 		]]

--- a/modules/vstudio/vs2010_vcxproj_filters.lua
+++ b/modules/vstudio/vs2010_vcxproj_filters.lua
@@ -52,7 +52,32 @@
 --
 
 	function m.uniqueIdentifiers(prj)
-		local tr = project.getsourcetree(prj)
+		-- This map contains the sort key for the known filters.
+		local knownFilters = {
+			['Source Files'] = 1,
+			['Header Files'] = 2,
+			['Resource Files'] = 3,
+		}
+
+		local sortInFilterOrder = function (a,b)
+			if #a.children > 0 or #b.children > 0 then
+				local orderA = knownFilters[a.name] or 999
+				local orderB = knownFilters[b.name] or 999
+				if orderA < orderB then
+					return true
+				end
+				if orderA > orderB then
+					return false
+				end
+				-- This can only happen if both filters are
+				-- unknown, fall back on default comparison.
+			end
+
+			-- Use default order
+			return a.name < b.name
+		end
+
+		local tr = project.getsourcetree(prj, sortInFilterOrder)
 		local contents = p.capture(function()
 			p.push()
 			tree.traverse(tr, {

--- a/src/base/project.lua
+++ b/src/base/project.lua
@@ -270,9 +270,16 @@
 --
 
 	function project.getsourcetree(prj, sorter)
-
+		-- Reuse the previously generated tree if we have it.
 		if prj._.sourcetree then
-			return prj._.sourcetree
+			tr = prj._.sourcetree
+
+			-- But sort it if necessary, as it is always unsorted.
+			if sorter then
+				tree.sort(tr, sorter)
+			end
+
+			return tr
 		end
 
 		local tr = tree.new(prj.name)
@@ -324,9 +331,11 @@
 		end)
 
 		tree.trimroot(tr)
-		tree.sort(tr, sorter)
-
 		prj._.sourcetree = tr
+
+		if sorter then
+			tree.sort(tr, sorter)
+		end
 		return tr
 	end
 


### PR DESCRIPTION
**What does this PR do?**

This PR brings the generated `.vcxproj.filters` files closer to the files created by MSVS itself. This is considered to be a good thing because it facilitates comparing Premake-generated files with the existing ones.

**How does this PR change Premake's behavior?**

There are no breaking changes, but the contents of the generated projects does change slightly. It shouldn't result in any problems.

**Documentation**

I'm not sure if it's appropriate to mention the special treatment of these filters in `vpaths` documentation. Currently documentation seems to be mostly module-agnostic, so I didn't change it, but I could add an MSVS-specific note, of course, if it's considered to be useful.