### PR TITLE
Add NetBSD CI job

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -218,6 +218,36 @@ jobs:
       with:
         name: premake-openbsd-${{ matrix.platform }}
         path: bin/${{ matrix.config }}/
+  netbsd:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config: [debug, release]
+        platform: [x64]
+        cc: [gcc]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Start NetBSD VM
+      uses: vmactions/netbsd-vm@v1
+      with:
+        prepare: |
+          pkg_add gmake
+    - name: Build
+      shell: netbsd {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--cc=${{ matrix.cc }}" ./Bootstrap.sh
+    - name: Test
+      shell: netbsd {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        bin/${{ matrix.config }}/premake5 test --test-all
+    - name: Docs check
+      shell: netbsd {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        bin/${{ matrix.config }}/premake5 docs-check
 
   # This job will be required for PRs to be merged.
   # This should depend on (via needs) all jobs that need to be successful for the PR to be merged.

--- a/contrib/curl/lib/config-linux.h
+++ b/contrib/curl/lib/config-linux.h
@@ -185,7 +185,7 @@
 #define HAVE_GETHOSTBYNAME 1
 
 /* Define to 1 if you have the gethostbyname_r function. */
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__NetBSD__)
 #define HAVE_GETHOSTBYNAME_R 1
 #endif
 

--- a/contrib/curl/premake5.lua
+++ b/contrib/curl/premake5.lua
@@ -38,6 +38,7 @@ project "curl-lib"
 		local ca = nil
 		for _, f in ipairs {
 			"/etc/ssl/certs/ca-certificates.crt",
+			"/etc/openssl/certs/ca-certificates.crt",
 			"/etc/pki/tls/certs/ca-bundle.crt",
 			"/usr/share/ssl/certs/ca-bundle.crt",
 			"/usr/local/share/certs/ca-root.crt",


### PR DESCRIPTION
**What does this PR do?**

Adds NetBSD CI job.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

NetBSD stores the root CA certs in different location this has been added to the list, and while it seems to have `gethostbyname_r` it was unable to resolve host names using it.

Due to issues with the `netbsd-vm` action, it is not possible to upload the build artifacts as we do for FreeBSD and OpenBSD.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
