### PR TITLE
Add a `os.hostarch()` function to get the host system architecture.

### DIFF
--- a/src/host/os_hostarch.c
+++ b/src/host/os_hostarch.c
@@ -1,0 +1,13 @@
+/**
+ * \file   os_hostarch.c
+ * \brief  Get the architecture for the current host OS we're executing on.
+ * \author Copyright (c) 2014-2024 Jason Perkins and the Premake project
+ */
+
+#include "premake.h"
+
+int os_hostarch(lua_State* L)
+{
+	lua_pushstring(L, PLATFORM_ARCHITECTURE);
+	return 1;
+}

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -72,6 +72,7 @@ static const luaL_Reg os_functions[] = {
 	{ "listWindowsRegistry",    os_listWindowsRegistry  },
 	{ "getversion",             os_getversion           },
 	{ "host",                   os_host                 },
+	{ "hostarch",               os_hostarch             },
 	{ "isfile",                 os_isfile               },
 	{ "islink",                 os_islink               },
 	{ "locate",                 os_locate               },

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -45,6 +45,18 @@
 
 #define PLATFORM_POSIX  (PLATFORM_LINUX || PLATFORM_BSD || PLATFORM_MACOSX || PLATFORM_SOLARIS || PLATFORM_HAIKU)
 
+#if defined(__x86_64__) || defined(__x86_64) || defined(__amd64__) || defined(__amd64) || \
+    defined(_M_X64) || defined(_M_AMD64)
+#define PLATFORM_ARCHITECTURE "x86_64"
+#elif defined(i386) || defined(__i386) || defined(__i386__) || defined(__i486__) || defined(__i586__) || \
+    defined(__i686__) || defined(_M_IX86)|| defined(__X86__) || defined(_X86_)
+#define PLATFORM_ARCHITECTURE "x86"
+#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__AARCH64EL__) || defined(__arm64)
+#define PLATFORM_ARCHITECTURE "ARM64"
+#elif defined(__arm__) || defined(__thumb__) || defined(__TARGET_ARCH_ARM) || defined(__TARGET_ARCH_THUMB) || \
+    defined(__ARM) || defined(_M_ARM) || defined(_M_ARM_T) || defined(__ARM_ARCH)
+#define PLATFORM_ARCHITECTURE "ARM"
+#endif
 
 /* Pull in platform-specific headers required by built-in functions */
 #if PLATFORM_WINDOWS
@@ -127,6 +139,7 @@ int os_getWindowsRegistry(lua_State* L);
 int os_listWindowsRegistry(lua_State* L);
 int os_getversion(lua_State* L);
 int os_host(lua_State* L);
+int os_hostarch(lua_State* L);
 int os_is64bit(lua_State* L);
 int os_isdir(lua_State* L);
 int os_isfile(lua_State* L);

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -498,3 +498,13 @@
 		local numcpus = os.getnumcpus()
 		test.istrue(numcpus > 0)
 	end
+
+
+--
+-- os.hostarch() tests.
+--
+
+	function suite.hostarch()
+		local arch = os.hostarch()
+		test.istrue(string.len(arch) > 0)
+	end

--- a/website/docs/Lua-Library-Additions.md
+++ b/website/docs/Lua-Library-Additions.md
@@ -39,6 +39,7 @@
 * [os.getpass](os.getpass.md)
 * [os.getversion](os.getversion.md)
 * [os.host](os.host.md)
+* [os.hostarch](os.hostarch.md)
 * [os.is](os.is.md)
 * [os.is64bit](os.is64bit.md)
 * [os.isdir](os.isdir.md)

--- a/website/docs/os.hostarch.md
+++ b/website/docs/os.hostarch.md
@@ -1,0 +1,31 @@
+Identify the architecture for the currently executing operating system.
+
+```lua
+id = os.hostarch()
+```
+
+### Parameters ###
+
+None.
+
+### Return Value ###
+
+An architecture identifier; see [architecture()](architecture.md) for a complete list of identifiers.
+
+Note that this function returns the architecture for the OS that Premake is currently running on, which is not necessarily the same as the architecture that Premake is generating files for.
+
+### Availability ###
+
+Premake 5.0.0 beta 3 or later.
+
+### Examples ###
+
+```lua
+if os.hostarch() == "x86_64" then
+   -- do something x64-specific
+end
+```
+
+### See Also ###
+
+* [architecture](architecture.md)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -387,6 +387,7 @@ module.exports = {
 						'os.getpass',
 						'os.getversion',
 						'os.host',
+						'os.hostarch',
 						'os.is',
 						'os.is64bit',
 						'os.isdir',


### PR DESCRIPTION
**What does this PR do?**

Add a `os.hostarch()` function to get the host system architecture.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
