### PR TITLE
Add support for riscv64

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -28,6 +28,7 @@
 			p.X86_64,
 			p.ARM,
 			p.ARM64,
+			p.RISCV64,
 		},
 		aliases = {
 			i386  = p.X86,

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -61,6 +61,7 @@
 	premake.X86_64      = "x86_64"
 	premake.ARM         = "ARM"
 	premake.ARM64       = "ARM64"
+	premake.RISCV64     = "RISCV64"
 
 
 

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -62,6 +62,8 @@
 #define PLATFORM_ARCHITECTURE "ARM"
 #elif defined(_M_RISCV64) || (defined(__riscv) && __riscv_xlen == 64)
 #define PLATFORM_ARCHITECTURE "RISCV64"
+#elif !defined(RC_INVOKED)
+#error Unknown architecture detected
 #endif
 
 /* Pull in platform-specific headers required by built-in functions */

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -60,6 +60,8 @@
 #elif defined(__arm__) || defined(__thumb__) || defined(__TARGET_ARCH_ARM) || defined(__TARGET_ARCH_THUMB) || \
     defined(__ARM) || defined(_M_ARM) || defined(_M_ARM_T) || defined(__ARM_ARCH)
 #define PLATFORM_ARCHITECTURE "ARM"
+#elif defined(_M_RISCV64) || (defined(__riscv) && __riscv_xlen == 64)
+#define PLATFORM_ARCHITECTURE "RISCV64"
 #endif
 
 /* Pull in platform-specific headers required by built-in functions */

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -13,6 +13,7 @@ architecture ("value")
 * `x86_64`
 * `ARM`
 * `ARM64`
+* `RISCV64`
 * `armv5`: Only supported in VSAndroid projects
 * `armv7`: Only supported in VSAndroid projects
 * `aarch64`: Only supported in VSAndroid projects


### PR DESCRIPTION
**What does this PR do?**

This PR adds support for riscv64. More specifically, this PR fixes building premake on riscv64: https://archriscv.felixc.at/.status/log.htm?url=logs/premake/premake-5.0beta3-1.log

**How does this PR change Premake's behavior?**

Support riscv64 architecture.

**Anything else we should know?**


**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
