### PR TITLE
Added ci job to simplify required checks in PRs

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -109,3 +109,17 @@ jobs:
       with:
         name: premake-${{ matrix.msystem }}-${{ matrix.platform }}
         path: bin\${{ matrix.config }}\
+
+  # This job will be required for PRs to be merged.
+  # This should depend on (via needs) all jobs that need to be successful for the PR to be merged.
+  ci:
+    runs-on: ubuntu-latest
+    needs: [linux, macosx, windows]
+    if: always()
+    steps:
+      - name: All builds ok
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some builds failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
**What does this PR do?**

Creates a single job that we can require for approval of PRs. GitHub doesn't allow us to require the whole CI workflow, or a specific job such as `linux`, we must require each combination from the `matrix` setting; `linux (debug, x64)` and `linux (release, x64)`. A new axis in the matrix setting replaces all combinations with new combinations, this means that `linux (debug, x64)` becomes `linux (debug, x64, ...)` but GitHub will still be requiring `linux (debug, x64)` which won't exist - #2275 is an example of this happening.

This new job allows us to select a single job that will automatically depend on all versions of the jobs we specify using the `needs` setting. The purpose of this job is to group all of our required jobs statuses into a single job status that we can require from GitHub.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
