### PR TITLE
Fatal warnings API fixes

### DIFF
--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -108,6 +108,7 @@ return {
 
 	-- Visual Studio 2022+ C/C++ Projects
 	"vc2022/test_compile_settings.lua",
+	"vc2022/test_link.lua",
 	"vc2022/test_output_props.lua",
 	"vc2022/test_toolset_settings.lua",
 	

--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -113,5 +113,8 @@ return {
 	
 	-- Android projects
 	"android/test_android_files.lua",
-	"android/test_android_project.lua"
+	"android/test_android_project.lua",
+
+	-- Linux projects
+	"linux/test_linux_files.lua",
 }

--- a/modules/vstudio/tests/cs2005/test_compiler_props.lua
+++ b/modules/vstudio/tests/cs2005/test_compiler_props.lua
@@ -84,7 +84,7 @@
 
 
 	function suite.treatWarningsAsErrors_onFatalWarningsAPI()
-		fatalwarnings { "Compile" }
+		fatalwarnings { "All" }
 		prepare()
 		test.capture [[
 		<DefineConstants></DefineConstants>

--- a/modules/vstudio/tests/linux/test_linux_files.lua
+++ b/modules/vstudio/tests/linux/test_linux_files.lua
@@ -1,0 +1,61 @@
+local p = premake
+local suite = test.declare("test_linux_files")
+local vc2010 = p.vstudio.vc2010
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2019")
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepareOutputProperties()
+		system "linux"
+		local cfg = test.getconfig(prj, "Debug")
+		vc2010.outputProperties(cfg)
+	end
+
+	local function prepareConfigProperties()
+		system "linux"
+		local cfg = test.getconfig(prj, "Debug", platform)
+		vc2010.configurationProperties(cfg)
+	end
+
+--
+-- Test link time optimization.
+--
+
+	function suite.linkTimeOptimization_On()
+		linktimeoptimization('on')
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>v142</PlatformToolset>
+	<LinkTimeOptimization>true</LinkTimeOptimization>
+</PropertyGroup>
+		]]
+	end
+
+--
+-- Test multiprocessor compilation.
+--
+
+	function suite.multiProcessorCompile_On()
+		flags { "MultiProcessorCompile" }
+		prepareOutputProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+	<IntDir>obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>
+	</TargetExt>
+	<MultiProcNumber>8</MultiProcNumber>
+</PropertyGroup>
+		]]
+	end

--- a/modules/vstudio/tests/vc200x/test_compiler_block.lua
+++ b/modules/vstudio/tests/vc200x/test_compiler_block.lua
@@ -374,7 +374,7 @@
 
 
 	function suite.runtimeLibraryIsDebug_onFatalWarningsViaAPI()
-		fatalwarnings { "Compile" }
+		fatalwarnings { "All" }
 		prepare()
 		test.capture [[
 <Tool
@@ -416,7 +416,7 @@
 
 
 	function suite.runtimeLibraryIsDebug_onNoWarnings_whichDisablesAllOtherWarningsFlagsViaAPI()
-		fatalwarnings { "Compile" }
+		fatalwarnings { "All" }
 		warnings "Off"
 		prepare()
 		test.capture [[

--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -164,7 +164,7 @@
 
 
 	function suite.warningLevel_onNoWarningsOverOtherWarningsAPI()
-		fatalwarnings { "Compile" }
+		fatalwarnings { "All" }
 		warnings "Off"
 		prepare()
 		test.capture [[
@@ -571,7 +571,7 @@
 
 
 	function suite.treatWarningsAsError_onFatalWarningsViaAPI()
-		fatalwarnings { "Compile" }
+		fatalwarnings { "All" }
 		prepare()
 		test.capture [[
 <ClCompile>

--- a/modules/vstudio/tests/vc2022/test_link.lua
+++ b/modules/vstudio/tests/vc2022/test_link.lua
@@ -5,7 +5,7 @@
 --
 
 local p = premake
-local suite = test.declare("vstudio_vs2019_link")
+local suite = test.declare("vstudio_vs2022_link")
 local vc2010 = p.vstudio.vc2010
 local project = p.project
 
@@ -16,7 +16,7 @@ local project = p.project
 	local wks, prj
 
 	function suite.setup()
-		p.action.set("vs2019")
+		p.action.set("vs2022")
 		wks, prj = test.createWorkspace()
 	end
 
@@ -29,13 +29,12 @@ local project = p.project
 -- Check link command for a static library using a clang toolset
 --
 
-	function suite.toolsetClangAdditionalDependencies()
-		links { "lua", "zlib" }
-		toolset "clang"
+	function suite.linkerFatalWarnings()
+		linkerfatalwarnings { "4123", "4124" }
 		prepare()
 		test.capture [[
 <Link>
 	<SubSystem>Console</SubSystem>
-	<AdditionalDependencies>lua.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+	<AdditionalOptions>/wx:4123,4124 %(AdditionalOptions)</AdditionalOptions>
 		]]
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2178,17 +2178,7 @@
 
 			if #filteredFatalWarnings > 0 then
 				-- Create a comma-separated set of warnings to elevate as errors
-				local fatalWarningString = '/wx:'
-			
-				for i, fatal in ipairs(filteredFatalWarnings) do
-					if i ~= 1 then
-						fatalWarningString = fatalWarningString..","
-					end
-
-					fatalWarningString = fatalWarningString..fatal
-				end
-
-				table.insert(opts, fatalWarningString)
+				table.insert(opts, '/wx:'..table.implode(filteredFatalWarnings, "", "", ","))
 			end
 		end
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -400,6 +400,9 @@
 				m.libraryPath,
 				m.extensionsToDeleteOnClean,
 				m.executablePath,
+
+				-- Linux
+				m.linuxMultiProcNumber
 			}
 		end
 
@@ -631,6 +634,7 @@
 			m.linuxLanguageStandardCpp,
 			m.linuxLanguageStandardC,
 			m.linuxWarningLevel,
+			m.linuxLinkTimeCodeGeneration,
 		}
 
 		return calls
@@ -799,7 +803,7 @@
 				m.fullProgramDatabaseFile,
 				m.generateDebugInformation,
 				m.optimizeReferences,
-				m.LinkTimeCodeGeneration,
+				m.linkTimeCodeGeneration,
 			}
 		else
 			return {
@@ -807,7 +811,7 @@
 				m.fullProgramDatabaseFile,
 				m.generateDebugInformation,
 				m.optimizeReferences,
-				m.LinkTimeCodeGeneration,
+				m.linkTimeCodeGeneration,
 				m.additionalDependencies,
 				m.additionalLibraryDirectories,
 				m.importLibrary,
@@ -1152,6 +1156,7 @@
 			m.linuxExceptionHandling,
 			m.linuxPIC,
 			m.gccClangAdditionalCompileOptions,
+			m.linuxLinkTimeCodeGeneration,
 		}
 
 	end
@@ -3027,7 +3032,7 @@
 		end
 	end
 
-	function m.LinkTimeCodeGeneration(cfg)
+	function m.linkTimeCodeGeneration(cfg)
 		if cfg.linktimeoptimization == "On" then
 			m.element("LinkTimeCodeGeneration", nil, "UseLinkTimeCodeGeneration")
 		end
@@ -3964,6 +3969,20 @@
 			m.element("LinkTimeOptimization", nil, "true")
 		elseif cfg.linktimeoptimization == "Off" then
 			m.element("LinkTimeOptimization", nil, "false")
+		end
+	end
+
+	function m.linuxMultiProcNumber(cfg)
+		-- Linux equivalent of 'MultiProcessorCompilation'
+		-- Default to 8 parallel jobs
+		if cfg.flags.MultiProcessorCompile then
+			m.element("MultiProcNumber", nil, "8")
+		end
+	end
+
+	function m.linuxLinkTimeCodeGeneration(cfg)
+		if cfg.linktimeoptimization == "On" then
+			m.element("LinkTimeOptimization", nil, "true")
 		end
 	end
 

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -2725,7 +2725,8 @@
 
 
 	function suite.XCBuildConfigurationProject_OnFatalWarningsViaAPI()
-		fatalwarnings { "Compile", "Link" }
+		fatalwarnings { "All" }
+		linkerfatalwarnings { "All" }
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1506,7 +1506,7 @@
 			settings['GCC_CHAR_IS_UNSIGNED_CHAR'] = iif(cfg.unsignedchar, "YES", "NO")
 		end
 
-		if p.hasFatalCompileWarnings(cfg.fatalwarnings) and p.hasFatalLinkWarnings(cfg.fatalwarnings) then
+		if p.hasFatalCompileWarnings(cfg.fatalwarnings) or p.hasFatalLinkWarnings(cfg.linkerfatalwarnings) then
 			settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'YES'
 		end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -306,7 +306,9 @@
 		name = "fatalwarnings",
 		scope = "config",
 		kind = "list:string",
-		tokens = true,
+		reserved = {
+			"All"
+		}
 	}
 
 	api.register {
@@ -577,6 +579,15 @@
 		allowed = {
 			"Default",
 			"LLD",
+		}
+	}
+
+	api.register {
+		name = "linkerfatalwarnings",
+		scope = "config",
+		kind = "list:string",
+		reserved = {
+			"All"
 		}
 	}
 
@@ -1113,34 +1124,34 @@
 		linktimeoptimization("Default")
 	end)
 
-	api.deprecateValue("flags", "FatalWarnings", "Use `fatalwarnings { \"Compile\", \"Link\" }` instead.",
+	api.deprecateValue("flags", "FatalWarnings", "Use `fatalwarnings { \"All\" }` instead.",
 	function(value)
-		fatalwarnings({ "Compile", "Link" })
+		fatalwarnings({ "All" })
 	end,
 	function(value)
-		removefatalwarnings({ "Compile", "Link" })
+		removefatalwarnings({ "All" })
 	end)
 
-	api.deprecateValue("flags", "FatalCompileWarnings", "Use `fatalwarnings { \"Compile\" }` instead.",
+	api.deprecateValue("flags", "FatalCompileWarnings", "Use `fatalwarnings { \"All\" }` instead.",
 	function(value)
-		fatalwarnings({ "Compile" })
+		fatalwarnings({ "All" })
 	end,
 	function(value)
-		removefatalwarnings({ "Compile" })
+		removefatalwarnings({ "All" })
 	end)
 
-	api.deprecateValue("flags", "FatalLinkWarnings", "Use `fatalwarnings { \"Link\" }` instead.",
+	api.deprecateValue("flags", "FatalLinkWarnings", "Use `linkerfatalwarnings { \"All\" }` instead.",
 	function(value)
-		fatalwarnings({ "Link" })
+		linkerfatalwarnings({ "All" })
 	end,
 	function(value)
-		removefatalwarnings({ "Link" })
+		removelinkerfatalwarnings({ "All" })
 	end)
 
 	premake.filterFatalWarnings = function(tbl)
 		if type(tbl) == "table" then
 			return table.filter(tbl, function(warning)
-				return not (warning == "Compile" or warning == "Link")
+				return not (warning == "All")
 			end)
 		else
 			return tbl
@@ -1149,7 +1160,7 @@
 
 	premake.hasFatalCompileWarnings = function(tbl)
 		if (type(tbl) == "table") then
-			return table.contains(tbl, "Compile")
+			return table.contains(tbl, "All")
 		else
 			return false
 		end
@@ -1157,7 +1168,7 @@
 
 	premake.hasFatalLinkWarnings = function(tbl)
 		if (type(tbl) == "table") then
-			return table.contains(tbl, "Link")
+			return table.contains(tbl, "All")
 		else
 			return false
 		end

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -45,7 +45,7 @@
 	clang.shared = {
 		architecture = gcc.shared.architecture,
 		fatalwarnings = {
-			Compile = "-Werror"
+			All = "-Werror"
 		},
 		flags = gcc.shared.flags,
 		floatingpoint = {
@@ -230,8 +230,8 @@
 			x86 = "-m32",
 			x86_64 = "-m64",
 		},
-		fatalwarnings = {
-			Link = "-Wl,--fatal-warnings",
+		linkerfatalwarnings = {
+			All = "-Wl,--fatal-warnings",
 		},
 		linktimeoptimization = clang.shared.linktimeoptimization,
 		kind = {

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -58,7 +58,7 @@
 			x86_64 = "-m64",
 		},
 		fatalwarnings = {
-			Compile = "-Werror",
+			All = "-Werror",
 		},
 		flags = {
 			ShadowedVariables = "-Wshadow",
@@ -475,8 +475,8 @@
 			x86 = "-m32",
 			x86_64 = "-m64",
 		},
-		fatalwarnings = {
-			Link = "-Wl,--fatal-warnings",
+		linkerfatalwarnings = {
+			All = "-Wl,--fatal-warnings",
 		},
 		linktimeoptimization = gcc.shared.linktimeoptimization,
 		kind = {

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -62,7 +62,7 @@
 			["C++"] = "/TP",
 		},
 		fatalwarnings = {
-			Compile = "/WX",
+			All = "/WX"
 		},
 		flags = {
 			MultiProcessorCompile = "/MP",
@@ -334,8 +334,8 @@
 --
 
 	msc.linkerFlags = {
-		fatalwarnings = {
-			Link = "/WX",
+		linkerfatalwarnings = {
+			All = "/WX",
 		},
 		flags = {
 			NoIncrementalLink = "/INCREMENTAL:NO",
@@ -355,8 +355,8 @@
 	}
 
 	msc.librarianFlags = {
-		fatalwarnings = {
-			Link = "/WX",
+		linkerfatalwarnings = {
+			All = "/WX",
 		}
 	}
 

--- a/src/tools/snc.lua
+++ b/src/tools/snc.lua
@@ -17,7 +17,7 @@
 
 	snc.shared = {
 		fatalwarnings = {
-			Compile = "-Xquit=2",
+			All = "-Xquit=2",
 		},
 		optimize = {
 			Off = "-O0",

--- a/tests/test_premake.lua
+++ b/tests/test_premake.lua
@@ -42,31 +42,31 @@
 --
 
 	function suite.filterFatalWarnings()
-		local warnings = { "Link", "4996" }
+		local warnings = { "All", "4996" }
 		local filtered = p.filterFatalWarnings(warnings)
 		test.isequal({ "4996" }, filtered)
 	end
 
 	function suite.hasFatalCompileWarnings()
-		local warnings = { "Compile", "4996" }
+		local warnings = { "All", "4996" }
 		local hasFatal = p.hasFatalCompileWarnings(warnings)
 		test.istrue(hasFatal)
 	end
 
 	function suite.hasFatalCompileWarningsNotPresent()
-		local warnings = { "Link", "4996" }
+		local warnings = { "4996" }
 		local hasFatal = p.hasFatalCompileWarnings(warnings)
 		test.isfalse(hasFatal)
 	end
 
 	function suite.hasFatalLinkWarnings()
-		local warnings = { "Link", "4996" }
+		local warnings = { "All", "4996" }
 		local hasFatal = p.hasFatalLinkWarnings(warnings)
 		test.istrue(hasFatal)
 	end
 
 	function suite.hasFatalLinkWarningsNotPresent()
-		local warnings = { "Compile", "4996" }
+		local warnings = { "4996" }
 		local hasFatal = p.hasFatalLinkWarnings(warnings)
 		test.isfalse(hasFatal)
 	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -128,7 +128,7 @@
 	end
 
 	function suite.cflags_onFatalWarningsViaAPI()
-		fatalwarnings { "Compile" }
+		fatalwarnings { "All" }
 		prepare()
 		test.contains({ "-Werror" }, gcc.getcflags(cfg))
 	end
@@ -420,7 +420,7 @@
 -- Check the basic translation of LDFLAGS for a Posix system.
 --
 	function suite.ldflags_onFatalLinkWarningsAPI()
-		fatalwarnings { "Link" }
+		linkerfatalwarnings { "All" }
 		prepare()
 		test.contains({ "-Wl,--fatal-warnings" }, gcc.getldflags(cfg))
 	end

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -249,7 +249,7 @@
 	end
 
 	function suite.cflags_OnFatalWarningsViaAPI()
-		fatalwarnings { "Compile" }
+		fatalwarnings { "All" }
 		prepare()
 		test.contains("/WX", msc.getcflags(cfg))
 	end
@@ -262,14 +262,8 @@
 		test.contains({ '/w1"enable"', '/wd"disable"', '/we"fatal"' }, msc.getcflags(cfg))
 	end
 
-	function suite.ldflags_OnFatalWarningsViaFlag()
-		flags "FatalWarnings"
-		prepare()
-		test.contains("/WX", msc.getldflags(cfg))
-	end
-
 	function suite.ldflags_OnFatalWarningsViaAPI()
-		fatalwarnings { "Link" }
+		linkerfatalwarnings { "All" }
 		prepare()
 		test.contains("/WX", msc.getldflags(cfg))
 	end

--- a/tests/tools/test_snc.lua
+++ b/tests/tools/test_snc.lua
@@ -68,7 +68,7 @@
 
 
 	function suite.cflag_onFatalWarningsViaAPI()
-		fatalwarnings { "Compile" }
+		fatalwarnings { "All" }
 		prepare()
 		test.isequal({ "-Xquit=2" }, snc.getcflags(cfg))
 	end

--- a/website/docs/fatalwarnings.md
+++ b/website/docs/fatalwarnings.md
@@ -28,10 +28,12 @@ Premake 5.0 or later. Special value `All` available since Premake 5.0-beta5 or l
 
 ```lua
 filter { "toolset:msc" }
-	fatalwarnings { "4035" }
+	fatalwarnings { "4035" } -- 'function': no return value
 
 filter { "toolset:clang" }
 	fatalwarnings { "-Wreturn-type" }
+
+filter {}
 ```
 
 ### See Also ###

--- a/website/docs/fatalwarnings.md
+++ b/website/docs/fatalwarnings.md
@@ -10,7 +10,7 @@ fatalwarnings { "warnings" }
 
 For Visual Studio, the MSC warning number should be used to specify the warning. On other compilers, the warning should be identified by name.
 
-In addition, Premake provides two special values to turn on all compiler and linker warnings.
+In addition, Premake provides a special value to turn on all compiler warnings.
 
 | Value   | Description                   |
 -------------------------------------------
@@ -23,6 +23,16 @@ Project configurations.
 ### Availability ###
 
 Premake 5.0 or later. Special value `All` available since Premake 5.0-beta5 or later.
+
+### Examples ###
+
+```lua
+filter { "toolset:msc" }
+	fatalwarnings { "4035" }
+
+filter { "toolset:clang" }
+	fatalwarnings { "-Wreturn-type" }
+```
 
 ### See Also ###
 

--- a/website/docs/linkerfatalwarnings.md
+++ b/website/docs/linkerfatalwarnings.md
@@ -28,5 +28,7 @@ Premake 5.0 or later. Special value `All` available since Premake 5.0-beta5 or l
 
 ```lua
 filter { "toolset:msc" }
-	fatalwarnings { "4044" }
+	fatalwarnings { "4044" } -- unrecognized option 'option'; ignored
+
+filter {}
 ```

--- a/website/docs/linkerfatalwarnings.md
+++ b/website/docs/linkerfatalwarnings.md
@@ -1,7 +1,7 @@
-Specifies specific compiler warnings that should be interpreted as errors.
+Specifies specific linker warnings that should be interpreted as errors.
 
 ```lua
-fatalwarnings { "warnings" }
+linkerfatalwarnings { "warnings" }
 ```
 
 ### Parameters ###
@@ -14,7 +14,7 @@ In addition, Premake provides two special values to turn on all compiler and lin
 
 | Value   | Description                   |
 -------------------------------------------
-| All | Treat all compiler warnings as errors |
+| All | Treat all linker warnings as errors   |
 
 ### Applies To ###
 
@@ -23,8 +23,3 @@ Project configurations.
 ### Availability ###
 
 Premake 5.0 or later. Special value `All` available since Premake 5.0-beta5 or later.
-
-### See Also ###
-
-* [enablewarnings](enablewarnings.md)
-* [disablewarnings](disablewarnings.md)

--- a/website/docs/linkerfatalwarnings.md
+++ b/website/docs/linkerfatalwarnings.md
@@ -10,7 +10,7 @@ linkerfatalwarnings { "warnings" }
 
 For Visual Studio, the MSC warning number should be used to specify the warning. On other compilers, the warning should be identified by name.
 
-In addition, Premake provides two special values to turn on all compiler and linker warnings.
+In addition, Premake provides a special value to turn on all linker warnings.
 
 | Value   | Description                   |
 -------------------------------------------
@@ -23,3 +23,10 @@ Project configurations.
 ### Availability ###
 
 Premake 5.0 or later. Special value `All` available since Premake 5.0-beta5 or later.
+
+### Examples ###
+
+```lua
+filter { "toolset:msc" }
+	fatalwarnings { "4044" }
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -182,6 +182,7 @@ module.exports = {
 						'libdirs',
 						'linkbuildoutputs',
 						'linker',
+						'linkerfatalwarnings',
 						'linkgroups',
 						'linkoptions',
 						'links',


### PR DESCRIPTION
**What does this PR do?**

Splits the fatalwarnings api into fatalwarnings for compiler and linkerfatalwarnings for linker. Changes the special Compile and Link values to All in each api. Implements fatal warnings for the linker in VS2022

**How does this PR change Premake's behavior?**

Changes the fatalwarnings api

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
