### PR TITLE
Prevent empty arrays as expected values for test.contains and test.excludes

### DIFF
--- a/modules/self-test/test_assertions.lua
+++ b/modules/self-test/test_assertions.lua
@@ -51,6 +51,9 @@
 
 	function m.contains(expected, actual)
 		if type(expected) == "table" then
+			if #expected == 0 then
+				m.fail("expected cannot be empty")
+			end
 			for i, v in ipairs(expected) do
 				m.contains(v, actual)
 			end
@@ -63,6 +66,9 @@
 
 	function m.excludes(expected, actual)
 		if type(expected) == "table" then
+			if #expected == 0 then
+				m.fail("expected cannot be empty")
+			end
 			for i, v in ipairs(expected) do
 				m.excludes(v, actual)
 			end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -868,204 +868,204 @@ end
 	function suite.cflags_onCDefault()
 		cdialect "Default"
 		prepare()
-		test.contains({ }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_onC89()
 		cdialect "C89"
 		prepare()
 		test.contains({ "-std=c89" }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_onC90()
 		cdialect "C90"
 		prepare()
 		test.contains({ "-std=c90" }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_onC99()
 		cdialect "C99"
 		prepare()
 		test.contains({ "-std=c99" }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_onC11()
 		cdialect "C11"
 		prepare()
 		test.contains({ "-std=c11" }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_onC17()
 		cdialect "C17"
 		prepare()
 		test.contains({ "-std=c17" }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_ongnu89()
 		cdialect "gnu89"
 		prepare()
 		test.contains({ "-std=gnu89" }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_ongnu90()
 		cdialect "gnu90"
 		prepare()
 		test.contains({ "-std=gnu90" }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_ongnu99()
 		cdialect "gnu99"
 		prepare()
 		test.contains({ "-std=gnu99" }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_ongnu11()
 		cdialect "gnu11"
 		prepare()
 		test.contains({ "-std=gnu11" }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cflags_ongnu17()
 		cdialect "gnu17"
 		prepare()
 		test.contains({ "-std=gnu17" }, gcc.getcflags(cfg))
-		test.contains({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cxxflags_onCppDefault()
 		cppdialect "Default"
 		prepare()
-		test.contains({ }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcxxflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCpp98()
 		cppdialect "C++98"
 		prepare()
 		test.contains({ "-std=c++98" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCpp11()
 		cppdialect "C++11"
 		prepare()
 		test.contains({ "-std=c++11" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCpp14()
 		cppdialect "C++14"
 		prepare()
 		test.contains({ "-std=c++14" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCpp17()
 		cppdialect "C++17"
 		prepare()
 		test.contains({ "-std=c++17" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCpp2a()
 		cppdialect "C++2a"
 		prepare()
 		test.contains({ "-std=c++2a" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCpp20()
 		cppdialect "C++20"
 		prepare()
 		test.contains({ "-std=c++20" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCpp2b()
 		cppdialect "C++2b"
 		prepare()
 		test.contains({ "-std=c++2b" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCpp23()
 		cppdialect "C++23"
 		prepare()
 		test.contains({ "-std=c++23" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCppLatest()
 		cppdialect "C++latest"
 		prepare()
 		test.contains({ "-std=c++23" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCppGnu98()
 		cppdialect "gnu++98"
 		prepare()
 		test.contains({ "-std=gnu++98" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCppGnu11()
 		cppdialect "gnu++11"
 		prepare()
 		test.contains({ "-std=gnu++11" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCppGnu14()
 		cppdialect "gnu++14"
 		prepare()
 		test.contains({ "-std=gnu++14" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCppGnu17()
 		cppdialect "gnu++17"
 		prepare()
 		test.contains({ "-std=gnu++17" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCppGnu2a()
 		cppdialect "gnu++2a"
 		prepare()
 		test.contains({ "-std=gnu++2a" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCppGnu20()
 		cppdialect "gnu++20"
 		prepare()
 		test.contains({ "-std=gnu++20" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCppGnu2b()
 		cppdialect "gnu++23"
 		prepare()
 		test.contains({ "-std=gnu++23" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 	function suite.cxxflags_onCppGnu23()
 		cppdialect "gnu++2b"
 		prepare()
 		test.contains({ "-std=gnu++2b" }, gcc.getcxxflags(cfg))
-		test.contains({ }, gcc.getcflags(cfg))
+		test.isequal({ }, gcc.getcflags(cfg))
 	end
 
 --


### PR DESCRIPTION
- Fixed GCC tests that used empty arrays

**What does this PR do?**

Prevents misuse of `test.contains` and `test.excludes` and fixes the GCC tests that misused them.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
