### PR TITLE
[CI] Add depsrc matrix to mingw build

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -93,6 +93,8 @@ jobs:
       matrix:
         config: [debug, release]
         msystem: [mingw32, mingw64]
+        depsrc: [none, contrib, system]
+        cc: [mingw]
         include:
           - platform: x86
             msystem: mingw32
@@ -115,14 +117,22 @@ jobs:
           make
         pacboy: >-
           toolchain:p
+    - name: Install dependencies
+      if: matrix.depsrc == 'system' && matrix.platform == 'x64'
+      run: |
+        pacman -Suy --noconfirm mingw-w64-x86_64-curl mingw-w64-x86_64-lua53 mingw-w64-x86_64-libzip mingw-w64-x86_64-zlib
+    - name: Install dependencies
+      if: matrix.depsrc == 'system' && matrix.platform == 'x86'
+      run: |
+        pacman -Suy --noconfirm mingw-w64-i686-curl mingw-w64-i686-lua53 mingw-w64-i686-libzip mingw-w64-i686-zlib
     - name: Build
-      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} ./Bootstrap.sh
+      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--lib-src=${{ matrix.depsrc }} --cc=${{ matrix.cc }}" ./Bootstrap.sh
     - name: Test
       run: bin/${{ matrix.config }}/premake5.exe test --test-all
     - name: Docs check
       run: bin/${{ matrix.config }}/premake5.exe docs-check
     - name: Upload Artifacts
-      if: matrix.config == 'release'
+      if: matrix.config == 'release' && matrix.depsrc == 'contrib' && matrix.cc == 'mingw'
       uses: actions/upload-artifact@v4
       with:
         name: premake-${{ matrix.msystem }}-${{ matrix.platform }}


### PR DESCRIPTION
**What does this PR do?**

matrix build mingw for dependencies (none, contrib, system)

**How does this PR change Premake's behavior?**

Only CI changes

**Anything else we should know?**

Confirm that build can be done with system libraries for mingw, asked in #2386

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
