### PR TITLE
Add documentation specifying that filters are space sensitive

### DIFF
--- a/website/docs/filter.md
+++ b/website/docs/filter.md
@@ -143,6 +143,8 @@ filter {}
 
 * Filters can be viewed as a scoping concept.  A currently set filter goes 'out of scope' when either a filter reset operation is invoked or a project definition is started.
 
+* Filters are whitespace sensitive. For example, a filter of `system:not windows` is fundamentally different from `system: not windows`.
+
 ### See Also ###
 
 * [Filters](Filters.md)


### PR DESCRIPTION
**What does this PR do?**

Documentation change that explicitly calls out the whitespace sensitive nature of filters.
Resolves #2420 

**How does this PR change Premake's behavior?**

No changes.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
