### PR TITLE
[vs2010+] Handle `compileas` for files with "unknown" extensions.

### DIFF
--- a/modules/vstudio/tests/vc2010/test_files.lua
+++ b/modules/vstudio/tests/vc2010/test_files.lua
@@ -657,6 +657,18 @@
 		]]
 	end
 
+	function suite.onCompileAsExt()
+		files { "hello.unknown_ext" }
+		filter "files:hello.unknown_ext"
+			compileas "C++"
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="hello.unknown_ext">
+		<CompileAs>CompileAsCpp</CompileAs>
+		]]
+	end
+
 --
 -- Check handling of per-file cdialect.
 --

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1360,6 +1360,10 @@
 				if fcfg.buildaction then
 					return m.categories[fcfg.buildaction] or m.categories.None
 				end
+
+				if fcfg.compileas ~= nil and fcfg.compileas ~= "Default" then
+					return m.categories.ClCompile
+				end
 			end
 		end
 


### PR DESCRIPTION
**What does this PR do?**

Handle `compileas` for files with "unknown"/mismatching_categories  extensions for vs* generator.

**How does this PR change Premake's behavior?**

Only vs* generators impacted.

**Anything else we should know?**

Tested with https://github.com/Jarod42/premake-sample-projects/tree/vs_compileas/projects/project-compileas
with action: https://github.com/Jarod42/premake-sample-projects/actions/runs/8392851053

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
