### PR TITLE
[contrib][premake] Add missing `"library/*.h"` in `files` in contrib/mbedtls/premake5.lua

### DIFF
--- a/contrib/mbedtls/premake5.lua
+++ b/contrib/mbedtls/premake5.lua
@@ -9,4 +9,5 @@ project "mbedtls-lib"
 	{
 		"include/**.h",
 		"library/*.c",
+		"library/*.h",
 	}


### PR DESCRIPTION
**What does this PR do?**

Add missing header in `files`

**How does this PR change Premake's behavior?**

No behavior changes.
The missing headers would appears in IDEs.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
