### PR TITLE
Added NativeWithManagedCore as an allowed value for debuggertype

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -299,6 +299,7 @@
 			"Mixed",
 			"NativeOnly",
 			"ManagedOnly",
+			"NativeWithManagedCore"
 		}
 	}
 

--- a/website/docs/debuggertype.md
+++ b/website/docs/debuggertype.md
@@ -10,6 +10,7 @@ debuggertype "value"
 * `Mixed` - needs documentation.
 * `NativeOnly` - needs documentation.
 * `ManagedOnly` - needs documentation.
+* `NativeWithManagedCore` - needs documentation.
 
 ### Applies To ###
 

--- a/website/docs/debuggertype.md
+++ b/website/docs/debuggertype.md
@@ -7,10 +7,10 @@ debuggertype "value"
 ### Parameters ###
 
 `value` one of:
-* `Mixed` - needs documentation.
-* `NativeOnly` - needs documentation.
-* `ManagedOnly` - needs documentation.
-* `NativeWithManagedCore` - needs documentation.
+* `Mixed` - Enables simultanoues debugging of native and .NET Framework code.
+* `NativeOnly` - Restricts debugging to native code only.
+* `ManagedOnly` - Restricts debugging to managed code only.
+* `NativeWithManagedCore` - Enables simultanoues debugging of native and .NET Core code.
 
 ### Applies To ###
 


### PR DESCRIPTION
**What does this PR do?**
Added `NativeWithManagedCore` as an allowed value to `debuggertype`, this value is the .NET Core equivalent of the `Mixed` value, allowing debugging of both native and .NET Core code

**How does this PR change Premake's behavior?**
This changes the vs2010 generator, specifically the vcxproj.user generator

**Anything else we should know?**
I'm unsure when support for the `NativeWithManagedCore` value was added to Visual Studio, it seems to be there in vs2019, but I was unable to find exactly when it was added.
