### PR TITLE
Fix `os.host` for Cosmopolitan build

### DIFF
--- a/src/_premake_main.lua
+++ b/src/_premake_main.lua
@@ -8,8 +8,11 @@
 	local versionhelp   = "premake5 (Premake Build Script Generator) %s"
 	local startTime     = os.clock()
 
--- set a global.
+-- set main globals.
 	_PREMAKE_STARTTIME = startTime
+
+	-- default the target OS to the host OS
+	_TARGET_OS = os.host()
 
 -- Load the collection of core scripts, required for everything else to work
 

--- a/src/host/os_host.c
+++ b/src/host/os_host.c
@@ -6,8 +6,30 @@
 
 #include "premake.h"
 
+#if PLATFORM_COSMO
+#include <cosmo.h>
+#include <assert.h>
+#endif
+
+static const char* host_os()
+{
+#if PLATFORM_COSMO
+	if (IsLinux()) { return "linux"; }
+	else if (IsWindows()) { return "windows"; }
+	else if (IsXnu()) { return "macosx"; }
+	else if (IsBsd()) { return "bsd"; }
+	else
+	{
+		assert(0 && "Platform is unknown to Cosmopolitan Libc");
+		return 0;
+	}
+#else
+	return PLATFORM_OS;
+#endif
+}
+
 int os_host(lua_State* L)
 {
-	lua_pushstring(L, PLATFORM_OS);
+	lua_pushstring(L, host_os());
 	return 1;
 }

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -20,10 +20,6 @@
 #include <sys/sysctl.h>
 #endif
 
-#if PLATFORM_COSMO
-#include <cosmo.h>
-#endif
-
 #define ERROR_MESSAGE  "Error: %s\n"
 
 
@@ -174,24 +170,6 @@ void luaL_register(lua_State *L, const char *libname, const luaL_Reg *l)
 	lua_getorcreate_table(L, libname);
 	luaL_setfuncs(L, l, 0);
 	lua_pop(L, 1);
-}
-
-
-static const char* premake_host_os()
-{
-#if PLATFORM_COSMO
-	if (IsLinux()) { return "linux"; }
-	else if (IsWindows()) { return "windows"; }
-	else if (IsXnu()) { return "macosx"; }
-	else if (IsBsd()) { return "bsd"; }
-	else
-	{
-		assert(0 && "Platform is unknown to Cosmopolitan Libc");
-		return 0;
-	}
-#else
-	return PLATFORM_OS;
-#endif
 }
 
 

--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -213,14 +213,6 @@ int premake_init(lua_State* L)
 	lua_pushstring(L, PREMAKE_PROJECT_URL);
 	lua_setglobal(L, "_PREMAKE_URL");
 
-	/* set the target OS platform variable */
-	lua_pushstring(L, premake_host_os());
-	lua_setglobal(L, "_TARGET_OS");
-
-	/* set the target arch platform variable */
-	lua_pushnil(L);
-	lua_setglobal(L, "_TARGET_ARCH");
-
 #if PLATFORM_COSMO
 	/* set _COSMOPOLITAN if its a Cosmopolitan build */
 	lua_pushboolean(L, TRUE);

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -501,6 +501,20 @@
 
 
 --
+-- os.host() tests.
+--
+
+function suite.host()
+	local host = os.host()
+	test.istrue(string.len(host) > 0)
+
+	if _COSMOPOLITAN then
+		test.istrue(host ~= "cosmopolitan")
+	end
+end
+
+
+--
 -- os.hostarch() tests.
 --
 


### PR DESCRIPTION
**What does this PR do?**

Fixes `os.host` for Cosmopolitan build

**Anything else we should know?**

Also a minor cleanup where `_TARGET_OS` is moved to Lua which would have prevented this bug in the first place.

Should we still leave an assignement to `_TARGET_ARCH = nil` just for documentation sake that it exists?
