### PR TITLE
Replace MFC flag with a dedicated API

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -1,6 +1,6 @@
 --
 -- _preload.lua
--- Define the makefile action(s).
+-- Define the Visual Studio action(s).
 -- Copyright (c) Jess Perkins and the Premake project
 --
 
@@ -607,6 +607,27 @@
 		kind = "string",
 		tokens = "true",
 	}
+
+	p.api.register {
+		name = "mfc",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"Off",
+			"On",
+			"Static",
+			"Dynamic",
+		}
+	}
+
+	p.api.deprecateValue("flags", "MFC", 'Use `mfc` instead.',
+	function(value)
+		mfc("On")
+	end,
+	function(value)
+		mfc("Off")
+	end)
 
 --
 -- Decide when the full module should be loaded.

--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -174,7 +174,18 @@
 --
 
 	function suite.useOfMfc_onDynamicRuntime()
-		flags "MFC"
+		mfc "On"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<UseOfMfc>Dynamic</UseOfMfc>
+		]]
+	end
+
+	function suite.useOfMfc_onDynamicRuntimeViaFlag()
+		flags { "MFC" }
 		prepare()
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -185,6 +196,18 @@
 	end
 
 	function suite.useOfMfc_onStaticRuntime()
+		mfc "On"
+		staticruntime "On"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<UseOfMfc>Static</UseOfMfc>
+		]]
+	end
+	
+	function suite.useOfMfc_onStaticRuntimeViaFlag()
 		flags { "MFC" }
 		staticruntime "On"
 		prepare()
@@ -193,6 +216,29 @@
 	<ConfigurationType>Application</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
 	<UseOfMfc>Static</UseOfMfc>
+		]]
+	end
+	
+	function suite.useOfMfc_forceStatic()
+		mfc "Static"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<UseOfMfc>Static</UseOfMfc>
+		]]
+	end
+
+	function suite.useOfMfc_forceDynamic()
+		mfc "Dynamic"
+		staticruntime "On"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<UseOfMfc>Dynamic</UseOfMfc>
 		]]
 	end
 

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -1539,8 +1539,12 @@
 
 
 	function m.useOfMFC(cfg)
-		if (cfg.flags.MFC) then
+		if (cfg.mfc == "On") then
 			p.w('UseOfMFC="%d"', iif(cfg.staticruntime == "On", 1, 2))
+		elseif (cfg.mfc == "Static") then
+			p.w('UseOfMFC="1"')
+		elseif (cfg.mfc == "Dynamic") then
+			p.w('UseOfMFC="2"')
 		end
 	end
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -3225,8 +3225,14 @@
 
 
 	function m.useOfMfc(cfg)
-		if cfg.flags.MFC then
+		if (cfg.mfc == "On") then
 			m.element("UseOfMfc", nil, iif(cfg.staticruntime == "On", "Static", "Dynamic"))
+		elseif (cfg.mfc == "Off") then
+			m.element("UseOfMfc", nil, "false")
+		elseif (cfg.mfc == "Static") then
+			m.element("UseOfMfc", nil, "Static")
+		elseif (cfg.mfc == "Dynamic") then
+			m.element("UseOfMfc", nil, "Dynamic")
 		end
 	end
 

--- a/tests/base/test_configset.lua
+++ b/tests/base/test_configset.lua
@@ -177,10 +177,10 @@
 	function suite.remove_onExactValueMatch()
 		local f = field.get("flags")
 
-		local r, err = configset.store(cset, f, { "MFC", "MultiProcessorCompile", "NoPCH" })
+		local r, err = configset.store(cset, f, { "WPF", "MultiProcessorCompile", "NoPCH" })
 		test.isnil(err)
 
-		configset.remove(cset, f, { "MFC" })
+		configset.remove(cset, f, { "WPF" })
 
 		local result = configset.fetch(cset, f)
 		test.isequal({ "MultiProcessorCompile", "NoPCH" }, result)
@@ -190,10 +190,10 @@
 	function suite.remove_onMultipleValues()
 		local f = field.get("flags")
 
-		local r, err = configset.store(cset, f, { "Maps", "MFC", "MultiProcessorCompile", "NoPCH" })
+		local r, err = configset.store(cset, f, { "Maps", "WPF", "MultiProcessorCompile", "NoPCH" })
 		test.isnil(err)
 
-		configset.remove(cset, f, { "Maps", "MFC" })
+		configset.remove(cset, f, { "Maps", "WPF" })
 
 		local result = configset.fetch(cset, f)
 		test.isequal({ "MultiProcessorCompile", "NoPCH" }, result)

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -16,7 +16,7 @@ flags { "flag_list" }
 | FatalWarnings         | Treat all warnings as errors; equivalent to FatalCompileWarnings, FatalLinkWarnings |
 | LinkTimeOptimization  | Enable link-time (i.e. whole program) optimizations.                |
 | Maps                  | Enable Generate Map File for Visual Studio                          |
-| MFC                   | Enable support for Microsoft Foundation Classes.                    |
+| MFC                   | Enable support for Microsoft Foundation Classes. Deprecated in Premake 5.0.0-beta4. |
 | MultiProcessorCompile | Enable Visual Studio to use multiple compiler processes when building. |
 | No64BitChecks         | Disable 64-bit portability warnings.                                |
 | NoBufferSecurityCheck | Turn off stack protection checks.                                   |

--- a/website/docs/mfc.md
+++ b/website/docs/mfc.md
@@ -1,0 +1,25 @@
+Sets the version of the MFC libraries to link against.
+
+```lua
+mfc "On"
+```
+
+### Parameters ###
+
+*value* specifies the desired PIC mode:
+
+| Value       | Description                                                                                            |
+|-------------|--------------------------------------------------------------------------------------------------------|
+| Default     | Perform the default linkage against the MFC libraries for your project type.                           |
+| Off         | Do not link against MFC libraries.                                                                     |
+| On          | Link against the MFC libraries corresponding with the runtime type you are using (static or dynamic).  |
+| Static      | Force static linkage to the MFC libraries.                                                             |
+| Dynamic     | Force dynamic linkage to the MFC libraries.                                                            |
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0-beta4 or later on Visual Studio.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -190,6 +190,7 @@ module.exports = {
 						'llvmdir',
 						'llvmversion',
 						'makesettings',
+						'mfc',
 						'namespace',
 						'nativewchar',
 						'newaction',


### PR DESCRIPTION
**What does this PR do?**

Replaces the MFC flag for a dedicated API, `mfc`.

**How does this PR change Premake's behavior?**

Deprecates MFC flag (warn) and will be removed after 5.0.0-beta4.

**Anything else we should know?**

Part of 5.0 release prep.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
