### PR TITLE
Add TSan and UBSan to sanitize options

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1149,6 +1149,8 @@
 		allowed = {
 			"Address",
 			"Fuzzer",              -- Visual Studio 2022+ only
+			"Thread",
+			"UndefinedBehavior",
 		}
 	}
 

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -66,7 +66,9 @@
 		unsignedchar = gcc.shared.unsignedchar,
 		omitframepointer = gcc.shared.omitframepointer,
 		compileas = gcc.shared.compileas,
-		sanitize = gcc.shared.sanitize,
+		sanitize = table.merge(gcc.shared.sanitize, {
+			Fuzzer = "-fsanitize=fuzzer",
+		}),
 		visibility = gcc.shared.visibility,
 		inlinesvisibility = gcc.shared.inlinesvisibility
 	}
@@ -118,9 +120,6 @@
 --
 
 	clang.cxxflags = table.merge(gcc.cxxflags, {
-		sanitize = {
-			Fuzzer = "-fsanitize=fuzzer",
-		},
 	})
 
 	function clang.getcxxflags(cfg)
@@ -254,9 +253,9 @@
 			end,
 		},
 		linker = gcc.ldflags.linker,
-		sanitize = {
-			Address = "-fsanitize=address",
-		},
+		sanitize = table.merge(gcc.ldflags.sanitize, {
+			Fuzzer = "-fsanitize=fuzzer",
+		}),
 		system = {
 			wii = "$(MACHDEP)",
 		}

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -142,7 +142,7 @@
 		sanitize = {
 			Address = "-fsanitize=address",
 			Thread = "-fsanitize=thread",
-			Undefined = "-fsanitize=undefined",
+			UndefinedBehavior = "-fsanitize=undefined",
 		},
 		visibility = {
 			Default = "-fvisibility=default",

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -490,6 +490,8 @@
 		},
 		sanitize = {
 			Address = "-fsanitize=address",
+			Thread = "-fsanitize=thread",
+			UndefinedBehavior = "-fsanitize=undefined",
 		},
 		system = {
 			wii = "$(MACHDEP)",

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -141,6 +141,8 @@
 		},
 		sanitize = {
 			Address = "-fsanitize=address",
+			Thread = "-fsanitize=thread",
+			Undefined = "-fsanitize=undefined",
 		},
 		visibility = {
 			Default = "-fvisibility=default",

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -146,7 +146,7 @@
 
 	-- UBSan
 	function suite.cxxflags_onSanitizeUndefined()
-		sanitize { "Undefined" }
+		sanitize { "UndefinedBehavior" }
 		prepare()
 		test.contains({ "-fsanitize=undefined" }, clang.getcxxflags(cfg))
 		test.contains({ "-fsanitize=undefined" }, clang.getcflags(cfg))

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -110,25 +110,45 @@
 -- Check handling of linker flag.
 --
 
-function suite.ldflags_linker_lld()
-	linker "LLD"
-	prepare()
-	test.contains("-fuse-ld=lld", clang.getldflags(cfg))
-end
+	function suite.ldflags_linker_lld()
+		linker "LLD"
+		prepare()
+		test.contains("-fuse-ld=lld", clang.getldflags(cfg))
+	end
 
 --
 -- Check the translation of CXXFLAGS.
 --
 
-function suite.onSanitizeAddress()
-	sanitize { "Address" }
-	prepare()
-	test.contains({ "-fsanitize=address" }, clang.getcxxflags(cfg))
-	test.contains({ "-fsanitize=address" }, clang.getldflags(cfg))
-end
+	function suite.onSanitizeAddress()
+		sanitize { "Address" }
+		prepare()
+		test.contains({ "-fsanitize=address" }, clang.getcxxflags(cfg))
+		test.contains({ "-fsanitize=address" }, clang.getcflags(cfg))
+		test.contains({ "-fsanitize=address" }, clang.getldflags(cfg))
+	end
 
-function suite.cxxflags_onSanitizeFuzzer()
-	sanitize { "Fuzzer" }
-	prepare()
-	test.contains({ "-fsanitize=fuzzer" }, clang.getcxxflags(cfg))
-end
+	function suite.cxxflags_onSanitizeFuzzer()
+		sanitize { "Fuzzer" }
+		prepare()
+		test.contains({ "-fsanitize=fuzzer" }, clang.getcxxflags(cfg))
+		test.contains({ "-fsanitize=fuzzer" }, clang.getcflags(cfg))
+		test.contains({ "-fsanitize=fuzzer" }, clang.getldflags(cfg))
+	end
+
+	function suite.cxxflags_onSanitizeThread()
+		sanitize { "Thread" }
+		prepare()
+		test.contains({ "-fsanitize=thread" }, clang.getcxxflags(cfg))
+		test.contains({ "-fsanitize=thread" }, clang.getcflags(cfg))
+		test.contains({ "-fsanitize=thread" }, clang.getldflags(cfg))
+	end
+
+	-- UBSan
+	function suite.cxxflags_onSanitizeUndefined()
+		sanitize { "Undefined" }
+		prepare()
+		test.contains({ "-fsanitize=undefined" }, clang.getcxxflags(cfg))
+		test.contains({ "-fsanitize=undefined" }, clang.getcflags(cfg))
+		test.contains({ "-fsanitize=undefined" }, clang.getldflags(cfg))
+	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -393,6 +393,23 @@
 		test.contains({ "-fsanitize=address" }, gcc.getldflags(cfg))
 	end
 
+	function suite.cxxflags_onSanitizeThread()
+		sanitize { "Thread" }
+		prepare()
+		test.contains({ "-fsanitize=thread" }, gcc.getcxxflags(cfg))
+		test.contains({ "-fsanitize=thread" }, gcc.getcflags(cfg))
+		test.contains({ "-fsanitize=thread" }, gcc.getldflags(cfg))
+	end
+
+	-- UBSan
+	function suite.cxxflags_onSanitizeUndefined()
+		sanitize { "Undefined" }
+		prepare()
+		test.contains({ "-fsanitize=undefined" }, gcc.getcxxflags(cfg))
+		test.contains({ "-fsanitize=undefined" }, gcc.getcflags(cfg))
+		test.contains({ "-fsanitize=undefined" }, gcc.getldflags(cfg))
+	end
+
 --
 -- Check the basic translation of LDFLAGS for a Posix system.
 --

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -403,7 +403,7 @@
 
 	-- UBSan
 	function suite.cxxflags_onSanitizeUndefined()
-		sanitize { "Undefined" }
+		sanitize { "UndefinedBehavior" }
 		prepare()
 		test.contains({ "-fsanitize=undefined" }, gcc.getcxxflags(cfg))
 		test.contains({ "-fsanitize=undefined" }, gcc.getcflags(cfg))

--- a/website/docs/sanitize.md
+++ b/website/docs/sanitize.md
@@ -12,6 +12,8 @@ sanitize { "value_list" }
 |-------------|--------------------------------------------------------|
 | Address     | Enables compiler support for AddressSanitizer. | Visual Studio support starts with 2019 16.9 |
 | Fuzzer      | Enables support for LibFuzzer, a coverage-guided fuzzing library. | Visual Studio support starts with 2019 16.9 |
+| Thread      | Enables compiler support for ThreadSanitizer. |
+| Undefined   | Enables compiler support for UndefinedBehaviorSanitizer (UBSan). |
 
 ### Applies To ###
 

--- a/website/docs/sanitize.md
+++ b/website/docs/sanitize.md
@@ -8,12 +8,12 @@ sanitize { "value_list" }
 
 `value_list` specifies the desired `fsanitize` options to enable.
 
-| Value       | Description                                            |
-|-------------|--------------------------------------------------------|
-| Address     | Enables compiler support for AddressSanitizer. | Visual Studio support starts with 2019 16.9 |
-| Fuzzer      | Enables support for LibFuzzer, a coverage-guided fuzzing library. | Visual Studio support starts with 2019 16.9 |
-| Thread      | Enables compiler support for ThreadSanitizer. |
-| Undefined   | Enables compiler support for UndefinedBehaviorSanitizer (UBSan). |
+| Value             | Description                                            | Notes |
+|-------------------|--------------------------------------------------------|---|
+| Address           | Enables compiler support for AddressSanitizer (ASan). | Visual Studio support starts with 2019 16.9 |
+| Fuzzer            | Enables support for LibFuzzer, a coverage-guided fuzzing library. | Unsupported with GCC. Visual Studio support starts with 2019 16.9 |
+| Thread            | Enables compiler support for ThreadSanitizer (TSan). | GCC & Clang only |
+| UndefinedBehavior | Enables compiler support for UndefinedBehaviorSanitizer (UBSan). | GCC & Clang only |
 
 ### Applies To ###
 


### PR DESCRIPTION
**What does this PR do?**
Add TSan and UBSan to the list of sanitize options

**How does this PR change Premake's behavior?**
It is possible for users to enable TSan and UBSan now.

**Anything else we should know?**
I'm unable to run the tests so I'm unsure if they actually pass.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
