### PR TITLE
Add CA root certificate path for Haiku

### DIFF
--- a/contrib/curl/premake5.lua
+++ b/contrib/curl/premake5.lua
@@ -27,7 +27,7 @@ project "curl-lib"
 	filter { "system:not windows", "system:not macosx" }
 		defines { "USE_MBEDTLS" }
 
-	filter { "system:linux or bsd or solaris" }
+	filter { "system:linux or bsd or solaris or haiku" }
 		defines { "CURL_HIDDEN_SYMBOLS" }
 
 		-- find the location of the ca bundle
@@ -39,7 +39,8 @@ project "curl-lib"
 			"/usr/local/share/certs/ca-root.crt",
 			"/usr/local/share/certs/ca-root-nss.crt",
 			"/etc/certs/ca-certificates.crt",
-			"/etc/ssl/cert.pem" } do
+			"/etc/ssl/cert.pem",
+			"/boot/system/data/ssl/CARootCertificates.pem" } do
 			if os.isfile(f) then
 				ca = f
 				break


### PR DESCRIPTION
**What does this PR do?**

Add the root certificate path for Haiku so that http.download() from sites like github.com work properly.

**How does this PR change Premake's behavior?**

Allows downloads from SSL sites when using Haiku.

Are there any breaking changes? Will any existing behavior change?

Should not affect any other systems.

**Anything else we should know?**

NA

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [X] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*