### PR TITLE
Introduce a tools `getrelative` function to allow relative path customization.

### DIFF
--- a/src/base/tools.lua
+++ b/src/base/tools.lua
@@ -59,3 +59,14 @@
 		local parts = identifier:explode("-", true, 1)
 		return p.tools[parts[1]], parts[2]
 	end
+
+
+--
+-- Returns the relative path to passed value for the given project.
+-- This can be overriden by actions to allow for more customized relative
+-- path behaviors.
+--
+
+	function p.tools.getrelative(prj, value)
+		return p.project.getrelative(prj, value)
+	end

--- a/src/tools/dotnet.lua
+++ b/src/tools/dotnet.lua
@@ -286,7 +286,7 @@
 		table.insert(flags, '/noconfig')
 
 		if cfg.project.icon then
-			local fn = project.getrelative(cfg.project, cfg.project.icon)
+			local fn = p.tools.getrelative(cfg.project, cfg.project.icon)
 			table.insert(flags, string.format('/win32icon:"%s"', fn))
 		end
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -289,7 +289,7 @@
 		local result = {}
 
 		table.foreachi(cfg.forceincludes, function(value)
-			local fn = project.getrelative(cfg.project, value)
+			local fn = p.tools.getrelative(cfg.project, value)
 			table.insert(result, string.format('-include %s', p.quoted(fn)))
 		end)
 
@@ -322,24 +322,24 @@
 	function gcc.getincludedirs(cfg, dirs, extdirs, frameworkdirs, includedirsafter)
 		local result = {}
 		for _, dir in ipairs(dirs) do
-			dir = project.getrelative(cfg.project, dir)
+			dir = p.tools.getrelative(cfg.project, dir)
 			table.insert(result, '-I' .. p.quoted(dir))
 		end
 
 		if table.contains(os.getSystemTags(cfg.system), "darwin") then
 			for _, dir in ipairs(frameworkdirs or {}) do
-				dir = project.getrelative(cfg.project, dir)
+				dir = p.tools.getrelative(cfg.project, dir)
 				table.insert(result, '-F' .. p.quoted(dir))
 			end
 		end
 
 		for _, dir in ipairs(extdirs or {}) do
-			dir = project.getrelative(cfg.project, dir)
+			dir = p.tools.getrelative(cfg.project, dir)
 			table.insert(result, '-isystem ' .. p.quoted(dir))
 		end
 
 		for _, dir in ipairs(includedirsafter or {}) do
-			dir = project.getrelative(cfg.project, dir)
+			dir = p.tools.getrelative(cfg.project, dir)
 			table.insert(result, '-idirafter ' .. p.quoted(dir))
 		end
 
@@ -370,18 +370,18 @@
 		-- test locally in the project folder first (this is the most likely location)
 		local testname = path.join(cfg.project.basedir, pch)
 		if os.isfile(testname) then
-			return project.getrelative(cfg.project, testname)
+			return p.tools.getrelative(cfg.project, testname)
 		else
 			-- else scan in all include dirs.
 			for _, incdir in ipairs(cfg.includedirs) do
 				testname = path.join(incdir, pch)
 				if os.isfile(testname) then
-					return project.getrelative(cfg.project, testname)
+					return p.tools.getrelative(cfg.project, testname)
 				end
 			end
 		end
 
-		return project.getrelative(cfg.project, path.getabsolute(pch))
+		return p.tools.getrelative(cfg.project, path.getabsolute(pch))
 	end
 
 --
@@ -535,14 +535,14 @@
 
 		if table.contains(os.getSystemTags(cfg.system), "darwin") then
 			for _, dir in ipairs(cfg.frameworkdirs) do
-				dir = project.getrelative(cfg.project, dir)
+				dir = p.tools.getrelative(cfg.project, dir)
 				table.insert(flags, '-F' .. p.quoted(dir))
 			end
 		end
 
 		if cfg.flags.RelativeLinks then
 			for _, dir in ipairs(config.getlinks(cfg, "siblings", "directory")) do
-				local libFlag = "-L" .. p.project.getrelative(cfg.project, dir)
+				local libFlag = "-L" .. p.tools.getrelative(cfg.project, dir)
 				if not table.contains(flags, libFlag) then
 					table.insert(flags, libFlag)
 				end

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -280,7 +280,7 @@
 		local result = {}
 
 		table.foreachi(cfg.forceincludes, function(value)
-			local fn = project.getrelative(cfg.project, value)
+			local fn = p.tools.getrelative(cfg.project, value)
 			table.insert(result, "/FI" .. p.quoted(fn))
 		end)
 
@@ -298,12 +298,12 @@
 	function msc.getincludedirs(cfg, dirs, extdirs, frameworkdirs, includedirsafter)
 		local result = {}
 		for _, dir in ipairs(dirs) do
-			dir = project.getrelative(cfg.project, dir)
+			dir = p.tools.getrelative(cfg.project, dir)
 			table.insert(result, '-I' ..  p.quoted(dir))
 		end
 
 		for _, dir in ipairs(extdirs or {}) do
-			dir = project.getrelative(cfg.project, dir)
+			dir = p.tools.getrelative(cfg.project, dir)
 			if isVersionGreaterOrEqualTo(cfg.toolset, "msc-v142") then
 				table.insert(result, '/external:I' ..  p.quoted(dir))
 			else
@@ -312,7 +312,7 @@
 		end
 
 		for _, dir in ipairs(includedirsafter or {}) do
-			dir = project.getrelative(cfg.project, dir)
+			dir = p.tools.getrelative(cfg.project, dir)
 			if isVersionGreaterOrEqualTo(cfg.toolset, "msc-v142") then
 				table.insert(result, '/external:I' ..  p.quoted(dir))
 			else
@@ -394,7 +394,7 @@
 		local flags = {}
 		local dirs = table.join(cfg.libdirs, cfg.syslibdirs)
 		for i, dir in ipairs(dirs) do
-			dir = project.getrelative(cfg.project, dir)
+			dir = p.tools.getrelative(cfg.project, dir)
 			table.insert(flags, '/LIBPATH:"' .. dir .. '"')
 		end
 		return flags


### PR DESCRIPTION
This just centralizes all `project.getrelative` in the GCC toolset, allowing for customization by external code, by overriding this function.

This is needed for instance in Ninja generators, when the location of a project is not the workspace location, but the code of the Ninja file itself should still refer to workspace-relative paths.
