### PR TITLE
Add clang-tidy as a Visual Studio code analyser option

### DIFF
--- a/website/community/modules.md
+++ b/website/community/modules.md
@@ -41,5 +41,6 @@ These add-on modules are available from other developers; follow the links for m
 
 ## Library Modules
 
+* [CUDA](https://github.com/theComputeKid/premake5-cuda) : Enables CUDA development in Visual Studio using the native CUDA Toolkit integration and with nvcc on Linux
 * [Qt](https://github.com/dcourtois/premake-qt) : [Qt](https://www.qt.io) support
 * [WIX](https://github.com/mikisch81/premake-wix) : Premake extension to support [WIX](http://wixtoolset.org/) project files on Visual Studio


### PR DESCRIPTION
### What does this PR do?

This PR enables the selection of clang-tidy as a code analyser when the code analyser action of Visual Studio is run in the IDE. Further details can be found in the [official documentation](https://learn.microsoft.com/en-us/cpp/code-quality/clang-tidy?view=msvc-170).

### How does this PR change Premake's behavior?

Add configuration-scoped option `clangtidy` for Visual Studio 2019 and above.

I have tried to follow pre-existing conventions:
- The option name was a lowercase boolean based on `compilebuildoutputs` as an example.
- The test_output_props tests for vs2019 were based on vs2022 test_output_props.
- A test was also added to ensure pre-vs2019 configs were not affected.
- Documentation was added based on the `buildstlmodules` example, which was a similar boolean.

### Did you check all the boxes?

- [x]  Focus on a single fix or feature; remove any unrelated formatting or code changes

- [x]  Add unit tests showing fix or feature works; all tests pass
- [ ]  Mention any [related issues](https://github.com/premake/premake-core/issues) (put closes #XXXX in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes