### PR TITLE
[CI] Fix dependencies as ubuntu-latest becomes ubuntu-24.04

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Install booststrap's dependencies
+      run: |
+        sudo apt-get update 
+        sudo apt-get -y install uuid-dev
     - name: Install dependencies
       if: matrix.depsrc == 'system'
       run: |


### PR DESCRIPTION
**What does this PR do?**

Fix CI for linux after for Ubuntu-24.04

> Ubuntu-latest workflows will use Ubuntu-24.04 image [#10636](https://github.com/actions/runner-images/issues/10636)
> Rollout will begin on December 5th and will complete on January 17th, 2025.

**How does this PR change Premake's behavior?**

No changes.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
