### PR TITLE
Remove mingw toolset

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -94,7 +94,7 @@ jobs:
         config: [debug, release]
         msystem: [mingw32, mingw64]
         depsrc: [none, contrib, system]
-        cc: [mingw]
+        cc: [gcc]
         include:
           - platform: x86
             msystem: mingw32
@@ -132,7 +132,7 @@ jobs:
     - name: Docs check
       run: bin/${{ matrix.config }}/premake5.exe docs-check
     - name: Upload Artifacts
-      if: matrix.config == 'release' && matrix.depsrc == 'contrib' && matrix.cc == 'mingw'
+      if: matrix.config == 'release' && matrix.depsrc == 'contrib' && matrix.cc == 'gcc'
       uses: actions/upload-artifact@v4
       with:
         name: premake-${{ matrix.msystem }}-${{ matrix.platform }}

--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -89,7 +89,7 @@ mingw: mingw-clean
 	mkdir -p build/bootstrap
 	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_STATICLIB -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lole32 -lversion
 	./build/bootstrap/premake_bootstrap embed
-	./build/bootstrap/premake_bootstrap --arch=$(PLATFORM) --os=windows --to=build/bootstrap --cc=mingw $(PREMAKE_OPTS) gmake2
+	./build/bootstrap/premake_bootstrap --arch=$(PLATFORM) --os=windows --to=build/bootstrap --cc=gcc $(PREMAKE_OPTS) gmake2
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)_$(PLATFORM:x86=win32)
 
 macosx: osx

--- a/premake5.lua
+++ b/premake5.lua
@@ -253,8 +253,8 @@
 			flags       { "NoIncrementalLink" }
 
 		-- MinGW AR does not handle LTO out of the box and need a plugin to be setup
-		filter { "system:windows", "configurations:Release", "toolset:not mingw" }
-			flags		{ "LinkTimeOptimization" }
+		filter { "system:windows", "configurations:Release", "toolset:msc" }
+			flags { "LinkTimeOptimization" }
 
 		filter { "system:uwp" }
 			systemversion "latest:latest"
@@ -312,8 +312,8 @@
 			links       { "ole32", "ws2_32", "advapi32", "version" }
 			files { "src/**.rc" }
 
-		filter "toolset:mingw"
-			links		{ "crypt32", "bcrypt" }
+		filter { "system:windows", "toolset:not msc" }
+			links { "crypt32", "bcrypt" }
 
 		filter "system:linux or bsd or hurd"
 			defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }

--- a/src/_manifest.lua
+++ b/src/_manifest.lua
@@ -63,7 +63,6 @@
 		"tools/msc.lua",
 		"tools/snc.lua",
 		"tools/clang.lua",
-		"tools/mingw.lua",
 		"tools/cosmocc.lua",
 		"tools/emcc.lua",
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1215,7 +1215,7 @@
 		allowed = {
 			{ "clang", "Clang (clang)" },
 			{ "gcc", "GNU GCC (gcc/g++)" },
-			{ "mingw", "MinGW GCC (gcc/g++)" },
+			{ "mingw", "MinGW GCC (gcc/g++)" }, -- deprecated
 			{ "msc-v80", "Microsoft compiler (Visual Studio 2005)" },
 			{ "msc-v90", "Microsoft compiler (Visual Studio 2008)" },
 			{ "msc-v100", "Microsoft compiler (Visual Studio 2010)" },
@@ -1231,6 +1231,11 @@
 			end
 		}
 	}
+
+	if _OPTIONS[cc] == "mingw" then
+		p.warn("--cc=mingw is deprecated, use --cc=gcc instead")
+		_OPTIONS[cc] = "gcc"
+	end
 
 	newoption
 	{

--- a/src/tools/mingw.lua
+++ b/src/tools/mingw.lua
@@ -1,8 +1,0 @@
---
--- mingw.lua
--- MinGW toolset adapter for Premake
--- Copyright (c) 2018 Jess Perkins and the Premake project
---
-
-	local p = premake
-	p.tools.mingw = p.tools.gcc


### PR DESCRIPTION
**What does this PR do?**

It removes toolset mingw
which is mostly an alias of "gcc on windows" (for filtering).

**How does this PR change Premake's behavior?**

`filter { "toolset:mingw" }` is broken, and alternative should be used, as `filter { "system:windows", "toolset:not msc" }`

**Anything else we should know?**

- Detecting correct mingw-w64/llvm-mingw/msys2 is currently not done anyway
- Some mingw uses clang and not gcc

So some works should be done if we want to handle mingw correctly.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
