### PR TITLE
Remove the 'Android' architecture from pre-vs2015 support

### DIFF
--- a/modules/vstudio/tests/android/test_android_project.lua
+++ b/modules/vstudio/tests/android/test_android_project.lua
@@ -157,7 +157,7 @@
 		externalincludedirs { "externalincludedirs" }
 		prepareOutputProperties()
 		test.capture [[
-<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Android'">
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
 	<IntDir>obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>

--- a/modules/vstudio/vstudio.lua
+++ b/modules/vstudio/vstudio.lua
@@ -36,10 +36,6 @@
 		win32   = "x86",
 	}
 
-	if _ACTION < "vs2015" then
-		vstudio.vs2010_architectures.android = "Android"
-	end
-
 	local function architecture(system, arch)
 		local result
 		if _ACTION >= "vs2010" then


### PR DESCRIPTION
**What does this PR do?**

Fixs issues when users set require(vstudio) in a script du to _ACTION not being set at the time of using
Android is not officially supported pre vs2015

Discussion about it here https://github.com/premake/premake-core/pull/2366

**How does this PR change Premake's behavior?**

Nothing that we might be worried about as support pre vs2015 was custom

**Anything else we should know?**

Add any other context about your changes here.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
