### PR TITLE
Post Release 5.0.0-beta3 Cleanup

### DIFF
--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -1,7 +1,7 @@
 /**
  * \file   premake.h
  * \brief  Program-wide constants and definitions.
- * \author Copyright (c) 2002-2021 Jess Perkins and the Premake project
+ * \author Copyright (c) 2002-2024 Jess Perkins and the Premake project
  */
 
 #define lua_c
@@ -12,8 +12,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define PREMAKE_VERSION        "5.0.0-beta3"
-#define PREMAKE_COPYRIGHT      "Copyright (C) 2002-2021 Jess Perkins and the Premake Project"
+#define PREMAKE_VERSION        "5.0.0-dev"
+#define PREMAKE_COPYRIGHT      "Copyright (C) 2002-2024 Jess Perkins and the Premake Project"
 #define PREMAKE_PROJECT_URL    "https://github.com/premake/premake-core/wiki"
 
 #if defined(__linux__)


### PR DESCRIPTION
Reverts the version back to 5.0.0-dev in the build, updates copyright year in `src/host/premake.h`