### PR TITLE
Allow to use wildcard for `buildinputs`.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -117,7 +117,7 @@
 	api.register {
 		name = "buildinputs",
 		scope = "config",
-		kind = "list:path",
+		kind = "list:file",
 		tokens = true,
 		pathVars = false,
 	}

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -48,6 +48,7 @@ return {
 	"api/test_boolean_kind.lua",
 	"api/test_containers.lua",
 	"api/test_directory_kind.lua",
+	"api/test_file_kind.lua",
 	"api/test_list_kind.lua",
 	"api/test_path_kind.lua",
 	"api/test_register.lua",

--- a/tests/api/test_file_kind.lua
+++ b/tests/api/test_file_kind.lua
@@ -1,0 +1,47 @@
+--
+-- tests/api/test_file_kind.lua
+-- Tests the file API value type.
+-- Copyright (c) 2023 the Premake project
+--
+
+local p = premake
+local suite = test.declare("api_file_kind")
+local api = p.api
+
+--
+-- Setup and teardown
+--
+
+function suite.setup()
+	api.register {
+		name = "testapi",
+		kind = "file",
+		list = true,
+		scope = "project"
+	}
+	test.createWorkspace()
+end
+
+function suite.teardown()
+	testapi = nil
+end
+
+--
+-- Values should be converted to absolute paths,
+-- relative to the currently running script.
+--
+function suite.convertsToAbsolute()
+	testapi "self/local"
+
+	test.isequal({os.getcwd() .. "/self/local"}, api.scope.project.testapi)
+end
+
+
+--
+-- Check expansion of wildcards.
+--
+function suite.expandsWildcards()
+	testapi (_TESTS_DIR .. "/api/*")
+
+	test.istrue(table.contains(api.scope.project.testapi, _TESTS_DIR .. "/api/test_file_kind.lua"))
+end


### PR DESCRIPTION
**What does this PR do?**

Allow to use wildcard for [`buildinputs`](https://premake.github.io/docs/buildinputs/).

i.e
```
buildinputs {"*.extra_inputs"}
-- instead of
-- buildinputs(os.matchfiles("*.extra_inputs"))
```

**How does this PR change Premake's behavior?**

Paths which have `*` now use wilcard instead of being passed as-is.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
