### PR TITLE
Added API for Action Deprecation

### DIFF
--- a/src/base/criteria.lua
+++ b/src/base/criteria.lua
@@ -117,6 +117,19 @@
 					end
 				end
 
+				-- Check if the prefix is an action
+				if prefix == "action" or prefix == "_action" then
+					local actname = word[1]
+					-- Resolve the action alias
+					word[1] = p.action.resolvealias(actname)
+
+					-- Check if the action was deprecated
+					local actiondeprecation = p.action.deprecatedalias(actname)
+					if actiondeprecation ~= nil and actiondeprecation.filter ~= nil and type(actiondeprecation.filter) == "function" then
+						actiondeprecation.filter()
+					end
+				end
+
 				table.insert(pattern, word)
 			end
 

--- a/website/docs/newaction.md
+++ b/website/docs/newaction.md
@@ -28,6 +28,8 @@ newaction { description }
 | onCleanProject  | A callback for each project, when the clean action is selected. |
 | onCleanTarget   | A callback for each target, when the clean action is selected. |
 | pathVars    | A map of Premake tokens to toolset specific identifiers. |
+| aliases | A list of action names to alias to this action. |
+| deprecatedaliases | A table containing a mapping of aliases to callbacks to invoke on action invocation and filters containing the deprecated alias. Each value in the deprecatedaliases table is a table optionally containing an "action" and "filter" key. The values in this table are functions taking zero arguments. See the example below. |
 
 The callbacks will fire in this order:
 
@@ -63,6 +65,26 @@ newaction {
    execute     = function ()
       os.copyfile("bin/debug/myprogram", "/usr/local/bin/myprogram")
    end
+}
+```
+
+Register a new action with aliases and deprecations.
+
+```lua
+newaction {
+   trigger           = "myaction",
+   description       = "Custom action",
+   aliases           = { "myalias", "deprecatedalias" },
+   deprecatedaliases = {
+      ["deprecatedalias" ] = {
+         [ "action" ] = function()
+                           p.warn("Use myaction instead of deprecatedalias.") 
+                        end,
+         [ "filter" ] = function()
+                           p.warn("deprecatedalias has been deprecated. Filter on myaction instead.") 
+                        end
+      }
+   }
 }
 ```
 


### PR DESCRIPTION
**What does this PR do?**

This adds an API for action deprecation. This is in preparation for the official deprecation of gmake.

**How does this PR change Premake's behavior?**

No breaking changes with this PR. This will be as a stepping stone to introduce breaking changes to actions later.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] ~~Add unit tests showing fix or feature works; all tests pass~~ No existing action tests exist
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
