### PR TITLE
Extracts target dir compute from `config.buildtargetinfo` into `config.targetdir`

### DIFF
--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -11,6 +11,27 @@
 	local project = p.project
 	local config = p.config
 
+---
+-- Helper function to get the target directory for a config or project.
+--
+-- @param cfg
+--    The configuration object or project being queried.
+	function config.targetdir(cfg)
+		if cfg.targetdir then
+			return cfg.targetdir
+		end
+
+		local basedir = cfg.location
+
+		local targetdir
+		if cfg.platform then
+			targetdir = path.join(basedir, 'bin', cfg.platform, cfg.buildcfg)
+		else
+			targetdir = path.join(basedir, 'bin', cfg.buildcfg)
+		end
+
+		return targetdir
+	end
 
 ---
 -- Helper function for getlinkinfo() and gettargetinfo(); builds the
@@ -29,16 +50,8 @@
 ---
 
 	function config.buildtargetinfo(cfg, kind, field)
-		local basedir = cfg.project.location
-
-		local targetdir
-		if cfg.platform then
-			targetdir = path.join(basedir, 'bin', cfg.platform, cfg.buildcfg)
-		else
-			targetdir = path.join(basedir, 'bin', cfg.buildcfg)
-		end
-
-		local directory = cfg[field.."dir"] or cfg.targetdir or targetdir
+		local targetdir = config.targetdir(cfg)
+		local directory = cfg[field.."dir"] or targetdir
 		local basename = cfg[field.."name"] or cfg.targetname or cfg.project.name
 
 		local prefix = cfg[field.."prefix"] or cfg.targetprefix or ""


### PR DESCRIPTION
This adds a new internal helper API to get the target dir of a config or project: `config.targetdir`, which is a refactor of the existing logic.

I needed a way to access the `targetdir` of a project pre-bake, which was not possible before. With the new `config.targetdir` function its straightforward to get it.
