### PR TITLE
Added CI timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -11,6 +11,7 @@ jobs:
         platform: [x64]
         depsrc: [none, contrib, system]
         cc: [gcc, clang]
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -37,6 +38,7 @@ jobs:
       matrix:
         config: [debug, release]
         platform: [x64]
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -59,6 +61,7 @@ jobs:
         config: [debug, release]
         platform: [Win32, x64]
         msdev: [vs2022]
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -91,6 +94,7 @@ jobs:
             msystem: mingw32
           - platform: x64
             msystem: mingw64
+    timeout-minutes: 30
     defaults:
       run:
         shell: msys2 {0}
@@ -124,6 +128,7 @@ jobs:
     strategy:
       matrix:
         config: [debug, release]
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -149,6 +154,7 @@ jobs:
         config: [debug, release]
         platform: [x64]
         cc: [gcc, clang]
+    timeout-minutes: 30
     defaults:
       run:
         shell: freebsd {0}
@@ -187,6 +193,7 @@ jobs:
         config: [debug, release]
         platform: [x64]
         cc: [clang]
+    timeout-minutes: 30
     defaults:
       run:
         shell: openbsd {0}
@@ -225,6 +232,7 @@ jobs:
         config: [debug, release]
         platform: [x64]
         cc: [gcc]
+    timeout-minutes: 30
     defaults:
       run:
         shell: netbsd {0}
@@ -255,6 +263,7 @@ jobs:
         config: [debug, release]
         platform: [x64]
         cc: [gcc]
+    timeout-minutes: 30
     defaults:
       run:
         shell: dragonflybsd {0}
@@ -285,6 +294,7 @@ jobs:
         config: [debug, release]
         platform: [x64]
         cc: [gcc]
+    timeout-minutes: 30
     defaults:
       run:
         shell: solaris {0}


### PR DESCRIPTION
**What does this PR do?**

Prevents long running jobs, enabling faster reporting of hung jobs.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

30 minutes chosen arbitrarily, willing to change that.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] ~Add unit tests showing fix or feature works; all tests pass~
- [ ] ~Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)~
- [ ] ~Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)~
- [x] Minimize the number of commits
- [ ] ~Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes~

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
