### PR TITLE
Fix code using gmake2 to properly display warning

### DIFF
--- a/modules/gmake/_preload.lua
+++ b/modules/gmake/_preload.lua
@@ -44,10 +44,10 @@
 		deprecatedaliases = {
 			["gmake2"] = {
 				["action"] = function()
-					p.warnOnce("gmake2 has been renamed to gmake. Use gmake to generate makefiles instead.")
+					p.warnOnce("gmake2-action-deprecate", "gmake2 has been renamed to gmake. Use gmake to generate makefiles instead.")
 				end,
 				["filter"] = function()
-					p.warnOnce("gmake2 has been renamed to gmake. Update your filters to use gmake instead.")
+					p.warnOnce("gmake2-filter-deprecate", "gmake2 has been renamed to gmake. Update your filters to use gmake instead.")
 				end
 			}
 		},


### PR DESCRIPTION
**What does this PR do?**

Follow on to #2408 to fix issue surfaced in #2414.

**How does this PR change Premake's behavior?**

Fixes the gmake2 deprecation warnings.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
