### PR TITLE
Upgrade docs to latest Docusaurus version.

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '18'
       - name: Test Build
         run: |
           cd website
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '18'
       - name: Add key to allow access to repository
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/website/blog/2019-08-31-community-update-1.md
+++ b/website/blog/2019-08-31-community-update-1.md
@@ -1,10 +1,7 @@
 ---
 title: "Community Update #1"
 tags: [community-updates]
-author: starkos
-author_url: https://github.com/starkos
-author_image_url: https://avatars.githubusercontent.com/u/249247?v=4
-author_title: Premake Admin & Developer
+authors: starkos
 ---
 
 Say hello to [the new Premake OpenCollective](https://opencollective.com/premake)!
@@ -22,6 +19,8 @@ The experiment is now officially underway. As long as it continues, I'll provide
 - Improve the project on-boarding experience with a new [README.md](https://github.com/premake/premake-core/blob/master/README.md) and [CONTRIBUTING.md](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md) ([#1324](https://github.com/premake/premake-core/pull/1324), [#1325](https://github.com/premake/premake-core/pull/1325))
 
 - Improve the collaboration process with new issue, feature, and pull request templates ([#1326](https://github.com/premake/premake-core/pull/1326), [#1327](https://github.com/premake/premake-core/pull/1327))
+
+{/* truncate */}
 
 I'm not charging any expenses against the collective this cycle so we can build up a balance to recognize cool or important contributions from the community. You can track our finances and transactions at any time on [our OpenCollective page](https://opencollective.com/premake).
 

--- a/website/blog/2019-10-23- community-update-2.md
+++ b/website/blog/2019-10-23- community-update-2.md
@@ -1,10 +1,7 @@
 ---
 title: "Community Update #2"
 tags: [community-updates]
-author: starkos
-author_url: https://github.com/starkos
-author_image_url: https://avatars.githubusercontent.com/u/249247?v=4
-author_title: Premake Admin & Developer
+authors: starkos
 ---
 
 For this cycle (I work in eight-week cycles and fill in as much Premake work as I can), I completed a long overdue pruning of [the pull request backlog](https://github.com/starkos/premake-next/pulls). Working up from the oldest, I was able to get it down to just four, all in striking distance of merging and just needing a little follow-up (assistance welcome!). I'll drop a list of all the PRs that were moved at the bottom of this update. Because…
@@ -18,6 +15,8 @@ Which brings me to the part where I give a huge THANK YOU! to our continuing spo
 For the next cycle, I plan to start filling in the details of an improved configuration storage approach and, if possible, merge another [pull request or two](https://github.com/premake/premake-core/pulls).
 
 ~st.
+
+{/* truncate */}
 
 **Completed Tasks:**
 

--- a/website/blog/2020-01-08-community-update-3.md
+++ b/website/blog/2020-01-08-community-update-3.md
@@ -1,10 +1,7 @@
 ---
 title: "Community Update #3"
 tags: [community-updates]
-author: starkos
-author_url: https://github.com/starkos
-author_image_url: https://avatars.githubusercontent.com/u/249247?v=4
-author_title: Premake Admin & Developer
+authors: starkos
 ---
 
 Just a quick update this time: I had big plans for new features this cycle, but ended up getting swamped in end-of-year deadlines, and was only able to deliver a small portion of what I had intended (and late, at that). Still, I did manage a quick port-and-polish of the unit testing module and all of its dependencies, so I'm well positioned to begin the new user scripting API work in earnest. I will be on the road a fair bit over the next quarter, but I'm still optimistic that I can get enough of the new system online to give folks a sense of where things are headed.
@@ -16,3 +13,5 @@ Many thanks to **[CitizenFX Collective](https://opencollective.com/_fivem)** and
 ~st.
 
 (Your feedback is welcome and appreciated—come find us at [github.com/premake](https://github.com/premake) or [@premakeapp](https://twitter.com/premakeapp).)
+
+{/* truncate */}

--- a/website/blog/2020-04-07-community-update-4.md
+++ b/website/blog/2020-04-07-community-update-4.md
@@ -1,10 +1,7 @@
 ---
 title: "Community Update #4"
 tags: [community-updates]
-author: starkos
-author_url: https://github.com/starkos
-author_image_url: https://avatars.githubusercontent.com/u/249247?v=4
-author_title: Premake Admin & Developer
+authors: starkos
 ---
 
 It's been much longer than anticipated since the last community update. I was out of the country for a bit, and then shortly after my return the whole Situation hit the fan and things got crazy for a while. I'm back now, up and running and looking ahead to what's next. I hope all of you are also safe and sound and getting your groove back.
@@ -20,6 +17,8 @@ Whew!
 #### Alpha-15
 
 With inbox zero reached, we also cut [a new 5.0 alpha release](https://github.com/premake/premake-core/releases/tag/v5.0.0-alpha15) with over 50 changes and fixes, from over 20 different contributors. Nicely done everyone, and thanks! 🙌
+
+{/* truncate */}
 
 #### Premake5 Stable?
 

--- a/website/blog/2020-08-04-community-update-5.md
+++ b/website/blog/2020-08-04-community-update-5.md
@@ -1,10 +1,7 @@
 ---
 title: "Community Update #5"
 tags: [community-updates]
-author: starkos
-author_url: https://github.com/starkos
-author_image_url: https://avatars.githubusercontent.com/u/249247?v=4
-author_title: Premake Admin & Developer
+authors: starkos
 ---
 
 ### The new storage system has arrived
@@ -16,6 +13,8 @@ I am happy to be able to say that I've wrapped up the first round of development
 Learning my lesson from past development, I did my best to make this new version as open-ended and unconstrained as possible.
 
 **A proper API.** The storage and query API have been cleaned up and condensed to make things easier and more powerful for module authors. (Sorry for the inline images, the OpenCollective editor won't allow me to author code blocks?)
+
+{/* truncate */}
 
 ```lua
 -- create a new query, targeting a particular "environment";

--- a/website/blog/2020-11-02-community-udpate-6.md
+++ b/website/blog/2020-11-02-community-udpate-6.md
@@ -1,10 +1,7 @@
 ---
 title: "Community Update #6"
 tags: [community-updates]
-author: starkos
-author_url: https://github.com/starkos
-author_image_url: https://avatars.githubusercontent.com/u/249247?v=4
-author_title: Premake Admin & Developer
+authors: starkos
 ---
 
 ### Enter the Exporters
@@ -26,6 +23,8 @@ For those of you who are more interested in "is it done yet?" than "what's new?"
 - Add **kind, links,** and the most important switches (e.g. **includedirs, symbols, optimize**)—be able to support the most common C/C++ builds
 
 Somewhere in there I should also backfill the documentation so people know what's working. All of this is subject to change and peer pressure, feedback welcome.
+
+{/* truncate */}
 
 ### What's New
 

--- a/website/blog/2021-02-24-community-update-7.md
+++ b/website/blog/2021-02-24-community-update-7.md
@@ -1,10 +1,7 @@
 ---
 title: "Community Update #7"
 tags: [community-updates]
-author: starkos
-author_url: https://github.com/starkos
-author_image_url: https://avatars.githubusercontent.com/u/249247?v=4
-author_title: Premake Admin & Developer
+authors: starkos
 ---
 
 A quick update this cycle so I can get right back to it: I managed to free up meaningful blocks of time for Premake in February—felt good!—and tackle **files** and **removeFiles**, support configuration and platform specific files, and get it all exporting to Visual Studio (…and bulldoze through the rabbit holes along the way). From the user-facing side not a big change, but [a hefty commit](https://github.com/starkos/premake-next/commit/f5cb8678a6cc2939faceacbb8143bd9a094709f6) just the same. The core platform is starting to feel reasonably complete.
@@ -15,6 +12,8 @@ A quick update this cycle so I can get right back to it: I managed to free up me
 - Work with [@KyrietS](https://github.com/KyrietS) to bring [a new & improved documentation system online](https://github.com/premake/premake-core/pull/1587).
 
 Longer term: push to get the new code to the point where it can generate its own Visual Studio project files. I've actually done a good chunk of work on this, but wasn't quite able to bring it home this month. Then do the same with Xcode.
+
+{/* truncate */}
 
 ### Meanwhile in V5
 

--- a/website/blog/2021-04-20-community-update-8.md
+++ b/website/blog/2021-04-20-community-update-8.md
@@ -1,10 +1,7 @@
 ---
 title: "Community Update #8"
 tags: [community-updates]
-author: starkos
-author_url: https://github.com/starkos
-author_image_url: https://avatars.githubusercontent.com/u/249247?v=4
-author_title: Premake Admin & Developer
+authors: starkos
 ---
 
 ### Welcome Website!
@@ -24,6 +21,8 @@ Very happy about this.
 I…did not realize how long it had been since there was a proper release. Pandemic and all that. I've corrected the matter: [v5.0-alpha16 is now available](https://github.com/premake/premake-core/releases/tag/v5.0.0-alpha16), with lots of good improvements. See the full changelog [here](https://github.com/premake/premake-core/releases/tag/v5.0.0-alpha16).
 
 (By the way, if anyone out there has a knack for build automation I'd love to see these releases automated. Get in touch!)
+
+{/* truncate */}
 
 ### RFC: Branch or Backport
 

--- a/website/blog/2021-08-01-community-update-9.md
+++ b/website/blog/2021-08-01-community-update-9.md
@@ -1,10 +1,7 @@
 ---
 title: "Community Update #9"
 tags: [community-updates]
-author: starkos
-author_url: https://github.com/starkos
-author_image_url: https://avatars.githubusercontent.com/u/249247?v=4
-author_title: Premake Admin & Developer
+authors: starkos
 ---
 
 I can't believe we're already eight months into 2021, how did this happen.
@@ -26,6 +23,8 @@ I've [opened a 5.0 milestone](https://github.com/premake/premake-core/milestone/
 In other news, Premake6 can now generate its own Visual Studio project files and bootstrap itself. That doesn't sound very impressive, but it does means that all of the under the hood stuff is now online and working as intended, and a full vertical slice has been completed. 🎉
 
 [@nickclark2016](https://github.com/nickclark2016) has volunteered to begin looking into a new-and-improved makefile exporter, which frees me up to start looking at Xcode and improving the way we represent toolsets like Clang and GCC. The stable release of 5.0 is likely to take up all the air in the room for a bit, but hopefully I can report progress on those soon.
+
+{/* truncate */}
 
 ### Community Contributions
 

--- a/website/blog/2021-11-21-community-update-10.md
+++ b/website/blog/2021-11-21-community-update-10.md
@@ -1,10 +1,7 @@
 ---
 title: "Community Update #10"
 tags: [community-updates]
-author: starkos
-author_url: https://github.com/starkos
-author_image_url: https://avatars.githubusercontent.com/u/249247?v=4
-author_title: Premake Admin & Developer
+authors: starkos
 ---
 
 ### Premake 5.0-beta1! 🥳
@@ -14,6 +11,8 @@ After one of the world's longest alpha cycles, Premake5 has finally entered beta
 As [previously discussed](/blog/2021/08/01/community-update-9#the-path-to-50), we've started the process of stabilizing 5.0 and shifting breaking changes over to the new v6.x branch. We've [set up a milestone to track our progress](https://github.com/premake/premake-core/milestone/3) toward a stable 5.0 release, and this is the first step in working it down.
 
 Most of the changes in the queue are under-the-hood: release automation, bootstrapping, and unit test fixes. The only potentially significant breaking change remaining is [promoting the `gmake2` exporter](https://github.com/premake/premake-core/issues/1099), which I will be prioritizing for the next beta. If you happen to still be using the older `gmake` exporter, please give `gmake2` a try and let us know if you encounter issues! Most fixes have been going to `gmake2` lately, so we expect your experience will be a good one.
+
+{/* truncate */}
 
 ### Premake6
 
@@ -59,7 +58,7 @@ Yay open source development! 🎉 Big shout out to everyone who took the time to
 
 Extra thanks to the unsung heroes not mentioned here who helped review pull requests, triage issues, and generally keep the machine humming.
 
-### Our Sponsors
+### Our Sponsors {#our-sponsors}
 
 <div style={{textAlign: 'center'}}>
 	<a href="https://opencollective.com/_fivem">

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -1,0 +1,5 @@
+starkos:
+  name: Jess Perkins
+  title: Premake Admin & Developer
+  url: https://github.com/starkos
+  image_url: https://github.com/starkos.png

--- a/website/docs/Style-Guide.md
+++ b/website/docs/Style-Guide.md
@@ -67,7 +67,7 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 
 Or leave it empty and use the [link text itself].
 
-URLs and URLs in angle brackets will automatically get turned into links. http://www.example.com/ or <http://www.example.com/> and sometimes example.com (but not on GitHub, for example).
+URLs will automatically get turned into links. http://www.example.com/ and sometimes example.com (but not on GitHub, for example).
 
 Some text to show that the reference links can follow later.
 

--- a/website/docs/xcodebuildsettings.md
+++ b/website/docs/xcodebuildsettings.md
@@ -23,8 +23,10 @@ xcodebuildsettings { ["MY_KEY"] = "MY_VALUE" }
 ```
 will generate:
 
+```
     buildSettings = {
         ...
         MY_KEY = MY_VALUE;
         ...
     }
+```

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
 	title: 'Premake',
 	tagline: 'Powerfully simple build configuration',
 	url: 'https://premake.github.io/',
@@ -11,6 +11,9 @@ module.exports = {
 	favicon: 'img/favicon.ico',
 	organizationName: 'premake',
 	projectName: 'premake.github.io',
+	markdown: {
+		format: 'detect'
+	},
 	themeConfig: {
 		prism: {
 			additionalLanguages: ['lua'],

--- a/website/package.json
+++ b/website/package.json
@@ -12,10 +12,10 @@
     "clear": "docusaurus clear"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
-    "@docusaurus/preset-classic": "2.0.0-beta.9",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "@docusaurus/core": "3.5.2",
+    "@docusaurus/preset-classic": "3.5.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "browserslist": {
     "production": [

--- a/website/src/pages/download.js
+++ b/website/src/pages/download.js
@@ -53,7 +53,7 @@ const Download = () =>
 						<h1>Download Premake</h1>
 						<p>
 							Premake is a self-contained, single file command line executable which should build and run pretty much everywhere.
-							See <Link to="/docs/using-premake">Using Premake</Link> for usage instructions and help getting started.
+							See <Link to="/docs/Using-Premake">Using Premake</Link> for usage instructions and help getting started.
 						</p>
 						<p>
 							The latest released version is <b>v{LATEST_VERSION}</b>. <Link to="https://github.com/premake/premake-core/releases">See all releases</Link>.

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -49,7 +49,7 @@ function Home() {
 									syntax, and build it everywhere.
 								</p>
 								<p>
-									&#8594; <Link to="docs/your-first-script">See an example</Link>
+									&#8594; <Link to="docs/Your-First-Script">See an example</Link>
 								</p>
 							</Feature>
 							<Feature title="Script Once, Target Many">
@@ -58,7 +58,7 @@ function Home() {
 									across Windows, Mac OS X, and Linux.
 								</p>
 								<p>
-									&#8594; <Link to="docs/using-premake">See the full list</Link>
+									&#8594; <Link to="docs/Using-Premake">See the full list</Link>
 								</p>
 							</Feature>
 							<Feature title="Full Powered">


### PR DESCRIPTION
Noticed I was getting some notices about how Docusaurus should be upgraded while building the website locally, so upgraded it to latest.

It's a bit more strict in some things so had to make some minor changes, and also factor out author information into an `authors.yml`. I noticed @starkos has updated names on their profile, so I used the new one from their profile/website. Happy to revert to old one if that's your wish.