### PR TITLE
Use `stdbool.h` instead of defining custom bool types.

### DIFF
--- a/src/host/os_compile.c
+++ b/src/host/os_compile.c
@@ -46,7 +46,7 @@ int os_compile(lua_State* L)
 			return 2;
 		}
 
-		lua_dump(P, writer, outputFile, FALSE);
+		lua_dump(P, writer, outputFile, false);
 		fclose(outputFile);
 
 		lua_close(P);

--- a/src/host/os_copyfile.c
+++ b/src/host/os_copyfile.c
@@ -29,7 +29,7 @@ int os_copyfile(lua_State* L)
 		return lua_error(L);
 	}
 
-	z = CopyFileW(wide_src, wide_dst, FALSE);
+	z = CopyFileW(wide_src, wide_dst, false);
 #else
 	lua_pushfstring(L, "cp \"%s\" \"%s\"", src, dst);
 	z = (system(lua_tostring(L, -1)) == 0);

--- a/src/host/os_getversion.c
+++ b/src/host/os_getversion.c
@@ -75,11 +75,11 @@ int getKernelVersion(struct OsVersionInfo* info)
 				info->majorversion = HIWORD(fileInfo->dwProductVersionMS);
 				info->minorversion = LOWORD(fileInfo->dwProductVersionMS);
 				info->revision = HIWORD(fileInfo->dwProductVersionLS);
-				return TRUE;
+				return true;
 			}
 		}
 	}
-	return FALSE;
+	return false;
 }
 
 int getversion(struct OsVersionInfo* info)
@@ -119,7 +119,7 @@ int getversion(struct OsVersionInfo* info)
 int getversion(struct OsVersionInfo* info)
 {
 	const char * propertyListFilePath = "/System/Library/CoreServices/SystemVersion.plist";
-	Boolean fallback = TRUE;
+	Boolean fallback = true;
 
 	info->description = "Mac OS";
 	info->majorversion = 10;
@@ -133,7 +133,7 @@ int getversion(struct OsVersionInfo* info)
 		CFReadStreamRef streamRef = NULL;
 		CFPropertyListRef propertyListRef = NULL;
 		CFTypeID typeId = 0;
-		Boolean result = FALSE;
+		Boolean result = false;
 
 		stringRef = CFStringCreateWithCStringNoCopy(
 						kCFAllocatorDefault,
@@ -165,7 +165,7 @@ int getversion(struct OsVersionInfo* info)
 
 		result = CFReadStreamOpen (streamRef);
 
-		if (result == FALSE)
+		if (result == false)
 		{
 			goto getversion_macosx_cleanup;
 		}
@@ -196,7 +196,7 @@ int getversion(struct OsVersionInfo* info)
 				CFStringGetCString(stringValueRef, &versionString[0], (CFIndex)sizeof (versionString), kCFStringEncodingASCII);
 				sscanf (versionString, "%d.%d.%d", &info->majorversion, &info->minorversion, &info->revision);
 
-				fallback = FALSE;
+				fallback = false;
 			}
 		}
 
@@ -208,7 +208,7 @@ getversion_macosx_cleanup:
 		if (stringRef) CFRelease (stringRef);
 	}
 
-	if (fallback == TRUE)
+	if (fallback == true)
 	{
 		int mib[] = { CTL_KERN, KERN_OSRELEASE };
 		size_t len;

--- a/src/host/os_is64bit.c
+++ b/src/host/os_is64bit.c
@@ -16,7 +16,7 @@ int os_is64bit(lua_State* L)
 	WowFuncSig func = (WowFuncSig)GetProcAddress(GetModuleHandle(TEXT("kernel32")), "IsWow64Process");
 	if (func)
 	{
-		BOOL isWow = FALSE;
+		BOOL isWow = false;
 		if (func(GetCurrentProcess(), &isWow))
 		{
 			lua_pushboolean(L, isWow);

--- a/src/host/os_touchfile.c
+++ b/src/host/os_touchfile.c
@@ -17,13 +17,6 @@
 	#include <sys/types.h>
 #endif
 
-#ifndef FALSE
-#define FALSE 0
-#endif
-#ifndef TRUE
-#define TRUE 1
-#endif
-
 static int truncate_file(const char* fn)
 {
 	FILE* file = fopen(fn, "rb");
@@ -31,7 +24,7 @@ static int truncate_file(const char* fn)
 	file = fopen(fn, "ab");
 	if (file == NULL)
 	{
-		return FALSE;
+		return false;
 	}
 	fseek(file, 0, SEEK_END);
 	size = ftell(file);
@@ -41,23 +34,23 @@ static int truncate_file(const char* fn)
 	if (fwrite(" ", 1, 1, file) != 1)
 	{
 		fclose(file);
-		return FALSE;
+		return false;
 	}
 #if PLATFORM_WINDOWS
 	if (_chsize(_fileno(file), (long)size) != 0)
 	{
 		fclose(file);
-		return FALSE;
+		return false;
 	}
 #endif
 	fclose(file);
 #if !PLATFORM_WINDOWS
 	if (truncate(fn, (off_t)size) != 0)
 	{
-		return FALSE;
+		return false;
 	}
 #endif
-	return TRUE;
+	return true;
 }
 
 int os_touchfile(lua_State* L)

--- a/src/host/os_writefile_ifnotequal.c
+++ b/src/host/os_writefile_ifnotequal.c
@@ -21,7 +21,7 @@ static int compare_file(const char* content, size_t length, const char* dst)
 	#if PLATFORM_WINDOWS
 	wchar_t wide_path[PATH_MAX];
 	if (MultiByteToWideChar(CP_UTF8, 0, dst, -1, wide_path, PATH_MAX) == 0)
-		return FALSE;
+		return false;
 
 	file = _wfopen(wide_path, L"rb");
 	#else
@@ -30,7 +30,7 @@ static int compare_file(const char* content, size_t length, const char* dst)
 
 	if (file == NULL)
 	{
-		return FALSE;
+		return false;
 	}
 
 	// check sizes.
@@ -41,7 +41,7 @@ static int compare_file(const char* content, size_t length, const char* dst)
 	if (length != size)
 	{
 		fclose(file);
-		return FALSE;
+		return false;
 	}
 
 	while (size > 0)
@@ -52,13 +52,13 @@ static int compare_file(const char* content, size_t length, const char* dst)
 		if (read != num)
 		{
 			fclose (file);
-			return FALSE;
+			return false;
 		}
 
 		if (memcmp(content, buffer, num) != 0)
 		{
 			fclose(file);
-			return FALSE;
+			return false;
 		}
 
 		size    -= num;
@@ -66,7 +66,7 @@ static int compare_file(const char* content, size_t length, const char* dst)
 	}
 
 	fclose(file);
-	return TRUE;
+	return true;
 }
 
 
@@ -87,7 +87,7 @@ int os_writefile_ifnotequal(lua_State* L)
 	#if PLATFORM_WINDOWS
 	wchar_t wide_path[PATH_MAX];
 	if (MultiByteToWideChar(CP_UTF8, 0, dst, -1, wide_path, PATH_MAX) == 0)
-		return FALSE;
+		return false;
 
 	file = _wfopen(wide_path, L"wb");
 	#else

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -54,14 +54,7 @@
 #include <unistd.h>
 #endif
 #include <stdint.h>
-
-/* not all platforms define this */
-#ifndef FALSE
-#define FALSE 0
-#endif
-#ifndef TRUE
-#define TRUE 1
-#endif
+#include <stdbool.h>
 
 /* Fill in any missing bits */
 #ifndef PATH_MAX


### PR DESCRIPTION
**What does this PR do?**

Just modernizes the codebase a little bit as I don't think Premake needs to define its own bools anymore?