### PR TITLE
Forbid empty `defines`, 

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -364,6 +364,9 @@
 		scope = "config",
 		kind = "list:string",
 		tokens = true,
+		allowed = function(value)
+			return iif(value == "", nil, value)
+		end
 	}
 
 	api.register {


### PR DESCRIPTION
**What does this PR do?**

Forbid `defines ""`

**How does this PR change Premake's behavior?**

Error out wrong script using `defines ""`

**Anything else we should know?**

closes #2174

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
