### PR TITLE
Added ability to use system zlib

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,9 +17,9 @@ jobs:
       if: matrix.depsrc == 'system'
       run: |
         sudo apt-get update 
-        sudo apt-get -y install libcurl4-openssl-dev
+        sudo apt-get -y install libcurl4-openssl-dev libzip-dev
     - name: Build
-      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--curl-src=${{ matrix.depsrc }}" ./Bootstrap.sh
+      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--curl-src=${{ matrix.depsrc }} --zlib-src=${{ matrix.depsrc }}" ./Bootstrap.sh
     - name: Test
       run: bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check

--- a/Bootstrap.sh
+++ b/Bootstrap.sh
@@ -25,23 +25,25 @@ fi
 
 if [ -n "$PREMAKE_OPTS" ]; then
   PREMAKE_OPTS_ARG="PREMAKE_OPTS=$PREMAKE_OPTS"
+else
+  PREMAKE_OPTS_ARG="PREMAKE_OPTS="
 fi
 
 case "$(uname -s)" in
    Linux)
      NPROC=$(nproc --all)
-     make -f Bootstrap.mak ${COSMO_FLAG:-linux} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC
+     make -f Bootstrap.mak ${COSMO_FLAG:-linux} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
      ;;
    Darwin)
      NPROC=$(sysctl -n hw.ncpu)
-     make -f Bootstrap.mak ${COSMO_FLAG:-osx} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC
+     make -f Bootstrap.mak ${COSMO_FLAG:-osx} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
      ;;
    FreeBSD|OpenBSD|NetBSD)
      NPROC=$(sysctl -n hw.ncpu)
-     gmake -f Bootstrap.mak ${COSMO_FLAG:-bsd} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC
+     gmake -f Bootstrap.mak ${COSMO_FLAG:-bsd} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
      ;;
    CYGWIN*|MINGW32*|MSYS*|MINGW*)
-     make -f Bootstrap.mak ${COSMO_FLAG:-mingw} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC
+     make -f Bootstrap.mak ${COSMO_FLAG:-mingw} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
      ;;
    *)
     echo "Unsupported platform"

--- a/premake5.lua
+++ b/premake5.lua
@@ -100,9 +100,24 @@
 
 
 	newoption {
+		trigger = "zlib-src",
+		description = "Specify the source of the Zlib/Zip 3rd party library",
+		allowed = {
+			{ "none", "Disables Zlib/Zip" },
+			{ "contrib", "Uses Zlib/Zip in contrib folder" },
+			{ "system", "Uses Zlib/Zip from the host system" },
+		},
+		default = "contrib",
+	}
+
+	newoption {
 		trigger = "no-zlib",
 		description = "Disable Zlib/Zip 3rd party lib"
 	}
+	if _OPTIONS["no-zlib"] then
+		premake.warn("--no-zlib is deprecated, please use --zlib-src=none")
+		_OPTIONS["zlib-src"] = "none"
+	end
 
 	newoption {
 		trigger = "no-luasocket",
@@ -150,9 +165,8 @@
 		flags { "MultiProcessorCompile" }
 		warnings "Extra"
 
-		if not _OPTIONS["no-zlib"] then
+		filter { "options:not zlib-src=none" }
 			defines { "PREMAKE_COMPRESSION" }
-		end
 
 		filter { "options:not curl-src=none" }
 			defines { "PREMAKE_CURL" }
@@ -217,10 +231,12 @@
 		links       { "lua-lib" }
 
 		-- optional 3rd party libraries
-		if not _OPTIONS["no-zlib"] then
+		filter { "options:zlib-src=contrib" }
 			includedirs { "contrib/zlib", "contrib/libzip" }
 			links { "zip-lib", "zlib-lib" }
-		end
+		filter { "options:zlib-src=system" }
+			links { "zip", "z" }
+		filter {}
 
 		filter { "options:curl-src=contrib" }
 			includedirs { "contrib/curl/include" }
@@ -314,7 +330,7 @@ end
 		include "contrib/lua"
 		include "contrib/luashim"
 
-		if not _OPTIONS["no-zlib"] then
+		if _OPTIONS["zlib-src"] == "contrib" then
 			include "contrib/zlib"
 			include "contrib/libzip"
 		end


### PR DESCRIPTION
**What does this PR do?**

This PR introduces the `--zlib-src` option which deprecates `--no-zlib` (for backwards compatibility), this new option allows users to pick between:
- `none`, replaces `--no-zlib`
- `contrib`, default and what is currently used
- `system`, the system library

**How does this PR change Premake's behavior?**

Users can still build with `--no-zlib` but it will warn and prompt users to migrate to `--zlib-src=none`.

The core focus of this PR was to allow users to build Premake with their system zlib instead.

**Anything else we should know?**

Due to spaces in `PREMAKE_OPTS` some minor changes to `Bootstrap.sh` were needed to avoid errors.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
