### PR TITLE
Fix visibility setting on android and gcc VS

### DIFF
--- a/modules/android/vsandroid_vcxproj.lua
+++ b/modules/android/vsandroid_vcxproj.lua
@@ -346,7 +346,7 @@
 
 			-- -fvisibility=<>
 			if cfg.visibility ~= nil then
-				table.insert(opts, p.tools.gcc.cxxflags.visibility[cfg.visibility])
+				table.insert(opts, p.tools.gcc.shared.visibility[cfg.visibility])
 			end
 
 			if #opts > 0 then

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -3665,7 +3665,7 @@
 
 		-- -fvisibility=<>
 		if cfg.visibility ~= nil then
-			table.insert(opts, p.tools.gcc.cxxflags.visibility[cfg.visibility])
+			table.insert(opts, p.tools.gcc.shared.visibility[cfg.visibility])
 		end
 
 		if #opts > 0 then


### PR DESCRIPTION
Commit d363e35f5b335b15694bd6e8e96166fcf51e510d broke visibility by not updating internal code to use new location

**What does this PR do?**

Fixes the `visibility` setting for android and gcc VS projects (untested for gcc VS, just noticed it used the same old location for `visibility`)

**How does this PR change Premake's behavior?**

Doesn't error anymore

**Anything else we should know?**

Wanted to add a unit test but no idea in which file to add it

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes