### PR TITLE
Default to compiling `.m` and `.mm` files as `Objective-C/C++`.

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -2013,6 +2013,12 @@
 	filter { "system:darwin" }
 		toolset "clang"
 
+	filter "files:**.m"
+		compileas(p.OBJECTIVEC)
+
+	filter "files:**.mm"
+		compileas(p.OBJECTIVECPP)
+
 	filter { "platforms:Win32" }
 		architecture "x86"
 

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -31,6 +31,7 @@ return {
 	-- Project object tests
 	"project/test_config_maps.lua",
 	"project/test_eachconfig.lua",
+	"project/test_fileconfig.lua",
 	"project/test_getconfig.lua",
 	"project/test_location.lua",
 	"project/test_sources.lua",

--- a/tests/project/test_fileconfig.lua
+++ b/tests/project/test_fileconfig.lua
@@ -1,0 +1,60 @@
+--
+-- tests/project/test_fileconfig.lua
+-- Test the project fileconfig properties.
+-- Copyright (c) 2024 Jason Perkins and the Premake project
+--
+
+	local p = premake
+	local suite = test.declare("project_fileconfig")
+
+--
+-- Setup and teardown
+--
+
+	local wks, prj, cfg
+
+	function suite.setup()
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		wks = test.getWorkspace(wks)
+		prj = test.getproject(wks, 1)
+		cfg = test.getconfig(prj, "Debug")
+	end
+
+
+--
+-- Check that .m files are compiled as Objective-C.
+--
+
+function suite.compile_mFiles_asObjC()
+	files { "foo.m" }
+	prepare()
+	local tr = p.project.getsourcetree(prj)
+	p.tree.traverse(tr, {
+		-- source files are handled at the leaves
+		onleaf = function(node, depth)
+			local fcfg = p.fileconfig.getconfig(node, cfg)
+			test.isequal(p.OBJECTIVEC, fcfg.compileas)
+		end,
+	}, true)
+end
+
+
+--
+-- Check that .mm files are compiled as Objective-C++.
+--
+
+	function suite.compile_mmFiles_asObjCPP()
+		files { "foo.mm" }
+		prepare()
+		local tr = p.project.getsourcetree(prj)
+		p.tree.traverse(tr, {
+			-- source files are handled at the leaves
+			onleaf = function(node, depth)
+				local fcfg = p.fileconfig.getconfig(node, cfg)
+				test.isequal(p.OBJECTIVECPP, fcfg.compileas)
+			end,
+		}, true)
+	end


### PR DESCRIPTION
As the title says, defaults to compiling `.m` and `.mm` files as `Objective-C/C++`.

Another setting I've often had to set in my projects, and AFAICT there should be no problem setting this as the default.