### PR TITLE
Remove generated "website/node_modules"'s files from project

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -277,7 +277,8 @@ if premake.action.supports("None") then
 	project "Web"
 		kind "None"
 
-		files "website/**"
+		files { "website/blog/**", "website/community/**", "website/doc/**", "website/src/**", "website/static/**", "website/*" }
+		-- ensure that "website/node_modules/**" is not there (generated files)
 
 	project "Github"
 		kind "None"

--- a/premake5.lua
+++ b/premake5.lua
@@ -277,7 +277,15 @@ if premake.action.supports("None") then
 	project "Web"
 		kind "None"
 
-		files { "website/blog/**", "website/community/**", "website/doc/**", "website/src/**", "website/static/**", "website/*" }
+		files
+		{
+			"website/blog/**",
+			"website/community/**",
+			"website/doc/**",
+			"website/src/**",
+			"website/static/**",
+			"website/*"
+		}
 		-- ensure that "website/node_modules/**" is not there (generated files)
 
 	project "Github"


### PR DESCRIPTION
**What does this PR do?**

According to https://github.com/premake/premake-core/pull/2294 comments, there is a slowdown
so removing the extra generated files under website/node_modules

**How does this PR change Premake's behavior?**

No behavior change.

**Anything else we should know?**

@tritao: is it ok like that?

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
