### PR TITLE
Add OpenBSD CI job

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -180,6 +180,44 @@ jobs:
       with:
         name: premake-freebsd-${{ matrix.platform }}
         path: bin/${{ matrix.config }}/
+  openbsd:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config: [debug, release]
+        platform: [x64]
+        cc: [clang]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Start OpenBSD VM
+      uses: vmactions/openbsd-vm@v1
+      with:
+        usesh: true
+        sync: sshfs
+        prepare: |
+          pkg_add gmake
+    - name: Build
+      shell: openbsd {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--cc=${{ matrix.cc }}" ./Bootstrap.sh
+    - name: Test
+      shell: openbsd {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        bin/${{ matrix.config }}/premake5 test --test-all
+    - name: Docs check
+      shell: openbsd {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        bin/${{ matrix.config }}/premake5 docs-check
+    - name: Upload Artifacts
+      if: matrix.config == 'release' && matrix.cc == 'clang'
+      uses: actions/upload-artifact@v4
+      with:
+        name: premake-openbsd-${{ matrix.platform }}
+        path: bin/${{ matrix.config }}/
 
   # This job will be required for PRs to be merged.
   # This should depend on (via needs) all jobs that need to be successful for the PR to be merged.

--- a/contrib/curl/lib/config-linux.h
+++ b/contrib/curl/lib/config-linux.h
@@ -185,7 +185,9 @@
 #define HAVE_GETHOSTBYNAME 1
 
 /* Define to 1 if you have the gethostbyname_r function. */
+#if !defined(__OpenBSD__)
 #define HAVE_GETHOSTBYNAME_R 1
+#endif
 
 /* gethostbyname_r() takes 3 args */
 /* #undef HAVE_GETHOSTBYNAME_R_3 */

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -30,6 +30,17 @@
 			test.istrue(os.findlib("user32"))
 		elseif os.istarget("haiku") then
 			test.istrue(os.findlib("root"))
+		elseif os.istarget("bsd") and os.getversion().description == "OpenBSD" then
+			-- OpenBSD doesn't have a 'libm.so' symlink like other systems,
+			-- it only has the versioned files, 'libm.so.X.Y' which will
+			-- change between versions of OpenBSD. os.findlib currently won't
+			-- find these versioned files without the version info.
+
+			-- libm should be '/usr/lib/libm.so.X.Y' find the exact filename
+			-- and use that.
+			local libms = os.matchfiles("/usr/lib/libm.so.*")
+			test.isfalse(0 == #libms)
+			test.istrue(os.findlib(path.getname(libms[1])))
 		else
 			test.istrue(os.findlib("m"))
 		end


### PR DESCRIPTION
**What does this PR do?**

Add OpenBSD CI job

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

OpenBSD doesn't have symlinks in the system libraries folder like other systems. So, there is no `libm.so`, for the `os.findlib` test we instead find the exact versioned `libm.so` and search for that name in all of the paths. While this still technically tests `os.findlib`, it would be preferable to use the same path as other systems with the `m` library one day by expanding it to find versioned libraries too.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
