### PR TITLE
Override Lua functions without injecting code into the library

### DIFF
--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -7,6 +7,7 @@ PREMAKE_OPTS =
 
 SRC		= src/host/*.c			\
 		$(LUA_DIR)/lapi.c		\
+		$(LUA_DIR)/lauxlib.c	\
 		$(LUA_DIR)/lbaselib.c	\
 		$(LUA_DIR)/lbitlib.c	\
 		$(LUA_DIR)/lcode.c		\

--- a/contrib/lua/premake5.lua
+++ b/contrib/lua/premake5.lua
@@ -13,7 +13,6 @@ project "lua-lib"
 
 	excludes
 	{
-		"src/lauxlib.c",
 		"src/lua.c",
 		"src/luac.c",
 		"src/print.c",

--- a/src/host/os_compile.c
+++ b/src/host/os_compile.c
@@ -8,8 +8,6 @@
 #include "lundump.h"
 #include "lstate.h"
 
-extern int original_luaL_loadfilex(lua_State* L, const char* filename, const char* mode);
-
 static int writer(lua_State* L, const void* p, size_t size, void* u)
 {
 	UNUSED(L);
@@ -22,7 +20,7 @@ int os_compile(lua_State* L)
 	const char* output = luaL_checkstring(L, 2);
 	lua_State* P = luaL_newstate();
 
-	if (original_luaL_loadfilex(P, input, NULL) != LUA_OK)
+	if (luaL_loadfilex(P, input, NULL) != LUA_OK)
 	{
 		const char* msg = lua_tostring(P, -1);
 		if (msg == NULL)

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -218,3 +218,13 @@ const buildin_mapping* premake_find_embedded_script(const char* filename);
 int premake_locate_executable(lua_State* L, const char* argv0);
 int premake_locate_file(lua_State* L, const char* filename, int searchMask);
 void premake_handle_lua_error(lua_State* L);
+
+// Overridden Lua functions
+int premake_luaL_loadfilex(lua_State *L, const char *filename, const char *mode);
+int premake_luaB_loadfile(lua_State* L);
+int premake_luaB_dofile(lua_State* L);
+int premake_searcher_Lua(lua_State *L);
+
+#define premake_luaL_loadfile(L,f)	premake_luaL_loadfilex(L,f,NULL)
+#define premake_luaL_dofile(L, fn) \
+	(premake_luaL_loadfile(L, fn) || lua_pcall(L, 0, LUA_MULTRET, 0))


### PR DESCRIPTION
**What does this PR do?**

Changes how we override Lua file loading for `loadfile`, `dofile` and `require`. This change is required to allow us to use the system Lua.

**How does this PR change Premake's behavior?**

It shouldn't change the behaviour.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
