### PR TITLE
added premake manager extension to extensions.md

### DIFF
--- a/website/community/extensions.md
+++ b/website/community/extensions.md
@@ -1,0 +1,8 @@
+---
+title: Extensions
+---
+
+These IDE extensions are available from other developers; follow the links for more information. If you've developed an extension you would like to share with others, feel free to [add a link](https://github.com/premake/premake-core/edit/master/website/community/extensions.md) to the list!
+
+# Visual Studio Code
+- [premake mananager](https://marketplace.visualstudio.com/items?itemName=lolrobbe2.premake-manager) : Manage premake projects and use the integrated premake terminal.


### PR DESCRIPTION
**What does this PR do?**

This just adds a new extensions file to the docs same as modules but then for extensions.

**How does this PR change Premake's behavior?**
it does not change anything.

**Anything else we should know?**

this adds the premake manager vscode extension to the list of available extension

**bootstrapping premake example:**
this was a quick bootstrapping of premake using the permake terminal.
![image](https://github.com/user-attachments/assets/63d87456-c327-4c69-ab3c-7fa6859de35c)

**Workspaces viewer: **
(current version does not always want to play along because of AST traverse bug)
![image](https://github.com/user-attachments/assets/19ec58fc-b2a7-4643-b754-af0cdb58b925)

**integrated premake terminal**
(handy for making premake workspaces)
![image](https://github.com/user-attachments/assets/76f8dfe5-ae3d-4f9d-a195-04098b18e619)


**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes

- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*


**`PS lua debug adapter is on the way :) `**