### PR TITLE
Show error messages from broken includes

### DIFF
--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -244,9 +244,13 @@
 
 		local res = os.locate(fname, with_ext, p5, p4)
 		res = res or fname
-		local compiled_chunk = loadfile(res)
+		local compiled_chunk, err = loadfile(res)
 		if compiled_chunk == nil then
-			premake.error("Cannot find either " .. table.implode({fname, with_ext, p5, p4}, "", "", " or "))
+			if err then
+				premake.error("Cannot load " .. fname .. ": " .. err)
+			else
+				premake.error("Cannot find either " .. table.implode({fname, with_ext, p5, p4}, "", "", " or "))
+			end
 		end
 		return res, compiled_chunk
 	end

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -242,14 +242,16 @@
 		local p5 = path.join(fname, "premake5.lua")
 		local p4 = path.join(fname, "premake4.lua")
 
+		local compiled_chunk
 		local res = os.locate(fname, with_ext, p5, p4)
-		res = res or fname
-		local compiled_chunk, err = loadfile(res)
-		if compiled_chunk == nil then
-			if err then
-				premake.error("Cannot load " .. fname .. ": " .. err)
-			else
-				premake.error("Cannot find either " .. table.implode({fname, with_ext, p5, p4}, "", "", " or "))
+		if res == nil then
+			local caller = filelineinfo(3)
+			premake.error(caller .. ": Cannot find neither " .. table.implode({fname, with_ext, p5, p4}, "", "", " nor "))
+		else
+			compiled_chunk, err = loadfile(res)
+			if err ~= nil then
+				local caller = filelineinfo(3)
+				premake.error(caller .. ": Error loading '" .. fname .. ": " .. err)
 			end
 		end
 		return res, compiled_chunk

--- a/src/base/globals.lua
+++ b/src/base/globals.lua
@@ -48,10 +48,18 @@
 	io._includedFiles = {}
 
 	function include(fname)
-		fname, compiled_chunk = premake.findProjectScript(fname)
-		if not io._includedFiles[fname] then
-			io._includedFiles[fname] = true
-			return compiled_chunk()
+		local actualFname, compiled_chunk = premake.findProjectScript(fname)
+		if not io._includedFiles[actualFname] then
+			io._includedFiles[actualFname] = true
+			local success, res = pcall(compiled_chunk)
+			if success then
+				-- res is the return value of the script
+				return res
+			else
+				-- res is the error message
+				local caller = filelineinfo(2)
+				premake.error(caller .. ": Error executing '" .. fname .. ": " .. res)
+			end
 		end
 	end
 


### PR DESCRIPTION
**What does this PR do?**

Displays the error message returned from loadfile(), which includes the file and line information (necessary for nested includes!), as well as the specific error that was encountered.

**How does this PR change Premake's behavior?**

Rather than the generic "Cannot find..." message, if there's error information available it's now displayed:

Before:
```console
Error: ** Error: Cannot find either foobar/L0a or foobar/L0a.lua or foobar/L0a/premake5.lua or foobar/L0a/premake4.lua
```

After:
```console
Error: ** Error: Cannot load foobar/L0a: D:/dev/build-sys-eval/foobar/src/foobar/L0a/premake5.lua:7: '(' expected near '['
```

**Anything else we should know?**

Nope, it's a simple one but really, REALLY helps!

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
