### PR TITLE
Fix `gmake`/`gmake2` action mixing up compilers

### DIFF
--- a/modules/gmake/tests/cpp/test_tools.lua
+++ b/modules/gmake/tests/cpp/test_tools.lua
@@ -30,6 +30,15 @@
 	function suite.usesCorrectTools()
 		make.cppTools(cfg, p.tools.gcc)
 		test.capture [[
+  ifeq ($(origin CC), default)
+    CC = gcc
+  endif
+  ifeq ($(origin CXX), default)
+    CXX = g++
+  endif
+  ifeq ($(origin AR), default)
+    AR = ar
+  endif
   RESCOMP = windres
 		]]
 	end

--- a/modules/gmake2/tests/test_gmake2_tools.lua
+++ b/modules/gmake2/tests/test_gmake2_tools.lua
@@ -28,9 +28,34 @@
 -- Make sure that the correct tools are used.
 --
 
-	function suite.usesCorrectTools()
+	function suite.usesCorrectTools_gcc()
 		gmake2.cpp.tools(cfg, p.tools.gcc)
 		test.capture [[
+ifeq ($(origin CC), default)
+  CC = gcc
+endif
+ifeq ($(origin CXX), default)
+  CXX = g++
+endif
+ifeq ($(origin AR), default)
+  AR = ar
+endif
+RESCOMP = windres
+		]]
+	end
+
+	function suite.usesCorrectTools_clang()
+		gmake2.cpp.tools(cfg, p.tools.clang)
+		test.capture [[
+ifeq ($(origin CC), default)
+  CC = clang
+endif
+ifeq ($(origin CXX), default)
+  CXX = clang++
+endif
+ifeq ($(origin AR), default)
+  AR = ar
+endif
 RESCOMP = windres
 		]]
 	end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -681,8 +681,5 @@
 		else
 			version = ""
 		end
-		if ((cfg.gccprefix  or version ~= "") and gcc.tools[tool]) or tool == "rc" then
-			return (cfg.gccprefix or "") .. gcc.tools[tool] .. version
-		end
-		return nil
+		return (cfg.gccprefix or "") .. gcc.tools[tool] .. version
 	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -33,9 +33,18 @@
 
 	function suite.tools_onDefaults()
 		prepare()
-		test.isnil(gcc.gettoolname(cfg, "cc"))
-		test.isnil(gcc.gettoolname(cfg, "cxx"))
-		test.isnil(gcc.gettoolname(cfg, "ar"))
+		test.isequal("gcc", gcc.gettoolname(cfg, "cc"))
+		test.isequal("g++", gcc.gettoolname(cfg, "cxx"))
+		test.isequal("ar", gcc.gettoolname(cfg, "ar"))
+		test.isequal("windres", gcc.gettoolname(cfg, "rc"))
+	end
+
+	function suite.tools_withGcc()
+		toolset "gcc"
+		prepare()
+		test.isequal("gcc", gcc.gettoolname(cfg, "cc"))
+		test.isequal("g++", gcc.gettoolname(cfg, "cxx"))
+		test.isequal("ar", gcc.gettoolname(cfg, "ar"))
 		test.isequal("windres", gcc.gettoolname(cfg, "rc"))
 	end
 


### PR DESCRIPTION
Due to Make behavior, specifically its default values to the CC and CXX implicit rules, we could end up in a scenario where the gcc and clang compilers would be used in the same project.

Be more explicit and do not rely on using the system default compilers, and use the `gcc` and `g++` compilers explicitly.

Fixes https://github.com/premake/premake-core/issues/2207.
