### PR TITLE
Added Instrumented Profiling Support

### DIFF
--- a/modules/vstudio/tests/vc2010/test_link.lua
+++ b/modules/vstudio/tests/vc2010/test_link.lua
@@ -767,3 +767,33 @@
 </Link>
 		]]
 	end
+
+
+--
+-- Test for the Profile flag.
+--
+
+	function suite.profileOn()
+		profile "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<Profile>true</Profile>
+</Link>
+	]]
+	end
+
+
+	function suite.profileOff()
+		profile "Off"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+	<Profile>false</Profile>
+</Link>
+	]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -825,6 +825,7 @@
 				m.additionalLinkOptions,
 				m.programDatabaseFile,
 				m.assemblyDebug,
+				m.profile,
 			}
 		end
 	end
@@ -2550,7 +2551,14 @@
 
 	function m.assemblyDebug(cfg)
 		if cfg.assemblydebug then
-      		m.element("AssemblyDebug", nil, "true")
+			m.element("AssemblyDebug", nil, "true")
+		end
+	end
+
+
+	function m.profile(cfg)
+		if cfg.profile ~= nil then
+			m.element("Profile", nil, iif(cfg.profile, "true", "false"))
 		end
 	end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1188,6 +1188,12 @@
 		kind = "list:string",
 	}
 
+	p.api.register {
+		name = "profile",
+		scope = "config",
+		kind = "boolean"
+	}
+
 
 -----------------------------------------------------------------------------
 --

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -67,7 +67,8 @@
 		}),
 		visibility = gcc.shared.visibility,
 		inlinesvisibility = gcc.shared.inlinesvisibility,
-		linktimeoptimization = gcc.shared.linktimeoptimization
+		linktimeoptimization = gcc.shared.linktimeoptimization,
+		profile = gcc.shared.profile,
 	}
 
 	clang.cflags = table.merge(gcc.cflags, {
@@ -253,6 +254,7 @@
 			end,
 		},
 		linker = gcc.ldflags.linker,
+		profile = gcc.ldflags.profile,
 		sanitize = table.merge(gcc.ldflags.sanitize, {
 			Fuzzer = "-fsanitize=fuzzer",
 		}),

--- a/src/tools/emcc.lua
+++ b/src/tools/emcc.lua
@@ -16,6 +16,13 @@ emcc.tools = {
 	ar = "emar"
 }
 
+-- Disable the default clang flags for profiling, since they don't work with emcc.
+--
+-- TODO: Investigate how to apply --cpuprofiler, --memoryprofiler, and ---threadprofiler
+-- flags correctly to emcc builds.
+emcc.shared.profile = nil
+emcc.ldflags.profile = nil
+
 function emcc.gettoolname(cfg, tool)
 	return emcc.tools[tool]
 end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -162,6 +162,9 @@
 		},
 		inlinesvisibility = {
 			Hidden = "-fvisibility-inlines-hidden"
+		},
+		profile = {
+			On = "-pg",
 		}
 	}
 
@@ -500,6 +503,9 @@
 		linker = {
 			Default = "",
 			LLD = "-fuse-ld=lld"
+		},
+		profile = {
+			On = "-pg",
 		},
 		sanitize = {
 			Address = "-fsanitize=address",

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -386,6 +386,12 @@
 			table.insert(flags, '/NODEFAULTLIB:' .. ignore)
 		end
 
+		if cfg.kind == "ConsoleApp" or cfg.kind == "WindowedApp" or cfg.kind == "SharedLib" then
+			if cfg.profile then
+				table.insert(flags, "/PROFILE")
+			end
+		end
+
 		return flags
 	end
 

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -197,3 +197,25 @@
 		test.contains("-O3", clang.getcflags(cfg))
 		test.contains("-O3", clang.getcxxflags(cfg))
 	end
+
+--
+-- Test profiling flag
+--
+
+	function suite.flags_onProfileOff()
+		profile "Off"
+
+		prepare()
+		test.excludes({ "-pg" }, clang.getcflags(cfg))
+		test.excludes({ "-pg" }, clang.getcxxflags(cfg))
+		test.excludes({ "-pg" }, clang.getldflags(cfg))
+	end
+
+	function suite.flags_onProfileOn()
+		profile "On"
+
+		prepare()
+		test.contains({ "-pg" }, clang.getcflags(cfg))
+		test.contains({ "-pg" }, clang.getcxxflags(cfg))
+		test.contains({ "-pg" }, clang.getldflags(cfg))
+	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -1252,3 +1252,25 @@ end
 		test.contains({ "-x objective-c++" }, gcc.getcflags(cfg))
 		test.contains({ "-x objective-c++" }, gcc.getcxxflags(cfg))
 	end
+
+--
+-- Test profiling flag
+--
+
+	function suite.flags_onProfileOff()
+		profile "Off"
+
+		prepare()
+		test.excludes({ "-pg" }, gcc.getcflags(cfg))
+		test.excludes({ "-pg" }, gcc.getcxxflags(cfg))
+		test.excludes({ "-pg" }, gcc.getldflags(cfg))
+	end
+
+	function suite.flags_onProfileOn()
+		profile "On"
+
+		prepare()
+		test.contains({ "-pg" }, gcc.getcflags(cfg))
+		test.contains({ "-pg" }, gcc.getcxxflags(cfg))
+		test.contains({ "-pg" }, gcc.getldflags(cfg))
+	end

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -628,7 +628,26 @@ end
 		test.contains("/DLL", msc.getldflags(cfg))
 	end
 
+	function suite.ldflags_onProfile()
+		kind "ConsoleApp"
+		profile "On"
+		prepare()
+		test.contains("/PROFILE", msc.getldflags(cfg))
+	end
 
+	function suite.ldflags_onNoProfile()
+		kind "ConsoleApp"
+		profile "Off"
+		prepare()
+		test.missing("/PROFILE", msc.getldflags(cfg))
+	end
+
+	function suite.ldflags_onProfileInvalidKind()
+		kind "StaticLib"
+		profile "On"
+		prepare()
+		test.missing("/PROFILE", msc.getldflags(cfg))
+	end
 
 --
 -- Check handling of CLR settings.

--- a/website/docs/profile.md
+++ b/website/docs/profile.md
@@ -1,0 +1,27 @@
+Enable or disable instrumented performance profiling support for binaries.
+
+```lua
+profile "value"
+```
+
+### Parameters ###
+| Value   | Description                                                             |
+-------------------------------------------------------------------------------------
+| On      | Turn on instrumented performance profiling.                             |
+| Off     | Turn off instrumented performance profiling.                            |
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0-beta6 or later.
+
+### Examples ###
+
+```lua
+project "MyProject"
+    kind "ConsoleApp"
+    profile "On"
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -215,6 +215,7 @@ module.exports = {
 						'preferredtoolarchitecture',
 						'prelinkcommands',
 						'prelinkmessage',
+						'profile',
 						'project',
 						'propertydefinition',
 						'rebuildcommands',


### PR DESCRIPTION
**What does this PR do?**

Adds an API for enabling instrumented profiling in gcc, clang, cosmocc, and msc, as well as the Visual Studio exporter.

**How does this PR change Premake's behavior?**

No breaking changes. Only a functionality add.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
