### PR TITLE
Use call array for MSVS filters file generation too

### DIFF
--- a/modules/vstudio/vs2010_vcxproj_filters.lua
+++ b/modules/vstudio/vs2010_vcxproj_filters.lua
@@ -15,11 +15,18 @@
 -- Generate a Visual Studio 201x C++ project, with support for the new platforms API.
 --
 
+	m.elements.filters = function(prj)
+		return {
+			m.xmlDeclaration,
+			m.filtersProject,
+			m.uniqueIdentifiers,
+			m.filterGroups,
+		}
+	end
+
 	function m.generateFilters(prj)
-		m.xmlDeclaration()
-		m.filtersProject()
-		m.uniqueIdentifiers(prj)
-		m.filterGroups(prj)
+		p.utf8()
+		p.callArray(m.elements.filters, prj)
 		p.out('</Project>')
 	end
 


### PR DESCRIPTION
This is consistent with the project generation and allows for the same
flexibility, e.g. the version of the output customization example in
website/docs/Overrides-and-Call-Arrays.md using call arrays can be now
made to work for the .filters file as well by just replacing "project"
with "filters".
