### PR TITLE
Add `os.getnumcpus` function to get number of logical CPU cores.

### DIFF
--- a/src/host/os_getnumcpus.c
+++ b/src/host/os_getnumcpus.c
@@ -1,0 +1,91 @@
+/**
+ * \file   os_getnumcpus.c
+ * \brief  Retrieve the logical number of CPUs of the host system.
+ * \author Copyright (c) 2002-2024 Jason Perkins and the Premake project
+ */
+
+#if __linux__
+#define _GNU_SOURCE
+#endif
+
+#include "premake.h"
+
+#if PLATFORM_LINUX
+#include <sched.h>
+#elif PLATFORM_SOLARIS | PLATFORM_AIX | PLATFORM_MACOSX | PLATFORM_BSD
+#include <sys/sysctl.h>
+#elif PLATFORM_WINDOWS
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+int do_getnumcpus()
+{
+#if PLATFORM_WINDOWS
+	SYSTEM_INFO sysinfo;
+	GetSystemInfo(&sysinfo);
+	return sysinfo.dwNumberOfProcessors;
+#elif PLATFORM_LINUX
+	cpu_set_t set;
+	int count, i;
+
+	if (sched_getaffinity(0, sizeof(cpu_set_t), &set) != -1)
+	{
+		count = 0;
+		for (i = 0; i < CPU_SETSIZE; i++)
+		{
+			if (CPU_ISSET(i, &set))
+			{
+				count++;
+			}
+		}
+
+		return count;
+	}
+	else
+	{
+		return 0;
+	}
+#elif PLATFORM_SOLARIS | PLATFORM_AIX | PLATFORM_MACOSX
+	return sysconf(_SC_NPROCESSORS_ONLN);
+#elif PLATFORM_BSD
+	int mib[4];
+	int numCPU;
+	size_t len = sizeof(numCPU);
+
+	/* set the mib for hw.ncpu */
+	mib[0] = CTL_HW;
+	mib[1] = HW_AVAILCPU;  // alternatively, try HW_NCPU;
+
+	/* get the number of CPUs from the system */
+	sysctl(mib, 2, &numCPU, &len, NULL, 0);
+
+	if (numCPU < 1)
+	{
+		mib[1] = HW_NCPU;
+		sysctl(mib, 2, &numCPU, &len, NULL, 0);
+		if (numCPU < 1)
+			return 0;
+	}
+
+	return numCPU;
+#else
+	#warning do_getnumcpus is not implemented for your platform yet
+	return 0;
+#endif
+}
+
+int os_getnumcpus(lua_State* L)
+{
+	int result = do_getnumcpus();
+	if (result > 0)
+	{
+		lua_pushinteger(L, result);
+		return 1;
+	}
+	else
+	{
+		return 0;
+	}
+}
+

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -66,6 +66,7 @@ static const luaL_Reg os_functions[] = {
 	{ "_is64bit",               os_is64bit              },
 	{ "isdir",                  os_isdir                },
 	{ "getcwd",                 os_getcwd               },
+	{ "getnumcpus",             os_getnumcpus           },
 	{ "getpass",                os_getpass              },
 	{ "getWindowsRegistry",     os_getWindowsRegistry   },
 	{ "listWindowsRegistry",    os_listWindowsRegistry  },

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -121,6 +121,7 @@ int os_chmod(lua_State* L);
 int os_comparefiles(lua_State* L);
 int os_copyfile(lua_State* L);
 int os_getcwd(lua_State* L);
+int os_getnumcpus(lua_State* L);
 int os_getpass(lua_State* L);
 int os_getWindowsRegistry(lua_State* L);
 int os_listWindowsRegistry(lua_State* L);

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -488,3 +488,13 @@
 		test.isequal(true, ok)
 		test.isnil(err)
 	end
+
+
+--
+-- os.getnumcpus() tests.
+--
+
+	function suite.numcpus()
+		local numcpus = os.getnumcpus()
+		test.istrue(numcpus > 0)
+	end

--- a/website/docs/os.getnumcpus.md
+++ b/website/docs/os.getnumcpus.md
@@ -1,0 +1,17 @@
+Gets the number of logical CPU cores.
+
+```lua
+os.getnumcpus()
+```
+
+### Parameters ###
+
+None.
+
+### Return Value ###
+
+The number of logical CPU cores of the running system.
+
+### Availability ###
+
+Premake 5.0.0 beta 3 or later.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -375,6 +375,7 @@ module.exports = {
 						'os.findlib',
 						'os.get',
 						'os.getcwd',
+						'os.getnumcpus',
 						'os.getpass',
 						'os.getversion',
 						'os.host',


### PR DESCRIPTION
**What does this PR do?**

Adds a new `os.getnumcpus` API to get the number of logical CPU cores.

This can be helpful to know the parameter to pass to `make -j` flag, which in my case I need to generate correct VS Code tasks files. 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes