### PR TITLE
Deprecate gmake action

### DIFF
--- a/modules/gmake/_preload.lua
+++ b/modules/gmake/_preload.lua
@@ -24,6 +24,10 @@
 			dotnet = { "mono", "msnet", "pnet" }
 		},
 
+		onDeprecate = function()
+			p.warnOnce("gmake-deprecate", "The gmake action has been deprecated in favor of gmake2. Please update your scripts to use the new action.")
+		end,
+
 		onWorkspace = function(wks)
 			p.escaper(p.make.esc)
 			wks.projects = table.filter(wks.projects, function(prj) return p.action.supports(prj.kind) and prj.kind ~= p.NONE end)

--- a/src/base/action.lua
+++ b/src/base/action.lua
@@ -98,6 +98,10 @@
 	function action.call(name)
 		local a = action._list[name]
 
+		if a.onDeprecate then
+			a.onDeprecate()
+		end
+
 		if a.onStart then
 			a.onStart()
 		end

--- a/website/docs/Building-Premake.md
+++ b/website/docs/Building-Premake.md
@@ -36,7 +36,7 @@ On other platforms, if the bootstrap fails to build, you will need to have a wor
 Once you have a working Premake available, you can generate the project files for your toolset by running a command like the following in the top-level Premake directory:
 
 ```bash
-premake5 gmake  # for makefiles
+premake5 gmake2 # for makefiles
 premake5 vs2012 # for a Visual Studio 2012 solution
 premake --help  # to see a list of supported toolsets
 ```

--- a/website/docs/Your-First-Script.md
+++ b/website/docs/Your-First-Script.md
@@ -48,7 +48,7 @@ This particular command will generate `HelloWorld.sln` and `HelloWorld.vcxproj` 
 If you happened to be on Linux, you could generate and build a makefile like so:
 
 ```bash
-$ premake5 gmake
+$ premake5 gmake2
 $ make                # build default (Debug) configuration
 $ make config=release # build release configuration
 $ make help           # show available configurations

--- a/website/docs/buildoptions.md
+++ b/website/docs/buildoptions.md
@@ -23,6 +23,6 @@ Premake 4.0 or later.
 Use `pkg-config` style configuration when building on Linux with GCC. Build options are always compiler specific and should be targeted to a particular toolset.
 
 ```lua
-filter { "system:linux", "action:gmake" }
+filter { "system:linux", "action:gmake*" }
   buildoptions { "`wx-config --cxxflags`", "-ansi", "-pedantic" }
 ```

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -16,7 +16,7 @@ The available sources for keywords. Keywords are not case-sensitive.
 
 * **Configuration names.** Any of the configuration names supplied to the **[configurations](configurations.md)** or **[platforms](platforms.md)** functions.
 
-* **Action names** such as **vs2010** or **gmake**. See the [Using Premake](Using-Premake.md) for a complete list.
+* **Action names** such as **vs2010** or **gmake2**. See the [Using Premake](Using-Premake.md) for a complete list.
 
 * **Command line options**.
 

--- a/website/docs/globals/premake_OS.md
+++ b/website/docs/globals/premake_OS.md
@@ -11,7 +11,7 @@ Stores the name of the operating system currently being targeted; see [system()]
 The current OS may be overridden on the command line with the `--os` option.
 
 ```
-$ premake5 --os=linux gmake
+$ premake5 --os=linux gmake2
 ```
 
 ### Availability ###

--- a/website/docs/globals/premake_TARGET_ARCH.md
+++ b/website/docs/globals/premake_TARGET_ARCH.md
@@ -7,7 +7,7 @@ Stores the name of the architecture currently being targeted; see [architecture(
 The current architecture may be overridden on the command line with the `--arch` option.
 
 ```
-$ premake5 --arch=x86 gmake
+$ premake5 --arch=x86 gmake2
 ```
 
 ### Availability ###

--- a/website/docs/globals/premake_TARGET_OS.md
+++ b/website/docs/globals/premake_TARGET_OS.md
@@ -7,7 +7,7 @@ Stores the name of the operating system currently being targeted; see [system()]
 The current OS may be overridden on the command line with the `--os` option.
 
 ```
-$ premake5 --os=linux gmake
+$ premake5 --os=linux gmake2
 ```
 
 ### Availability ###

--- a/website/docs/linkgroups.md
+++ b/website/docs/linkgroups.md
@@ -1,4 +1,4 @@
-Turns on/off linkgroups for gcc/clang in the gmake backend.
+Turns on/off linkgroups for gcc/clang in the gmake and gmake2 backend.
 
 ```lua
 linkgroups ("value")

--- a/website/docs/linkoptions.md
+++ b/website/docs/linkoptions.md
@@ -22,6 +22,6 @@ Premake 4.0 or later.
 Use `pkg-config` style configuration when building on Linux with GCC. Build options are always linker specific and should be targeted to a particular toolset.
 
 ```lua
-filter { "system:linux", "action:gmake" }
+filter { "system:linux", "action:gmake*" }
   linkoptions { "`wx-config --libs`" }
 ```

--- a/website/docs/resoptions.md
+++ b/website/docs/resoptions.md
@@ -21,6 +21,6 @@ Premake 4.0 or later.
 Use `pkg-config` style configuration when building on Linux with GCC. Build options are always compiler specific and should be targeted to a particular toolset.
 
 ```lua
-filter { "system:linux", "action:gmake" }
+filter { "system:linux", "action:gmake*" }
   resoptions { "`wx-config --cxxflags`", "-ansi", "-pedantic" }
 ```

--- a/website/docs/staticruntime.md
+++ b/website/docs/staticruntime.md
@@ -6,7 +6,7 @@ staticruntime "value"
 
 ### Parameters ###
 
-| Value      | Visual Studio                                 | XCode     | gmake     |
+| Value      | Visual Studio                                 | XCode     | gmake/gmake2 |
 |------------|-----------------------------------------------|-----------|-----------|
 | `Default`  | Does not set a value for `<RuntimeLibrary>`   | No Effect | No Effect |
 | `On`       | Sets `<RuntimeLibrary>` to "MultiThreaded"    | No Effect | No Effect |


### PR DESCRIPTION
**What does this PR do?**

In preparation for 5.0, this deprecates the `gmake` action officially in favor of `gmake2`. Updated references of gmake to gmake2 in documentation where applicable.

**How does this PR change Premake's behavior?**

No existing code will break.

**Anything else we should know?**

This lays the groundwork for changing `gmake` to `gmake-legacy` in the future and remapping `gmake2` to `gmake`.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
