### PR TITLE
Fix shared library $ORIGIN escape for non-gmake actions.

### DIFF
--- a/modules/gmake/tests/cpp/test_make_linking.lua
+++ b/modules/gmake/tests/cpp/test_make_linking.lua
@@ -18,6 +18,7 @@
 
 	function suite.setup()
 		_TARGET_OS = "linux"
+		_ACTION = "gmake"
 		wks, prj = test.createWorkspace()
 	end
 

--- a/modules/gmake2/tests/test_gmake2_linking.lua
+++ b/modules/gmake2/tests/test_gmake2_linking.lua
@@ -20,6 +20,7 @@
 
 	function suite.setup()
 		_OS = "linux"
+		_ACTION = "gmake2"
 		wks, prj = test.createWorkspace()
 	end
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -412,7 +412,12 @@
 				rpath = "@loader_path/" .. rpath
 			elseif (cfg.system == p.LINUX) then
 				rpath = iif(rpath == ".", "", "/" .. rpath)
-				rpath = "$$ORIGIN" .. rpath
+				local origin = "$ORIGIN"
+				-- need to escape the $ for make if using gmake actions
+				if string.startswith(_ACTION, "gmake") then
+					origin = "$" .. origin
+				end
+				rpath = origin .. rpath
 			end
 
 			if mode == "linker" then


### PR DESCRIPTION
**What does this PR do?**

Fixes toolset ldflags code to only escape `$` when targetting gmake-based generators.

**Anything else we should know?**

This will allow the Ninja generator to support `runpathdirs`.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
