### PR TITLE
Cleaned up VM-based CI jobs

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -149,6 +149,9 @@ jobs:
         config: [debug, release]
         platform: [x64]
         cc: [gcc, clang]
+    defaults:
+      run:
+        shell: freebsd {0}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -160,17 +163,14 @@ jobs:
         prepare: |
           pkg install -y gmake ca_root_nss gcc
     - name: Build
-      shell: freebsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--cc=${{ matrix.cc }}" ./Bootstrap.sh
     - name: Test
-      shell: freebsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check
-      shell: freebsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         bin/${{ matrix.config }}/premake5 docs-check
@@ -187,6 +187,9 @@ jobs:
         config: [debug, release]
         platform: [x64]
         cc: [clang]
+    defaults:
+      run:
+        shell: openbsd {0}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -198,17 +201,14 @@ jobs:
         prepare: |
           pkg_add gmake
     - name: Build
-      shell: openbsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--cc=${{ matrix.cc }}" ./Bootstrap.sh
     - name: Test
-      shell: openbsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check
-      shell: openbsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         bin/${{ matrix.config }}/premake5 docs-check
@@ -225,6 +225,9 @@ jobs:
         config: [debug, release]
         platform: [x64]
         cc: [gcc]
+    defaults:
+      run:
+        shell: netbsd {0}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -234,17 +237,14 @@ jobs:
         prepare: |
           pkg_add gmake
     - name: Build
-      shell: netbsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--cc=${{ matrix.cc }}" ./Bootstrap.sh
     - name: Test
-      shell: netbsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check
-      shell: netbsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         bin/${{ matrix.config }}/premake5 docs-check
@@ -255,6 +255,9 @@ jobs:
         config: [debug, release]
         platform: [x64]
         cc: [gcc]
+    defaults:
+      run:
+        shell: dragonflybsd {0}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -264,17 +267,14 @@ jobs:
         prepare: |
           pkg install -y gmake
     - name: Build
-      shell: dragonflybsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--cc=${{ matrix.cc }}" ./Bootstrap.sh
     - name: Test
-      shell: dragonflybsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check
-      shell: dragonflybsd {0}
       run: |
         cd $GITHUB_WORKSPACE
         bin/${{ matrix.config }}/premake5 docs-check
@@ -285,6 +285,9 @@ jobs:
         config: [debug, release]
         platform: [x64]
         cc: [gcc]
+    defaults:
+      run:
+        shell: solaris {0}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -296,17 +299,14 @@ jobs:
         mem: 8192
         release: 11.4-gcc
     - name: Build
-      shell: solaris {0}
       run: |
         cd $GITHUB_WORKSPACE
         CC=${{ matrix.cc }} PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--cc=${{ matrix.cc }}" ./Bootstrap.sh
     - name: Test
-      shell: solaris {0}
       run: |
         cd $GITHUB_WORKSPACE
         bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check
-      shell: solaris {0}
       run: |
         cd $GITHUB_WORKSPACE
         bin/${{ matrix.config }}/premake5 docs-check


### PR DESCRIPTION
**What does this PR do?**

Sets the default shell on the FreeBSD, OpenBSD, NetBSD, DragonflyBSD and Solaris jobs to their respective VM shells.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

Setting the default `working_directory` does not work with the VM shells.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
