### PR TITLE
Do not write file in `io.writefile` if contents hasn't changed

### DIFF
--- a/src/base/io.lua
+++ b/src/base/io.lua
@@ -26,6 +26,10 @@
 -- Write content to a new file.
 --
 	function io.writefile(filename, content)
+		if content == io.readfile(filename) then
+			return true
+		end
+	
 		local file = io.open(filename, "w+b")
 		if file then
 			file:write(content)


### PR DESCRIPTION
**What does this PR do?**

`io.writefile` utility function always writes the file it's been given, even if the contents didn't change.

This is problematic for build systems that check file timestamps in order to determine whether a particular file and whatever depends on it should be rebuilt.

In my particular case, there was a premake build step ran before every build to generate primary version file. But to do so, premake first had to run to parse all workspaces, and scripts in there would generate some files within project on their own (transforming `.h.in` to `.h` etc.). This unfortunately caused parts of these dependent projects to rebuild every single time, despite no changes in them.

**How does this PR change Premake's behavior?**

No breaking changes. Files will still be written if different or not existing yet. It will help build systems to rebuild less files when not needed.

Besides, there is no reason that I see to write a file and update its timestamp on drive if the contents hasn't changed, thus I didn't provide an option to forcefully write it out. If someone really wants that, they can use `io.open` manually...

**Anything else we should know?**

This is consistent with main logic for generating project files: files won't get written to drive if their contents hasn't changed. So this PR should make this behavior more consistent for if someone uses `io.writefile` function somewhere. Plus it makes for cleaner code than if someone was to check for this manually.

I was considering using `a+b` file mode, then seek to beginning to read the file, in order to avoid creating two file handles in the process. Unfortunately I'm not aware of a way for Lua to truncate the file then to write out the new contents. So the current way I think is better, simpler, more readable...

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
