### PR TITLE
Add `term.clearToEndOfLine` and `term.moveLeft` API additions.

### DIFF
--- a/src/base/term.lua
+++ b/src/base/term.lua
@@ -43,3 +43,11 @@ function term.popColor()
 		term.setTextColor(color)
 	end
 end
+
+function term.clearToEndOfLine()
+	io.write("\027[K")
+end
+
+function term.moveLeft(n)
+	io.write(string.format("\027[%sD", n))
+end

--- a/website/docs/Lua-Library-Additions.md
+++ b/website/docs/Lua-Library-Additions.md
@@ -128,6 +128,8 @@
 * [term.setTextColor](term.setTextColor.md)
 * [term.pushColor](term.pushColor.md)
 * [term.popColor](term.popColor.md)
+* [term.clearToEndOfLine](term.clearToEndOfLine.md)
+* [term.moveLeft](term.moveLeft.md)
 
 ### Zip
 

--- a/website/docs/term.clearToEndOfLine.md
+++ b/website/docs/term.clearToEndOfLine.md
@@ -1,0 +1,24 @@
+Clears the console from the cursor location to the end of the line.
+
+```lua
+term.clearToEndOfLine()
+```
+
+### Parameters ###
+None
+
+### Return Value ###
+None
+
+### Example ###
+``` lua
+term.clearToEndOfLine()
+```
+
+### See Also ###
+* [term.moveLeft](term.moveLeft.md)
+
+### Availability ###
+
+Premake 5.0.0 beta 3 or later.
+

--- a/website/docs/term.moveLeft.md
+++ b/website/docs/term.moveLeft.md
@@ -1,0 +1,24 @@
+Moves the console cursor left by a number of columns.
+
+```lua
+term.moveLeft(columns)
+```
+
+### Parameters ###
+`columns` is the number of columns to move left.
+
+### Return Value ###
+None
+
+### Example ###
+``` lua
+term.moveLeft(2)
+```
+
+### See Also ###
+* [term.clearToEndOfLine](term.clearToEndOfLine.md)
+
+### Availability ###
+
+Premake 5.0.0 beta 3 or later.
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -489,10 +489,11 @@ module.exports = {
 					label: 'term',
 					items: [
 						'term.getTextColor',
+						'term.setTextColor',
 						'term.popColor',
 						'term.pushColor',
-						'term.setTextColor',
-						'term.clearToEndOfLine'
+						'term.clearToEndOfLine',
+						'term.moveLeft'
 					]
 				},
 				{

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -491,7 +491,8 @@ module.exports = {
 						'term.getTextColor',
 						'term.popColor',
 						'term.pushColor',
-						'term.setTextColor'
+						'term.setTextColor',
+						'term.clearToEndOfLine'
 					]
 				},
 				{


### PR DESCRIPTION
**What does this PR do?**

Adds `term.clearToEndOfLine` and `term.moveLeft` APIs to `term`.

**Anything else we should know?**

These depend on ANSI escape codes, which from what I've read Windows now supports.

Haven't tested it on Windows yet and I think support for it needs to be explicitly enabled: https://superuser.com/a/1300251

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

