### PR TITLE
Move sanitize, visibility and inlinesvisibility to shared table.

### DIFF
--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -65,7 +65,10 @@
 		symbols = gcc.shared.symbols,
 		unsignedchar = gcc.shared.unsignedchar,
 		omitframepointer = gcc.shared.omitframepointer,
-		compileas = gcc.shared.compileas
+		compileas = gcc.shared.compileas,
+		sanitize = gcc.shared.sanitize,
+		visibility = gcc.shared.visibility,
+		inlinesvisibility = gcc.shared.inlinesvisibility
 	}
 
 	clang.cflags = table.merge(gcc.cflags, {

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -138,6 +138,18 @@
 			["C++"] = "-x c++",
 			["Objective-C"] = "-x objective-c",
 			["Objective-C++"] = "-x objective-c++",
+		},
+		sanitize = {
+			Address = "-fsanitize=address",
+		},
+		visibility = {
+			Default = "-fvisibility=default",
+			Hidden = "-fvisibility=hidden",
+			Internal = "-fvisibility=internal",
+			Protected = "-fvisibility=protected",
+		},
+		inlinesvisibility = {
+			Hidden = "-fvisibility-inlines-hidden"
 		}
 	}
 
@@ -230,18 +242,6 @@
 		},
 		rtti = {
 			Off = "-fno-rtti"
-		},
-		sanitize = {
-			Address = "-fsanitize=address",
-		},
-		visibility = {
-			Default = "-fvisibility=default",
-			Hidden = "-fvisibility=hidden",
-			Internal = "-fvisibility=internal",
-			Protected = "-fvisibility=protected",
-		},
-		inlinesvisibility = {
-			Hidden = "-fvisibility-inlines-hidden"
 		}
 	}
 

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -389,6 +389,7 @@
 		sanitize { "Address" }
 		prepare()
 		test.contains({ "-fsanitize=address" }, gcc.getcxxflags(cfg))
+		test.contains({ "-fsanitize=address" }, gcc.getcflags(cfg))
 		test.contains({ "-fsanitize=address" }, gcc.getldflags(cfg))
 	end
 
@@ -1083,28 +1084,28 @@
 	function suite.cxxflags_onVisibilityDefault()
 		visibility "Default"
 		prepare()
-		test.excludes({ "-fvisibility=default" }, gcc.getcflags(cfg))
+		test.contains({ "-fvisibility=default" }, gcc.getcflags(cfg))
 		test.contains({ "-fvisibility=default" }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cxxflags_onVisibilityHidden()
 		visibility "Hidden"
 		prepare()
-		test.excludes({ "-fvisibility=hidden" }, gcc.getcflags(cfg))
+		test.contains({ "-fvisibility=hidden" }, gcc.getcflags(cfg))
 		test.contains({ "-fvisibility=hidden" }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cxxflags_onVisibilityInternal()
 		visibility "Internal"
 		prepare()
-		test.excludes({ "-fvisibility=internal" }, gcc.getcflags(cfg))
+		test.contains({ "-fvisibility=internal" }, gcc.getcflags(cfg))
 		test.contains({ "-fvisibility=internal" }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cxxflags_onVisibilityProtected()
 		visibility "Protected"
 		prepare()
-		test.excludes({ "-fvisibility=protected" }, gcc.getcflags(cfg))
+		test.contains({ "-fvisibility=protected" }, gcc.getcflags(cfg))
 		test.contains({ "-fvisibility=protected" }, gcc.getcxxflags(cfg))
 	end
 
@@ -1122,7 +1123,7 @@
 	function suite.cxxflags_onInlinesVisibilityHidden()
 		inlinesvisibility "Hidden"
 		prepare()
-		test.excludes({ "-fvisibility-inlines-hidden" }, gcc.getcflags(cfg))
+		test.contains({ "-fvisibility-inlines-hidden" }, gcc.getcflags(cfg))
 		test.contains({ "-fvisibility-inlines-hidden" }, gcc.getcxxflags(cfg))
 	end
 


### PR DESCRIPTION
This enable sanitizer flags for C lang.

**What does this PR do?**

Enable gcc sanitizer and visibility flags for C language.

**How does this PR change Premake's behavior?**

Adds sanitize and visibility to C

**Anything else we should know?**

closes #2033

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
