### PR TITLE
`os.findheader` support relative headerdirs

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -159,7 +159,16 @@
 		elseif type(headerdirs) == "table" then
 			userpaths = headerdirs
 		end
-		paths = table.join(userpaths, paths)
+
+		for _, userpath in ipairs(userpaths) do
+			if path.isabsolute(userpath) then
+				paths = table.join({userpath}, paths)
+			else
+				for _, p in ipairs(paths) do
+					paths = table.join({path.join(p, userpath)}, paths)
+				end
+			end
+		end
 
 		local result = os.pathsearch (headerpath, table.unpack(paths))
 		return result

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -102,6 +102,15 @@
 					 os.findheader("test.h", path.getabsolute("folder/subfolder/include")))
 	end
 
+	function suite.findheader_provided_relative()
+		local os_getenv = os.getenv
+		os.getenv = create_mock_os_getenv({ [get_LD_PATH_variable_name()] = get_surrounded_env_path("folder/subfolder/lib") })
+
+		test.isequal(path.getabsolute("folder/subfolder/include/testlib"), os.findheader("testlib2.h", "testlib"))
+
+		os.getenv = os_getenv
+	end
+
 	function suite.findheader_frompath_lib()
 		local os_getenv = os.getenv
 		os.getenv = create_mock_os_getenv({ [get_LD_PATH_variable_name()] = get_surrounded_env_path("folder/subfolder/lib") })

--- a/tests/folder/subfolder/include/testlib/testlib2.h
+++ b/tests/folder/subfolder/include/testlib/testlib2.h
@@ -1,0 +1,1 @@
+// Only used for presence in tests

--- a/website/docs/os/os.findheader.md
+++ b/website/docs/os/os.findheader.md
@@ -6,13 +6,20 @@ p = os.findheader("headerfile" [, additionalpaths])
 
 ### Parameters ###
 
-`headerfile` is a file name or a the end of a file path to locate.
+`headerfile` is a file name of a file path to locate.
 
-`additionalpaths` is a string or a table of one or more additional search path.
+`additionalpaths` is a string or a table of one or more additional search path. Can be absolute or relative paths. If relative, they are relative to all the default search paths.
 
 ### Return Value ###
 
 The path containing the header file, if found. Otherwise, nil.
+
+### Example ###
+
+``` lua
+os.findheader("event.h") -- /usr/include
+os.findheader("ft2build.h", "freetype2") -- /usr/include/freetype2
+```
 
 ### Remarks ###
 `os.findheader` mostly use the same paths as [[os.findlib]] but replace `/lib` by `/include`.

--- a/website/docs/os/os.findheader.md
+++ b/website/docs/os/os.findheader.md
@@ -8,7 +8,7 @@ p = os.findheader("headerfile" [, additionalpaths])
 
 `headerfile` is a file name of a file path to locate.
 
-`additionalpaths` is a string or a table of one or more additional search path. Can be absolute or relative paths. If relative, they are relative to all the default search paths.
+`additionalpaths` is a string or a table of one or more additional search path. The paths may be absolute or relative. If the path is a relative path, it is relative to each of the default search paths.
 
 ### Return Value ###
 


### PR DESCRIPTION
**What does this PR do?**

Let `os.findheader` can support searching relative paths.
Some libraries, by default, install header files within folders. For example, the header files for libfreetype-dev are located in:
/usr/include/freetype2/freetype/*.h
/usr/include/freetype2/ft2build.h

Previously, if a program included the header with `#include <ft2build.h>`, you had to use:
`os.findheader("freetype2/ft2build.h") .. "freetype2"`
to locate it.

Now you can simply use:
`os.findheader("ft2build.h", "freetype2")`
to achieve the same result.

**How does this PR change Premake's behavior?**

Nothing.

**Anything else we should know?**

Nothing.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
