### PR TITLE
[Draft] [VS] Add UAC configuration

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -152,23 +152,6 @@
 		},
 	}
 
-	p.api.register {   -- DEPRECATED 2019-10-21
-		name = "debuggerflavor",
-		scope = "config",
-		kind = "string",
-		allowed = {
-			"Local",
-			"Remote",
-			"WebBrowser",
-			"WebService"
-		}
-	}
-
-	p.api.deprecateField("debuggerflavor", 'Use `debugger` instead.',
-	function(value)
-		debugger('VisualStudio' .. value)
-	end)
-
 	p.api.register {
 		name = "scanformoduledependencies",
 		scope = "config",
@@ -194,6 +177,60 @@
 			"Off"
 		}
 	}
+
+	api.register {
+		name = "uacexecutionlevel",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"AsInvoker",
+			"HighestAvailable",
+			"RequireAdministrator"
+		},
+		aliases = {
+			Invoker = 'AsInvoker',
+			Highest = 'HighestAvailable',
+			Admin = 'RequireAdministrator'
+		}
+	}
+
+	api.register {
+		name = "uacuiaccess",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off"
+		},
+		aliases = {
+			Bypass = 'On',
+			True = 'On',
+			False = 'Off'
+		}
+	}
+
+--
+-- Deprecated fields
+--
+
+	p.api.register {   -- DEPRECATED 2019-10-21
+		name = "debuggerflavor",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Local",
+			"Remote",
+			"WebBrowser",
+			"WebService"
+		}
+	}
+
+	p.api.deprecateField("debuggerflavor", 'Use `debugger` instead.',
+	function(value)
+		debugger('VisualStudio' .. value)
+	end)
 
 --
 -- Decide when the full module should be loaded.

--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -186,12 +186,14 @@
 			"Default",
 			"AsInvoker",
 			"HighestAvailable",
-			"RequireAdministrator"
+			"RequireAdministrator",
+			"Disabled"
 		},
 		aliases = {
 			Invoker = 'AsInvoker',
 			Highest = 'HighestAvailable',
-			Admin = 'RequireAdministrator'
+			Admin = 'RequireAdministrator',
+			None = 'Disabled'
 		}
 	}
 

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -533,6 +533,7 @@
 				m.largeAddressAware,
 				m.optimizeReferences,
 				m.enableCOMDATFolding,
+				m.userAccountControl,
 				m.entryPointSymbol,
 				m.importLibrary,
 				m.targetMachine,
@@ -1025,6 +1026,20 @@
 	function m.enableCOMDATFolding(cfg, toolset)
 		if config.isOptimizedBuild(cfg) and not toolset then
 			p.w('EnableCOMDATFolding="2"')
+		end
+	end
+
+
+
+	function m.userAccountControl(cfg)
+		if cfg.uacexecutionlevel and cfg.uacexecutionlevel ~= "Default" then
+			-- TODO
+		end
+
+		local map = { Off = "false", On = "true" }
+		local value = map[cfg.uacuiaccess]
+		if value then
+			-- TODO
 		end
 	end
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2029,14 +2029,22 @@
 
 
 	function m.userAccountControl(cfg)
+		local disabled = false
 		if cfg.uacexecutionlevel and cfg.uacexecutionlevel ~= "Default" then
-			m.element("UACExecutionLevel", nil, cfg.uacexecutionlevel)
+			if (cfg.uacexecutionlevel == "Disabled") then
+				disabled = true
+				m.element("EnableUAC", nil, "false")
+			else
+				m.element("UACExecutionLevel", nil, cfg.uacexecutionlevel)
+			end
 		end
 
-		local map = { Off = "false", On = "true" }
-		local value = map[cfg.uacuiaccess]
-		if value then
-			m.element("UACUIAccess", nil, value)
+		if (not disabled) then
+			local map = { Off = "false", On = "true" }
+			local value = map[cfg.uacuiaccess]
+			if value then
+				m.element("UACUIAccess", nil, value)
+			end
 		end
 	end
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -556,6 +556,7 @@
 				m.additionalLinkOptions,
 				m.programDatabaseFile,
 				m.assemblyDebug,
+				m.userAccountControl,
 			}
 		end
 	end
@@ -2019,9 +2020,23 @@
 		end
 	end
 
+
 	function m.assemblyDebug(cfg)
 		if cfg.assemblydebug then
       		m.element("AssemblyDebug", nil, "true")
+		end
+	end
+
+
+	function m.userAccountControl(cfg)
+		if cfg.uacexecutionlevel and cfg.uacexecutionlevel ~= "Default" then
+			m.element("UACExecutionLevel", nil, cfg.uacexecutionlevel)
+		end
+
+		local map = { Off = "false", On = "true" }
+		local value = map[cfg.uacuiaccess]
+		if value then
+			m.element("UACUIAccess", nil, value)
 		end
 	end
 


### PR DESCRIPTION
**What does this PR do?**

Adds the UAC (User Account Control) configuration property for VS targeting Windows applications.
Refer to issue below for in-depth explanation.

- Closes #2132 

**How does this PR change Premake's behavior?**

This PR is purely additional and will not change existing behaviour nor introduce breaking changes.

**TODO**

- [x] VS2010 functionality implemented
- [ ] VS200x functionality implemented
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

**Anything else we should know?**

This is a draft PR where just the base functionality for VS2010-format projects is implemented and tested to work under VS2019.

The [patch branch](https://github.com/anzz1/premake-core/tree/patch-vs-add-uac-props) is open for PR's and any help with adding documentation, unit tests, VS200x functionality, testing other versions than VS2019, or whatever else is appreciated.
