### PR TITLE
Add support of per-file configuration `buildaction "Copy"` for Codelite.

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -405,6 +405,15 @@
 		local dependencies = {}
 		local makefilerules = {}
 		local function addrule(dependencies, makefilerules, config, filename)
+			if config.buildaction == "Copy" and filename ~= "" then
+				local output = project.getrelative(cfg.workspace, path.join(cfg.targetdir, config.name))
+				local create_directory_command = '\t@$(MakeDirCommand) $(@D)\n'
+				local command = '\t' .. os.translateCommands('{COPYFILE} "' .. filename .. '" "' .. output ..'"') .. '\n'
+
+				table.insert(makefilerules, output .. ": " .. filename .. '\n' .. create_directory_command .. command)
+				table.insert(dependencies, output)
+				return true
+			end
 			if #config.buildcommands == 0 or #config.buildoutputs == 0 then
 				return false
 			end

--- a/modules/codelite/tests/test_codelite_additional_rules.lua
+++ b/modules/codelite/tests/test_codelite_additional_rules.lua
@@ -286,3 +286,25 @@ foo.c: foo.txt foo.h extra_dependency
       </AdditionalRules>]]
 	end
 
+	function suite.buildactionCopy()
+		targetdir "bin"
+		files {"foo.txt", "bar.txt"}
+		filter "files:**.txt"
+			buildaction "Copy"
+
+		prepare()
+		codelite.project.additionalRules(cfg)
+		test.capture( [[
+      <AdditionalRules>
+        <CustomPostBuild/>
+        <CustomPreBuild>bin/bar.txt bin/foo.txt
+bin/bar.txt: bar.txt
+	@$(MakeDirCommand) $(@D)
+	]] .. os.translateCommands('{COPYFILE} "bar.txt" "bin/bar.txt"') .. '\n' ..	[[
+
+bin/foo.txt: foo.txt
+	@$(MakeDirCommand) $(@D)
+	]]  .. os.translateCommands('{COPYFILE} "foo.txt" "bin/foo.txt"') .. '\n' .. [[
+</CustomPreBuild>
+      </AdditionalRules>]])
+	end


### PR DESCRIPTION
**What does this PR do?**

Add support of per-file configuration `buildaction "Copy"` for Codelite.

**How does this PR change Premake's behavior?**

Add support of per-file configuration `buildaction "Copy"` for Codelite.

**Anything else we should know?**

Tested with https://github.com/Jarod42/premake-sample-projects/actions/runs/7196871990

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
