### PR TITLE
Use git to retrieve version instead of manually change `PREMAKE_VERSION`.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 Bootstrap.bat text eol=crlf
+git-tags.txt export-subst

--- a/git-tags.txt
+++ b/git-tags.txt
@@ -1,0 +1,1 @@
+$Format:%(describe:tags=true)$

--- a/premake5.lua
+++ b/premake5.lua
@@ -192,6 +192,27 @@
 --    symbols "On"
 --
 
+	local function retrieve_git_tag()
+		local git_tag, errorCode = os.outputof("git describe --tag --exact-match")
+		if errorCode == 0 then
+			return git_tag
+		else
+			return nil
+		end
+	end
+
+	if premake.action.isConfigurable() then
+		local git_tag = retrieve_git_tag() or io.readfile("git-tags.txt")
+
+		if git_tag == "$Format:%(describe:tags=true)$" then
+			git_tag = nil
+		end
+		if git_tag and git_tag:startswith('v') then -- tags use v5.x.x-xxx format whereas premake uses 5.x.x-xxx
+			git_tag = git_tag:sub(2)
+		end
+		print("Current git tag: ", git_tag)
+	end
+
 	solution "Premake5"
 		configurations { "Release", "Debug" }
 		location ( _OPTIONS["to"] )
@@ -277,6 +298,10 @@
 			"contrib/**.*",
 			"binmodules/**.*"
 		}
+
+		if git_tag then
+			defines { 'PREMAKE_VERSION="' .. git_tag .. '"'}
+		end
 
 		filter { "options:lua-src=contrib" }
 			includedirs { "contrib/lua/src", "contrib/luashim" }

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -18,7 +18,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define PREMAKE_VERSION        "5.0.0-dev"
+#ifndef PREMAKE_VERSION
+# define PREMAKE_VERSION "5.0.0-dev"
+#endif
+
 #define PREMAKE_COPYRIGHT      "Copyright (C) 2002-2025 Jess Perkins and the Premake Project"
 #define PREMAKE_PROJECT_URL    "https://github.com/premake/premake-core/wiki"
 


### PR DESCRIPTION
**What does this PR do?**

Handle `PREMAKE_VERSION` from git tag

**How does this PR change Premake's behavior?**

No behavior changed.

**Anything else we should know?**

`gitintegration` setup, so premake5 is launched at each checkout.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
