### PR TITLE
Add clangtidy for gmake2

### DIFF
--- a/modules/gmake2/tests/_tests.lua
+++ b/modules/gmake2/tests/_tests.lua
@@ -3,6 +3,7 @@ require ("gmake2")
 return {
 	"test_gmake2_buildcmds.lua",
 	"test_gmake2_clang.lua",
+	"test_gmake2_clangtidy.lua",
 	"test_gmake2_file_rules.lua",
 	"test_gmake2_flags.lua",
 	"test_gmake2_includes.lua",

--- a/modules/gmake2/tests/test_gmake2_clangtidy.lua
+++ b/modules/gmake2/tests/test_gmake2_clangtidy.lua
@@ -1,0 +1,45 @@
+--
+-- test_gmake2_clangtidy.lua
+-- Test ClangTidy support in Makefiles.
+--
+
+local suite = test.declare("gmake2_clangtidy")
+local gmake2 = premake.modules.gmake2
+
+local wks, prj, cfg
+
+function suite.setup()
+	wks = workspace("MyWorkspace")
+	configurations { "Debug", "Release" }
+  targetname "blink"
+	kind "StaticLib"
+	language "C++"
+	prj = test.createProject(wks)
+end
+
+local function prepare()
+	wks = test.getWorkspace(wks)
+	prj = test.getproject(wks, 1)
+	cfg = test.getconfig(prj, "Debug")
+  gmake2.cpp.clangtidy(cfg, toolset)
+  files { "src/hello.cpp", "src/hello2.c" }
+
+end
+
+function suite.clangtidyOn()
+  clangtidy "On"
+
+	prepare()
+
+  test.capture [[
+CLANG_TIDY = clang-tidy
+  ]]
+end
+
+function suite.clangtidyOff()
+	prepare()
+
+  test.capture [[
+CLANG_TIDY = \#
+  ]]
+end

--- a/modules/gmake2/tests/test_gmake2_file_rules.lua
+++ b/modules/gmake2/tests/test_gmake2_file_rules.lua
@@ -94,9 +94,11 @@
 
 $(OBJDIR)/hello.o: src/greetings/hello.cpp
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/hello1.o: src/hello.cpp
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 
 		]]
@@ -119,6 +121,7 @@ $(OBJDIR)/hello.o: src/hello.c
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/test.o: src/test.cpp
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 
 		]]
@@ -139,6 +142,7 @@ $(OBJDIR)/test.o: src/test.cpp
 
 $(OBJDIR)/hello.o: src/hello.c
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/test.o: src/test.c
 	@echo "$(notdir $<)"
@@ -166,6 +170,7 @@ $(OBJDIR)/test.o: src/test.c
 ifeq ($(config),debug)
 $(OBJDIR)/hello.o: src/hello.c
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 
 else ifeq ($(config),release)

--- a/modules/gmake2/tests/test_gmake2_pch.lua
+++ b/modules/gmake2/tests/test_gmake2_pch.lua
@@ -70,9 +70,11 @@
 
 $(OBJDIR)/a.o: a.cpp
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/b.o: b.cpp
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 ]]
 	end
@@ -194,9 +196,11 @@ PCH = ../../../../src/host/premake.h
 
 $(OBJDIR)/a.o: a.cpp
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/b.o: b.cpp
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 ]]
 	end
@@ -216,9 +220,11 @@ $(OBJDIR)/b.o: b.cpp
 
 $(OBJDIR)/a.o: a.cpp
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/b.o: b.cpp
 	@echo "$(notdir $<)"
+	$(SILENT) $(CLANG_TIDY) "$<" -- -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 ]]
 	end

--- a/website/docs/clangtidy.md
+++ b/website/docs/clangtidy.md
@@ -1,6 +1,6 @@
 Enables clang-tidy code analysis for Visual Studio.
 
-The `clangtidy` option enables running clang-tidy code analysis in Visual Studio projects.
+The `clangtidy` option enables running clang-tidy code analysis in Visual Studio and gmake2 projects.
 
 ```lua
 clangtidy("value")
@@ -19,7 +19,7 @@ The `config` scope.
 
 ### Availability ###
 
-Premake 5.0.0 beta 3 or later for Visual Studio 2019 and later.
+Premake 5.0.0 beta 3 or later. Implemented for Visual Studio 2019 and later, and gmake2.
 
 ### See Also ###
 


### PR DESCRIPTION
ClangTidy code checks have been added to the Visual Studio generator in #2187. A request for the equivalent in gmake2 has been made in #2245 as well as in [this](https://github.com/premake/premake-core/pull/2187#discussion_r1494649407) comment. Static analysis is a necessary tool for software developers.

This PR enables clang tidy for gmake2 at the configuration level. It adds a build command to the cpp rule enforcing the checks.

When clangtidy is Off, the build command enforcing clang tidy expands to a no-op, and it is skipped. When clangtidy is On, the command first runs clang tidy on the file, and then compiles it if the checks are successful. This method of working allows finishing the build early if clang tidy fails. This is also how the Visual Studio generator works, as well as how CMake implements clang tidy.

Closes #2245 

I may need more help with this PR. Due to the invasive nature of the changes (a new build command is added to the makefile, which may understandably make the code reviewers uncomfortable), the following alternatives were considered:

1. Add a pre/post build command performing clang tidy checks on all files. This is not possible as it requires a compile_commands.json file, and would probably run every time the build is run. Not a good idea.
2. Conditionally add the build rule only if `clangtidy` is On. I don't know how to do this, because `cfg.clangtidy` does not seem to be available during `cpp.initialize`.

Because of these reasons, I instead decided to go with the implementation in this PR.

Future work is possible to make clang tidy in premake more powerful:

1. Enable per-file clang tidy.
2. Set clang tidy location.
3. Set clang tidy additional args, including config file location.
4. etc etc.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes