### PR TITLE
nuget python package error fix

### DIFF
--- a/modules/vstudio/tests/vc2010/test_ensure_nuget_imports.lua
+++ b/modules/vstudio/tests/vc2010/test_ensure_nuget_imports.lua
@@ -44,7 +44,7 @@
 
 if http ~= nil and _OPTIONS["test-all"] then
 	function suite.structureIsCorrect()
-		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
+		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2", "python:3.13.2" }
 		prepare()
 		test.capture [[
 <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -57,6 +57,7 @@ if http ~= nil and _OPTIONS["test-all"] then
 	<Error Condition="!Exists('packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WinPixEventRuntime.1.0.220810001\build\WinPixEventRuntime.targets'))" />
 	<Error Condition="!Exists('packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.props'))" />
 	<Error Condition="!Exists('packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.targets'))" />
+	<Error Condition="!Exists('packages\python.3.13.2\build\native\python.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\python.3.13.2\build\native\python.props'))" />
 </Target>
 		]]
 	end

--- a/modules/vstudio/tests/vc2010/test_extension_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_extension_settings.lua
@@ -34,11 +34,12 @@
 
 if http ~= nil and _OPTIONS["test-all"] then
 	function suite.importOnlyNugetPackagesWithProps()
-		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
+		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2", "python:3.13.2" }
 		prepare()
 	test.capture [[
 <ImportGroup Label="ExtensionSettings">
 	<Import Project="packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.props" Condition="Exists('packages\Microsoft.Direct3D.D3D12.1.608.2\build\native\Microsoft.Direct3D.D3D12.props')" />
+	<Import Project="packages\python.3.13.2\build\native\python.props" Condition="Exists('packages\python.3.13.2\build\native\python.props')" />
 </ImportGroup>
 		]]
 	end

--- a/modules/vstudio/tests/vc2010/test_extension_targets.lua
+++ b/modules/vstudio/tests/vc2010/test_extension_targets.lua
@@ -65,7 +65,7 @@
 
 if http ~= nil and _OPTIONS["test-all"] then
 	function suite.addsImport_onEachNuGetPackage()
-		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
+		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2", "python:3.13.2" }
 		prepare()
 		test.capture [[
 <ImportGroup Label="ExtensionTargets">

--- a/modules/vstudio/tests/vc2010/test_nuget_packages_config.lua
+++ b/modules/vstudio/tests/vc2010/test_nuget_packages_config.lua
@@ -44,7 +44,7 @@
 --
 
 	function suite.structureIsCorrect()
-		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2" }
+		nuget { "boost:1.59.0-b1", "sdl2.v140:2.0.3", "sdl2.v140.redist:2.0.3", "WinPixEventRuntime:1.0.220810001", "Microsoft.Direct3D.D3D12:1.608.2", "python:3.13.2" }
 		prepare()
 		test.capture [[
 <?xml version="1.0" encoding="utf-8"?>
@@ -54,6 +54,7 @@
 	<package id="sdl2.v140.redist" version="2.0.3" targetFramework="native" />
 	<package id="WinPixEventRuntime" version="1.0.220810001" targetFramework="native" />
 	<package id="Microsoft.Direct3D.D3D12" version="1.608.2" targetFramework="native" />
+	<package id="python" version="3.13.2" targetFramework="native" />
 </packages>
 		]]
 	end


### PR DESCRIPTION
**What does this PR do?**

Closes #2436

**How does this PR change Premake's behavior?**

If the nuget package information could not be retrieved from the `items` element of the `items` element,
modify the `items` element to retrieve it from the url in the `@id` element of the `items` element.

**Anything else we should know?**

This may slow down the generation time because of multiple url requests.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
