### PR TITLE
Support powerpc

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -172,6 +172,8 @@
 			{ "ARM64", "ARM64" },
 			{ "x86", "x86 (On macOS, same as x86_64.)" },
 			{ "x86_64", "x86_64" },
+			{ "ppc", "PowerPC 32-bit" },
+			{ "ppc64", "PowerPC 64-bit" },
 			{ "Universal", "Universal Binary (macOS only)" },
 			--
 			{ "Win32", "Same as x86" },
@@ -242,6 +244,14 @@
 		filter { "system:macosx", "options:arch=Universal" }
 			buildoptions { "-arch arm64", "-arch x86_64" }
 			linkoptions { "-arch arm64", "-arch x86_64" }
+
+		filter { "system:macosx", "options:arch=ppc" }
+			buildoptions { "-arch ppc" }
+			linkoptions { "-arch ppc" }
+
+		filter { "system:macosx", "options:arch=ppc64" }
+			buildoptions { "-arch ppc64" }
+			linkoptions { "-arch ppc64" }
 
 		filter { "system:windows", "options:arch=ARM" }
 			platforms { "ARM" }

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -30,6 +30,8 @@
 			p.ARM64,
 			p.RISCV64,
 			p.LOONGARCH64,
+			p.PPC,
+			p.PPC64,
 			p.WASM32,
 			p.WASM64,
 			p.E2K
@@ -968,6 +970,7 @@
 			"SSSE3",
 			"SSE4.1",
 			"SSE4.2",
+			"ALTIVEC",
 		}
 	}
 

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -65,6 +65,8 @@
 	premake.ARM64       = "ARM64"
 	premake.RISCV64     = "RISCV64"
 	premake.LOONGARCH64 = "loongarch64"
+	premake.PPC         = "ppc"
+	premake.PPC64       = "ppc64"
 	premake.WASM32 = "wasm32"
 	premake.WASM64 = "wasm64"
 	premake.E2K = "e2k"

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -75,6 +75,10 @@
 #define PLATFORM_ARCHITECTURE "loongarch64"
 #elif defined(__e2k__)
 #define PLATFORM_ARCHITECTURE "e2k"
+#elif defined(__ppc64__) || defined(__powerpc64__)
+#define PLATFORM_ARCHITECTURE "ppc64"
+#elif defined(__ppc__) || defined(__powerpc__)
+#define PLATFORM_ARCHITECTURE "ppc"
 #elif !defined(RC_INVOKED)
 #error Unknown architecture detected
 #endif

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -100,6 +100,7 @@
 			SSSE3 = "-mssse3",
 			["SSE4.1"] = "-msse4.1",
 			["SSE4.2"] = "-msse4.2",
+			ALTIVEC = "-maltivec",
 		},
 		isaextensions = {
 			MOVBE = "-mmovbe",

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -15,6 +15,8 @@ architecture ("value")
 * `ARM64`
 * `RISCV64`
 * `loongarch64`
+* `ppc`
+* `ppc64`
 * `wasm32`,
 * `wasm64`,
 * `e2k`,

--- a/website/docs/vectorextensions.md
+++ b/website/docs/vectorextensions.md
@@ -22,6 +22,7 @@ If no value is set for a configuration, the toolset's default vector extension s
 | SSSE3       | Use the SSSE3 instruction set.                         |
 | SSE4.1      | Use the SSE4.1 instruction set.                        |
 | SSE4.2      | Use the SSE4.2 instruction set.                        |
+| ALTIVEC     | Use Altivec (ISA 2.02) instruction set.                |
 | NEON        | Use the NEON instruction set (Android only)            |
 | MXU         | Use the XBurst SIMD instructions (Android only)        |
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds initial support for PowerPC.

P. S. Could someone explain how to force the build system actually use the patches .lua sources? Currently the build somehow sabotages applied changes, whether I build in a standard way or via boostrap script. I can build a working executable for powerpc with no issues, but it still does not acknowledge ppc among supported archs.
From earlier PRs adding support for `riscv` and `loongarch` it follows that nothing else needs to be changed, and a search across codebase does not point to any other instances of arch definitions. Yet the build ignores whatever is added.

**How does this PR change Premake's behavior?**

It does not affect currently supported archs.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
