### PR TITLE
Fixed potential use-after-free bug when calling os.getversion

### DIFF
--- a/src/host/os_getversion.c
+++ b/src/host/os_getversion.c
@@ -293,15 +293,8 @@ int getversion(struct OsVersionInfo* info)
 		return 0;
 	}
 
-#if __GLIBC__
-	// When using glibc, info->description gets set to u.sysname,
-	// but it isn't passed out of this function, so we need to copy
-	// the string.
 	info->description = strdup(u.sysname);
 	info->isalloc = 1;
-#else
-	info->description = u.sysname;
-#endif
 
 	if ((ver = strtok(u.release, ".-")) != NULL)
 	{


### PR DESCRIPTION
**What does this PR do?**

Fixes a potential use-after-free bug in `os.getversion` for certain platforms and only ones that don't use GLIBC - this was an issue found on OpenBSD.

**How does this PR change Premake's behavior?**

Non-GLIBC platforms also duplicate the string now. Shouldn't have a negative impact on behaviour.

**Anything else we should know?**

The original code wasn't iterated into this, it has always had this bug. It's possible that by removing this check, a system no longer compiles due to the `strdup`. However, I think it's better to break that system and provide an alternate solution if required, than to have other systems be prone to error (or worse).

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
