### PR TITLE
Deprecate FatalWarnings flags in favor of fatalwarnings API

### DIFF
--- a/modules/vstudio/tests/cs2005/test_compiler_props.lua
+++ b/modules/vstudio/tests/cs2005/test_compiler_props.lua
@@ -81,3 +81,15 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		]]
 	end
+
+
+	function suite.treatWarningsAsErrors_onFatalWarningsAPI()
+		fatalwarnings { "Compile" }
+		prepare()
+		test.capture [[
+		<DefineConstants></DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		]]
+	end

--- a/modules/vstudio/tests/vc200x/test_compiler_block.lua
+++ b/modules/vstudio/tests/vc200x/test_compiler_block.lua
@@ -354,8 +354,27 @@
 -- Verify the correct warnings settings are used when FatalWarnings are enabled.
 --
 
-	function suite.runtimeLibraryIsDebug_onFatalWarnings()
+	function suite.runtimeLibraryIsDebug_onFatalWarningsViaFlag()
 		flags { "FatalWarnings" }
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	Optimization="0"
+	BasicRuntimeChecks="3"
+	RuntimeLibrary="2"
+	EnableFunctionLevelLinking="true"
+	UsePrecompiledHeader="0"
+	WarningLevel="3"
+	WarnAsError="true"
+	DebugInformationFormat="0"
+/>
+		]]
+	end
+
+
+	function suite.runtimeLibraryIsDebug_onFatalWarningsViaAPI()
+		fatalwarnings { "Compile" }
 		prepare()
 		test.capture [[
 <Tool
@@ -377,8 +396,27 @@
 -- Verify the correct warnings settings are used when no warnings are enabled.
 --
 
-	function suite.runtimeLibraryIsDebug_onNoWarnings_whichDisablesAllOtherWarningsFlags()
+	function suite.runtimeLibraryIsDebug_onNoWarnings_whichDisablesAllOtherWarningsFlagsViaFlag()
 		flags { "FatalWarnings" }
+		warnings "Off"
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	Optimization="0"
+	BasicRuntimeChecks="3"
+	RuntimeLibrary="2"
+	EnableFunctionLevelLinking="true"
+	UsePrecompiledHeader="0"
+	WarningLevel="0"
+	DebugInformationFormat="0"
+/>
+		]]
+	end
+
+
+	function suite.runtimeLibraryIsDebug_onNoWarnings_whichDisablesAllOtherWarningsFlagsViaAPI()
+		fatalwarnings { "Compile" }
 		warnings "Off"
 		prepare()
 		test.capture [[

--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -158,6 +158,20 @@
 <ClCompile>
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>TurnOffAllWarnings</WarningLevel>
+	<Optimization>Disabled</Optimization>
+		]]
+	end
+
+
+	function suite.warningLevel_onNoWarningsOverOtherWarningsAPI()
+		fatalwarnings { "Compile" }
+		warnings "Off"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>TurnOffAllWarnings</WarningLevel>
+	<Optimization>Disabled</Optimization>
 		]]
 	end
 
@@ -544,8 +558,20 @@
 -- Add <TreatWarningAsError> if FatalWarnings flag is set.
 --
 
-	function suite.treatWarningsAsError_onFatalWarnings()
+	function suite.treatWarningsAsError_onFatalWarningsViaFlag()
 		flags { "FatalCompileWarnings" }
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<TreatWarningAsError>true</TreatWarningAsError>
+		]]
+	end
+
+
+	function suite.treatWarningsAsError_onFatalWarningsViaAPI()
+		fatalwarnings { "Compile" }
 		prepare()
 		test.capture [[
 <ClCompile>

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -286,7 +286,7 @@
 			dotnetbase.allowUnsafeBlocks(cfg)
 		end
 
-		if cfg.flags.FatalCompileWarnings then
+		if p.hasFatalCompileWarnings(cfg.fatalwarnings) then
 			_p(2,'<TreatWarningsAsErrors>true</TreatWarningsAsErrors>')
 		end
 

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -1585,7 +1585,7 @@
 
 
 	function m.warnAsError(cfg)
-		if cfg.flags.FatalCompileWarnings and cfg.warnings ~= p.OFF then
+		if p.hasFatalCompileWarnings(cfg.fatalwarnings) and cfg.warnings ~= p.OFF then
 			p.w('WarnAsError="true"')
 		end
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -3179,7 +3179,7 @@
 
 
 	function m.treatLinkerWarningAsErrors(cfg)
-		if cfg.flags.FatalLinkWarnings then
+		if p.hasFatalLinkWarnings(cfg.fatalwarnings) then
 			local el = iif(cfg.kind == p.STATICLIB, "Lib", "Linker")
 			m.element("Treat" .. el .. "WarningAsErrors", nil, "true")
 		end
@@ -3196,7 +3196,7 @@
 
 
 	function m.treatWarningAsError(cfg)
-		if cfg.flags.FatalCompileWarnings and cfg.warnings ~= p.OFF then
+		if p.hasFatalCompileWarnings(cfg.fatalwarnings) and cfg.warnings ~= p.OFF then
 			m.element("TreatWarningAsError", nil, "true")
 		end
 	end
@@ -3212,8 +3212,10 @@
 
 
 	function m.treatSpecificWarningsAsErrors(cfg, condition)
-		if #cfg.fatalwarnings > 0 then
-			local fatal = table.concat(cfg.fatalwarnings, ";")
+		local filteredWarnings = p.filterFatalWarnings(cfg.fatalwarnings)
+
+		if #filteredWarnings > 0 then
+			local fatal = table.concat(filteredWarnings, ";")
 			fatal = fatal .. ";%%(TreatSpecificWarningsAsErrors)"
 			m.element('TreatSpecificWarningsAsErrors', condition, fatal)
 		end

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -2698,8 +2698,34 @@
 	end
 
 
-	function suite.XCBuildConfigurationProject_OnFatalWarnings()
+	function suite.XCBuildConfigurationProject_OnFatalWarningsViaFlag()
 		flags { "FatalWarnings" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+
+	function suite.XCBuildConfigurationProject_OnFatalWarningsViaAPI()
+		fatalwarnings { "Compile", "Link" }
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1506,7 +1506,7 @@
 			settings['GCC_CHAR_IS_UNSIGNED_CHAR'] = iif(cfg.unsignedchar, "YES", "NO")
 		end
 
-		if cfg.flags.FatalWarnings then
+		if p.hasFatalCompileWarnings(cfg.fatalwarnings) and p.hasFatalLinkWarnings(cfg.fatalwarnings) then
 			settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'YES'
 		end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -335,8 +335,9 @@
 			"DebugEnvsDontMerge",
 			"DebugEnvsInherit",
 			"ExcludeFromBuild",
-			"FatalCompileWarnings",
-			"FatalLinkWarnings",
+			"FatalCompileWarnings",	-- DEPRECATED
+			"FatalLinkWarnings",	-- DEPRECATED
+			"FatalWarnings",		-- DEPRECATED
 			"LinkTimeOptimization", -- DEPRECATED
 			"Maps",
 			"MFC",
@@ -356,9 +357,6 @@
 			"ShadowedVariables",
 			"UndefinedIdentifiers",
 			"WPF",
-		},
-		aliases = {
-			FatalWarnings = { "FatalWarnings", "FatalCompileWarnings", "FatalLinkWarnings" },
 		},
 	}
 
@@ -1112,6 +1110,56 @@
 	function(value)
 		linktimeoptimization("Default")
 	end)
+
+	api.deprecateValue("flags", "FatalWarnings", "Use `fatalwarnings { \"Compile\", \"Link\" }` instead.",
+	function(value)
+		fatalwarnings({ "Compile", "Link" })
+	end,
+	function(value)
+		removefatalwarnings({ "Compile", "Link" })
+	end)
+
+	api.deprecateValue("flags", "FatalCompileWarnings", "Use `fatalwarnings { \"Compile\" }` instead.",
+	function(value)
+		fatalwarnings({ "Compile" })
+	end,
+	function(value)
+		removefatalwarnings({ "Compile" })
+	end)
+
+	api.deprecateValue("flags", "FatalLinkWarnings", "Use `fatalwarnings { \"Link\" }` instead.",
+	function(value)
+		fatalwarnings({ "Link" })
+	end,
+	function(value)
+		removefatalwarnings({ "Link" })
+	end)
+
+	premake.filterFatalWarnings = function(tbl)
+		if type(tbl) == "table" then
+			return table.filter(tbl, function(warning)
+				return not (warning == "Compile" or warning == "Link")
+			end)
+		else
+			return tbl
+		end
+	end
+
+	premake.hasFatalCompileWarnings = function(tbl)
+		if (type(tbl) == "table") then
+			return table.contains(tbl, "Compile")
+		else
+			return false
+		end
+	end
+
+	premake.hasFatalLinkWarnings = function(tbl)
+		if (type(tbl) == "table") then
+			return table.contains(tbl, "Link")
+		else
+			return false
+		end
+	end
 
 
 -----------------------------------------------------------------------------

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -44,6 +44,9 @@
 
 	clang.shared = {
 		architecture = gcc.shared.architecture,
+		fatalwarnings = {
+			Compile = "-Werror"
+		},
 		flags = gcc.shared.flags,
 		floatingpoint = {
 			Fast = "-ffast-math",
@@ -226,6 +229,9 @@
 		architecture = {
 			x86 = "-m32",
 			x86_64 = "-m64",
+		},
+		fatalwarnings = {
+			Link = "-Wl,--fatal-warnings",
 		},
 		linktimeoptimization = clang.shared.linktimeoptimization,
 		kind = {

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -57,8 +57,10 @@
 			x86 = "-m32",
 			x86_64 = "-m64",
 		},
+		fatalwarnings = {
+			Compile = "-Werror",
+		},
 		flags = {
-			FatalCompileWarnings = "-Werror",
 			ShadowedVariables = "-Wshadow",
 			UndefinedIdentifiers = "-Wundef",
 		},
@@ -194,7 +196,7 @@
 		for _, disable in ipairs(cfg.disablewarnings) do
 			table.insert(result, '-Wno-' .. disable)
 		end
-		for _, fatal in ipairs(cfg.fatalwarnings) do
+		for _, fatal in ipairs(p.filterFatalWarnings(cfg.fatalwarnings)) do
 			table.insert(result, '-Werror=' .. fatal)
 		end
 		return result
@@ -472,6 +474,9 @@
 		architecture = {
 			x86 = "-m32",
 			x86_64 = "-m64",
+		},
+		fatalwarnings = {
+			Link = "-Wl,--fatal-warnings",
 		},
 		linktimeoptimization = gcc.shared.linktimeoptimization,
 		kind = {

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -61,8 +61,10 @@
 			["C"] = "/TC",
 			["C++"] = "/TP",
 		},
+		fatalwarnings = {
+			Compile = "/WX",
+		},
 		flags = {
-			FatalCompileWarnings = "/WX",
 			MultiProcessorCompile = "/MP",
 			NoMinimalRebuild = "/Gm-",
 			OmitDefaultLibrary = "/Zl"
@@ -332,8 +334,10 @@
 --
 
 	msc.linkerFlags = {
+		fatalwarnings = {
+			Link = "/WX",
+		},
 		flags = {
-			FatalLinkWarnings = "/WX",
 			NoIncrementalLink = "/INCREMENTAL:NO",
 			NoManifest = "/MANIFEST:NO",
 			OmitDefaultLibrary = "/NODEFAULTLIB",
@@ -351,8 +355,8 @@
 	}
 
 	msc.librarianFlags = {
-		flags = {
-			FatalLinkWarnings = "/WX",
+		fatalwarnings = {
+			Link = "/WX",
 		}
 	}
 
@@ -484,7 +488,7 @@
 			table.insert(result, '/wd"' .. disable .. '"')
 		end
 
-		for _, fatal in ipairs(cfg.fatalwarnings) do
+		for _, fatal in ipairs(p.filterFatalWarnings(cfg.fatalwarnings)) do
 			table.insert(result, '/we"' .. fatal .. '"')
 		end
 

--- a/src/tools/snc.lua
+++ b/src/tools/snc.lua
@@ -16,8 +16,8 @@
 --
 
 	snc.shared = {
-		flags = {
-			FatalCompileWarnings = "-Xquit=2",
+		fatalwarnings = {
+			Compile = "-Xquit=2",
 		},
 		optimize = {
 			Off = "-O0",

--- a/tests/test_premake.lua
+++ b/tests/test_premake.lua
@@ -36,3 +36,37 @@
 		p.generate(prj, ".prj", function () end)
 		test.closedfile(true)
 	end
+
+--
+-- Fatal Warnings related tests
+--
+
+	function suite.filterFatalWarnings()
+		local warnings = { "Link", "4996" }
+		local filtered = p.filterFatalWarnings(warnings)
+		test.isequal({ "4996" }, filtered)
+	end
+
+	function suite.hasFatalCompileWarnings()
+		local warnings = { "Compile", "4996" }
+		local hasFatal = p.hasFatalCompileWarnings(warnings)
+		test.istrue(hasFatal)
+	end
+
+	function suite.hasFatalCompileWarningsNotPresent()
+		local warnings = { "Link", "4996" }
+		local hasFatal = p.hasFatalCompileWarnings(warnings)
+		test.isfalse(hasFatal)
+	end
+
+	function suite.hasFatalLinkWarnings()
+		local warnings = { "Link", "4996" }
+		local hasFatal = p.hasFatalLinkWarnings(warnings)
+		test.istrue(hasFatal)
+	end
+
+	function suite.hasFatalLinkWarningsNotPresent()
+		local warnings = { "Compile", "4996" }
+		local hasFatal = p.hasFatalLinkWarnings(warnings)
+		test.isfalse(hasFatal)
+	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -121,8 +121,14 @@
 		test.contains({ "-Weverything" }, gcc.getcflags(cfg))
 	end
 
-	function suite.cflags_onFatalWarnings()
+	function suite.cflags_onFatalWarningsViaFlag()
 		flags { "FatalWarnings" }
+		prepare()
+		test.contains({ "-Werror" }, gcc.getcflags(cfg))
+	end
+
+	function suite.cflags_onFatalWarningsViaAPI()
+		fatalwarnings { "Compile" }
 		prepare()
 		test.contains({ "-Werror" }, gcc.getcflags(cfg))
 	end
@@ -413,6 +419,11 @@
 --
 -- Check the basic translation of LDFLAGS for a Posix system.
 --
+	function suite.ldflags_onFatalLinkWarningsAPI()
+		fatalwarnings { "Link" }
+		prepare()
+		test.contains({ "-Wl,--fatal-warnings" }, gcc.getldflags(cfg))
+	end
 
 	function suite.ldflags_onNoSymbols()
 		prepare()

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -242,8 +242,14 @@
 		test.contains("/Wall", msc.getcflags(cfg))
 	end
 
-	function suite.cflags_OnFatalWarnings()
+	function suite.cflags_OnFatalWarningsViaFlag()
 		flags "FatalWarnings"
+		prepare()
+		test.contains("/WX", msc.getcflags(cfg))
+	end
+
+	function suite.cflags_OnFatalWarningsViaAPI()
+		fatalwarnings { "Compile" }
 		prepare()
 		test.contains("/WX", msc.getcflags(cfg))
 	end
@@ -256,12 +262,17 @@
 		test.contains({ '/w1"enable"', '/wd"disable"', '/we"fatal"' }, msc.getcflags(cfg))
 	end
 
-	function suite.ldflags_OnFatalWarnings()
+	function suite.ldflags_OnFatalWarningsViaFlag()
 		flags "FatalWarnings"
 		prepare()
 		test.contains("/WX", msc.getldflags(cfg))
 	end
 
+	function suite.ldflags_OnFatalWarningsViaAPI()
+		fatalwarnings { "Link" }
+		prepare()
+		test.contains("/WX", msc.getldflags(cfg))
+	end
 
 --
 -- Check handling externalwarnings.

--- a/tests/tools/test_snc.lua
+++ b/tests/tools/test_snc.lua
@@ -60,8 +60,15 @@
 -- Check the translation of CFLAGS.
 --
 
-	function suite.cflags_onFatalWarnings()
+	function suite.cflags_onFatalWarningsViaFlag()
 		flags { "FatalWarnings" }
+		prepare()
+		test.isequal({ "-Xquit=2" }, snc.getcflags(cfg))
+	end
+
+
+	function suite.cflag_onFatalWarningsViaAPI()
+		fatalwarnings { "Compile" }
 		prepare()
 		test.isequal({ "-Xquit=2" }, snc.getcflags(cfg))
 	end

--- a/website/docs/fatalwarnings.md
+++ b/website/docs/fatalwarnings.md
@@ -1,4 +1,4 @@
-Specifies specific warnings that should be interpreted as compile errors.
+Specifies specific warnings that should be interpreted as errors.
 
 ```lua
 fatalwarnings { "warnings" }
@@ -10,13 +10,20 @@ fatalwarnings { "warnings" }
 
 For Visual Studio, the MSC warning number should be used to specify the warning. On other compilers, the warning should be identified by name.
 
+In addition, Premake provides two special values to turn on all compiler and linker warnings.
+
+| Value   | Description                   |
+-------------------------------------------
+| Compile | Treat all compiler warnings as errors |
+| Link    | Treat all linker warnings as errors   |
+
 ### Applies To ###
 
 Project configurations.
 
 ### Availability ###
 
-Premake 5.0 or later.
+Premake 5.0 or later. `Compile` and `Link` special values available since Premake 5.0-beta4 or later.
 
 ### See Also ###
 

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -11,9 +11,9 @@ flags { "flag_list" }
 | Flag                  | Description                                                         | Notes |
 |-----------------------|---------------------------------------------------------------------|----------------|
 | ExcludeFromBuild      | Exclude a source code file from the build, for the current configuration. |
-| FatalCompileWarnings  | Treat compiler warnings as errors.                                  |
-| FatalLinkWarnings     | Treat linker warnings as errors.                                    |
-| FatalWarnings         | Treat all warnings as errors; equivalent to FatalCompileWarnings, FatalLinkWarnings |
+| FatalCompileWarnings  | Treat compiler warnings as errors. Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. |
+| FatalLinkWarnings     | Treat linker warnings as errors.  Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. |
+| FatalWarnings         | Treat all warnings as errors; equivalent to FatalCompileWarnings, FatalLinkWarnings.  Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. |
 | LinkTimeOptimization  | Enable link-time (i.e. whole program) optimizations. Deprecated in Premake 5.0.0-beta4. Use `linktimeoptimization` API instead. |
 | Maps                  | Enable Generate Map File for Visual Studio                          |
 | MFC                   | Enable support for Microsoft Foundation Classes. Deprecated in Premake 5.0.0-beta4. Use `mfc` API instead. |
@@ -56,3 +56,10 @@ flags { "LinkTimeOptimization" }
 
 [1]: https://docs.microsoft.com/en-us/cpp/build/reference/gm-enable-minimal-rebuild?view=vs-2017
 [2]: http://msdn.microsoft.com/en-us/library/8wtf2dfz.aspx
+
+### See Also ###
+
+* [fatalwarnings](fatalwarnings.md)
+* [linktimeoptimization](linktimeoptimization.md)
+* [mfc](mfc.md)
+


### PR DESCRIPTION
**What does this PR do?**

Moves the existing `FatalWarnings`, `FatalCompileWarnings`, and `FatalLinkWarnings` flags to the existing `fatalwarnings` API.

**How does this PR change Premake's behavior?**

Deprecates the `FatalWarnings` (and friends) flags. Translates the calls to:

```lua
flags { "FatalWarnings" }
-- becomes
fatalwarnings { "Compile", "Link" }

flags { "FatalCompileWarnings" }
-- becomes
fatalwarnings { "Compile" }

flags { "FatalLinkWarnings" }
-- becomes
fatalwarnings { "Link" }
```

**Anything else we should know?**

Deprecation of flags ahead of 5.0 release.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
