### PR TITLE
fix documentationfile bug

### DIFF
--- a/modules/vstudio/vs2005_csproj.lua
+++ b/modules/vstudio/vs2005_csproj.lua
@@ -84,7 +84,7 @@
 			dotnetbase.compilerProps,
 			dotnetbase.additionalProps,
 			dotnetbase.NoWarn,
-			dotnetbase.documentationFile,
+			dotnetbase.documentationfile,
 		}
 	end
 

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -786,11 +786,11 @@
 	end
 
 	function dotnetbase.documentationfile(cfg)
-		if cfg.documentationFile then
-			if _ACTION > "vs2015" and cfg.documentationFile == true then
+		if cfg.documentationfile then
+			if _ACTION > "vs2015" and dotnetbase.isNewFormatProject(cfg) and cfg.documentationfile == true  then
 				_p(2,'<GenerateDocumentationFile>true</GenerateDocumentationFile>')
 			else
-				local documentationFile = iif(cfg.documentationFile ~= true, cfg.documentationFile, cfg.targetdir)
+				local documentationFile = iif(cfg.documentationfile ~= true, cfg.documentationfile, cfg.targetdir)
 				_p(2, string.format('<DocumentationFile>%s\\%s.xml</DocumentationFile>', vstudio.path(cfg, documentationFile),cfg.project.name))
 			end
 		end


### PR DESCRIPTION
**What does this PR do?**
fixes a bug where using release the documentationfile property was not being written
`closes #2339`
**How does this PR change Premake's behavior?**
id does not change the behaviour!
**Anything else we should know?**

Add any other context about your changes here.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
