### PR TITLE
Enable nested vsprops

### DIFF
--- a/modules/vstudio/tests/cs2005/test_additional_props.lua
+++ b/modules/vstudio/tests/cs2005/test_additional_props.lua
@@ -48,6 +48,26 @@
 
 
 --
+-- Check handling of nested AdditionalProps.
+-- Elements are nested properly.
+--
+
+	function suite.propsAreNested()
+		vsprops {
+			RandomKey = {
+				RandomNestedKey = "NestedValue"
+			}
+		}
+		prepare()
+		test.capture [[
+		<RandomKey>
+			<RandomNestedKey>NestedValue</RandomNestedKey>
+		</RandomKey>
+		]]
+	end
+
+
+--
 -- Check handling of AdditionialProps.
 -- Element groups set multiple times are placed in the order in which they are set.
 --
@@ -80,5 +100,3 @@
 		<ValueRequiringEscape>if (age &gt; 3 &amp;&amp; age &lt; 8)</ValueRequiringEscape>
 		]]
 	end
-
-

--- a/modules/vstudio/tests/vc2010/test_globals.lua
+++ b/modules/vstudio/tests/vc2010/test_globals.lua
@@ -540,6 +540,44 @@ end
 	end
 
 
+	function suite.additionalPropsNested()
+		p.action.set("vs2022")
+		filter "Debug"
+			vsprops {
+				Key3 = {
+					NestedKey = "NestedValue"
+				}
+			}
+		filter "Release"
+			vsprops {
+				Key1 = "Value1",
+				Key2 = {
+					NestedKey = "NestedValue"
+				}
+			}
+		filter {}
+		prepare()
+		test.capture [[
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
+	<Keyword>Win32Proj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Globals">
+	<Key3>
+		<NestedKey>NestedValue</NestedKey>
+	</Key3>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Globals">
+	<Key1>Value1</Key1>
+	<Key2>
+		<NestedKey>NestedValue</NestedKey>
+	</Key2>
+</PropertyGroup>
+		]]
+	end
+
 	function suite.disableFastUpToDateCheck()
 		fastuptodate "Off"
 		prepare()

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -247,12 +247,22 @@
 --
 
 	function dotnetbase.additionalProps(cfg)
-		for i = 1, #cfg.vsprops do
-			for key, value in spairs(cfg.vsprops[i]) do
-				_p(2, '<%s>%s</%s>', key, vs2005.esc(value), key)
+		local function recurseTableIfNeeded(tbl, tab_level)
+			for key, value in spairs(tbl) do
+				if (type(value) == "table") then
+					_p(tab_level, '<%s>', key)
+					recurseTableIfNeeded(value, tab_level + 1)
+					_p(tab_level, '</%s>', key)
+				else
+					_p(tab_level, '<%s>%s</%s>', key, vs2005.esc(value), key)
+				end
 			end
 		end
+		for i = 1, #cfg.vsprops do
+			recurseTableIfNeeded(cfg.vsprops[i], 2)
+		end
 	end
+
 
 --
 -- Write the compiler flags for a particular configuration.

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2201,7 +2201,7 @@
 			if #includes > 0 then
 				m.element("ForcedIncludeFiles", condition, table.concat(includes, ';'))
 			end
-		end		
+		end
 	end
 
 	function m.forceUsings(cfg, condition)
@@ -2793,7 +2793,7 @@
 		if llvmdir and _ACTION >= "vs2019" then
 			m.element("LLVMInstallDir", nil, vstudio.path(cfg, llvmdir))
 		end
-		
+
 		if llvmversion and _ACTION >= "vs2019" then
 			m.element("LLVMToolsVersion", nil, llvmversion)
 		end
@@ -3128,10 +3128,19 @@
 
 
 	function m.additionalProps(prj, cfg)
-		for i = 1, #cfg.vsprops do
-			for key, value in spairs(cfg.vsprops[i]) do
-				m.element(key, nil, vs2010.esc(value))
+		local function recurseTableIfNeeded(tbl)
+			for key, value in spairs(tbl) do
+				if (type(value) == "table") then
+					p.push("<" .. key .. ">")
+						recurseTableIfNeeded(value)
+					p.pop("</" .. key .. ">")
+				else
+					m.element(key, nil, vs2010.esc(value))
+				end
 			end
+		end
+		for i = 1, #cfg.vsprops do
+			recurseTableIfNeeded(cfg.vsprops[i])
 		end
 	end
 
@@ -3481,7 +3490,7 @@
 
 	function m.linuxDebugInformationFormat(cfg)
 		if cfg.symbols then
-	
+
 			if cfg.symbols == p.OFF then
 				m.element("DebugInformationFormat", nil, "None")
 			elseif cfg.symbols == "Full" then
@@ -3524,7 +3533,7 @@
 			["gnu++17"] = "gnu++17",
 			["gnu++20"] = "gnu++20",
 		}
-		
+
 		if cpp_langmap[cfg.cppdialect] ~= nil then
 			m.element("CppLanguageStandard", nil, cpp_langmap[cfg.cppdialect])
 		end
@@ -3587,7 +3596,7 @@
 			["wsl"] = "WSL_1_0",
 			["wsl2"] = "WSL2_1_0",
 		}
-		
+
 		local clang_map = {
 			["remote"] = "Remote_Clang_1_0",
 			["wsl"] = "WSL_Clang_1_0",

--- a/website/docs/vsprops.md
+++ b/website/docs/vsprops.md
@@ -14,6 +14,17 @@ If you want to output groups of values in any order, set multiple times.
 	}
 ```
 
+Nested values are also supported.
+
+```lua
+	vsprops {
+		Name1 = "value1",
+		Name2 = {
+			Name3 = "value3"
+		}
+	}
+```
+
 ### Parameters ###
 
 Name and value are strings


### PR DESCRIPTION
`vsprops` was added in #2112 with the following API:

```lua
vsprops {
  Name1 = "value1",
  Name2 = "value2",
}
```
This is a useful addition. However, nested properties are not allowed, and only one level of properties can be added to the project XML. This change enables nested properties. This is useful for custom tooling/extensions for Visual Studio.

This is not a breaking change for the original behaviour, it only adds nested `vsprops`:

```lua
vsprops {
  Name1 = "value1",
  Name2 = {
     Name3 = "value3"
  }
}
```
Translating to:
```
<Name1>Value1</Name1>
<Name2>
  <Name3>Value3</Name3>
</Name2>
```
While editing the file, I took the opportunity to remove unnecessary harmless extra spaces from a few lines in `modules/vstudio/vs2010_vcxproj.lua`, my IDE formatted them.

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes