### PR TITLE
Fix targetdir and objdir for Linux and Android

### DIFF
--- a/modules/vstudio/tests/android/test_android_project.lua
+++ b/modules/vstudio/tests/android/test_android_project.lua
@@ -158,7 +158,8 @@
 		prepareOutputProperties()
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>
 	</TargetExt>

--- a/modules/vstudio/tests/linux/test_linux_files.lua
+++ b/modules/vstudio/tests/linux/test_linux_files.lua
@@ -51,7 +51,8 @@ local vc2010 = p.vstudio.vc2010
 		prepareOutputProperties()
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>
 	</TargetExt>

--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -300,8 +300,8 @@
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
 	<ConfigurationType>Makefile</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 </PropertyGroup>
 		]]
 	end
@@ -313,8 +313,8 @@
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
 	<ConfigurationType>Makefile</ConfigurationType>
 	<UseDebugLibraries>false</UseDebugLibraries>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 </PropertyGroup>
 		]]
 	end

--- a/modules/vstudio/tests/vc2010/test_output_props.lua
+++ b/modules/vstudio/tests/vc2010/test_output_props.lua
@@ -35,8 +35,8 @@ function suite.onClangTidy()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 </PropertyGroup>
@@ -53,8 +53,8 @@ function suite.onRunCodeAnalysis()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 </PropertyGroup>
@@ -70,8 +70,8 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 </PropertyGroup>
@@ -104,7 +104,7 @@ end
 		prepare()
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-	<OutDir>bin\Debug\</OutDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
 		]]
 	end
 
@@ -131,7 +131,7 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>..\bin\</OutDir>
+	<OutDir>$(ProjectDir)..\bin\</OutDir>
 		]]
 	end
 
@@ -142,7 +142,7 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>..\bin\</OutDir>
+	<OutDir>$(ProjectDir)..\bin\</OutDir>
 		]]
 	end
 
@@ -156,8 +156,8 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>..\tmp\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)..\tmp\Debug\</IntDir>
 		]]
 	end
 
@@ -171,8 +171,8 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyTarget</TargetName>
 		]]
 	end
@@ -210,7 +210,7 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
 		]]
 	end
 
@@ -225,8 +225,8 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<GenerateManifest>false</GenerateManifest>
@@ -244,8 +244,8 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>
 	</TargetExt>
@@ -265,8 +265,8 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<ExtensionsToDeleteOnClean>*.temp1;*.temp2;$(ExtensionsToDeleteOnClean)</ExtensionsToDeleteOnClean>
@@ -285,8 +285,8 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<IncludePath>$(DXSDK_DIR)\Include;$(IncludePath)</IncludePath>
@@ -300,8 +300,8 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<LibraryPath>$(DXSDK_DIR)\lib\x86;$(LibraryPath)</LibraryPath>
@@ -319,8 +319,8 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<ExecutablePath>$(ProjectDir)..\Include;$(ExecutablePath)</ExecutablePath>
@@ -334,8 +334,8 @@ end
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<ExecutablePath>C:\Include;$(ExecutablePath)</ExecutablePath>

--- a/modules/vstudio/tests/vc2010/test_output_props.lua
+++ b/modules/vstudio/tests/vc2010/test_output_props.lua
@@ -146,6 +146,16 @@ end
 		]]
 	end
 
+	function suite.outDir_onTargetDirAbsolute()
+		targetdir "C:/bin"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>C:\bin\</OutDir>
+		]]
+	end
+
 --
 -- The objects directory is applied, if specified.
 --
@@ -158,6 +168,17 @@ end
 	<LinkIncremental>true</LinkIncremental>
 	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
 	<IntDir>$(ProjectDir)..\tmp\Debug\</IntDir>
+		]]
+	end
+
+	function suite.intDir_onTargetDirAbsolute()
+		objdir "C:/tmp"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+	<LinkIncremental>true</LinkIncremental>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>C:\tmp\Debug\</IntDir>
 		]]
 	end
 

--- a/modules/vstudio/tests/vc2019/test_output_props.lua
+++ b/modules/vstudio/tests/vc2019/test_output_props.lua
@@ -35,8 +35,8 @@ function suite.onClangTidy_Enabled()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<EnableClangTidyCodeAnalysis>true</EnableClangTidyCodeAnalysis>
@@ -54,8 +54,8 @@ function suite.onClangTidy_Disabled()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<EnableClangTidyCodeAnalysis>false</EnableClangTidyCodeAnalysis>
@@ -73,8 +73,8 @@ function suite.onRunCodeAnalysis_Enabled()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<RunCodeAnalysis>true</RunCodeAnalysis>
@@ -92,8 +92,8 @@ function suite.RunCodeAnalysis_Disabled()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<RunCodeAnalysis>false</RunCodeAnalysis>

--- a/modules/vstudio/tests/vc2019/test_toolset_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_toolset_settings.lua
@@ -109,8 +109,8 @@ function suite.onAllModulesPublicOn()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<AllProjectBMIsArePublic>true</AllProjectBMIsArePublic>
@@ -125,8 +125,8 @@ function suite.onAllModulesPublicOff()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<AllProjectBMIsArePublic>false</AllProjectBMIsArePublic>

--- a/modules/vstudio/tests/vc2022/test_output_props.lua
+++ b/modules/vstudio/tests/vc2022/test_output_props.lua
@@ -35,8 +35,8 @@ function suite.onExternalIncludeDirs()
 	test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 	<LinkIncremental>true</LinkIncremental>
-	<OutDir>bin\Debug\</OutDir>
-	<IntDir>obj\Debug\</IntDir>
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>.exe</TargetExt>
 	<ExternalIncludePath>src\include;$(ExternalIncludePath)</ExternalIncludePath>

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -393,6 +393,7 @@
 			}
 		else
 			return {
+				m.outDir,
 				m.intDir,
 				m.targetName,
 				m.targetExt,
@@ -418,6 +419,7 @@
 			}
 		else
 			return {
+				m.outDir,
 				m.intDir,
 				m.targetName,
 				m.targetExt,
@@ -2833,6 +2835,11 @@
 
 	function m.intDir(cfg)
 		local objdir = vstudio.path(cfg, cfg.objdir)
+
+		if not path.isabsolute(objdir) then
+			objdir = "$(ProjectDir)" .. objdir
+		end
+
 		m.element("IntDir", nil, "%s\\", objdir)
 	end
 
@@ -3079,7 +3086,13 @@
 
 	function m.outDir(cfg)
 		local outdir = vstudio.path(cfg, cfg.buildtarget.directory)
+
+		if not path.isabsolute(outdir) then
+			outdir = "$(ProjectDir)" .. outdir
+		end
+
 		m.element("OutDir", nil, "%s\\", outdir)
+
 	end
 
 

--- a/modules/vstudio/vs2015_androidproj.lua
+++ b/modules/vstudio/vs2015_androidproj.lua
@@ -116,7 +116,7 @@
 
 	m.elements.outputProperties = function(cfg)
 		return {
-			m.androidOutDir,
+			vc2010.outDir,
 			vc2010.intDir,
 			vc2010.targetName,
 		}
@@ -134,10 +134,6 @@
 		for cfg in project.eachconfig(prj) do
 			m.outputProperties(cfg)
 		end
-	end
-
-	function m.androidOutDir(cfg)
-		vc2010.element("OutDir", nil, "%s\\", cfg.buildtarget.directory)
 	end
 
 --


### PR DESCRIPTION
Linux and Android don't assume that the path is relative to project directory when specifying targetdir which causes issues. For consistency, apply to all platforms and to the intermediate directory, and fix unit tests

Closes https://github.com/premake/premake-core/issues/2448

**What does this PR do?**

Fixes targetdir for Linux and Android

**How does this PR change Premake's behavior?**

Fixes targetdir and objdir, no breaking changes

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
