### PR TITLE
Add basic support for tvOS

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -256,6 +256,19 @@
 	end
 
 
+	function suite.PBXFileReference_ListsTVOSWindowedTarget()
+		_TARGET_OS = "tvos"
+		kind "WindowedApp"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		E5FB9875FD0E33A7ED2A2EB5 /* MyProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = MyProject.app; path = MyProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
 	function suite.PBXFileReference_ListsStaticLibTarget()
 		kind "StaticLib"
 		prepare()
@@ -281,6 +294,19 @@
 	end
 
 
+	function suite.PBXFileReference_ListsTVOSStaticLibTarget()
+		_TARGET_OS = "tvos"
+		kind "StaticLib"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		FDCF31ACF735331EEAD08FEC /* libMyProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libMyProject.a; path = libMyProject.a; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
 	function suite.PBXFileReference_ListsSharedLibTarget()
 		kind "SharedLib"
 		prepare()
@@ -295,6 +321,19 @@
 
 	function suite.PBXFileReference_ListsIOSSharedLibTarget()
 		_TARGET_OS = "ios"
+		kind "SharedLib"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		2781AF7F7E0F19F156882DBF /* libMyProject.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libMyProject.dylib; path = libMyProject.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+
+	function suite.PBXFileReference_ListsTVOSSharedLibTarget()
+		_TARGET_OS = "tvos"
 		kind "SharedLib"
 		prepare()
 		xcode.PBXFileReference(tr)
@@ -332,6 +371,19 @@
 		]]
 	end
 
+	function suite.PBXFileReference_ListsTVOSOSXBundleTarget()
+		_TARGET_OS = "tvos"
+		kind "SharedLib"
+		sharedlibtype "OSXBundle"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		8AD066EE75BC8CE0BDA2552E /* MyProject.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.bundle; path = MyProject.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
 	function suite.PBXFileReference_ListsXCTestTarget()
 		kind "SharedLib"
 		sharedlibtype "XCTest"
@@ -346,6 +398,19 @@
 
 	function suite.PBXFileReference_ListsIOSXCTestTarget()
 		_TARGET_OS = "ios"
+		kind "SharedLib"
+		sharedlibtype "XCTest"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		F573990FE05FBF012845874F /* MyProject.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = MyProject.xctest; path = MyProject.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
+
+	function suite.PBXFileReference_ListsTVOSXCTestTarget()
+		_TARGET_OS = "tvos"
 		kind "SharedLib"
 		sharedlibtype "XCTest"
 		prepare()
@@ -383,6 +448,19 @@
 		]]
 	end
 
+
+	function suite.PBXFileReference_ListsTVOSOSXFrameworkTarget()
+		_TARGET_OS = "tvos"
+		kind "SharedLib"
+		sharedlibtype "OSXFramework"
+		prepare()
+		xcode.PBXFileReference(tr)
+		test.capture [[
+/* Begin PBXFileReference section */
+		2D914F2255CC07D43D679562 /* MyProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = MyProject.framework; path = MyProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+		]]
+	end
 
 
 	function suite.PBXFileReference_ListsSourceFiles()
@@ -2232,6 +2310,99 @@
 				PRODUCT_NAME = MyProject;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationTarget_OnTVOS()
+		_TARGET_OS = "tvos"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "Apple Developer";
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+				SDKROOT = appletvos;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationTarget_OnTVOSMinVersion()
+		_TARGET_OS = "tvos"
+		systemversion "8.3"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "Apple Developer";
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 8.3;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationTarget_OnTVOSMinMaxVersion()
+		_TARGET_OS = "tvos"
+		systemversion "8.3:9.1"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "Apple Developer";
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 8.3;
+			};
+			name = Debug;
+		};
+		]]
+	end
+
+	function suite.XCBuildConfigurationTarget_OnTVOSCodeSigningIdentity()
+		_TARGET_OS = "tvos"
+		xcodecodesigningidentity "Premake Developers"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		FDC4CBFB4635B02D8AD4823B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "Premake Developers";
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+				SDKROOT = appletvos;
 			};
 			name = Debug;
 		};

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1341,6 +1341,15 @@
 			if family then
 				settings['TARGETED_DEVICE_FAMILY'] = family
 			end
+		elseif os.istarget(p.TVOS) then
+			settings['SDKROOT'] = 'appletvos'
+
+			settings['CODE_SIGN_IDENTITY[sdk=appletvos*]'] = cfg.xcodecodesigningidentity or 'Apple Developer'
+
+			local minOSVersion = project.systemversion(cfg)
+			if minOSVersion ~= nil then
+				settings['TVOS_DEPLOYMENT_TARGET'] = minOSVersion
+			end
 		else
 			local minOSVersion = project.systemversion(cfg)
 			if minOSVersion ~= nil then

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -855,6 +855,7 @@
 			"linux",
 			"macosx",
 			"solaris",
+			"tvos",
 			"uwp",
 			"wii",
 			"windows",
@@ -1306,6 +1307,7 @@
 			{ "linux",      "Linux" },
 			{ "macosx",     "Apple Mac OS X" },
 			{ "solaris",    "Solaris" },
+			{ "tvos",       "tvOS" },
 			{ "uwp",        "Microsoft Universal Windows Platform"},
 			{ "windows",    "Microsoft Windows" },
 		}

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -36,6 +36,7 @@
 	premake.ANDROID     = "android"
 	premake.EMSCRIPTEN  = "emscripten"
 	premake.IOS         = "ios"
+	premake.TVOS        = "tvos"
 	premake.LINUX       = "linux"
 	premake.MACOSX      = "macosx"
 	premake.MAKEFILE    = "Makefile"

--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -834,6 +834,7 @@
 		["linux"]      = { "linux",   "posix", "desktop" },
 		["macosx"]     = { "macosx",  "darwin", "posix", "desktop" },
 		["solaris"]    = { "solaris", "posix", "desktop" },
+		["tvos"]       = { "tvos",    "darwin", "posix", "mobile" },
 		["uwp"]        = { "uwp", "windows", "desktop" },
 		["windows"]    = { "windows", "win32", "desktop" },
 	}

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -95,10 +95,15 @@
 	function clang.getsystemversionflags(cfg)
 		local flags = {}
 
-		if cfg.system == p.MACOSX or cfg.system == p.IOS then
+		if cfg.system == p.MACOSX or cfg.system == p.IOS or cfg.system == p.TVOS then
 			local minVersion = p.project.systemversion(cfg)
 			if minVersion ~= nil then
-				local name = iif(cfg.system == p.MACOSX, "macosx", "iphoneos")
+				local name = "macosx"
+				if cfg.system == p.IOS then
+					name = "iphoneos"
+				elseif cfg.system == p.TVOS then
+					name = "appletvos"
+				end
 				table.insert (flags, "-m" .. name .. "-version-min=" .. p.project.systemversion(cfg))
 			end
 		end

--- a/tests/config/test_targetinfo.lua
+++ b/tests/config/test_targetinfo.lua
@@ -220,7 +220,7 @@
 
 
 --
--- Bundle path should be set for macOS/iOS cocoa bundle.
+-- Bundle path should be set for macOS/iOS/tvOS cocoa bundle.
 --
 
 	function suite.bundlepathSet_onMacSharedLibOSXBundle()
@@ -232,7 +232,7 @@
 	end
 
 --
--- Bundle path should be set for macOS/iOS cocoa unit test bundle.
+-- Bundle path should be set for macOS/iOS/tvOS cocoa unit test bundle.
 --
 
 	function suite.bundlepathSet_onMacSharedLibXCTest()
@@ -245,7 +245,7 @@
 
 
 --
--- Bundle path should be set for macOS/iOS framework.
+-- Bundle path should be set for macOS/iOS/tvOS framework.
 --
 
 	function suite.bundlepathSet_onMacSharedLibOSXFramework()

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -91,6 +91,24 @@
 	end
 
 --
+-- Check tvOS deployment target flags
+--
+
+function suite.cflags_tvos_systemversion()
+	system "tvOS"
+	systemversion "12.1"
+	prepare()
+	test.contains({ "-mappletvos-version-min=12.1" }, clang.getcflags(cfg))
+end
+
+function suite.cxxflags_tvos_systemversion()
+	system "tvOS"
+	systemversion "5.0"
+	prepare()
+	test.contains({ "-mappletvos-version-min=5.0" }, clang.getcxxflags(cfg))
+end
+
+--
 -- Check handling of openmp.
 --
 

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -838,6 +838,13 @@
 		test.contains("-F/Library/Frameworks", gcc.getincludedirs(cfg, {}, {}, cfg.frameworkdirs))
 	end
 
+	function suite.includeDirs_tvos_onFrameworkDirs()
+		system "tvOS"
+		frameworkdirs { "/Library/Frameworks" }
+		prepare()
+		test.contains("-F/Library/Frameworks", gcc.getincludedirs(cfg, {}, {}, cfg.frameworkdirs))
+	end
+
 
 --
 -- Check handling of linker flag.

--- a/website/docs/os/os.getSystemTags.md
+++ b/website/docs/os/os.getSystemTags.md
@@ -15,6 +15,7 @@ and meta tags like `posix`, `darwin`, `desktop` and `mobile` tags.
 | linux    | linux, posix, desktop                   |
 | macosx   | macosx, darwin, posix, desktop          |
 | solaris  | solaris, posix, desktop                 |
+| tvos     | tvos, darwin, posix, mobile             |
 | uwp      | uwp, windows, desktop                   |
 | windows  | windows, win32, desktop                 |
 

--- a/website/docs/system.md
+++ b/website/docs/system.md
@@ -19,6 +19,7 @@ If no system is specified, Premake will identify and target the current operatin
 * linux
 * macosx
 * solaris
+* tvos
 * uwp
 * wii
 * windows

--- a/website/docs/systemversion.md
+++ b/website/docs/systemversion.md
@@ -10,7 +10,7 @@ systemversion ("value")
 
 Ranges are currently only supported by the Windows targets with the Visual Studio actions.
 
-Otherwise, only a minimum version can be set for macOS/iOS targets with `xcode` and `gmake`-based actions.
+Otherwise, only a minimum version can be set for macOS/iOS/tvOS targets with `xcode` and `gmake`-based actions.
 
 ### Applies To ###
 
@@ -44,15 +44,21 @@ filter "system:macosx"
 
 ### Apple Targets ###
 
-Under macOS this sets the minimum version of the operating system required for the app to run and  is equivalent to setting the `-macosx-version-min` (or newer `-macos-version-min`) compiler flag.
+Under macOS this sets the minimum version of the operating system required for the app to run and is equivalent to setting the `-mmacosx-version-min` (or newer `-mmacos-version-min`) compiler flag.
 
-The same is true for iOS, iPadOS, tvOS, and watchOS system targets except it is equivalent to setting the `-miphoneos-version-min` (or newer `ios-version-min`) compiler flag.
+The same is true for iOS, iPadOS, and watchOS system targets except it is equivalent to setting the `-miphoneos-version-min` (or newer `-mios-version-min`) compiler flag.
 
 :::warning
-There is also a `-miphonesimulator-version` or `mios-simulator-version-min` compiler flag, but iOS simulator targets are not yet supported by Premake.
+There is also a `-miphonesimulator-version-min` or `-mios-simulator-version-min` compiler flag, but iOS simulator targets are not yet supported by Premake.
 :::
 
-For the `xcode` action this is equivalent to the `MACOSX_DEPLOYMENT_TARGET` Xcode setting.
+The same is also true for tvOS system targets except it is equivalent to setting the `-mappletvos-version-min` (or newer `-mtvos-version-min`) compiler flag.
+
+:::warning
+There is also a `-mappletvsimulator-version-min` or `-mtvos-simulator-version-min` compiler flag, but tvOS simulator targets are not yet supported by Premake.
+:::
+
+For the `xcode` action this is equivalent to the `MACOSX_DEPLOYMENT_TARGET`, `IPHONEOS_DEPLOYMENT_TARGET`, or `TVOS_DEPLOYMENT_TARGET` Xcode setting (depending on the target OS).
 
 ### Windows Targets ###
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds basic support for targeting tvOS.

For reference, when you're writing code that targets both iOS and tvOS, there are a bunch of small differences you have to worry about, but from an Xcode configuration point of view, there are only a few differences between iOS and tvOS:
1. Need to target the `appletvos` SDK instead of the `iphoneos` SDK.
2. Need to use `TVOS_DEPLOYMENT_TARGET` to set the min OS version supported, instead of `IPHONEOS_DEPLOYMENT_TARGET`.
3. There is no tvOS equivalent to `iosfamily`, so that can just be ignored.

So the amount of changes required for Premake to support tvOS is relatively small, with a large percent of the additions in this PR being duplications of iOS unit tests with minor changes.

**How does this PR change Premake's behavior?**

A new target OS has been added.

**Anything else we should know?**

To show how similar iOS and tvOS are from a builds perspective, I was literally using this small snippet of bash code to smash the small amount of changes needed from an iOS build, and that got things building successfully for tvOS:
```bash

function smash_tvos_changes {
  # HACK: Premake doesn't currently support tvOS as a separate target OS, so we passed iOS to Premake earlier in this script, and now we're going to smash
  # a small amount of changes needed to change the Xcode project from targeting iOS to targeting tvOS, that can't be overridden with Premake config

  # Need to convert lines like:
  #   "CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
  #   SDKROOT = iphoneos;
  # to:
  #   "CODE_SIGN_IDENTITY[sdk=appletvos*]" = "Apple Development";
  #   SDKROOT = appletvos;
  sed -i '' 's/iphoneos/appletvos/' "$1"

  # Need to convert lines like:
  #   IPHONEOS_DEPLOYMENT_TARGET = 12.0;
  # to:
  #   TVOS_DEPLOYMENT_TARGET = 12.0;
  sed -i '' 's/IPHONEOS_DEPLOYMENT_TARGET/TVOS_DEPLOYMENT_TARGET/' "$1"
}

if [ "${TARGET_OS}" == "tvos" ]; then
  smash_tvos_changes "${SOURCE_DIR}/Generated/${PROJECT}.xcodeproj/project.pbxproj"
fi
```

I would love to get tvOS support upstreamed, so I don't need to do ugly hacks like this anymore haha

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [X] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
