### PR TITLE
Bootstrap improvements

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build
-      run: make -f Bootstrap.mak linux PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }}
+      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} ./Bootstrap.sh
     - name: Test
       run: bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check
@@ -34,7 +34,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build
-      run: make -f Bootstrap.mak macosx PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }}
+      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} ./Bootstrap.sh
     - name: Test
       run: bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check
@@ -51,13 +51,16 @@ jobs:
       matrix:
         config: [debug, release]
         platform: [Win32, x64]
+        msdev: [vs2022]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build
-      run: |
-        $vcvarsall_path = vswhere.exe -find VC\Auxiliary\Build\vcvarsall.bat
-        cmd.exe /c "call ""$vcvarsall_path"" x86_amd64 && nmake -f Bootstrap.mak MSDEV=vs2019 windows-msbuild PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }}"
+      shell: cmd
+      env:
+        PLATFORM: ${{ matrix.platform }}
+        CONFIG: ${{ matrix.config }}
+      run: ./Bootstrap.bat ${{ matrix.msdev }}
     - name: Test
       run: bin\${{ matrix.config }}\premake5 test --test-all
       shell: cmd
@@ -98,7 +101,7 @@ jobs:
         pacboy: >-
           toolchain:p
     - name: Build
-      run: make -f Bootstrap.mak mingw PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }}
+      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} ./Bootstrap.sh
     - name: Test
       run: bin/${{ matrix.config }}/premake5.exe test --test-all
     - name: Docs check
@@ -121,7 +124,7 @@ jobs:
       with:
         version: '3.9.2'
     - name: Build
-      run: make -f Bootstrap.mak cosmo CONFIG=${{ matrix.config }}
+      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} ./Bootstrap.sh -cosmo
     - name: Test
       run: bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check

--- a/BUILD.txt
+++ b/BUILD.txt
@@ -27,7 +27,17 @@ BUILDING FROM A SOURCE PACKAGE
 BUILDING FROM THE REPOSITORY
 
  If you have pulled sources from the Premake source repository, you can
- use `Bootstrap.mak` to generate your first premake executable:
+ use `Bootstrap.sh` or `Bootstrap.bat` to generate your first premake executable:
+
+ On Windows:
+
+    $ ./Bootstrap.bat
+
+ On other platforms:
+
+    $ ./Bootstrap.sh
+
+Alternatively, you may call the Makefile directly:
 
     $ make -f Bootstrap.mak PLATFORM
 

--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -9,6 +9,17 @@ SET VsWherePath="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswher
 
 REM ===========================================================================
 
+SET "PlatformArg="
+SET "ConfigArg="
+
+IF NOT "%PLATFORM%" == "" (
+    SET "PlatformArg=PLATFORM=%PLATFORM%"
+)
+
+IF NOT "%CONFIG%" == "" (
+    SET "ConfigArg=CONFIG=%CONFIG%"
+)
+
 SET vsversion=%1
 IF "%vsversion%" == "" (
 	CALL :BootstrapLatest
@@ -67,7 +78,7 @@ IF NOT EXIST "%VsPath%vsdevcmd.bat" (
 	EXIT /B 2
 )
 
-CALL "%VsPath%vsdevcmd.bat" && nmake MSDEV="%~1" -f Bootstrap.mak windows
+CALL "%VsPath%vsdevcmd.bat" && nmake MSDEV="%~1" %PlatformArg% %ConfigArg% -f Bootstrap.mak windows
 EXIT /B %ERRORLEVEL%
 
 REM :LegacyVisualBootstrap
@@ -95,11 +106,11 @@ SET VsWhereCmdLine="!VsWherePath! -nologo -latest -version [%VsVersionMin%,%VsVe
 FOR /F "usebackq delims=" %%i in (`!VsWhereCmdLine!`) DO (
 
 	IF EXIST "%%i\VC\Auxiliary\Build\vcvars32.bat" (
-		CALL "%%i\VC\Auxiliary\Build\vcvars32.bat" && nmake MSDEV="%PremakeVsVersion%" -f Bootstrap.mak windows
+		CALL "%%i\VC\Auxiliary\Build\vcvars32.bat" && nmake MSDEV="%PremakeVsVersion%" %PlatformArg% %ConfigArg% -f Bootstrap.mak windows
 		EXIT /B %ERRORLEVEL%
 	) ELSE (
 		IF EXIST "%%i\VC\Auxiliary\Build\vcvars64.bat" (
-			CALL "%%i\VC\Auxiliary\Build\vcvars64.bat" && nmake MSDEV="%PremakeVsVersion%" -f Bootstrap.mak windows
+			CALL "%%i\VC\Auxiliary\Build\vcvars64.bat" && nmake MSDEV="%PremakeVsVersion%" %PlatformArg% %ConfigArg% -f Bootstrap.mak windows
 			EXIT /B %ERRORLEVEL%
 		)
 	)

--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -105,18 +105,18 @@ SET VsWhereCmdLine="!VsWherePath! -nologo -latest -version [%VsVersionMin%,%VsVe
 
 FOR /F "usebackq delims=" %%i in (`!VsWhereCmdLine!`) DO (
 
-	IF EXIST "%%i\VC\Auxiliary\Build\vcvars32.bat" (
-		CALL "%%i\VC\Auxiliary\Build\vcvars32.bat" && nmake MSDEV="%PremakeVsVersion%" %PlatformArg% %ConfigArg% -f Bootstrap.mak windows
+	IF EXIST "%%i\VC\Auxiliary\Build\vcvars64.bat" (
+		CALL "%%i\VC\Auxiliary\Build\vcvars64.bat" && nmake MSDEV="%PremakeVsVersion%" %PlatformArg% %ConfigArg% -f Bootstrap.mak windows
 		EXIT /B %ERRORLEVEL%
 	) ELSE (
-		IF EXIST "%%i\VC\Auxiliary\Build\vcvars64.bat" (
-			CALL "%%i\VC\Auxiliary\Build\vcvars64.bat" && nmake MSDEV="%PremakeVsVersion%" %PlatformArg% %ConfigArg% -f Bootstrap.mak windows
+		IF EXIST "%%i\VC\Auxiliary\Build\vcvars32.bat" (
+			CALL "%%i\VC\Auxiliary\Build\vcvars32.bat" && nmake MSDEV="%PremakeVsVersion%" %PlatformArg% %ConfigArg% -f Bootstrap.mak windows
 			EXIT /B %ERRORLEVEL%
 		)
 	)
 )
 
-ECHO Could not find vcvars32.bat or vcvars64.bat to setup Visual Studio environment
+ECHO Could not find vcvars64.bat or vcvars32.bat to setup Visual Studio environment
 EXIT /B 2
 
 REM :VsWhereVisualBootstrap

--- a/Bootstrap.sh
+++ b/Bootstrap.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+DIR=$( cd "$( dirname "$0" )" && pwd )
+cd "$DIR"
+
+COSMO_FLAG=""
+for arg in "$@"; do
+  if [ "$arg" = "-cosmo" ]; then
+    COSMO_FLAG="cosmo"
+    break
+  fi
+done
+
+PLATFORM_ARG=""
+CONFIG_ARG=""
+
+if [ -n "$PLATFORM" ]; then
+  PLATFORM_ARG="PLATFORM=$PLATFORM"
+fi
+
+if [ -n "$CONFIG" ]; then
+  CONFIG_ARG="CONFIG=$CONFIG"
+fi
+
+case "$(uname -s)" in
+   Linux)
+     NPROC=$(nproc --all)
+     make -f Bootstrap.mak ${COSMO_FLAG:-linux} $PLATFORM_ARG $CONFIG_ARG -j$NPROC
+     ;;
+   Darwin)
+     NPROC=$(sysctl -n hw.ncpu)
+     make -f Bootstrap.mak ${COSMO_FLAG:-osx} $PLATFORM_ARG $CONFIG_ARG -j$NPROC
+     ;;
+   FreeBSD|OpenBSD|NetBSD)
+     NPROC=$(sysctl -n hw.ncpu)
+     make -f Bootstrap.mak ${COSMO_FLAG:-bsd} $PLATFORM_ARG $CONFIG_ARG -j$NPROC
+     ;;
+   CYGWIN*|MINGW32*|MSYS*|MINGW*)
+     make -f Bootstrap.mak ${COSMO_FLAG:-mingw} $PLATFORM_ARG $CONFIG_ARG -j$NPROC
+     ;;
+   *)
+    echo "Unsupported platform"
+    exit 1
+     ;;
+esac

--- a/binmodules/luasocket/premake5.lua
+++ b/binmodules/luasocket/premake5.lua
@@ -32,7 +32,7 @@ project "luasocket"
 		links { 'ws2_32' }
 		characterset "MBCS"
 		
-		defines { "LUASOCKET_API=__declspec(dllexport)" }
+		defines { "LUASOCKET_API=__declspec(dllexport)", "_WINSOCK_DEPRECATED_NO_WARNINGS" }
 	
 	filter "system:not windows"
 		removefiles


### PR DESCRIPTION
**What does this PR do?**

Adds a new `Bootstrap.sh` script to simplify bootstrap in non-Windows platforms.
Re-uses all the bootstrap scripts for CI to make sure they are well tested.

**How does this PR change Premake's behavior?**

I updated CI to use `vs2022` as `MSDEV`. Previously we were using `vs2019`, however if you pass that to `Bootstrap.bat` then `vswhere.exe` cannot find VS.

AFACT there is no point in forcing Premake to generate `vs2019` files to build with MSVC 2022.

So either we just pass an empty value so it auto detects latest MSVC, or pass it explicitly as part of a matrix as I've done.
