### PR TITLE
Adjust Tokens.md to correspond to codebase

### DIFF
--- a/website/docs/Tokens.md
+++ b/website/docs/Tokens.md
@@ -105,7 +105,7 @@ The available tokens, and their replacements:
 | {COPYDIR}  | xcopy /Q /E /Y /I {args}                    | cp -rf {args}   |
 | {DELETE}   | del {args}                                  | rm -rf {args}   |
 | {ECHO}     | echo {args}                                 | echo {args}     |
-| {MKDIR}    | mkdir {args}                                | mkdir -p {args} |
+| {MKDIR}    | IF NOT EXIST {args} (mkdir {args})          | mkdir -p {args} |
 | {MOVE}     | move /Y {args}                              | mv -f {args}    |
 | {RMDIR}    | rmdir /S /Q {args}                          | rm -rf {args}   |
 | {TOUCH}    | type nul >> {arg} && copy /b {arg}+,, {arg} | touch {args}    |


### PR DESCRIPTION
Tokens page shows that {MKDIR} only calls mkdir Windows command, so it would be confusing to people who write "if not exist {MKDIR} blabla" when they happen to see an error while compiling

**What does this PR do?**

It fixes a documentation error

**How does this PR change Premake's behavior?**

It doesn't

**Anything else we should know?**

This misbehavior happened to me after I wrote something like "if not exist path {MKDIR} path",
 so it translated into "if not exist path IF NOT EXIST path (mkdir path)" and got an error.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
