### PR TITLE
updated dotnetbase to generate configurations list in opening propert…

### DIFF
--- a/modules/vstudio/tests/cs2005/test_netcore.lua
+++ b/modules/vstudio/tests/cs2005/test_netcore.lua
@@ -132,3 +132,20 @@ function suite.allowUnsafeProperty_core()
 	</PropertyGroup>
     ]]
 end
+
+function suite.project_element_configurations()
+	p.action.set("vs2022")
+	dotnetframework "net8.0"
+	prepareProjectProperties()
+
+	configurations { "Debug","Release","Distribution"}
+	test.capture [[
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <TargetFramework>net8.0</TargetFramework>
+        <Configurations>Debug;Release</Configurations>
+        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    </PropertyGroup>
+]]
+end

--- a/modules/vstudio/tests/cs2005/test_netcore.lua
+++ b/modules/vstudio/tests/cs2005/test_netcore.lua
@@ -20,6 +20,7 @@ local wks, prj
 function suite.setup()
     p.action.set("vs2005")
     wks, prj = test.createWorkspace()
+	configurations { "Debug", "Release", "Distribution"}
     language "C#"
 end
 
@@ -31,6 +32,10 @@ end
 local function targetFrameworkVersionPrepare()
     local cfg = test.getconfig(prj, "Debug")
     dn2005.targetFrameworkVersion(cfg)
+end
+
+local function projectConfigurationsPrepare()
+    dn2005.projectConfigurations(prj)
 end
 
 local function prepareNetcore()
@@ -136,16 +141,10 @@ end
 function suite.project_element_configurations()
 	p.action.set("vs2022")
 	dotnetframework "net8.0"
-	prepareProjectProperties()
 
-	configurations { "Debug","Release","Distribution"}
-	test.capture [[
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <TargetFramework>net8.0</TargetFramework>
-        <Configurations>Debug;Release</Configurations>
-        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    </PropertyGroup>
-]]
+	projectConfigurationsPrepare()
+
+test.capture [[
+		<Configurations>Debug;Release;Distribution</Configurations>
+	]]
 end

--- a/modules/vstudio/vs2005_csproj.lua
+++ b/modules/vstudio/vs2005_csproj.lua
@@ -52,6 +52,7 @@
 				dotnetbase.bindingRedirects,
 				dotnetbase.netcore.useWpf,
 				dotnetbase.csversion,
+				dotnetbase.projectConfigurations,
 				dotnetbase.netcore.enableDefaultCompileItems,
 			}
 		else

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -82,9 +82,6 @@
 		_p(1,'<PropertyGroup>')
 		local cfg = project.getfirstconfig(prj)
 		p.callArray(dotnetbase.elements.projectProperties, cfg)
-
-		dotnetbase.projectConfigurations(prj)
-
 		_p(1,'</PropertyGroup>')
 	end
 
@@ -92,12 +89,8 @@
 -- Write the available configurations to have correct configuration mapping on vs2022 format and later.
 --
 	function dotnetbase.projectConfigurations(prj)
-		if _ACTION >= "vs2022" and #prj._cfglist > 0 then
-			_p(2,'<Configurations>')
-			for prjcfg in project.eachconfig(prj) do
-				_p(3,'%s;',prjcfg.shortname)
-			end
-			_p(2,'</Configurations>')
+		if _ACTION >= "vs2022" and #prj.configurations > 0 then
+			_p(2,'<Configurations>%s</Configurations>',table.implode(prj.configurations,"", "", ";"))
 		end
 	end
 --

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -90,7 +90,7 @@
 --
 	function dotnetbase.projectConfigurations(prj)
 		if _ACTION >= "vs2022" and #prj.configurations > 0 then
-			_p(2,'<Configurations>%s</Configurations>',table.implode(prj.configurations,"", "", ";"))
+			_p(2, '<Configurations>%s</Configurations>', table.implode(prj.configurations, "", "", ";"))
 		end
 	end
 --

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -82,10 +82,24 @@
 		_p(1,'<PropertyGroup>')
 		local cfg = project.getfirstconfig(prj)
 		p.callArray(dotnetbase.elements.projectProperties, cfg)
+
+		dotnetbase.projectConfigurations(prj)
+
 		_p(1,'</PropertyGroup>')
 	end
 
-
+--
+-- Write the available configurations to have correct configuration mapping on vs2022 format and later.
+--
+	function dotnetbase.projectConfigurations(prj)
+		if _ACTION >= "vs2022" and #prj._cfglist > 0 then
+			_p(2,'<Configurations>')
+			for prjcfg in project.eachconfig(prj) do
+				_p(3,'%s;',prjcfg.shortname)
+			end
+			_p(2,'</Configurations>')
+		end
+	end
 --
 -- Write out the settings for the project configurations.
 --


### PR DESCRIPTION
…ygroup containing project properties

(fix for incorrect cofigurationmapping) (tests required)

**What does this PR do?**

Thanks for the contribution! Please provide a concise description of the problem this request solves.
this pr closes #2319 

Are there any breaking changes? Will any existing behavior change?

**Anything else we should know?**

should documentation be changed to tell people about this because it is auto genrated from vs2022 onwards
**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
