### PR TITLE
Replace LTO flag with dedicated API

### DIFF
--- a/modules/gmake/tests/cpp/test_clang.lua
+++ b/modules/gmake/tests/cpp/test_clang.lua
@@ -44,8 +44,25 @@ ifeq ($(config),debug)
 		]]
 	end
 
-	function suite.usesCorrectCompilersAndLinkTimeOptimization()
+	function suite.usesCorrectCompilersAndLinkTimeOptimizationViaFlag()
 		flags { "LinkTimeOptimization" }
+		make.cppConfigs(prj)
+		test.capture [[
+ifeq ($(config),debug)
+  ifeq ($(origin CC), default)
+    CC = clang
+  endif
+  ifeq ($(origin CXX), default)
+    CXX = clang++
+  endif
+  ifeq ($(origin AR), default)
+    AR = llvm-ar
+  endif
+		]]
+	end
+
+	function suite.usesCorrectCompilersAndLinkTimeOptimizationViaAPI()
+		linktimeoptimization "On"
 		make.cppConfigs(prj)
 		test.capture [[
 ifeq ($(config),debug)

--- a/modules/vstudio/tests/vc200x/test_compiler_block.lua
+++ b/modules/vstudio/tests/vc200x/test_compiler_block.lua
@@ -570,8 +570,20 @@
 -- Check the LinkTimeOptimization flag.
 --
 
-	function suite.flags_onLinkTimeOptimization()
+	function suite.flags_onLinkTimeOptimizationViaFlag()
 		flags { "LinkTimeOptimization" }
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	Optimization="0"
+	WholeProgramOptimization="true"
+		]]
+
+	end
+
+	function suite.flags_onLinkTimeOptimization()
+		linktimeoptimization "On"
 		prepare()
 		test.capture [[
 <Tool

--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -338,8 +338,21 @@
 -- Check the LinkTimeOptimization flag
 --
 
-	function suite.useOfLinkTimeOptimization()
+	function suite.useOfLinkTimeOptimizationViaFlag()
 		flags { "LinkTimeOptimization" }
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v100</PlatformToolset>
+	<WholeProgramOptimization>true</WholeProgramOptimization>
+		]]
+	end
+
+	function suite.useOfLinkTimeOptimizationViaAPI()
+		linktimeoptimization "On"
 		prepare()
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -1614,8 +1614,10 @@
 
 
 	function m.wholeProgramOptimization(cfg)
-		if cfg.flags.LinkTimeOptimization then
+		if cfg.linktimeoptimization == "On" then
 			p.x('WholeProgramOptimization="true"')
+		elseif cfg.linktimeoptimization == "Off" then
+			p.x('WholeProgramOptimization="false"')
 		end
 	end
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1964,8 +1964,10 @@
 
 
 	function m.wholeProgramOptimization(cfg)
-		if cfg.flags.LinkTimeOptimization then
+		if cfg.linktimeoptimization == "On" then
 			m.element("WholeProgramOptimization", nil, "true")
+		elseif cfg.linktimeoptimization == "Off" then
+			m.element("WholeProgramOptimization", nil, "false")
 		end
 	end
 
@@ -2730,7 +2732,7 @@
 	end
 
 	function m.LinkTimeCodeGeneration(cfg)
-		if cfg.flags.LinkTimeOptimization then
+		if cfg.linktimeoptimization == "On" then
 			m.element("LinkTimeCodeGeneration", nil, "UseLinkTimeCodeGeneration")
 		end
 	end
@@ -3655,8 +3657,10 @@
 	end
 
 	function m.linuxWholeProgramOptimization(cfg)
-		if cfg.flags.LinkTimeOptimization then
+		if cfg.linktimeoptimization == "On" then
 			m.element("LinkTimeOptimization", nil, "true")
+		elseif cfg.linktimeoptimization == "Off" then
+			m.element("LinkTimeOptimization", nil, "false")
 		end
 	end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -337,7 +337,7 @@
 			"ExcludeFromBuild",
 			"FatalCompileWarnings",
 			"FatalLinkWarnings",
-			"LinkTimeOptimization",
+			"LinkTimeOptimization", -- DEPRECATED
 			"Maps",
 			"MFC",
 			"MultiProcessorCompile",
@@ -1093,6 +1093,26 @@
 	function(value)
 		externalincludedirs(value)
 	end)
+
+	api.register {
+		name = "linktimeoptimization",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off"
+		}
+	}
+
+	api.deprecateValue("flags", "LinkTimeOptimization", "Use `linktimeoptimization` instead.",
+	function(value)
+		linktimeoptimization("On")
+	end,
+	function(value)
+		linktimeoptimization("Default")
+	end)
+
 
 -----------------------------------------------------------------------------
 --

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -153,7 +153,7 @@
 		if cfg.kind == "StaticLib"
 				or config.isOptimizedBuild(cfg)
 				or cfg.flags.NoIncrementalLink
-				or cfg.flags.LinkTimeOptimization then
+				or cfg.linktimeoptimization == "On" then
 			return false
 		end
 		return true

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -63,7 +63,8 @@
 			Fuzzer = "-fsanitize=fuzzer",
 		}),
 		visibility = gcc.shared.visibility,
-		inlinesvisibility = gcc.shared.inlinesvisibility
+		inlinesvisibility = gcc.shared.inlinesvisibility,
+		linktimeoptimization = gcc.shared.linktimeoptimization
 	}
 
 	clang.cflags = table.merge(gcc.cflags, {
@@ -226,9 +227,7 @@
 			x86 = "-m32",
 			x86_64 = "-m64",
 		},
-		flags = {
-			LinkTimeOptimization = "-flto",
-		},
+		linktimeoptimization = clang.shared.linktimeoptimization,
 		kind = {
 			SharedLib = function(cfg)
 				local r = { clang.getsharedlibarg(cfg) }
@@ -336,7 +335,7 @@
 	clang.tools = {
 		cc = "clang",
 		cxx = "clang++",
-		ar = function(cfg) return iif(cfg.flags.LinkTimeOptimization, "llvm-ar", "ar") end,
+		ar = function(cfg) return iif(cfg.linktimeoptimization == "On", "llvm-ar", "ar") end,
 		rc = "windres"
 	}
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -59,13 +59,15 @@
 		},
 		flags = {
 			FatalCompileWarnings = "-Werror",
-			LinkTimeOptimization = "-flto",
 			ShadowedVariables = "-Wshadow",
 			UndefinedIdentifiers = "-Wundef",
 		},
 		floatingpoint = {
 			Fast = "-ffast-math",
 			Strict = "-ffloat-store",
+		},
+		linktimeoptimization = {
+			On = "-flto",
 		},
 		strictaliasing = {
 			Off = "-fno-strict-aliasing",
@@ -471,9 +473,7 @@
 			x86 = "-m32",
 			x86_64 = "-m64",
 		},
-		flags = {
-			LinkTimeOptimization = "-flto",
-		},
+		linktimeoptimization = gcc.shared.linktimeoptimization,
 		kind = {
 			SharedLib = function(cfg)
 				local r = { gcc.getsharedlibarg(cfg) }

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -63,7 +63,6 @@
 		},
 		flags = {
 			FatalCompileWarnings = "/WX",
-			LinkTimeOptimization = "/GL",
 			MultiProcessorCompile = "/MP",
 			NoMinimalRebuild = "/Gm-",
 			OmitDefaultLibrary = "/Zl"
@@ -88,6 +87,9 @@
 		},
 		intrinsics = {
 			On = "/Oi",
+		},
+		linktimeoptimization = {
+			On = "/GL",
 		},
 		optimize = {
 			Off = "/Od",
@@ -332,7 +334,6 @@
 	msc.linkerFlags = {
 		flags = {
 			FatalLinkWarnings = "/WX",
-			LinkTimeOptimization = "/LTCG",
 			NoIncrementalLink = "/INCREMENTAL:NO",
 			NoManifest = "/MANIFEST:NO",
 			OmitDefaultLibrary = "/NODEFAULTLIB",
@@ -340,6 +341,9 @@
 		kind = {
 			SharedLib = "/DLL",
 			WindowedApp = "/SUBSYSTEM:WINDOWS"
+		},
+		linktimeoptimization = {
+			On = "/LTCG"
 		},
 		symbols = {
 			On = "/DEBUG"

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -843,14 +843,26 @@ end
 -- Check handling of link time optimization flag.
 --
 
-	function suite.cflags_onLinkTimeOptimization()
+	function suite.cflags_onLinkTimeOptimizationViaFlag()
 		flags "LinkTimeOptimization"
 		prepare()
 		test.contains("-flto", gcc.getcflags(cfg))
 	end
 
-	function suite.ldflags_onLinkTimeOptimization()
+	function suite.cflags_onLinkTimeOptimizationViaAPI()
+		linktimeoptimization "On"
+		prepare()
+		test.contains("-flto", gcc.getcflags(cfg))
+	end
+
+	function suite.ldflags_onLinkTimeOptimizationViaFlag()
 		flags "LinkTimeOptimization"
+		prepare()
+		test.contains("-flto", gcc.getldflags(cfg))
+	end
+
+	function suite.ldflags_onLinkTimeOptimizationViaAPI()
+		linktimeoptimization "On"
 		prepare()
 		test.contains("-flto", gcc.getldflags(cfg))
 	end

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -78,14 +78,26 @@
 		test.excludes("/Oy", msc.getcflags(cfg))
 	end
 
-	function suite.cflags_onLinkTimeOptimizations()
+	function suite.cflags_onLinkTimeOptimizationsViaFlag()
 		flags "LinkTimeOptimization"
 		prepare()
 		test.contains("/GL", msc.getcflags(cfg))
 	end
 
-	function suite.ldflags_onLinkTimeOptimizations()
+	function suite.cflags_onLinkTimeOptimizationsViaAPI()
+		linktimeoptimization "On"
+		prepare()
+		test.contains("/GL", msc.getcflags(cfg))
+	end
+
+	function suite.ldflags_onLinkTimeOptimizationsViaFlag()
 		flags "LinkTimeOptimization"
+		prepare()
+		test.contains("/LTCG", msc.getldflags(cfg))
+	end
+
+	function suite.ldflags_onLinkTimeOptimizationsViaAPI()
+		linktimeoptimization "On"
 		prepare()
 		test.contains("/LTCG", msc.getldflags(cfg))
 	end

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -14,9 +14,9 @@ flags { "flag_list" }
 | FatalCompileWarnings  | Treat compiler warnings as errors.                                  |
 | FatalLinkWarnings     | Treat linker warnings as errors.                                    |
 | FatalWarnings         | Treat all warnings as errors; equivalent to FatalCompileWarnings, FatalLinkWarnings |
-| LinkTimeOptimization  | Enable link-time (i.e. whole program) optimizations.                |
+| LinkTimeOptimization  | Enable link-time (i.e. whole program) optimizations. Deprecated in Premake 5.0.0-beta4. Use `linktimeoptimization` API instead. |
 | Maps                  | Enable Generate Map File for Visual Studio                          |
-| MFC                   | Enable support for Microsoft Foundation Classes. Deprecated in Premake 5.0.0-beta4. |
+| MFC                   | Enable support for Microsoft Foundation Classes. Deprecated in Premake 5.0.0-beta4. Use `mfc` API instead. |
 | MultiProcessorCompile | Enable Visual Studio to use multiple compiler processes when building. |
 | No64BitChecks         | Disable 64-bit portability warnings.                                |
 | NoBufferSecurityCheck | Turn off stack protection checks.                                   |

--- a/website/docs/linktimeoptimization.md
+++ b/website/docs/linktimeoptimization.md
@@ -1,0 +1,23 @@
+The **linktimeoptimization** function specifies whether or not the toolset should perform link time optimization.
+
+```lua
+linktimeoptimization "value"
+```
+
+### Parameters ###
+
+*value* specifies whether or not to use link time optimization, if the toolset and exporter support it.
+
+| Value   | Description                                            |
+|---------|--------------------------------------------------------|
+| Off     | No LTO to be performed.                                |
+| On      | LTO optimization enabled.                              |
+| Default | Default LTO optimizations for the toolset or exporter. |
+
+### Applies To ###
+
+Project configurations
+
+### Availability ###
+
+Premake 5.0-beta4 and later

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -185,6 +185,7 @@ module.exports = {
 						'linkgroups',
 						'linkoptions',
 						'links',
+						'linktimeoptimization',
 						'locale',
 						'location',
 						'llvmdir',


### PR DESCRIPTION
**What does this PR do?**

Replaces the LinkTimeOptimization Flag with a dedicated API.

**How does this PR change Premake's behavior?**

Deprecates "LinkTimeOptimization" flag.

**Anything else we should know?**

Prep for 5.0 release.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
