### PR TITLE
Ignore mkdir errors on Windows with gmake2 generator

### DIFF
--- a/modules/gmake2/gmake2.lua
+++ b/modules/gmake2/gmake2.lua
@@ -125,7 +125,7 @@
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) mkdir -p %s', dirname)
 		_p('else')
-		_p('\t$(SILENT) mkdir $(subst /,\\\\,%s)', dirname)
+		_p('\t$(SILENT) -mkdir $(subst /,\\\\,%s)', dirname)
 		_p('endif')
 	end
 


### PR DESCRIPTION
**What does this PR do?**

Two different paths are implemented for `sh` and Windows shells in `gmake2`, which output something like:
```Makefile
$(TARGETDIR):
	@echo Creating $(TARGETDIR)
ifeq (posix,$(SHELLTYPE))
	$(SILENT) mkdir -p $(TARGETDIR)
else
	$(SILENT) mkdir $(subst /,\\,$(TARGETDIR))
endif
```

There are some differences between the POSIX  `mkdir -p` and `mkdir` on `cmd`, one of them is that `mkdir` on Windows fails if a path already exists. This is not much of a problem in a single-threaded scenario, since the `Makefile` target takes care of checking whether the directory exists, but you quickly run into problems when running make with multiple parallel jobs (e.g. `-j16`), and anything may happen between the check and the `mkdir`, including some other job creating the directory.

**How does this PR change Premake's behavior?**

I did not find a better solution than ignoring the `mkdir` errors in the branch for `cmd`, so this PR effectively changes the output of the previous snippet to:
```Makefile
$(TARGETDIR):
	@echo Creating $(TARGETDIR)
ifeq (posix,$(SHELLTYPE))
	$(SILENT) mkdir -p $(TARGETDIR)
else
	$(SILENT) -mkdir $(subst /,\\,$(TARGETDIR))
endif
```

**Anything else we should know?**

Unfortunately all `mkdir` errors are ignored, not just the ones caused by the directory already existing. Although, while not ideal, it seemed better than building in a single thread for a large project.

Upon hitting the issue the output will now look like this and make will carry on instead of exiting:
```
make[1]: [foo.make:362: bin/release] Error 1 (ignored)
```

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
