### PR TITLE
Added ability to use system curl

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -9,17 +9,21 @@ jobs:
       matrix:
         config: [debug, release]
         platform: [x64]
+        depsrc: [none, contrib, system]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Install dependencies
+      if: matrix.depsrc == 'system'
+      run: sudo apt-get install libcurl4-openssl-dev
     - name: Build
-      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} ./Bootstrap.sh
+      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--curl-src=${{ matrix.depsrc }}" ./Bootstrap.sh
     - name: Test
       run: bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check
       run: bin/${{ matrix.config }}/premake5 docs-check
     - name: Upload Artifacts
-      if: matrix.config == 'release'
+      if: matrix.config == 'release' && matrix.depsrc == 'contrib'
       uses: actions/upload-artifact@v4
       with:
         name: premake-linux-${{ matrix.platform }}

--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -3,6 +3,7 @@ CONFIG      = release
 PLATFORM    = x86
 LUA_DIR     = contrib/lua/src
 LUASHIM_DIR = contrib/luashim
+PREMAKE_OPTS =
 
 SRC		= src/host/*.c			\
 		$(LUA_DIR)/lapi.c		\
@@ -87,7 +88,7 @@ mingw: mingw-clean
 	mkdir -p build/bootstrap
 	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lole32 -lversion
 	./build/bootstrap/premake_bootstrap embed
-	./build/bootstrap/premake_bootstrap --arch=$(PLATFORM) --os=windows --to=build/bootstrap --cc=mingw gmake2
+	./build/bootstrap/premake_bootstrap --arch=$(PLATFORM) --os=windows --to=build/bootstrap --cc=mingw $(PREMAKE_OPTS) gmake2
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)_$(PLATFORM:x86=win32)
 
 macosx: osx
@@ -100,7 +101,7 @@ osx: osx-clean
 	mkdir -p build/bootstrap
 	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_MACOSX -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" -framework CoreServices -framework Foundation -framework Security -lreadline $(SRC)
 	./build/bootstrap/premake_bootstrap embed
-	./build/bootstrap/premake_bootstrap --arch=$(PLATFORM) --to=build/bootstrap gmake2
+	./build/bootstrap/premake_bootstrap --arch=$(PLATFORM) --to=build/bootstrap $(PREMAKE_OPTS) gmake2
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)
 
 linux-clean: nix-clean
@@ -109,7 +110,7 @@ linux: linux-clean
 	mkdir -p build/bootstrap
 	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lm -ldl -lrt -luuid
 	./build/bootstrap/premake_bootstrap embed
-	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
+	./build/bootstrap/premake_bootstrap --to=build/bootstrap $(PREMAKE_OPTS) gmake2
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)
 
 bsd-clean: nix-clean
@@ -118,7 +119,7 @@ bsd: bsd-clean
 	mkdir -p build/bootstrap
 	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lm
 	./build/bootstrap/premake_bootstrap embed
-	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
+	./build/bootstrap/premake_bootstrap --to=build/bootstrap $(PREMAKE_OPTS) gmake2
 	$(MAKE) -C build/bootstrap -j`getconf NPROCESSORS_ONLN` config=$(CONFIG)
 
 solaris-clean: nix-clean
@@ -127,7 +128,7 @@ solaris: solaris-clean
 	mkdir -p build/bootstrap
 	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lm
 	./build/bootstrap/premake_bootstrap embed
-	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
+	./build/bootstrap/premake_bootstrap --to=build/bootstrap $(PREMAKE_OPTS) gmake2
 	$(MAKE) -C build/bootstrap -j`getconf NPROCESSORS_ONLN` config=$(CONFIG)
 
 haiku-clean: nix-clean
@@ -136,14 +137,14 @@ haiku: haiku-clean
 	mkdir -p build/bootstrap
 	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_USE_POSIX -DLUA_USE_DLOPEN -D_BSD_SOURCE -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lbsd
 	./build/bootstrap/premake_bootstrap embed
-	./build/bootstrap/premake_bootstrap --to=build/bootstrap gmake2
+	./build/bootstrap/premake_bootstrap --to=build/bootstrap $(PREMAKE_OPTS) gmake2
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)
 
 windows-base: windows-clean
 	if not exist build\bootstrap (mkdir build\bootstrap)
 	cl /Fo.\build\bootstrap\ /Fe.\build\bootstrap\premake_bootstrap.exe /DPREMAKE_NO_BUILTIN_SCRIPTS /I"$(LUA_DIR)" /I"$(LUASHIM_DIR)" user32.lib ole32.lib advapi32.lib $(SRC)
 	.\build\bootstrap\premake_bootstrap.exe embed
-	.\build\bootstrap\premake_bootstrap --arch=$(PLATFORM) --to=build/bootstrap $(MSDEV)
+	.\build\bootstrap\premake_bootstrap --arch=$(PLATFORM) --to=build/bootstrap $(PREMAKE_OPTS) $(MSDEV)
 
 windows: windows-base
 	devenv .\build\bootstrap\Premake5.sln /Upgrade

--- a/Bootstrap.sh
+++ b/Bootstrap.sh
@@ -13,6 +13,7 @@ done
 
 PLATFORM_ARG=""
 CONFIG_ARG=""
+PREMAKE_OPTS_ARG=""
 
 if [ -n "$PLATFORM" ]; then
   PLATFORM_ARG="PLATFORM=$PLATFORM"
@@ -22,21 +23,25 @@ if [ -n "$CONFIG" ]; then
   CONFIG_ARG="CONFIG=$CONFIG"
 fi
 
+if [ -n "$PREMAKE_OPTS" ]; then
+  PREMAKE_OPTS_ARG="PREMAKE_OPTS=$PREMAKE_OPTS"
+fi
+
 case "$(uname -s)" in
    Linux)
      NPROC=$(nproc --all)
-     make -f Bootstrap.mak ${COSMO_FLAG:-linux} $PLATFORM_ARG $CONFIG_ARG -j$NPROC
+     make -f Bootstrap.mak ${COSMO_FLAG:-linux} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC
      ;;
    Darwin)
      NPROC=$(sysctl -n hw.ncpu)
-     make -f Bootstrap.mak ${COSMO_FLAG:-osx} $PLATFORM_ARG $CONFIG_ARG -j$NPROC
+     make -f Bootstrap.mak ${COSMO_FLAG:-osx} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC
      ;;
    FreeBSD|OpenBSD|NetBSD)
      NPROC=$(sysctl -n hw.ncpu)
-     make -f Bootstrap.mak ${COSMO_FLAG:-bsd} $PLATFORM_ARG $CONFIG_ARG -j$NPROC
+     make -f Bootstrap.mak ${COSMO_FLAG:-bsd} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC
      ;;
    CYGWIN*|MINGW32*|MSYS*|MINGW*)
-     make -f Bootstrap.mak ${COSMO_FLAG:-mingw} $PLATFORM_ARG $CONFIG_ARG -j$NPROC
+     make -f Bootstrap.mak ${COSMO_FLAG:-mingw} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC
      ;;
    *)
     echo "Unsupported platform"

--- a/modules/vstudio/tests/cs2005/test_assembly_refs.lua
+++ b/modules/vstudio/tests/cs2005/test_assembly_refs.lua
@@ -202,7 +202,7 @@
 -- NuGet packages should get references.
 --
 
-if _OPTIONS["test-all"] then
+if http ~= nil and _OPTIONS["test-all"] then
 	function suite.nuGetPackages_net45()
 		dotnetframework "4.5"
 		nuget { "Newtonsoft.Json:10.0.2" }
@@ -250,7 +250,7 @@ end
 -- referenced.
 --
 
-if _OPTIONS["test-all"] then
+if http ~= nil and _OPTIONS["test-all"] then
 	function suite.nuGetPackages_multipleAssemblies()
 		dotnetframework "2.0"
 		nuget { "NUnit:3.6.1" }
@@ -285,7 +285,7 @@ end
 -- NuGet packages should respect copylocal() and the NoCopyLocal flag.
 --
 
-if _OPTIONS["test-all"] then
+if http ~= nil and _OPTIONS["test-all"] then
 	function suite.nugetPackages_onNoCopyLocal()
 		dotnetframework "2.0"
 		nuget { "NUnit:3.6.1" }
@@ -380,7 +380,7 @@ end
 -- properly.
 --
 
-if _OPTIONS["test-all"] then
+if http ~= nil and _OPTIONS["test-all"] then
 	function suite.nuGetPackages_netFolder()
 		dotnetframework "4.5"
 		nuget { "MetroModernUI:1.4.0" }

--- a/modules/vstudio/tests/cs2005/test_nuget_references.lua
+++ b/modules/vstudio/tests/cs2005/test_nuget_references.lua
@@ -32,7 +32,7 @@
 -- Check that we process Unix-style paths correctly.
 --
 
-if _OPTIONS["test-all"] then
+if http ~= nil and _OPTIONS["test-all"] then
 	function suite.unixPaths()
 		dotnetframework "4.6"
 		nuget "Mono.Cecil:0.9.6.4"

--- a/modules/vstudio/tests/vc2010/test_ensure_nuget_imports.lua
+++ b/modules/vstudio/tests/vc2010/test_ensure_nuget_imports.lua
@@ -42,7 +42,7 @@
 -- Writes the pre-build check that makes sure that all packages are installed.
 --
 
-if _OPTIONS["test-all"] then
+if http ~= nil and _OPTIONS["test-all"] then
 	function suite.structureIsCorrect()
 		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
 		prepare()

--- a/modules/vstudio/tests/vc2010/test_extension_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_extension_settings.lua
@@ -32,7 +32,7 @@
 -- Writes entries only for nuget packages with props files.
 --
 
-if _OPTIONS["test-all"] then
+if http ~= nil and _OPTIONS["test-all"] then
 	function suite.importOnlyNugetPackagesWithProps()
 		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
 		prepare()

--- a/modules/vstudio/tests/vc2010/test_extension_targets.lua
+++ b/modules/vstudio/tests/vc2010/test_extension_targets.lua
@@ -63,7 +63,7 @@
 -- Writes entries for NuGet packages.
 --
 
-if _OPTIONS["test-all"] then
+if http ~= nil and _OPTIONS["test-all"] then
 	function suite.addsImport_onEachNuGetPackage()
 		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
 		prepare()

--- a/modules/vstudio/vs2010_nuget.lua
+++ b/modules/vstudio/vs2010_nuget.lua
@@ -410,7 +410,7 @@
 
 	function nuget2010.NuGetHasHTTP(prj)
 		if not http and #prj.nuget > 0 and not nuget2010.supportsPackageReferences(prj) then
-			p.error("Premake was compiled with --no-curl, but Curl is required for NuGet support (project '%s' is referencing NuGet packages)", prj.name)
+			p.error("Premake was compiled with --curl-src=none, but Curl is required for NuGet support (project '%s' is referencing NuGet packages)", prj.name)
 		end
 	end
 

--- a/tests/base/test_http.lua
+++ b/tests/base/test_http.lua
@@ -4,7 +4,7 @@
 -- Copyright (c) 2016, 2020 Jess Perkins and the Premake project
 --
 
-if http.get ~= nil and _OPTIONS["test-all"] then
+if http ~= nil and http.get ~= nil and _OPTIONS["test-all"] then
 	local p = premake
 
 	local suite = test.declare("premake_http")


### PR DESCRIPTION
**What does this PR do?**

This PR introduces the `--curl-src` option which deprecates `--no-curl` (for backwards compatibility), this new option allows users to pick between:
- `none`, replaces `--no-curl`
- `contrib`, default and what is currently used
- `system`, the system library

In addition to this new option, the Linux builds will test all three options to ensure unit tests continue to work and don't have issues with the settings.

**How does this PR change Premake's behavior?**

Users can still build with `--no-curl` but it will warn and prompt users to migrate to `--curl-src=none`.

The core focus of this PR was to allow users to build Premake with their system curl instead.

**Anything else we should know?**

Various unit tests, specifically Nuget tests, weren't properly checking for the `http`. This check has been added so the builds continue to work.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
