### PR TITLE
Properly filter .NET build events for configuration

### DIFF
--- a/modules/vstudio/tests/cs2005/test_build_events.lua
+++ b/modules/vstudio/tests/cs2005/test_build_events.lua
@@ -45,7 +45,7 @@
 		prebuildcommands { "command1" }
 		prepare()
 		test.capture [[
-	<PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<PreBuildEvent>command1</PreBuildEvent>
 	</PropertyGroup>
 		]]
@@ -55,7 +55,7 @@
 		postbuildcommands { "command1" }
 		prepare()
 		test.capture [[
-	<PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<PostBuildEvent>command1</PostBuildEvent>
 	</PropertyGroup>
 		]]
@@ -66,13 +66,44 @@
 		postbuildcommands { "command2" }
 		prepare()
 		test.capture [[
-	<PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<PreBuildEvent>command1</PreBuildEvent>
 		<PostBuildEvent>command2</PostBuildEvent>
 	</PropertyGroup>
 		]]
 	end
 
+	function suite.onMultipleConfigs()
+		configurations {"Debug", "Release"}
+		filter "configurations:Debug"
+			prebuildcommands { "command1" }
+		filter "configurations:Release"
+			prebuildcommands { "command2" }
+		filter ""
+		prepare()
+		test.capture [[
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+		<PreBuildEvent>command1</PreBuildEvent>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+		<PreBuildEvent>command2</PreBuildEvent>
+	</PropertyGroup>
+		]]
+	end
+
+	function suite.onMultipleConfigsNoFilter()
+		configurations {"Debug", "Release"}
+		postbuildcommands { "command1" }
+		prepare()
+		test.capture [[
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+		<PostBuildEvent>command1</PostBuildEvent>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+		<PostBuildEvent>command1</PostBuildEvent>
+	</PropertyGroup>
+		]]
+	end
 
 --
 -- Multiple commands should be separated with un-escaped EOLs.
@@ -81,7 +112,7 @@
 	function suite.splits_onMultipleCommands()
 		postbuildcommands { "command1", "command2" }
 		prepare()
-		test.capture ("\t<PropertyGroup>\n\t\t<PostBuildEvent>command1\r\ncommand2</PostBuildEvent>\n\t</PropertyGroup>\n")
+		test.capture ("\t<PropertyGroup Condition=\" '$(Configuration)|$(Platform)' == 'Debug|x86' \">\n\t\t<PostBuildEvent>command1\r\ncommand2</PostBuildEvent>\n\t</PropertyGroup>\n")
 	end
 
 
@@ -94,7 +125,7 @@
 		postbuildcommands { '\' " < > &' }
 		prepare()
 		test.capture [[
-	<PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<PostBuildEvent>' " &lt; &gt; &amp;</PostBuildEvent>
 	</PropertyGroup>
 		]]

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -233,12 +233,13 @@
 			end
 		end
 
-		local cfg = project.getfirstconfig(prj)
-		if #cfg.prebuildcommands > 0 or #cfg.postbuildcommands > 0 then
-			_p(1,'<PropertyGroup>')
-			output("Pre", cfg.prebuildcommands)
-			output("Post", cfg.postbuildcommands)
-			_p(1,'</PropertyGroup>')
+		for cfg in project.eachconfig(prj) do
+			if #cfg.prebuildcommands > 0 or #cfg.postbuildcommands > 0 then
+				_p(1,'<PropertyGroup %s>', dotnetbase.condition(cfg))
+				output("Pre", cfg.prebuildcommands)
+				output("Post", cfg.postbuildcommands)
+				_p(1,'</PropertyGroup>')
+			end
 		end
 	end
 


### PR DESCRIPTION
closes #2214

**What does this PR do?**

This change properly generates per-configuration conditions for build events with .NET projects rather than pulling build events from the project's "first" configuration

**How does this PR change Premake's behavior?**

Allows configuration filters to work as expected with .NET project generation
