### PR TITLE
[vs*] Allow to have per-file `cdialect`/`cppdialect`.

### DIFF
--- a/modules/vstudio/tests/vc2010/test_files.lua
+++ b/modules/vstudio/tests/vc2010/test_files.lua
@@ -658,6 +658,55 @@
 	end
 
 --
+-- Check handling of per-file cdialect.
+--
+	function suite.onCDialect()
+		p.action.set("vs2019")
+		cdialect "c11"
+		files { "file.c", "file11.c", "file17.c" }
+		filter "files:file11.c"
+			cdialect "c11"
+		filter "files:file17.c"
+			cdialect "c17"
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="file.c" />
+	<ClCompile Include="file11.c">
+		<LanguageStandard_C>stdc11</LanguageStandard_C>
+	</ClCompile>
+	<ClCompile Include="file17.c">
+		<LanguageStandard_C>stdc17</LanguageStandard_C>
+	</ClCompile>
+  <ItemGroup>]]
+	end
+
+--
+-- Check handling of per-file cppdialect.
+--
+	function suite.onCppDialect()
+		p.action.set("vs2017")
+		cppdialect "c++14"
+		files { "file.cpp", "file14.cpp", "file17.cpp" }
+		filter "files:file14.cpp"
+			cppdialect "c++14"
+		filter "files:file17.cpp"
+			cppdialect "c++17"
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="file.cpp" />
+	<ClCompile Include="file14.cpp">
+		<LanguageStandard>stdcpp14</LanguageStandard>
+	</ClCompile>
+	<ClCompile Include="file17.cpp">
+		<LanguageStandard>stdcpp17</LanguageStandard>
+	</ClCompile>
+  <ItemGroup>]]
+	end
+
+
+--
 -- Check handling of per-file optimization levels.
 --
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -963,6 +963,8 @@
 			m.objectFileName,
 			m.clCompilePreprocessorDefinitions,
 			m.clCompileUndefinePreprocessorDefinitions,
+			m.languageStandard,
+			m.languageStandardC,
 			m.optimization,
 			m.forceIncludes,
 			m.forceUsings,
@@ -1485,7 +1487,7 @@
 
 				local contents = p.capture(function ()
 					p.push()
-					p.callArray(fileFunc, cfg, file)
+					p.callArray(fileFunc, nil, file)
 					m.conditionalElements = {}
 					for cfg in project.eachconfig(prj) do
 						local fcfg = fileconfig.getconfig(file, cfg)
@@ -1730,27 +1732,27 @@
 	end
 
 
-	function m.languageStandard(cfg)
+	function m.languageStandard(cfg, condition)
 		if _ACTION >= "vs2017" then
 			if (cfg.cppdialect == "C++14") then
-				m.element("LanguageStandard", nil, 'stdcpp14')
+				m.element("LanguageStandard", condition, 'stdcpp14')
 			elseif (cfg.cppdialect == "C++17") then
-				m.element("LanguageStandard", nil, 'stdcpp17')
+				m.element("LanguageStandard", condition, 'stdcpp17')
 			elseif (cfg.cppdialect == "C++20") then
-				m.element("LanguageStandard", nil, iif(_ACTION == "vs2017", 'stdcpplatest', 'stdcpp20'))
+				m.element("LanguageStandard", condition, iif(_ACTION == "vs2017", 'stdcpplatest', 'stdcpp20'))
 			elseif (cfg.cppdialect == "C++latest") then
-				m.element("LanguageStandard", nil, 'stdcpplatest')
+				m.element("LanguageStandard", condition, 'stdcpplatest')
 			end
 		end
 	end
 
 
-	function m.languageStandardC(cfg)
+	function m.languageStandardC(cfg, condition)
 		if _ACTION >= "vs2019" then
 			if (cfg.cdialect == "C11") then
-				m.element("LanguageStandard_C", nil, 'stdc11')
+				m.element("LanguageStandard_C", condition, 'stdc11')
 			elseif (cfg.cdialect == "C17") then
-				m.element("LanguageStandard_C", nil, 'stdc17')
+				m.element("LanguageStandard_C", condition, 'stdc17')
 			end
 		end
 	end


### PR DESCRIPTION
**What does this PR do?**

Handle  `cdialect`/`cppdialect` in per-file configuration for visual studio generators

**How does this PR change Premake's behavior?**

Only affect visual studio generators

**Anything else we should know?**

`cppdialect` tested with dedicated project https://github.com/Jarod42/premake-sample-projects/actions/runs/8377114412

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
