### PR TITLE
Added SunOS support to Bootstrap.sh

### DIFF
--- a/Bootstrap.sh
+++ b/Bootstrap.sh
@@ -29,7 +29,8 @@ else
   PREMAKE_OPTS_ARG="PREMAKE_OPTS="
 fi
 
-case "$(uname -s)" in
+SYSTEM=$(uname -s)
+case "${SYSTEM}" in
    Linux)
      NPROC=$(nproc --all)
      make -f Bootstrap.mak ${COSMO_FLAG:-linux} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
@@ -45,8 +46,12 @@ case "$(uname -s)" in
    CYGWIN*|MINGW32*|MSYS*|MINGW*)
      make -f Bootstrap.mak ${COSMO_FLAG:-mingw} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
      ;;
+   SunOS)
+     NPROC=$(nproc --all)
+     gmake -f Bootstrap.mak ${COSMO_FLAG:-solaris} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
+     ;;
    *)
-    echo "Unsupported platform"
+    echo "Unsupported platform: '${SYSTEM}'"
     exit 1
      ;;
 esac


### PR DESCRIPTION
- Bootstrap.sh now prints out the unsupported uname value to assist with updating

**What does this PR do?**

Adds SunOS/Solaris to the Bootstrap.sh, additionally improves the error message for users that don't know the exact `uname -s` value.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
