### PR TITLE
Add support of per-file configuration `buildaction "None"`

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -133,7 +133,7 @@
 				for cfg in project.eachconfig(prj) do
 					local cfgname = codelite.cfgname(cfg)
 					local fcfg = p.fileconfig.getconfig(node, cfg)
-					if not fcfg or fcfg.flags.ExcludeFromBuild then
+					if not fcfg or fcfg.flags.ExcludeFromBuild or fcfg.buildaction == "None" then
 						table.insert(excludesFromBuild, cfgname)
 					end
 				end

--- a/modules/codelite/tests/test_codelite_project.lua
+++ b/modules/codelite/tests/test_codelite_project.lua
@@ -118,3 +118,31 @@
   </VirtualDirectory>
 		]]
 	end
+
+	function suite.OnProject_SourceFiles_excluded_by_flag()
+		files { "a.cpp" }
+		filter {"files:a.cpp"}
+			flags "ExcludeFromBuild"
+		filter {}
+		prepare()
+		codelite.project.files(prj)
+		test.capture [[
+  <VirtualDirectory Name="MyProject">
+    <File Name="a.cpp" ExcludeProjConfig="Debug;Release" />
+  </VirtualDirectory>
+		]]
+	end
+
+	function suite.OnProject_SourceFiles_excluded_by_buildaction()
+		files { "a.cpp" }
+		filter {"files:a.cpp"}
+			buildaction "None"
+		filter {}
+		prepare()
+		codelite.project.files(prj)
+		test.capture [[
+  <VirtualDirectory Name="MyProject">
+    <File Name="a.cpp" ExcludeProjConfig="Debug;Release" />
+  </VirtualDirectory>
+		]]
+	end

--- a/modules/d/actions/gmake.lua
+++ b/modules/d/actions/gmake.lua
@@ -309,7 +309,7 @@
 				local custom = false
 				for cfg in project.eachconfig(prj) do
 					local filecfg = fileconfig.getconfig(node, cfg)
-					if filecfg and not filecfg.flags.ExcludeFromBuild then
+					if filecfg and not filecfg.flags.ExcludeFromBuild and filecfg.buildaction ~= "None" then
 						incfg[cfg] = filecfg
 						custom = fileconfig.hasCustomBuildRule(filecfg)
 					else

--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -292,7 +292,7 @@ end
 				local custom = false
 				for cfg in project.eachconfig(prj) do
 					local filecfg = fileconfig.getconfig(node, cfg)
-					if filecfg and not filecfg.flags.ExcludeFromBuild then
+					if filecfg and not filecfg.flags.ExcludeFromBuild and filecfg.buildaction ~= "None" then
 						incfg[cfg] = filecfg
 						custom = fileconfig.hasCustomBuildRule(filecfg)
 					else

--- a/modules/gmake/tests/cpp/test_objects.lua
+++ b/modules/gmake/tests/cpp/test_objects.lua
@@ -248,3 +248,25 @@ endif
 
 		]]
 	end
+
+	function suite.excludedFromBuild_onBuildactionNone()
+		files { "hello.cpp" }
+		filter { "Debug", "files:hello.cpp" }
+			buildaction "None"
+		filter {}
+		prepare()
+		test.capture [[
+OBJECTS := \
+
+RESOURCES := \
+
+CUSTOMFILES := \
+
+ifeq ($(config),release)
+  OBJECTS += \
+	$(OBJDIR)/hello.o \
+
+endif
+
+		]]
+	end

--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -152,7 +152,7 @@
 
 	function cpp.addFile(cfg, node)
 		local filecfg = fileconfig.getconfig(node, cfg)
-		if not filecfg or filecfg.flags.ExcludeFromBuild then
+		if not filecfg or filecfg.flags.ExcludeFromBuild or filecfg.buildaction == "None" then
 			return
 		end
 

--- a/modules/gmake2/gmake2_utility.lua
+++ b/modules/gmake2/gmake2_utility.lua
@@ -88,7 +88,7 @@
 
 	function utility.addFile(cfg, node, prj)
 		local filecfg = fileconfig.getconfig(node, cfg)
-		if not filecfg or filecfg.flags.ExcludeFromBuild then
+		if not filecfg or filecfg.flags.ExcludeFromBuild or filecfg.buildaction == "None" then
 			return
 		end
 

--- a/modules/gmake2/tests/test_gmake2_objects.lua
+++ b/modules/gmake2/tests/test_gmake2_objects.lua
@@ -472,3 +472,25 @@ endif
 
 		]]
 	end
+
+	function suite.excludedFromBuild_onBuildactionNone()
+		files { "hello.cpp" }
+		filter { "Debug", "files:hello.cpp" }
+			buildaction "None"
+		filter {}
+		prepare()
+		test.capture [[
+# File sets
+# #############################################
+
+GENERATED :=
+OBJECTS :=
+
+ifeq ($(config),release)
+GENERATED += $(OBJDIR)/hello.o
+OBJECTS += $(OBJDIR)/hello.o
+
+endif
+
+		]]
+	end

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -187,6 +187,34 @@
 		]]
 	end
 
+	function suite.PBXBuildFile_ExcludedFromBuildByFlags()
+		files { "source.cpp", "excluded.cpp" }
+		filter { "files:excluded.cpp" }
+			flags { "ExcludeFromBuild" }
+		filter {}
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		7018C364CB5A16D69EB461A4 /* source.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B47484CB259E37EA275DE8C /* source.cpp */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
+	function suite.PBXBuildFile_ExcludedFromBuildByBuildactionNone()
+		files { "source.cpp", "excluded.cpp" }
+		filter { "files:excluded.cpp" }
+			buildaction "None"
+		filter {}
+		prepare()
+		xcode.PBXBuildFile(tr)
+		test.capture [[
+/* Begin PBXBuildFile section */
+		7018C364CB5A16D69EB461A4 /* source.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B47484CB259E37EA275DE8C /* source.cpp */; };
+/* End PBXBuildFile section */
+		]]
+	end
+
 
 ---------------------------------------------------------------------------
 -- PBXFileReference tests

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1303,7 +1303,7 @@
 						-- ms this seems to work on visual studio !!!
 						-- why not in xcode ??
 						local filecfg = fileconfig.getconfig(node, cfg)
-						if filecfg and filecfg.flags.ExcludeFromBuild then
+						if not filecfg or filecfg.flags.ExcludeFromBuild or filecfg.buildaction == "None" then
 						--fileNameList = fileNameList .. " " ..filecfg.name
 							table.insert(fileNameList, xcode.escapeArg(node.name))
 						end

--- a/modules/xcode/xcode_project.lua
+++ b/modules/xcode/xcode_project.lua
@@ -36,7 +36,7 @@
 		for cfg in premake.project.eachconfig(prj) do
 			local filecfg = premake.fileconfig.getconfig(node, cfg)
 			if filecfg then
-				local newValue = not not filecfg.flags.ExcludeFromBuild
+				local newValue = not not filecfg.flags.ExcludeFromBuild or filecfg.buildaction == "None"
 				if value == nil then
 					value = newValue
 				elseif value ~= newValue then

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -754,7 +754,7 @@
 
 			for cfg in p.project.eachconfig(prj) do
 				local fcfg = p.fileconfig.getconfig(file, cfg)
-				if fcfg ~= nil and not fcfg.flags.ExcludeFromBuild then
+				if fcfg ~= nil and not fcfg.flags.ExcludeFromBuild and fcfg.buildaction ~= "None" then
 					oven.uniqueSequence(fcfg, cfg, sequences, bases)
 				end
 			end


### PR DESCRIPTION
**What does this PR do?**

Add support of per-file configuration `buildaction "None"` for Codelite, gmake, gmake2, xcode4.

**How does this PR change Premake's behavior?**

As for `flags "ExcludeFromBuild"`,
previously conflicting obj file name might now differ (as there are no longer built):
i.e
```
files {"src/toto.cpp", "excluded/toto.cpp" }
filters {"files:excluded/toto.cpp"}
    buildaction "None"
```
Both resulted in `"toto.o"` with special treatment
now "excluded/toto.cpp" won't have obj object, and so no conflict with the "src/" one.

**Anything else we should know?**

Tested with [my repo](https://github.com/Jarod42/premake-sample-projects/tree/buildaction_none_test)
especially:
- [codelite action](https://github.com/Jarod42/premake-sample-projects/actions/runs/7167279390)
- [gmake action](https://github.com/Jarod42/premake-sample-projects/actions/runs/7167279396)
- [gmake2 action](https://github.com/Jarod42/premake-sample-projects/actions/runs/7167279393)
- [xcode4 action](https://github.com/Jarod42/premake-sample-projects/actions/runs/7167279395)

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
