### PR TITLE
Fix issue with `lua_loadfile` and `require`.

### DIFF
--- a/tests/folder/init.lua
+++ b/tests/folder/init.lua
@@ -1,0 +1,1 @@
+-- empty file used by loadfile_with_require test

--- a/tests/test_lua.lua
+++ b/tests/test_lua.lua
@@ -35,3 +35,13 @@ end
 		test.isequal(10, value)
 	end
 
+
+--
+-- loadfile via require with init.lua
+--
+
+function suite.loadfile_with_require()
+	os.chdir(_SCRIPT_DIR)
+	assert(require("folder"))
+end
+


### PR DESCRIPTION
Fixes an regression introduced in https://github.com/premake/premake-core/commit/afcbbb2bb8f1ef79565ab8035f71f59a037d65e1.

`require` actually follows a different code path in Lua with a different stack layout expectation than the other code paths.

Fix the code to deal with this case, and also clean up some other tidbits around cleaning up stack values. The new approach is simpler to understand and should fix a potential issue that could happen in the error case.

Fixes https://github.com/premake/premake-core/issues/2314.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
