### PR TITLE
Fix libzip missing a library

### DIFF
--- a/contrib/libzip/premake5.lua
+++ b/contrib/libzip/premake5.lua
@@ -13,6 +13,7 @@ project "zip-lib"
 
 	filter "system:linux or bsd or solaris or haiku"
 		defines { "HAVE_SSIZE_T_LIBZIP", "HAVE_CONFIG_H" }
+		forceincludes { "unistd.h" }
 
 	filter "system:windows"
 		defines { "_WINDOWS" }


### PR DESCRIPTION
Fix premake compiling from undefined functions in libzip dependency.

Tested on `amd64`:
- Arch Linux
- Kernel: 6.4.12-arch1-1
- Clang: 16.0.6
- GNU

Tested on `armv7l`:
- postmarketOS
- Kernel: 6.3.0-postmarketos-qcom-msm8974-g65fa893de431
- Clang: 16.0.6
- Musl
