### PR TITLE
Add premake5-cuda (community) module to doc

### DIFF
--- a/website/community/modules.md
+++ b/website/community/modules.md
@@ -41,5 +41,6 @@ These add-on modules are available from other developers; follow the links for m
 
 ## Library Modules
 
+* [CUDA](https://github.com/theComputeKid/premake5-cuda) : Enables CUDA development in Visual Studio using the native CUDA Toolkit integration and with nvcc on Linux
 * [Qt](https://github.com/dcourtois/premake-qt) : [Qt](https://www.qt.io) support
 * [WIX](https://github.com/mikisch81/premake-wix) : Premake extension to support [WIX](http://wixtoolset.org/) project files on Visual Studio


### PR DESCRIPTION
**What does this PR do?**

CUDA support has been queried multiple times (#2168, #1898 etc.). I have been maintaining [this](https://github.com/theComputeKid/premake5-cuda) module for quite some time, so listing it here would let people use CUDA with Visual Studio (and on Linux). This PR was motivated by [this](https://github.com/premake/premake-core/issues/2168#issuecomment-1937772015) comment.

**How does this PR change Premake's behavior?**

This is a doc-only community change, outside of premake's codebase, therefore it is the maintainer's choice on whether to close those CUDA-related issues.