### PR TITLE
Added support for iOS Privacy Manifest file

### DIFF
--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -43,6 +43,7 @@
 			[".S"] = "Sources",
 			[".swift"] = "Sources",
 			[".metal"] = "Resources",
+			[".xcprivacy"] = "Resources",
 		}
 		if node.isResource then
 			return "Resources"
@@ -147,6 +148,7 @@
 			[".swift"]     = "sourcecode.swift",
 			[".metal"]     = "sourcecode.metal",
 			[".dylib"]     = "compiled.mach-o.dylib",
+			[".xcprivacy"] = "PrivacyInfo.xcprivacy",
 		}
 		return types[path.getextension(node.path)] or "text"
 	end


### PR DESCRIPTION
**What does this PR do?**

With the Xcode 15, Apple introduced the [Privacy manifest file](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files), which will be required in iOS frameworks:

> Apps and third-party SDKs — distributed as XCFrameworks, Swift packages, or framework bundles — can contain a privacy manifest file, named PrivacyInfo.xcprivacy. The privacy manifest is a property list that records the types of data collected by your app or third-party SDK, and the required reasons APIs your app or third-party SDK uses. For each type of data your app or third-party SDK collects and category of required reasons API it uses, record the reasons in your privacy manifest file.

**How does this PR change Premake's behavior?**

These changes add the `.xcprivacy` extension as a `Resource` file that can be recognized and imported by the Xcode project. With these changes, the following line in `premake5.lua` will pick up the file from the desired path:

``` 
files { "MyLibrary/Apple/PrivacyInfo.xcprivacy" }
``` 

Currently, the above line includes the file in the Xcode project, however, these changes are required so the file is added to the Xcode project target and can be included in the exported framework.

**Anything else we should know?**

The file name is PrivacyInfo.xcprivacy and, [according to Apple](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files#:~:text=By%20default%2C%20the%20file%20is%20named%20PrivacyInfo.xcprivacy%3B%20don%E2%80%99t%20change%20the%20filename.), we cannot change its name:

> By default, the file is named PrivacyInfo.xcprivacy; don’t change the filename.

I based my changes on the `.storeboard` file, and I can confirm it works. No tests were added since there were no tests for the `,storeboard` file either.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [X] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
