### PR TITLE
Custom LLVM Versions for VS2019+

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -265,6 +265,22 @@
 		kind = "string",
 	}
 
+	-- Directory of LLVM install
+	p.api.register {
+		name = "llvmdir",
+		scope = "config",
+		kind = "directory",
+		tokens = "true",
+	}
+
+	-- Version of LLVM Install
+	p.api.register {
+		name = "llvmversion",
+		scope = "config",
+		kind = "string",
+		tokens = "true",
+	}
+
 --
 -- Decide when the full module should be loaded.
 --

--- a/modules/vstudio/tests/vc2019/test_toolset_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_toolset_settings.lua
@@ -59,6 +59,45 @@
 	end
 
 
+---
+-- Check the project settings with the llvm version
+---
+
+	function suite.toolsetClang_llvmVersion()
+		toolset "clang"
+		llvmversion "16"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>ClangCL</PlatformToolset>
+	<LLVMToolsVersion>16</LLVMToolsVersion>
+</PropertyGroup>
+		]]
+	end
+
+---
+-- Check the project settings with the llvm version
+---
+
+	function suite.toolsetClang_llvmDir()
+		toolset "clang"
+		llvmdir "llvm/dir"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>ClangCL</PlatformToolset>
+	<LLVMInstallDir>llvm\dir</LLVMInstallDir>
+</PropertyGroup>
+		]]
+	end
+
+
 --
 -- If AllModulesPublic flag is set, add <AllProjectBMIsArePublic> element (supported from VS2019)
 --

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -224,6 +224,7 @@
 			return {
 				m.configurationType,
 				m.platformToolset,
+				m.llvmTools,
 				m.toolsVersion,
 			}
 		else
@@ -238,6 +239,7 @@
 				m.enableUnityBuild,
 				m.sanitizers,
 				m.toolsVersion,
+				m.llvmTools,
 				m.wholeProgramOptimization,
 				m.nmakeOutDirs,
 				m.windowsSDKDesktopARMSupport,
@@ -2773,6 +2775,19 @@
 			else
 				m.element("PlatformToolset", nil, version)
 			end
+		end
+	end
+
+	function m.llvmTools(cfg)
+		local llvmdir = cfg.llvmdir
+		local llvmversion = cfg.llvmversion
+
+		if llvmdir and _ACTION >= "vs2019" then
+			m.element("LLVMInstallDir", nil, vstudio.path(cfg, llvmdir))
+		end
+		
+		if llvmversion and _ACTION >= "vs2019" then
+			m.element("LLVMToolsVersion", nil, llvmversion)
 		end
 	end
 

--- a/website/docs/llvmdir.md
+++ b/website/docs/llvmdir.md
@@ -1,0 +1,23 @@
+Specifies a custom LLVM install location for Visual Studio.
+
+```lua
+llvmdir "path"
+```
+
+### Parameters ###
+
+`path` specifies a directory containing the LLVM installation.
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0.0 beta 3 or later for Visual Studio 2019 and later.
+
+## Examples ##
+
+```lua
+llvmdir "/path/to/install"
+```

--- a/website/docs/llvmversion.md
+++ b/website/docs/llvmversion.md
@@ -1,0 +1,23 @@
+Specifies a version for a custom installation of LLVM for Visual Studio.
+
+```lua
+llvmversion "version"
+```
+
+### Parameters ###
+
+`version` specifies the version of the LLVM installation.
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0.0 beta 3 or later for Visual Studio 2019 and later.
+
+## Examples ##
+
+```lua
+llvmversion "16"
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -202,6 +202,8 @@ module.exports = {
 						'links',
 						'locale',
 						'location',
+						'llvmdir',
+						'llvmversion',
 						'makesettings',
 						'namespace',
 						'nativewchar',


### PR DESCRIPTION
**What does this PR do?**

Adds an API to Visual Studio exporter for specifying custom LLVM versions and installation directories.

**How does this PR change Premake's behavior?**

No breaking changes.

**Anything else we should know?**

Closes #1864

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
