### PR TITLE
Remove Deprecated Flags with Replacements, Fix Tests

### DIFF
--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -645,7 +645,7 @@
 --
 
 	function suite.wchar_onNative()
-		flags "NativeWChar"
+		nativewchar "On"
 		prepare()
 		test.capture [[
 <ClCompile>
@@ -657,7 +657,7 @@
 	end
 
 	function suite.wchar_onNoNative()
-		flags "NoNativeWChar"
+		nativewchar "Off"
 		prepare()
 		test.capture [[
 <ClCompile>
@@ -1632,19 +1632,6 @@
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
 	<OmitFramePointers>false</OmitFramePointers>
-</ClCompile>
-		]]
-	end
-
-	function suite.omitFramePointer_DeprecationFlag()
-		flags "NoFramePointer"
-		prepare()
-		test.capture [[
-<ClCompile>
-	<PrecompiledHeader>NotUsing</PrecompiledHeader>
-	<WarningLevel>Level3</WarningLevel>
-	<Optimization>Disabled</Optimization>
-	<OmitFramePointers>true</OmitFramePointers>
 </ClCompile>
 		]]
 	end

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -2318,7 +2318,7 @@
 
 
 	function suite.XCBuildConfigurationProject_OnStaticRuntime()
-		flags { "StaticRuntime" }
+		staticruntime "On"
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
@@ -2725,7 +2725,7 @@
 
 
 	function suite.XCBuildConfigurationProject_OnFloatFast()
-		flags { "FloatFast" }
+		floatingpoint "Fast"
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
@@ -2858,7 +2858,7 @@
 
 
 	function suite.XCBuildConfigurationProject_OnNoFramePointer()
-		flags { "NoFramePointer" }
+		omitframepointer "On"
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1594,7 +1594,7 @@
 
 		settings['OTHER_LDFLAGS'] = table.join(flags, cfg.linkoptions)
 
-		if cfg.flags.StaticRuntime then
+		if cfg.staticruntime == "On" then
 			settings['STANDARD_C_PLUS_PLUS_LIBRARY_TYPE'] = 'static'
 		end
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -172,7 +172,7 @@
 
 		filter "configurations:Debug"
 			defines     "_DEBUG"
-			flags       { "Symbols" }
+			symbols	    "On"
 
 		filter "configurations:Release"
 			defines     "NDEBUG"

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -332,55 +332,33 @@
 		scope = "config",
 		kind  = "list:string",
 		allowed = {
-			"Component",           -- DEPRECATED
 			"DebugEnvsDontMerge",
 			"DebugEnvsInherit",
-			"EnableSSE",           -- DEPRECATED
-			"EnableSSE2",          -- DEPRECATED
 			"ExcludeFromBuild",
-			"ExtraWarnings",       -- DEPRECATED
 			"FatalCompileWarnings",
 			"FatalLinkWarnings",
-			"FloatFast",           -- DEPRECATED
-			"FloatStrict",         -- DEPRECATED
 			"LinkTimeOptimization",
-			"Managed",             -- DEPRECATED
 			"Maps",
 			"MFC",
 			"MultiProcessorCompile",
-			"NativeWChar",         -- DEPRECATED
 			"No64BitChecks",
 			"NoCopyLocal",
-			"NoEditAndContinue",   -- DEPRECATED
-			"NoFramePointer",      -- DEPRECATED
 			"NoImplicitLink",
 			"NoImportLib",         -- DEPRECATED
 			"NoIncrementalLink",
 			"NoManifest",
 			"NoMinimalRebuild",
-			"NoNativeWChar",       -- DEPRECATED
 			"NoPCH",
 			"NoRuntimeChecks",
 			"NoBufferSecurityCheck",
-			"NoWarnings",          -- DEPRECATED
 			"OmitDefaultLibrary",
-			"Optimize",            -- DEPRECATED
-			"OptimizeSize",        -- DEPRECATED
-			"OptimizeSpeed",       -- DEPRECATED
 			"RelativeLinks",
-			"ReleaseRuntime",      -- DEPRECATED
 			"ShadowedVariables",
-			"StaticRuntime",       -- DEPRECATED
-			"Symbols",             -- DEPRECATED
 			"UndefinedIdentifiers",
-			"WinMain",             -- DEPRECATED
 			"WPF",
 		},
 		aliases = {
 			FatalWarnings = { "FatalWarnings", "FatalCompileWarnings", "FatalLinkWarnings" },
-			Optimise = 'Optimize',
-			OptimiseSize = 'OptimizeSize',
-			OptimiseSpeed = 'OptimizeSpeed',
 		},
 	}
 
@@ -1146,178 +1124,6 @@
 		end
 		buildcommands(value.commands)
 		buildoutputs(value.outputs)
-	end)
-
-
-	api.deprecateValue("flags", "Component", 'Use `buildaction "Component"` instead.',
-	function(value)
-		buildaction "Component"
-	end)
-
-
-	api.deprecateValue("flags", "EnableSSE", 'Use `vectorextensions "SSE"` instead.',
-	function(value)
-		vectorextensions("SSE")
-	end,
-	function(value)
-		vectorextensions "Default"
-	end)
-
-
-	api.deprecateValue("flags", "EnableSSE2", 'Use `vectorextensions "SSE2"` instead.',
-	function(value)
-		vectorextensions("SSE2")
-	end,
-	function(value)
-		vectorextensions "Default"
-	end)
-
-
-	api.deprecateValue("flags", "FloatFast", 'Use `floatingpoint "Fast"` instead.',
-	function(value)
-		floatingpoint("Fast")
-	end,
-	function(value)
-		floatingpoint "Default"
-	end)
-
-
-	api.deprecateValue("flags", "FloatStrict", 'Use `floatingpoint "Strict"` instead.',
-	function(value)
-		floatingpoint("Strict")
-	end,
-	function(value)
-		floatingpoint "Default"
-	end)
-
-
-	api.deprecateValue("flags", "NativeWChar", 'Use `nativewchar "On"` instead."',
-	function(value)
-		nativewchar("On")
-	end,
-	function(value)
-		nativewchar "Default"
-	end)
-
-
-	api.deprecateValue("flags", "NoNativeWChar", 'Use `nativewchar "Off"` instead."',
-	function(value)
-		nativewchar("Off")
-	end,
-	function(value)
-		nativewchar "Default"
-	end)
-
-
-	api.deprecateValue("flags", "Optimize", 'Use `optimize "On"` instead.',
-	function(value)
-		optimize ("On")
-	end,
-	function(value)
-		optimize "Off"
-	end)
-
-
-	api.deprecateValue("flags", "OptimizeSize", 'Use `optimize "Size"` instead.',
-	function(value)
-		optimize ("Size")
-	end,
-	function(value)
-		optimize "Off"
-	end)
-
-
-	api.deprecateValue("flags", "OptimizeSpeed", 'Use `optimize "Speed"` instead.',
-	function(value)
-		optimize ("Speed")
-	end,
-	function(value)
-		optimize "Off"
-	end)
-
-
-	api.deprecateValue("flags", "ReleaseRuntime", 'Use `runtime "Release"` instead.',
-	function(value)
-		runtime "Release"
-	end,
-	function(value)
-	end)
-
-
-	api.deprecateValue("flags", "ExtraWarnings", 'Use `warnings "Extra"` instead.',
-	function(value)
-		warnings "Extra"
-	end,
-	function(value)
-		warnings "Default"
-	end)
-
-
-	api.deprecateValue("flags", "NoWarnings", 'Use `warnings "Off"` instead.',
-	function(value)
-		warnings "Off"
-	end,
-	function(value)
-		warnings "Default"
-	end)
-
-	api.deprecateValue("flags", "Managed", 'Use `clr "On"` instead.',
-	function(value)
-		clr "On"
-	end,
-	function(value)
-		clr "Off"
-	end)
-
-
-	api.deprecateValue("flags", "NoEditAndContinue", 'Use editandcontinue "Off"` instead.',
-	function(value)
-		editandcontinue "Off"
-	end,
-	function(value)
-		editandcontinue "On"
-	end)
-
-
-	-- 21 June 2016
-
-	api.deprecateValue("flags", "Symbols", 'Use `symbols "On"` instead',
-	function(value)
-		symbols "On"
-	end,
-	function(value)
-		symbols "Default"
-	end)
-
-
-	-- 13 April 2017
-
-	api.deprecateValue("flags", "WinMain", 'Use `entrypoint "WinMainCRTStartup"` instead',
-	function(value)
-		entrypoint "WinMainCRTStartup"
-	end,
-	function(value)
-		entrypoint "mainCRTStartup"
-	end)
-
-	-- 31 October 2017
-
-	api.deprecateValue("flags", "StaticRuntime", 'Use `staticruntime "On"` instead',
-	function(value)
-		staticruntime "On"
-	end,
-	function(value)
-		staticruntime "Default"
-	end)
-
-	-- 08 April 2018
-
-	api.deprecateValue("flags", "NoFramePointer", 'Use `omitframepointer "On"` instead.',
-	function(value)
-		omitframepointer("On")
-	end,
-	function(value)
-		omitframepointer("Default")
 	end)
 
 -----------------------------------------------------------------------------

--- a/tests/api/test_deprecations.lua
+++ b/tests/api/test_deprecations.lua
@@ -10,17 +10,48 @@
 
 
 	function suite.setup()
+		api.register {
+			name = "testsuiteflags",
+			kind = "list:string",
+			scope = "config",
+			allowed = {
+				"Symbols",
+				"Optimize",
+			}
+		}
+
+		api.deprecateValue("testsuiteflags", "Optimize", 'Use `optimize "On"` instead.',
+		function(value)
+			optimize ("On")
+		end,
+		function(value)
+			optimize "Off"
+		end)
+
+		api.deprecateValue("testsuiteflags", "Symbols", 'Use `symbols "On"` instead',
+		function(value)
+			symbols "On"
+		end,
+		function(value)
+			symbols "Default"
+		end)
+
 		workspace("MyWorkspace")
 		configurations { "Debug", "Release" }
+	end
+
+	
+	function suite.teardown()
+		api.unregister "testsuiteflags"
 	end
 
 	function suite.setsNewValue_whenOldValueIsRemovedViaWildcard_inSubConfig()
 		local prj = project "MyProject"
 			filter { "configurations:Debug" }
-				flags { "Symbols" }
+				testsuiteflags { "Symbols" }
 
 			filter { "*" }
-				removeflags { "*" }
+				removetestsuiteflags { "*" }
 
 		-- test output.
 		local cfg = test.getconfig(prj, "Debug", platform)
@@ -30,10 +61,10 @@
 
 	function suite.setsNewValue_whenOldValueIsRemovedInOtherConfig_inSubConfig()
 		local prj = project "MyProject"
-			flags { "Symbols" }
+			testsuiteflags { "Symbols" }
 
 			filter { "configurations:Release" }
-				removeflags { "*" }
+				removetestsuiteflags { "*" }
 
 		-- test output.
 		test.isequal("On",      test.getconfig(prj, "Debug", platform).Symbols)
@@ -44,7 +75,7 @@
 	function suite.dontRemoveFlagIfSetThroughNewApi()
 		local prj = project "MyProject"
 			floatingpoint "Fast"
-			removeflags "*"
+			removetestsuiteflags "*"
 
 		-- test output.
 		local cfg = test.getconfig(prj, "Debug", platform)
@@ -53,11 +84,11 @@
 
 
 	function suite.setsNewValue_whenOldValueFromParentIsRemovedInOtherConfig_inSubConfig()
-		flags { "Symbols" }
+		testsuiteflags { "Symbols" }
 
 		local prj = project "MyProject"
 			filter { "configurations:Release" }
-				removeflags { "*" }
+				removetestsuiteflags { "*" }
 
 		-- test output.
 		test.isequal("On",      test.getconfig(prj, "Debug", platform).Symbols)

--- a/tests/base/test_configset.lua
+++ b/tests/base/test_configset.lua
@@ -177,26 +177,26 @@
 	function suite.remove_onExactValueMatch()
 		local f = field.get("flags")
 
-		local r, err = configset.store(cset, f, { "Symbols", "WinMain", "MFC" })
+		local r, err = configset.store(cset, f, { "MFC", "MultiProcessorCompile", "NoPCH" })
 		test.isnil(err)
 
-		configset.remove(cset, f, { "WinMain" })
+		configset.remove(cset, f, { "MFC" })
 
 		local result = configset.fetch(cset, f)
-		test.isequal({ "Symbols", "MFC" }, result)
+		test.isequal({ "MultiProcessorCompile", "NoPCH" }, result)
 	end
 
 
 	function suite.remove_onMultipleValues()
 		local f = field.get("flags")
 
-		local r, err = configset.store(cset, f, { "Symbols", "Maps", "WinMain", "MFC" })
+		local r, err = configset.store(cset, f, { "Maps", "MFC", "MultiProcessorCompile", "NoPCH" })
 		test.isnil(err)
 
 		configset.remove(cset, f, { "Maps", "MFC" })
 
 		local result = configset.fetch(cset, f)
-		test.isequal({ "Symbols", "WinMain" }, result)
+		test.isequal({ "MultiProcessorCompile", "NoPCH" }, result)
 	end
 
 

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -66,12 +66,6 @@
 		test.contains("/Od", msc.getcflags(cfg))
 	end
 
-	function suite.cflags_onNoFramePointers()
-		flags "NoFramePointer"
-		prepare()
-		test.contains("/Oy", msc.getcflags(cfg))
-	end
-
 	function suite.cflags_onOmitFramePointer()
 		omitframepointer "On"
 		prepare()

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -32,27 +32,10 @@ flags { "flag_list" }
 | OmitDefaultLibrary    | Omit the specification of a runtime library in object files.        |
 | RelativeLinks         | Forces the linker to use relative paths to libraries instead of absolute paths. |
 | ShadowedVariables     | Warn when a variable, type declaration, or function is shadowed.    |
-| StaticRuntime         | Perform a static link against the standard runtime libraries.       | Deprecated - use staticruntime "On" instead. |
 | UndefinedIdentifiers | Warn if an undefined identifier is evaluated in an #if directive.   |
-| WinMain               | Use `WinMain()` as entry point for Windows applications, rather than the default `main()`. |
 | WPF                   | Mark the project as using Windows Presentation Framework, rather than WinForms. |
-| Component             | Needs documentation                                                        |
 | DebugEnvsDontMerge    | Needs documentation                                                        |
 | DebugEnvsInherit      | Needs documentation                                                        |
-| EnableSSE             | Needs documentation                                                        |
-| EnableSSE2            | Needs documentation                                                        |
-| ExtraWarnings         | Needs documentation                                                        |
-| FloatFast             | Needs documentation                                                        |
-| FloatStrict           | Needs documentation                                                        |
-| Managed               | Needs documentation                                                        |
-| NoNativeWChar         | Needs documentation                                                        |
-| NoEditAndContinue     | Needs documentation                                                        |
-| NoWarnings            | Needs documentation                                                        |
-| Optimize              | Needs documentation                                                        |
-| OptimizeSize          | Needs documentation                                                        |
-| OptimizeSpeed         | Needs documentation                                                        |
-| ReleaseRuntime        | Needs documentation                                                        |
-| Symbols               | Needs documentation                                                        |
 | Thumb                 | Needs documentation                                                        |
 
 ### Applies To ###


### PR DESCRIPTION
**What does this PR do?**

Removes the remaining flags that are deprecated and have existing replacements. Fixes unit tests corresponding to those removals. This also fixes an issue in xcode where the "StaticRuntime" flag was being used in the generator instead of the "staticruntime" field.

**How does this PR change Premake's behavior?**

Will break any code using those flags.

**Anything else we should know?**

Further clean up ahead of the 5.0 release.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
