### PR TITLE
Enable msbuild batching for custom rules

### DIFF
--- a/modules/codelite/_preload.lua
+++ b/modules/codelite/_preload.lua
@@ -46,6 +46,11 @@
 		onCleanTarget = function(prj)
 			p.modules.codelite.cleanTarget(prj)
 		end,
+
+		pathVars = {
+			["rule.inputs"]	 = { absolute = false, token = "$&lt;" },
+			["rule.outputs"] = { absolute = false, token = "$@" }
+		}
 	}
 
 

--- a/modules/gmake2/_preload.lua
+++ b/modules/gmake2/_preload.lua
@@ -62,7 +62,12 @@
 
 		onCleanProject = function(prj)
 			p.clean.file(prj, p.modules.gmake2.getmakefilename(prj, true))
-		end
+		end,
+
+		pathVars = {
+			["rule.inputs"]	 = { absolute = false, token = "$<" },
+			["rule.outputs"] = { absolute = false, token = "$@" }
+		}
 	}
 
 --

--- a/modules/vstudio/tests/vc2010/test_rule_props.lua
+++ b/modules/vstudio/tests/vc2010/test_rule_props.lua
@@ -38,6 +38,10 @@
 				'%{output_path}%{file.basename}.example.cc',
 				'%{output_path}%{file.basename}.example.h'
 			}
+			builddependencies {
+				'dependency_1.lib',
+				'dependency_2.lib',
+			}
 	end
 
 
@@ -68,3 +72,16 @@
 		]]
 	end
 
+
+--
+-- additionalDependencies
+--
+
+	function suite.additionalDependencies()
+		local r = test.getRule("example")
+		m.additionalDependencies(r)
+
+		test.capture [[
+<AdditionalDependencies>dependency_1.lib;dependency_2.lib</AdditionalDependencies>
+		]]
+	end

--- a/modules/vstudio/tests/vc2010/test_rule_targets.lua
+++ b/modules/vstudio/tests/vc2010/test_rule_targets.lua
@@ -95,3 +95,56 @@
 </UsingTask>
 		]]
 	end
+
+
+
+--
+-- ruleTask
+--
+
+	function suite.ruleTask()
+		local r = test.getRule("example")
+		m.rule(r)
+
+		test.capture [[
+<example
+	Condition="'@(example)' != '' and '%(example.ExcludedFromBuild)' != 'true'"
+	CommandLineTemplate="%(example.CommandLineTemplate)"
+	output_path="%(example.output_path)"
+	AdditionalOptions="%(example.AdditionalOptions)"
+	Inputs="@(example)"
+	Outputs="@(example->'%(Outputs)')"
+	StandardOutputImportance="High"
+	StandardErrorImportance="High" />
+		]]
+	end
+
+
+
+--
+-- targetInputs
+--
+
+	function suite.targetInputs()
+		local r = test.getRule("example")
+		m.targetInputs(r)
+
+		test.capture [[
+Inputs="@(example);%(example.AdditionalDependencies);$(MSBuildProjectFile)"
+		]]
+	end
+
+
+
+--
+-- targetOutputs
+--
+
+	function suite.targetOutputs()
+		local r = test.getRule("example")
+		m.targetOutputs(r)
+
+		test.capture [[
+Outputs="@(example->'%(Outputs)')"
+		]]
+	end

--- a/modules/vstudio/vs2010.lua
+++ b/modules/vstudio/vs2010.lua
@@ -36,6 +36,8 @@
 		["file.reldirectory"]           = { absolute = false, token = "%(RelativeDir)" },
 		["file.extension"]              = { absolute = false, token = "%(Extension)" },
 		["file.name"]                   = { absolute = false, token = "%(Filename)%(Extension)" },
+		["rule.inputs"]            		= { absolute = false, token = "[Inputs]" },
+		["rule.outputs"]            	= { absolute = false, token = "[Outputs]" },
 	}
 
 

--- a/modules/vstudio/vs2010_rules_targets.lua
+++ b/modules/vstudio/vs2010_rules_targets.lua
@@ -294,7 +294,9 @@
 
 
 	function m.inputs(r)
-		p.w('Inputs="%%(%s.Identity)"', r.name)
+		-- inputs and outputs passed to task
+		p.w('Inputs="@(%s)"', r.name)
+		p.w('Outputs="@(%s->\'%%(Outputs)\')"', r.name)
 	end
 
 
@@ -410,7 +412,7 @@
 			end
 		end
 		extra = table.concat(extra)
-		p.w('Inputs="%%(%s.Identity);%%(%s.AdditionalDependencies);%s$(MSBuildProjectFile)"', r.name, r.name, extra)
+		p.w('Inputs="@(%s);%%(%s.AdditionalDependencies);%s$(MSBuildProjectFile)"', r.name, r.name, extra)
 	end
 
 
@@ -422,7 +424,7 @@
 
 
 	function m.targetOutputs(r)
-		p.w('Outputs="%%(%s.Outputs)"', r.name)
+		p.w('Outputs="@(%s->\'%%(Outputs)\')"', r.name)
 	end
 
 

--- a/modules/vstudio/vs2010_rules_xml.lua
+++ b/modules/vstudio/vs2010_rules_xml.lua
@@ -406,8 +406,7 @@
 		p.push('<StringListProperty')
 		p.w('Name="Outputs"')
 		p.w('DisplayName="Outputs"')
-		p.w('Visible="False"')
-		p.w('IncludeInCommandLine="False" />')
+		p.w('IncludeInCommandLine="true" />')
 		p.pop()
 	end
 

--- a/website/docs/Custom-Rules.md
+++ b/website/docs/Custom-Rules.md
@@ -72,3 +72,14 @@ project "MyProject"
       StripDebugInfo = true
     }
 ```
+
+## Rule Batching
+
+With msbuild, custom rules can be batched if same properties are used. To enable this, use `rule.inputs` or `rule.outputs` tokens in `buildcommands`. If corresponding output is up-to-date to the input, then the input will be omitted.
+
+```lua
+rule "BatchRule"
+  fileextension ".xyz"
+  buildcommands 'MyProcessor.exe %{rule.inputs}'
+```
+


### PR DESCRIPTION
**What does this PR do?**

This PR lets users to write custom rules compatible with [msbuild batching](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching?view=vs-2022). By providing `@(Rule)` as input and `@(Rule->'%(Output)')` as output, msbuild can recognize this task can be batched and built incrementally.

**How does this PR change Premake's behavior?**

Existing rules should be unaffected because the behavior should be same when using tokens like `${file.relpath}` since properties like `%(Identity)` or `%(FullPath)` breaks batching.

To enable batching, user should write command with newly added tokens `${rule.inputs}` or `${rule.outputs}` which mapped to string list. For non-msbuild environments like `gmake2` or `codelite`, these tokens will be substituted as single input and output as there're no batching.

**Anything else we should know?**

Let me know if introducing new tokens is undesirable.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
