### PR TITLE
Port Premake to Cosmopolitan Libc

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -109,6 +109,29 @@ jobs:
       with:
         name: premake-${{ matrix.msystem }}-${{ matrix.platform }}
         path: bin\${{ matrix.config }}\
+  cosmopolitan:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config: [debug, release]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - uses: tritao/setup-cosmopolitan@v1.3
+      with:
+        version: '3.9.2'
+    - name: Build
+      run: make -f Bootstrap.mak cosmo CONFIG=${{ matrix.config }}
+    - name: Test
+      run: bin/${{ matrix.config }}/premake5 test --test-all
+    - name: Docs check
+      run: bin/${{ matrix.config }}/premake5 docs-check
+    - name: Upload Artifacts
+      if: matrix.config == 'release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: premake-cosmopolitan-universal
+        path: bin/${{ matrix.config }}/premake5
 
   # This job will be required for PRs to be merged.
   # This should depend on (via needs) all jobs that need to be successful for the PR to be merged.

--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -151,3 +151,12 @@ windows: windows-base
 
 windows-msbuild: windows-base
 	msbuild /p:Configuration=$(CONFIG) /p:Platform=$(PLATFORM:x86=win32) .\build\bootstrap\Premake5.sln
+
+cosmo-clean: nix-clean
+
+cosmo: cosmo-clean
+	mkdir -p build/bootstrap
+	cosmocc -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lm -ldl -lrt
+	./build/bootstrap/premake_bootstrap embed
+	./build/bootstrap/premake_bootstrap --to=build/bootstrap --cc=cosmocc gmake2
+	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)

--- a/contrib/curl/lib/curl_setup.h
+++ b/contrib/curl/lib/curl_setup.h
@@ -166,6 +166,10 @@
 #  include "config-linux.h"
 #endif
 
+#ifdef __COSMOPOLITAN__
+#  include "config-linux.h"
+#endif
+
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #  include "config-linux.h"
 #endif

--- a/contrib/libzip/premake5.lua
+++ b/contrib/libzip/premake5.lua
@@ -11,7 +11,7 @@ project "zip-lib"
 		"**.c"
 	}
 
-	filter "system:linux or bsd or solaris or haiku"
+	filter "toolset:gcc or clang or cosmocc"
 		defines { "HAVE_SSIZE_T_LIBZIP", "HAVE_CONFIG_H" }
 		forceincludes { "unistd.h" }
 

--- a/modules/gmake/_preload.lua
+++ b/modules/gmake/_preload.lua
@@ -20,7 +20,7 @@
 		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib", "Utility", "Makefile", "None" },
 		valid_languages = { "C", "C++", "C#" },
 		valid_tools     = {
-			cc     = { "clang", "gcc" },
+			cc     = { "clang", "gcc", "cosmocc" },
 			dotnet = { "mono", "msnet", "pnet" }
 		},
 

--- a/modules/gmake2/_preload.lua
+++ b/modules/gmake2/_preload.lua
@@ -22,7 +22,7 @@
 		valid_languages = { "C", "C++", "C#" },
 
 		valid_tools     = {
-			cc     = { "clang", "gcc" },
+			cc     = { "clang", "gcc", "cosmocc" },
 			dotnet = { "mono", "msnet", "pnet" }
 		},
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -256,7 +256,7 @@
 			defines     { "LUA_USE_MACOSX" }
 			links       { "CoreServices.framework", "Foundation.framework", "Security.framework", "readline" }
 
-		filter "system:linux"
+		filter { "system:linux", "toolset:not cosmocc" }
 			links		{ "uuid" }
 
 		filter { "system:macosx", "action:gmake" }
@@ -289,13 +289,14 @@
 			include "contrib/curl"
 		end
 
-	group "Binary Modules"
-		include "binmodules/example"
+	if _OPTIONS["cc"] ~= "cosmocc" then
+		group "Binary Modules"
+			include "binmodules/example"
 
-		if not _OPTIONS["no-luasocket"] then
-			include "binmodules/luasocket"
-		end
-
+			if not _OPTIONS["no-luasocket"] then
+				include "binmodules/luasocket"
+			end
+	end
 --
 -- A more thorough cleanup.
 --

--- a/src/_manifest.lua
+++ b/src/_manifest.lua
@@ -64,6 +64,7 @@
 		"tools/snc.lua",
 		"tools/clang.lua",
 		"tools/mingw.lua",
+		"tools/cosmocc.lua",
 
 		-- Clean action
 		"actions/clean/_clean.lua",

--- a/src/host/os_getnumcpus.c
+++ b/src/host/os_getnumcpus.c
@@ -10,7 +10,7 @@
 
 #include "premake.h"
 
-#if PLATFORM_LINUX
+#if PLATFORM_LINUX | PLATFORM_COSMO
 #include <sched.h>
 #elif PLATFORM_SOLARIS | PLATFORM_AIX | PLATFORM_MACOSX | PLATFORM_BSD
 #include <sys/sysctl.h>
@@ -25,7 +25,7 @@ int do_getnumcpus()
 	SYSTEM_INFO sysinfo;
 	GetSystemInfo(&sysinfo);
 	return sysinfo.dwNumberOfProcessors;
-#elif PLATFORM_LINUX
+#elif PLATFORM_LINUX | PLATFORM_COSMO
 	cpu_set_t set;
 	int count, i;
 

--- a/src/host/os_getpass.c
+++ b/src/host/os_getpass.c
@@ -31,8 +31,13 @@ int os_getpass(lua_State* L)
 
 		lua_pushstring(L, buffer);
 		return 1;
-	#else
+	#elif PLATFORM_COSMO
+		luaL_error(L, "Not supported by this platform");
+		return 0;
+	#elif PLATFORM_POSIX
 		lua_pushstring(L, getpass(prompt));
 		return 1;
+	#else
+		#error Not implemented yet for this platform
 	#endif
 }

--- a/src/host/os_getversion.c
+++ b/src/host/os_getversion.c
@@ -272,7 +272,7 @@ getversion_macosx_cleanup:
 
 /*************************************************************/
 
-#elif defined(PLATFORM_BSD) || defined(PLATFORM_LINUX) || defined(PLATFORM_SOLARIS) || defined(PLATFORM_HURD) || defined(PLATFORM_HAIKU)
+#elif defined(PLATFORM_BSD) || defined(PLATFORM_LINUX) || defined(PLATFORM_SOLARIS) || defined(PLATFORM_HURD) || defined(PLATFORM_HAIKU) || defined(PLATFORM_COSMO)
 
 #include <string.h>
 #include <sys/utsname.h>

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -4,6 +4,7 @@
  * \author Copyright (c) 2002-2017 Jason Perkins and the Premake project
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
@@ -17,6 +18,10 @@
 #if PLATFORM_BSD
 #include <sys/types.h>
 #include <sys/sysctl.h>
+#endif
+
+#if PLATFORM_COSMO
+#include <cosmo.h>
 #endif
 
 #define ERROR_MESSAGE  "Error: %s\n"
@@ -172,6 +177,24 @@ void luaL_register(lua_State *L, const char *libname, const luaL_Reg *l)
 }
 
 
+static const char* premake_host_os()
+{
+#if PLATFORM_COSMO
+	if (IsLinux()) { return "linux"; }
+	else if (IsWindows()) { return "windows"; }
+	else if (IsXnu()) { return "macosx"; }
+	else if (IsBsd()) { return "bsd"; }
+	else
+	{
+		assert(0 && "Platform is unknown to Cosmopolitan Libc");
+		return 0;
+	}
+#else
+	return PLATFORM_OS;
+#endif
+}
+
+
 /**
  * Initialize the Premake Lua environment.
  */
@@ -213,12 +236,18 @@ int premake_init(lua_State* L)
 	lua_setglobal(L, "_PREMAKE_URL");
 
 	/* set the target OS platform variable */
-	lua_pushstring(L, PLATFORM_OS);
+	lua_pushstring(L, premake_host_os());
 	lua_setglobal(L, "_TARGET_OS");
 
 	/* set the target arch platform variable */
 	lua_pushnil(L);
 	lua_setglobal(L, "_TARGET_ARCH");
+
+#if PLATFORM_COSMO
+	/* set _COSMOPOLITAN if its a Cosmopolitan build */
+	lua_pushboolean(L, TRUE);
+	lua_setglobal(L, "_COSMOPOLITAN");
+#endif
 
 	/* find the user's home directory */
 	value = getenv("HOME");

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -38,12 +38,15 @@
 #elif defined (__GNU__)
 #define PLATFORM_HURD  (1)
 #define PLATFORM_OS  "hurd"
+#elif defined (__COSMOPOLITAN__)
+#define PLATFORM_COSMO  (1)
+#define PLATFORM_OS  "cosmopolitan"
 #else
 #define PLATFORM_WINDOWS  (1)
 #define PLATFORM_OS   "windows"
 #endif
 
-#define PLATFORM_POSIX  (PLATFORM_LINUX || PLATFORM_BSD || PLATFORM_MACOSX || PLATFORM_SOLARIS || PLATFORM_HAIKU)
+#define PLATFORM_POSIX  (PLATFORM_LINUX || PLATFORM_BSD || PLATFORM_MACOSX || PLATFORM_SOLARIS || PLATFORM_HAIKU || PLATFORM_COSMO)
 
 #if defined(__x86_64__) || defined(__x86_64) || defined(__amd64__) || defined(__amd64) || \
     defined(_M_X64) || defined(_M_AMD64)

--- a/src/tools/cosmocc.lua
+++ b/src/tools/cosmocc.lua
@@ -7,16 +7,20 @@
 local p = premake
 local gcc = p.tools.gcc
 
-p.tools.cosmocc = table.merge(gcc, {})
+p.tools.cosmocc = table.deepcopy(gcc, {})
 local cosmocc = p.tools.cosmocc
+
+function cosmocc.getsharedlibarg(cfg)
+    return ""
+end
+
+cosmocc.ldflags.kind.SharedLib = cosmocc.getsharedlibarg
 
 cosmocc.tools = {
     cc = "cosmocc",
     cxx = "cosmoc++",
-    ar = "ar",
+    ar = "cosmoar",
 }
-
--- cosmocc.arargs = "rcs"
 
 function cosmocc.gettoolname(cfg, tool)
     return cosmocc.tools[tool]

--- a/src/tools/cosmocc.lua
+++ b/src/tools/cosmocc.lua
@@ -1,0 +1,23 @@
+--
+-- cosmocc.lua
+-- Cosmopolitan Libc toolset adapter for Premake
+-- Copyright (c) 2024 Premake project
+--
+
+local p = premake
+local gcc = p.tools.gcc
+
+p.tools.cosmocc = table.merge(gcc, {})
+local cosmocc = p.tools.cosmocc
+
+cosmocc.tools = {
+    cc = "cosmocc",
+    cxx = "cosmoc++",
+    ar = "ar",
+}
+
+-- cosmocc.arargs = "rcs"
+
+function cosmocc.gettoolname(cfg, tool)
+    return cosmocc.tools[tool]
+end

--- a/tests/base/test_binmodules.lua
+++ b/tests/base/test_binmodules.lua
@@ -7,6 +7,7 @@
 	local suite = test.declare("premake_binmodules")
 	local p = premake
 
+	if not _COSMOPOLITAN then
 
 	function suite.setup()
 		require("example")
@@ -16,4 +17,6 @@
 	function suite.testExample()
 		local result = example.test("world")
 		test.isequal("hello world", result)
+	end
+
 	end


### PR DESCRIPTION
**What does this PR do?**

Decided to have a little bit of fun tonight and try to port Premake to https://justine.lol/cosmopolitan/index.html

It outputs a single binary that runs natively on Linux + Mac + Windows + FreeBSD + OpenBSD + NetBSD + BIOS on AMD64 and ARM64. Premake at BIOS time anyone? :laughing: 

It was relatively painless and all tests are passing besides the binary module test.

It might be possible to support these with `cosmos_dlopen`, but doesn't seem worth it to spend time on it.

I think this would be most valuable for those who want to bundle a Premake binary with their code as a single binary is needed on Git.

**Anything else we should know?**

Seems like it would be worth to support this as the changes are pretty minor and maintenance going forward should be minimal, but let me know if you have other thoughts.

If it seems like it would be worth, I can probably add it to the CI build.
