### PR TITLE
Increase Lua's debug path size.

### DIFF
--- a/contrib/lua/src/luaconf.h
+++ b/contrib/lua/src/luaconf.h
@@ -782,9 +782,10 @@
 ** without modifying the main part of the file.
 */
 
-
-
-
+#ifdef LUA_IDSIZE
+#undef LUA_IDSIZE
+#endif
+#define LUA_IDSIZE 120
 
 #endif
 


### PR DESCRIPTION
**What does this PR do?**

When Lua reports a stack traceback, it prints the path to the files.

But by default, right now, it's limited to 60 characters, which gets super annoying when trying to work on the codebase, as paths are ellipsized if they are bigger, which prevents from Ctrl-clicking on them to go to the right location in the IDE/editor.

This increases the limit to double the default size, which so far has worked fine for me.

Before:
```
stack traceback:
        .../premake/modules/gmake/tests/cpp/test_make_pch.lua:66:
```

After:
```
stack traceback:
/home/joao/dev/tools/premake/modules/gmake/tests/cpp/test_make_pch.lua:66:
```

**How does this PR change Premake's behavior?**

Nicer path outputs for errors.

**Anything else we should know?**

It changes Lua's `luaconf.h`. Unfortunately I don't think there is any other way since the original header does not check if the value is already defined, so even if we define it ourselves in `premake5.lua`, the value is overriden by the default one, with some warnings to boot.

So change it in the conf file, which contains a section for local modifications anyway.