### PR TITLE
Fix wrong system include when targeting Emscripten.

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -505,14 +505,16 @@
 		architecture = {
 			x86 = function (cfg)
 				local r = {}
-				if not table.contains(os.getSystemTags(cfg.system), "darwin") then
+				if not (table.contains(os.getSystemTags(cfg.system), "darwin")
+					or table.contains(os.getSystemTags(cfg.system), "emscripten")) then
 					table.insert (r, "-L/usr/lib32")
 				end
 				return r
 			end,
 			x86_64 = function (cfg)
 				local r = {}
-				if not table.contains(os.getSystemTags(cfg.system), "darwin") then
+				if not (table.contains(os.getSystemTags(cfg.system), "darwin")
+					or table.contains(os.getSystemTags(cfg.system), "emscripten")) then
 					table.insert (r, "-L/usr/lib64")
 				end
 				return r


### PR DESCRIPTION
Fixes an extra system include when targetting Emscripten with the Emscripten Premake extension module.


