### PR TITLE
Fixed issue with include failing to find embedded files

### DIFF
--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -238,15 +238,23 @@
 --
 
 	function premake.findProjectScript(fname)
-		local with_ext = fname .. ".lua"
-		local p5 = path.join(fname, "premake5.lua")
-		local p4 = path.join(fname, "premake4.lua")
+		local filenames = {
+			fname,
+			fname .. ".lua",
+			path.join(fname, "premake5.lua"),
+			path.join(fname, "premake4.lua"),
+		}
+
+		-- If the currently running script was embedded, try to find this file as if it were embedded too.
+		if _SCRIPT_DIR and _SCRIPT_DIR:startswith('$') then
+			table.insert(filenames, path.getabsolute(fname, _SCRIPT_DIR))
+		end
 
 		local compiled_chunk
-		local res = os.locate(fname, with_ext, p5, p4)
+		local res = os.locate(table.unpack(filenames))
 		if res == nil then
 			local caller = filelineinfo(3)
-			premake.error(caller .. ": Cannot find neither " .. table.implode({fname, with_ext, p5, p4}, "", "", " nor "))
+			premake.error(caller .. ": Cannot find neither " .. table.implode(filenames, "", "", " nor "))
 		else
 			compiled_chunk, err = loadfile(res)
 			if err ~= nil then


### PR DESCRIPTION
**What does this PR do?**

Fixes issue with `include` failing to find embedded files when being called from an embedded file.

**How does this PR change Premake's behavior?**

Restores behaviour to before #2264.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
