### PR TITLE
Added FreeBSD CI job

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -141,6 +141,44 @@ jobs:
       with:
         name: premake-cosmopolitan-universal
         path: bin/${{ matrix.config }}/premake5
+  freebsd:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config: [debug, release]
+        platform: [x64]
+        cc: [gcc]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Start FreeBSD VM
+      uses: vmactions/freebsd-vm@v1
+      with:
+        usesh: true
+        sync: sshfs
+        prepare: |
+          pkg install -y gmake ca_root_nss gcc
+    - name: Build
+      shell: freebsd {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--cc=${{ matrix.cc }}" ./Bootstrap.sh
+    - name: Test
+      shell: freebsd {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        bin/${{ matrix.config }}/premake5 test --test-all
+    - name: Docs check
+      shell: freebsd {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        bin/${{ matrix.config }}/premake5 docs-check
+    - name: Upload Artifacts
+      if: matrix.config == 'release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: premake-freebsd-${{ matrix.platform }}
+        path: bin/${{ matrix.config }}/
 
   # This job will be required for PRs to be merged.
   # This should depend on (via needs) all jobs that need to be successful for the PR to be merged.

--- a/Bootstrap.sh
+++ b/Bootstrap.sh
@@ -38,7 +38,7 @@ case "$(uname -s)" in
      ;;
    FreeBSD|OpenBSD|NetBSD)
      NPROC=$(sysctl -n hw.ncpu)
-     make -f Bootstrap.mak ${COSMO_FLAG:-bsd} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC
+     gmake -f Bootstrap.mak ${COSMO_FLAG:-bsd} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC
      ;;
    CYGWIN*|MINGW32*|MSYS*|MINGW*)
      make -f Bootstrap.mak ${COSMO_FLAG:-mingw} $PLATFORM_ARG $CONFIG_ARG $PREMAKE_OPTS_ARG -j$NPROC


### PR DESCRIPTION
**What does this PR do?**

Adds FreeBSD CI job

**How does this PR change Premake's behavior?**

Should help ensure we don't break FreeBSD builds. Also uses `gmake` in `Bootstrap.sh` as it's required.

**Anything else we should know?**

Currently uses GCC due to an issue with Clang and mbedtls, future PRs will resolve this.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
