### PR TITLE
[vs20xx] Fix `flags { "LinkTimeOptimization" }` to add missing xml entity `LinkTimeCodeGeneration`

### DIFF
--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -675,6 +675,7 @@
 				m.fullProgramDatabaseFile,
 				m.generateDebugInformation,
 				m.optimizeReferences,
+				m.LinkTimeCodeGeneration,
 			}
 		else
 			return {
@@ -682,6 +683,7 @@
 				m.fullProgramDatabaseFile,
 				m.generateDebugInformation,
 				m.optimizeReferences,
+				m.LinkTimeCodeGeneration,
 				m.additionalDependencies,
 				m.additionalLibraryDirectories,
 				m.importLibrary,
@@ -2727,6 +2729,11 @@
 		end
 	end
 
+	function m.LinkTimeCodeGeneration(cfg)
+		if cfg.flags.LinkTimeOptimization then
+			m.element("LinkTimeCodeGeneration", nil, "UseLinkTimeCodeGeneration")
+		end
+	end
 
 	function m.optimization(cfg, condition)
 		local map = { Off="Disabled", On="Full", Debug="Disabled", Full="Full", Size="MinSpace", Speed="MaxSpeed" }

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -152,7 +152,8 @@
 	function config.canLinkIncremental(cfg)
 		if cfg.kind == "StaticLib"
 				or config.isOptimizedBuild(cfg)
-				or cfg.flags.NoIncrementalLink then
+				or cfg.flags.NoIncrementalLink
+				or cfg.flags.LinkTimeOptimization then
 			return false
 		end
 		return true


### PR DESCRIPTION
**What does this PR do?**

Fix `flags { "LinkTimeOptimization" }` to add missing xml entity `LinkTimeCodeGeneration`.

**How does this PR change Premake's behavior?**

Generated visual solutions with `flags { "LinkTimeOptimization" }` would be modified

**Anything else we should know?**

@StanleySweet Can you verify it fix your issue.

closes #2312

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
