### PR TITLE
Fix regression trying to use _ACTION in the global scope

### DIFF
--- a/modules/vstudio/vstudio.lua
+++ b/modules/vstudio/vstudio.lua
@@ -36,10 +36,6 @@
 		win32   = "x86",
 	}
 
-	if _ACTION < "vs2015" then
-		vstudio.vs2010_architectures.android = "Android"
-	end
-
 	local function architecture(system, arch)
 		local result
 		if _ACTION >= "vs2010" then


### PR DESCRIPTION
**What does this PR do?**

Fixes a reported issue when calling require(vstudio) at the top of a file. Mentioned here https://github.com/premake/premake-core/pull/2366#issuecomment-2590777784

This is simpler than trying to add the proper fix as versions < 2015 don't support Android anyway

**How does this PR change Premake's behavior?**

Not really, vs2015 doesn't support Android natively

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
