### PR TITLE
Fix vstudio/MSC not supporting the C++23 flag yet

### DIFF
--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -1412,7 +1412,7 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<LanguageStandard>stdcpp23</LanguageStandard>
+	<LanguageStandard>stdcpplatest</LanguageStandard>
 	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 </ClCompile>
 		]]

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1747,7 +1747,7 @@
 			elseif (cfg.cppdialect == "C++20") then
 				m.element("LanguageStandard", condition, iif(_ACTION <= "vs2017", 'stdcpplatest', 'stdcpp20'))
 			elseif (cfg.cppdialect == "C++23") then
-				m.element("LanguageStandard", condition, iif(_ACTION <= "vs2019", 'stdcpplatest', 'stdcpp23'))
+				m.element("LanguageStandard", condition, 'stdcpplatest')
 			elseif (cfg.cppdialect == "C++latest") then
 				m.element("LanguageStandard", condition, 'stdcpplatest')
 			end

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -196,7 +196,7 @@
 			["C++14"] = "/std:c++14",
 			["C++17"] = "/std:c++17",
 			["C++20"] = "/std:c++20",
-			["C++23"] = "/std:c++23",
+			["C++23"] = "/std:c++latest",
 			["C++latest"] = "/std:c++latest"
 		},
 		exceptionhandling = {

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -404,7 +404,7 @@ end
 	function suite.cppdialectCpp23()
 		cppdialect "C++23"
 		prepare()
-		test.contains('/std:c++23', msc.getcxxflags(cfg))
+		test.contains('/std:c++latest', msc.getcxxflags(cfg))
 	end
 
 	function suite.cppdialectCppLatest()


### PR DESCRIPTION
vs2022 and MSC need to use C++Latest flag to get C++23 features.

Follow-up of #2277