### PR TITLE
Handle `buildaction "Copy"` for gmake2.

### DIFF
--- a/modules/gmake2/gmake2.lua
+++ b/modules/gmake2/gmake2.lua
@@ -129,6 +129,15 @@
 		_p('endif')
 	end
 
+	function gmake2.copyfile_cmds(source, dest)
+		local cmd = '$(SILENT) {COPYFILE} ' .. source .. ' ' .. dest
+		return { 'ifeq (posix,$(SHELLTYPE))',
+			'\t' .. os.translateCommands(cmd, 'posix'),
+			'else',
+			'\t' .. os.translateCommands(cmd, 'windows'),
+			'endif' }
+	end
+
 	function gmake2.mkdirRules(dirname)
 		_p('%s:', dirname)
 		_p('\t@echo Creating %s', dirname)

--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -192,6 +192,17 @@
 					cpp.addGeneratedFile(cfg, node, output)
 				end
 			end
+		elseif filecfg.buildaction == "Copy" then
+			local output = '$(TARGETDIR)/' .. node.name
+			local file = {
+				buildoutputs  = { output },
+				source        = node.relpath,
+				buildmessage  = '$(notdir $<)',
+				verbatimbuildcommands = gmake2.copyfile_cmds('"$<"', '"$@"'),
+				buildinputs = {'$(TARGETDIR)'}
+			}
+			table.insert(cfg._gmake.fileRules, file)
+			cpp.addGeneratedFile(cfg, node, output)
 		else
 			cpp.addRuleFile(cfg, node)
 		end
@@ -761,7 +772,11 @@
 				end
 			end
 		end
-
+		if file.verbatimbuildcommands then
+			for _, cmd in ipairs(file.verbatimbuildcommands) do
+				_p('%s', cmd);
+			end
+		end
 		-- TODO: this is a hack with some imperfect side-effects.
 		--       better solution would be to emit a dummy file for the rule, and then outputs depend on it (must clean up dummy in 'clean')
 		--       better yet, is to use pattern rules, but we need to detect that all outputs have the same stem

--- a/modules/gmake2/tests/test_gmake2_file_rules.lua
+++ b/modules/gmake2/tests/test_gmake2_file_rules.lua
@@ -409,3 +409,27 @@ test2.obj: test2.rule
 	$(SILENT) dorule       S1 "test2.rule"
 		]]
 	end
+
+	function suite.fileRulesOnBuildactionCopy()
+		files { "hello.dll" }
+		filter { "Debug", "files:hello.dll" }
+			buildaction "Copy"
+		filter {}
+		prepare()
+		test.capture [[
+# File Rules
+# #############################################
+
+ifeq ($(config),debug)
+$(TARGETDIR)/hello.dll: hello.dll $(TARGETDIR)
+	@echo "$(notdir $<)"
+ifeq (posix,$(SHELLTYPE))
+	$(SILENT) cp -f "$<" "$@"
+else
+	$(SILENT) copy /B /Y "$<" "$@"
+endif
+
+endif
+]]
+	end
+

--- a/modules/gmake2/tests/test_gmake2_objects.lua
+++ b/modules/gmake2/tests/test_gmake2_objects.lua
@@ -494,3 +494,26 @@ endif
 
 		]]
 	end
+
+	function suite.objectsOnBuildactionCopy()
+		files { "hello.dll" }
+		filter { "Debug", "files:hello.dll" }
+			buildaction "Copy"
+		filter {}
+		prepare()
+		test.capture [[
+# File sets
+# #############################################
+
+CUSTOM :=
+GENERATED :=
+
+ifeq ($(config),debug)
+CUSTOM += $(TARGETDIR)/hello.dll
+GENERATED += $(TARGETDIR)/hello.dll
+
+endif
+
+		]]
+	end
+


### PR DESCRIPTION
**What does this PR do?**

Handle `buildaction "Copy"` for gmake2.

**How does this PR change Premake's behavior?**

Handle `buildaction "Copy"` for gmake2.

**Anything else we should know?**

Tested with https://github.com/Jarod42/premake-sample-projects/tree/master/projects/project-buildaction_copy
https://github.com/Jarod42/premake-sample-projects/actions/runs/7961205332/job/21731877841

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
