### PR TITLE
[docs] Add warning for `os.hostarch`

### DIFF
--- a/website/docs/os/os.hostarch.md
+++ b/website/docs/os/os.hostarch.md
@@ -12,7 +12,9 @@ None.
 
 An architecture identifier; see [architecture()](architecture.md) for a complete list of identifiers.
 
-Note that this function returns the architecture for the OS that Premake is currently running on, which is not necessarily the same as the architecture that Premake is generating files for.
+:::warning
+Currently, this function actually returns the architecture of the system that Premake was compiled for. This means that if you run the Win32 version of Premake on a 64-bit Windows system, this function will return 'x86' instead of 'x86_64'.
+:::
 
 ### Availability ###
 


### PR DESCRIPTION
**What does this PR do?**

Currently, there are issues with both the `os.hostarch` function and its documentation. The problem with the function is that it doesn't actually retrieve the runtime architecture, and the issue with the documentation is that it fails to point this out.


**How does this PR change Premake's behavior?**

Nothing.

**Anything else we should know?**

I think it is better to fix `os.hostarch` to reflect the actual arch.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
