### PR TITLE
Add support for loongarch64

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -29,6 +29,7 @@
 			p.ARM,
 			p.ARM64,
 			p.RISCV64,
+			p.LOONGARCH64
 		},
 		aliases = {
 			i386  = p.X86,

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -62,6 +62,7 @@
 	premake.ARM         = "ARM"
 	premake.ARM64       = "ARM64"
 	premake.RISCV64     = "RISCV64"
+	premake.LOONGARCH64 = "loongarch64"
 
 
 

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -62,6 +62,8 @@
 #define PLATFORM_ARCHITECTURE "ARM"
 #elif defined(_M_RISCV64) || (defined(__riscv) && __riscv_xlen == 64)
 #define PLATFORM_ARCHITECTURE "RISCV64"
+#elif (defined(__loongarch__) && __loongarch_grlen == 64) || defined(__loongarch64)
+#define PLATFORM_ARCHITECTURE "loongarch64"
 #elif !defined(RC_INVOKED)
 #error Unknown architecture detected
 #endif

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -14,6 +14,7 @@ architecture ("value")
 * `ARM`
 * `ARM64`
 * `RISCV64`
+* `loongarch64`
 * `armv5`: Only supported in VSAndroid projects
 * `armv7`: Only supported in VSAndroid projects
 * `aarch64`: Only supported in VSAndroid projects


### PR DESCRIPTION
**What does this PR do?**

This PR adds support for loongarch64, fixing building errors on loongarch64.

**How does this PR change Premake's behavior?**

Support loongarch64 architecture.

**Anything else we should know?**

To be clear, [LoongArch](https://docs.kernel.org/arch/loongarch/introduction.html) is a new RISC ISA developed by loongson. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
