### PR TITLE
Fix typo to link resources

### DIFF
--- a/modules/gmake2/gmake2_cpp.lua
+++ b/modules/gmake2/gmake2_cpp.lua
@@ -109,7 +109,7 @@
 			['.c']   = 'SOURCES',
 			['.s']   = 'SOURCES',
 			['.m']   = 'SOURCES',
-			['.rc']  = 'RESOURCES',
+			['.res'] = 'RESOURCES',
 		}
 
 		-- cache the result.

--- a/modules/gmake2/tests/test_gmake2_objects.lua
+++ b/modules/gmake2/tests/test_gmake2_objects.lua
@@ -50,6 +50,22 @@ OBJECTS += $(OBJDIR)/hello.o
 		]]
 	end
 
+	function suite.listResoucesInProjectObjects()
+		files { "src/hello.rc" }
+		prepare()
+		test.capture [[
+# File sets
+# #############################################
+
+GENERATED :=
+RESOURCES :=
+
+GENERATED += $(OBJDIR)/hello.res
+RESOURCES += $(OBJDIR)/hello.res
+
+		]]
+	end
+
 
 --
 -- Only buildable files should be listed.


### PR DESCRIPTION
**What does this PR do?**

Fix typo in gmake2 generator about resource

**How does this PR change Premake's behavior?**

Allow to link resource with gmake2

**Anything else we should know?**

closes #2310 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes