### PR TITLE
Enable code analysis via clang-tidy in Visual Studio

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -217,6 +217,12 @@
 	}
 
 	p.api.register {
+		name = "clangtidy",
+		scope = "config",
+		kind = "boolean"
+	}
+
+	p.api.register {
 		name = "vsprops",
 		scope = "config",
 		kind = "list:table",

--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -102,6 +102,7 @@ return {
 	-- Visual Studio 2019+ C/C++ Projects
 	"vc2019/test_compile_settings.lua",
 	"vc2019/test_link.lua",
+	"vc2019/test_output_props.lua",
 	"vc2019/test_toolset_settings.lua",
 
 	-- Visual Studio 2022+ C/C++ Projects

--- a/modules/vstudio/tests/vc2010/test_output_props.lua
+++ b/modules/vstudio/tests/vc2010/test_output_props.lua
@@ -25,6 +25,24 @@
 		vc2010.outputProperties(cfg)
 	end
 
+--
+-- Ensure clangtidy is not enabled for vc2010.
+--
+
+function suite.onClangTidy()
+	clangtidy "On"
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+</PropertyGroup>
+	]]
+end
+
 
 --
 -- Check the structure with the default project values.

--- a/modules/vstudio/tests/vc2019/test_output_props.lua
+++ b/modules/vstudio/tests/vc2019/test_output_props.lua
@@ -1,0 +1,64 @@
+--
+-- tests/actions/vstudio/vc2019/test_output_props.lua
+-- Validate generation of the output property groups.
+-- Copyright (c) 2024 Jason Perkins and the Premake project
+--
+
+local p = premake
+local suite = test.declare("vstudio_vs2019_output_props")
+local vc2010 = p.vstudio.vc2010
+
+
+--
+-- Setup
+--
+
+local wks, prj
+
+function suite.setup()
+	p.action.set("vs2019")
+	wks, prj = test.createWorkspace()
+end
+
+local function prepare()
+	local cfg = test.getconfig(prj, "Debug")
+	vc2010.outputProperties(cfg)
+end
+
+--
+-- Check clangtidy code analysis enabled.
+--
+
+function suite.onClangTidy_Enabled()
+	clangtidy "On"
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+	<EnableClangTidyCodeAnalysis>true</EnableClangTidyCodeAnalysis>
+</PropertyGroup>
+	]]
+end
+
+--
+-- Check clangtidy code analysis disabled.
+--
+
+function suite.onClangTidy_Disabled()
+	clangtidy "Off"
+	prepare()
+	test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>bin\Debug\</OutDir>
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>.exe</TargetExt>
+	<EnableClangTidyCodeAnalysis>false</EnableClangTidyCodeAnalysis>
+</PropertyGroup>
+	]]
+end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -322,6 +322,7 @@
 				m.extensionsToDeleteOnClean,
 				m.executablePath,
 				m.allModulesPublic,
+				m.clangtidy,
 			}
 		end
 	end
@@ -3036,6 +3037,11 @@
 		m.element("TargetName", nil, "%s%s", cfg.buildtarget.prefix, cfg.buildtarget.basename)
 	end
 
+	function m.clangtidy(cfg)
+		if _ACTION >= "vs2019" and cfg.clangtidy ~= nil then
+			m.element("EnableClangTidyCodeAnalysis", nil, iif(cfg.clangtidy, "true", "false"))
+		end
+	end
 
 	function m.latestTargetPlatformVersion(prj)
 		-- See https://developercommunity.visualstudio.com/content/problem/140294/windowstargetplatformversion-makes-it-impossible-t.html

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -170,12 +170,6 @@
 	}
 
 	api.register {
-		name = "clangtidy",
-		scope = "config",
-		kind = "boolean"
-	}
-
-	api.register {
 		name = "compilebuildoutputs",
 		scope = "config",
 		kind = "boolean"

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -170,6 +170,12 @@
 	}
 
 	api.register {
+		name = "clangtidy",
+		scope = "config",
+		kind = "boolean"
+	}
+
+	api.register {
 		name = "compilebuildoutputs",
 		scope = "config",
 		kind = "boolean"

--- a/website/docs/clangtidy.md
+++ b/website/docs/clangtidy.md
@@ -1,0 +1,26 @@
+Enables clang-tidy code analysis for Visual Studio.
+
+The `clangtidy` option enables running clang-tidy code analysis in Visual Studio projects.
+
+```lua
+clangtidy("value")
+```
+
+### Parameters ###
+
+`value` is one of:
+
+- `On`
+- `Off`
+
+### Applies To ###
+
+The `config` scope.
+
+### Availability ###
+
+Premake 5.0.0 beta 3 or later for Visual Studio 2019 and later.
+
+### See Also ###
+
+* [Using Clang-Tidy in Visual Studio](https://learn.microsoft.com/en-us/cpp/code-quality/clang-tidy?view=msvc-170)


### PR DESCRIPTION
### What does this PR do?

This PR enables the selection of clang-tidy as a code analyser when the code analyser action of Visual Studio is run in the IDE. Further details can be found in the [official documentation](https://learn.microsoft.com/en-us/cpp/code-quality/clang-tidy?view=msvc-170).

### How does this PR change Premake's behavior?

Add configuration-scoped option `clangtidy` for Visual Studio 2019 and above.

I have tried to follow pre-existing conventions:
- The option name was a lowercase boolean based on `compilebuildoutputs` as an example.
- The test_output_props tests for vs2019 were based on vs2022 test_output_props.
- A test was also added to ensure pre-vs2019 configs were not affected.
- Documentation was added based on the `buildstlmodules` example, which was a similar boolean.

### Did you check all the boxes?

- [x]  Focus on a single fix or feature; remove any unrelated formatting or code changes

- [x]  Add unit tests showing fix or feature works; all tests pass
- [ ]  Mention any [related issues](https://github.com/premake/premake-core/issues) (put closes #XXXX in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes