### PR TITLE
Fix token ordering for LINKFILE/LINKDIR

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -637,10 +637,38 @@
 				return "echo " .. v
 			end,
 			linkdir = function(v)
-				return "ln -s " .. path.normalize(v)
+				-- split the source and target
+				-- source and target may be quoted with spaces
+				-- if the source or target was quoted, retain the quotes
+				local src, tgt = v:match("^%s*\"(.-)\"%s+\"(.-)\"%s*$")
+				if not src then
+					src, _ = v:match("^%s*(.-)%s+(.-)%s*$")
+				else
+					src = '"' .. src .. '"'
+				end
+				if not tgt then
+					_, tgt = v:match("^%s*(.-)%s+(.-)%s*$")
+				else
+					tgt = '"' .. tgt .. '"'
+				end
+				return "ln -s " .. path.normalize(tgt) .. " " .. path.normalize(src)
 			end,
 			linkfile = function(v)
-				return "ln -s " .. path.normalize(v)
+				-- split the source and target
+				-- source and target may be quoted with spaces
+				-- if the source or target was quoted, retain the quotes
+				local src, tgt = v:match("^%s*\"(.-)\"%s+\"(.-)\"%s*$")
+				if not src then
+					src, _ = v:match("^%s*(.-)%s+(.-)%s*$")
+				else
+					src = '"' .. src .. '"'
+				end
+				if not tgt then
+					_, tgt = v:match("^%s*(.-)%s+(.-)%s*$")
+				else
+					tgt = '"' .. tgt .. '"'
+				end
+				return "ln -s " .. path.normalize(tgt) .. " " .. path.normalize(src)
 			end,
 			mkdir = function(v)
 				return "mkdir -p " .. path.normalize(v)

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -313,11 +313,15 @@
 	end
 
 	function suite.translateCommand_posixLinkDir()
-		test.isequal('ln -s a b', os.translateCommands('{LINKDIR} a b', "posix"))
+		test.isequal('ln -s b a', os.translateCommands('{LINKDIR} a b', "posix"))
 	end
 
 	function suite.translateCommand_posixLinkFile()
-		test.isequal('ln -s a b', os.translateCommands('{LINKFILE} a b', "posix"))
+		test.isequal('ln -s b a', os.translateCommands('{LINKFILE} a b', "posix"))
+	end
+
+	function suite.translateCommand_posixLinkDirWithSpaces()
+		test.isequal('ln -s "b b" "a a"', os.translateCommands('{LINKDIR} "a a" "b b"', "posix"))
 	end
 --
 -- os.getWindowsRegistry windows tests

--- a/website/docs/Tokens.md
+++ b/website/docs/Tokens.md
@@ -99,19 +99,19 @@ Command tokens are replaced with an appropriate command for the target shell. Fo
 
 The available tokens, and their replacements:
 
-| Token      | DOS/cmd                                     | Posix           |
-|------------|---------------------------------------------|-----------------|
-| {CHDIR}    | chdir {args}                                | cd {args}       |
-| {COPYFILE} | copy /B /Y {args}                           | cp -f {args}    |
-| {COPYDIR}  | xcopy /Q /E /Y /I {args}                    | cp -rf {args}   |
-| {DELETE}   | del {args}                                  | rm -rf {args}   |
-| {ECHO}     | echo {args}                                 | echo {args}     |
-| {LINKDIR}  | mklink /d {args}                            | ln -s {args}    |
-| {LINKFILE} | mklink {args}                               | ln -s {args}    |
-| {MKDIR}    | IF NOT EXIST {args} (mkdir {args})          | mkdir -p {args} |
-| {MOVE}     | move /Y {args}                              | mv -f {args}    |
-| {RMDIR}    | rmdir /S /Q {args}                          | rm -rf {args}   |
-| {TOUCH}    | type nul >> {arg} && copy /b {arg}+,, {arg} | touch {args}    |
+| Token      | DOS/cmd                                     | Posix                 |
+|------------|---------------------------------------------|-----------------------|
+| {CHDIR}    | chdir {args}                                | cd {args}             |
+| {COPYFILE} | copy /B /Y {args}                           | cp -f {args}          |
+| {COPYDIR}  | xcopy /Q /E /Y /I {args}                    | cp -rf {args}         |
+| {DELETE}   | del {args}                                  | rm -rf {args}         |
+| {ECHO}     | echo {args}                                 | echo {args}           |
+| {LINKDIR}  | mklink /d {args}                            | ln -s {reversed args} |
+| {LINKFILE} | mklink {args}                               | ln -s {reversed args} |
+| {MKDIR}    | IF NOT EXIST {args} (mkdir {args})          | mkdir -p {args}       |
+| {MOVE}     | move /Y {args}                              | mv -f {args}          |
+| {RMDIR}    | rmdir /S /Q {args}                          | rm -rf {args}         |
+| {TOUCH}    | type nul >> {arg} && copy /b {arg}+,, {arg} | touch {args}          |
 
 :::caution
 The following tokens are deprecated:
@@ -135,9 +135,11 @@ buildcommands {
 }
 ```
 
-### Symbolic Links and Windows
+### Symbolic Links
 
-For Windows, it is required to create symbolic links from an elevated context or to have Developer Mode enabled. The minimum required Windows version to execute symbolic links is Windows 10.
+For Windows, it is required to create symbolic links from an elevated context or to have Developer Mode enabled. The minimum required Windows version to execute symbolic links is Windows 10. 
+
+LINKDIR and LINKFILE follow Windows `mklink` semantics, i.e. `{LINKFILE} LINK TARGET`, instead of Posix semantics.
 
 ## Tokens and Filters
 


### PR DESCRIPTION
**What does this PR do?**

Fixes the ordering of `LINKDIR` and `LINKFILE` tokens to be consistent across platforms, selecting Windows semantics.

**How does this PR change Premake's behavior?**

Breaks anyone who used the API on Posix (should be a very small number, as the API was released since the last beta).

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
