### PR TITLE
Adds a new toolset `driver` flag to signal driver compatibility.

### DIFF
--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -44,6 +44,7 @@
 
 	clang.shared = {
 		architecture = gcc.shared.architecture,
+		driver = gcc.shared.driver,
 		flags = gcc.shared.flags,
 		floatingpoint = {
 			Fast = "-ffast-math",

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -51,6 +51,7 @@
 			x86 = "-m32",
 			x86_64 = "-m64",
 		},
+		driver = "gcc",
 		flags = {
 			FatalCompileWarnings = "-Werror",
 			LinkTimeOptimization = "-flto",

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -61,6 +61,7 @@
 			["C"] = "/TC",
 			["C++"] = "/TP",
 		},
+		driver = "msvc",
 		flags = {
 			FatalCompileWarnings = "/WX",
 			LinkTimeOptimization = "/GL",

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -33,6 +33,7 @@
 
 	function suite.tools_onDefaults()
 		prepare()
+		test.isequal("gcc", clang.shared.driver)
 		test.isequal("clang", clang.gettoolname(cfg, "cc"))
 		test.isequal("clang++", clang.gettoolname(cfg, "cxx"))
 		test.isequal("ar", clang.gettoolname(cfg, "ar"))

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -33,6 +33,7 @@
 
 	function suite.tools_onDefaults()
 		prepare()
+		test.isequal("gcc", gcc.shared.driver)
 		test.isequal("gcc", gcc.gettoolname(cfg, "cc"))
 		test.isequal("g++", gcc.gettoolname(cfg, "cxx"))
 		test.isequal("ar", gcc.gettoolname(cfg, "ar"))

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -26,6 +26,16 @@
 	end
 
 
+
+--
+-- Check the selection of tools based on the target system.
+--
+
+function suite.tools_onDefaults()
+	prepare()
+	test.isequal("msvc", msc.shared.driver)
+end
+
 --
 -- Check the optimization flags.
 --


### PR DESCRIPTION
This allows external consumers of those toolsets to know what kind of driver the tool uses.

This can be important in some cases, like in Ninja, which provides some dependency handling features that need to change depending if the compiler is GCC or MSVC-like.

The problem is that due to lack of this information, the Ninja generator ends up having hardcoded logic for this depending on the toolset, https://github.com/jimon/premake-ninja/blob/master/ninja.lua#L401.

Which this is not extensible to other modules that define their own toolset (like the Emscripten module).

