### PR TITLE
[bugfix] Fix crash with invalid argument type passed to `os.locate`

### DIFF
--- a/src/host/os_locate.c
+++ b/src/host/os_locate.c
@@ -36,6 +36,10 @@ int os_locate(lua_State* L)
 	for (i = 1; i <= nArgs; ++i) {
 		const char* name = lua_tostring(L, i);
 
+		if (name == NULL) {
+			continue;
+		}
+
 		/* Direct path to an embedded file? */
 		if (name[0] == '$' && name[1] == '/' && premake_find_embedded_script(name + 2)) {
 			lua_pushvalue(L, i);

--- a/website/docs/os/os.locate.md
+++ b/website/docs/os/os.locate.md
@@ -1,7 +1,7 @@
-Searches the [Premake path](Locating-Scripts.md) for a file.
+Searches the [Premake path](Locating-Scripts.md) for files.
 
 ```lua
-os.locate("file_name")
+os.locate("file_name1", ...)
 ```
 
 ### Parameters ###
@@ -11,7 +11,7 @@ os.locate("file_name")
 
 ### Return Value ###
 
-The full path to the file if found, or nil if the file could not be located.
+The full path to the first file found, or nil if the files could not be located.
 
 
 ### Availability ###


### PR DESCRIPTION
**What does this PR do?**

[bugfix] Fix crash with invalid argument type passed to `os.locate` (as `os.locate({})`)
[doc] Fix doc, `os.locate` is a variadic function

**How does this PR change Premake's behavior?**

Replace crash by skipping invalid arguments of `os.locate`

**Anything else we should know?**

closes #1912

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
