### PR TITLE
Removes deprecated language version flags

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -375,11 +375,6 @@
 			"UndefinedIdentifiers",
 			"WinMain",             -- DEPRECATED
 			"WPF",
-			"C++11",               -- DEPRECATED
-			"C++14",               -- DEPRECATED
-			"C90",                 -- DEPRECATED
-			"C99",                 -- DEPRECATED
-			"C11",                 -- DEPRECATED
 		},
 		aliases = {
 			FatalWarnings = { "FatalWarnings", "FatalCompileWarnings", "FatalLinkWarnings" },
@@ -1292,49 +1287,6 @@
 	end,
 	function(value)
 		symbols "Default"
-	end)
-
-
-	-- 31 January 2017
-
-	api.deprecateValue("flags", "C++11", 'Use `cppdialect "C++11"` instead',
-	function(value)
-		cppdialect "C++11"
-	end,
-	function(value)
-		cppdialect "Default"
-	end)
-
-	api.deprecateValue("flags", "C++14", 'Use `cppdialect "C++14"` instead',
-	function(value)
-		cppdialect "C++14"
-	end,
-	function(value)
-		cppdialect "Default"
-	end)
-
-	api.deprecateValue("flags", "C90",   'Use `cdialect "gnu90"` instead',
-	function(value)
-		cdialect "gnu90"
-	end,
-	function(value)
-		cdialect "Default"
-	end)
-
-	api.deprecateValue("flags", "C99",   'Use `cdialect "gnu99"` instead',
-	function(value)
-		cdialect "gnu99"
-	end,
-	function(value)
-		cdialect "Default"
-	end)
-
-	api.deprecateValue("flags", "C11",   'Use `cdialect "gnu11"` instead',
-	function(value)
-		cdialect "gnu11"
-	end,
-	function(value)
-		cdialect "Default"
 	end)
 
 

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -36,10 +36,6 @@ flags { "flag_list" }
 | UndefinedIdentifiers | Warn if an undefined identifier is evaluated in an #if directive.   |
 | WinMain               | Use `WinMain()` as entry point for Windows applications, rather than the default `main()`. |
 | WPF                   | Mark the project as using Windows Presentation Framework, rather than WinForms. |
-| C++11                 | Pass the c++11 flag to the gcc/clang compilers (msvc ignores this currently) |
-| C++14                 | Pass the c++14 flag to the gcc/clang compilers (msvc ignores this currently) |
-| C90                   | Pass the c90 flag to the gcc/clang compilers (msvc ignores this currently) |
-| C99                   | Pass the c99 flag to the gcc/clang compilers (msvc ignores this currently) |
 | Component             | Needs documentation                                                        |
 | DebugEnvsDontMerge    | Needs documentation                                                        |
 | DebugEnvsInherit      | Needs documentation                                                        |
@@ -57,7 +53,6 @@ flags { "flag_list" }
 | OptimizeSpeed         | Needs documentation                                                        |
 | ReleaseRuntime        | Needs documentation                                                        |
 | Symbols               | Needs documentation                                                        |
-| C11                   | Needs documentation                                                        |
 | Thumb                 | Needs documentation                                                        |
 
 ### Applies To ###
@@ -66,7 +61,7 @@ Project and file configurations, though not all flags are yet supported for file
 
 ### Availability ###
 
-Unless otherwise noted, Premake 5.0 or later.
+Flags are currently available in Premake 5.0 beta3, but are considered deprecated. Future releases will be deprecating and removing all flags in favor of dedicated APIs.
 
 ### Examples ###
 


### PR DESCRIPTION
**What does this PR do?**

Removes deprecated language version flags. Dedicated `cdialect` and `cppdialect` APIs already exist.

**How does this PR change Premake's behavior?**

This will break existing code using these flags. These flags have been deprecated since 2017.

**Anything else we should know?**

Part of preparation work for 5.0 stable.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] ~~Add unit tests showing fix or feature works;~~ all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
