### PR TITLE
Separates the functionality for bundle and binary extensions

### DIFF
--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -1908,9 +1908,9 @@
 	end
 
 
-	function suite.XCBuildConfigurationTarget_OnWindowedAppTargetExtension()
+	function suite.XCBuildConfigurationTarget_OnWindowedAppTargetBundleExtension()
 		kind "WindowedApp"
-		targetextension ".xyz"
+		targetbundleextension ".xyz"
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
@@ -1931,9 +1931,9 @@
 	end
 
 
-	function suite.XCBuildConfigurationTarget_OnWindowedAppNoTargetExtension()
+	function suite.XCBuildConfigurationTarget_OnWindowedAppNoTargetBundleExtension()
 		kind "WindowedApp"
-		targetextension ""
+		targetbundleextension ""
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
@@ -1954,10 +1954,10 @@
 	end
 
 
-	function suite.XCBuildConfigurationTarget_OnOSXBundleTargetExtension()
+	function suite.XCBuildConfigurationTarget_OnOSXBundleTargetBundleExtension()
 		kind "SharedLib"
 		sharedlibtype "OSXBundle"
-		targetextension ".xyz"
+		targetbundleextension ".xyz"
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
@@ -1978,10 +1978,10 @@
 	end
 
 
-	function suite.XCBuildConfigurationTarget_OnOSXBundleNoTargetExtension()
+	function suite.XCBuildConfigurationTarget_OnOSXBundleNoTargetBundleExtension()
 		kind "SharedLib"
 		sharedlibtype "OSXBundle"
-		targetextension ""
+		targetbundleextension ""
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
@@ -2002,10 +2002,10 @@
 	end
 
 
-	function suite.XCBuildConfigurationTarget_OnOSXFrameworkTargetExtension()
+	function suite.XCBuildConfigurationTarget_OnOSXFrameworkTargetBundleExtension()
 		kind "SharedLib"
 		sharedlibtype "OSXFramework"
-		targetextension ".xyz"
+		targetbundleextension ".xyz"
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[
@@ -2026,10 +2026,10 @@
 	end
 
 
-	function suite.XCBuildConfigurationTarget_OnOSXFrameworkNoTargetExtension()
+	function suite.XCBuildConfigurationTarget_OnOSXFrameworkNoTargetBundleExtension()
 		kind "SharedLib"
 		sharedlibtype "OSXFramework"
-		targetextension ""
+		targetbundleextension ""
 		prepare()
 		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
 		test.capture [[

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1255,7 +1255,7 @@
 			settings['EXECUTABLE_PREFIX'] = cfg.buildtarget.prefix
 		end
 
-		if cfg.buildtarget.extension then
+		if cfg.buildtarget.bundleextension then
 			local exts = {
 				WindowedApp  = "app",
 				SharedLib    = "dylib",
@@ -1264,7 +1264,7 @@
 				OSXFramework = "framework",
 				XCTest       = "xctest",
 			}
-			local ext = cfg.buildtarget.extension:sub(2)
+			local ext = iif(cfg.kind == "WindowedApp" or (cfg.kind == "SharedLib" and cfg.sharedlibtype), cfg.buildtarget.bundleextension:sub(2), cfg.buildtarget.extension:sub(2))
 			if ext ~= exts[iif(cfg.kind == "SharedLib" and cfg.sharedlibtype, cfg.sharedlibtype, cfg.kind)] then
 				if cfg.kind == "WindowedApp" or (cfg.kind == "SharedLib" and cfg.sharedlibtype) then
 					settings['WRAPPER_EXTENSION'] = ext

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1195,6 +1195,12 @@
 		kind = "boolean"
 	}
 
+	p.api.register {
+		name = "targetbundleextension",
+		scope = "config",
+		kind = "string"
+	}
+
 
 -----------------------------------------------------------------------------
 --
@@ -1402,22 +1408,22 @@
 	-- Add variations for other Posix-like systems.
 
 	filter { "system:darwin", "kind:WindowedApp" }
-		targetextension ".app"
+		targetbundleextension ".app"
 
 	filter { "system:darwin", "kind:SharedLib" }
 		targetextension ".dylib"
 
 	filter { "system:darwin", "kind:SharedLib", "sharedlibtype:OSXBundle" }
 		targetprefix ""
-		targetextension ".bundle"
+		targetbundleextension ".bundle"
 
 	filter { "system:darwin", "kind:SharedLib", "sharedlibtype:OSXFramework" }
 		targetprefix ""
-		targetextension ".framework"
+		targetbundleextension ".framework"
 
 	filter { "system:darwin", "kind:SharedLib", "sharedlibtype:XCTest" }
 		targetprefix ""
-		targetextension ".xctest"
+		targetbundleextension ".xctest"
 
 	-- Windows and friends.
 

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -44,26 +44,28 @@
 		local prefix = cfg[field.."prefix"] or cfg.targetprefix or ""
 		local suffix = cfg[field.."suffix"] or cfg.targetsuffix or ""
 		local extension = cfg[field.."extension"] or cfg.targetextension or ""
+		local bundleextension = cfg[field.."bundleextension"] or cfg.targetbundleextension or ""
 
 		local bundlename = ""
 		local bundlepath = ""
 
 		if table.contains(os.getSystemTags(cfg.system), "darwin") and (kind == p.WINDOWEDAPP or (kind == p.SHAREDLIB and cfg.sharedlibtype)) then
-			bundlename = basename .. extension
+			bundlename = basename .. bundleextension
 			bundlepath = path.join(bundlename, iif(kind == p.SHAREDLIB and cfg.sharedlibtype == "OSXFramework", "Versions/A", "Contents/MacOS"))
 		end
 
 		local info = {}
-		info.directory  = directory
-		info.basename   = basename .. suffix
-		info.name       = prefix .. info.basename .. extension
-		info.extension  = extension
-		info.abspath    = path.join(directory, info.name)
-		info.fullpath   = info.abspath
-		info.bundlename = bundlename
-		info.bundlepath = path.join(directory, bundlepath)
-		info.prefix     = prefix
-		info.suffix     = suffix
+		info.directory       = directory
+		info.basename        = basename .. suffix
+		info.name            = prefix .. info.basename .. extension
+		info.extension       = extension
+		info.bundleextension = bundleextension
+		info.abspath         = path.join(directory, info.name)
+		info.fullpath        = info.abspath
+		info.bundlename      = bundlename
+		info.bundlepath      = path.join(directory, bundlepath)
+		info.prefix          = prefix
+		info.suffix          = suffix
 		return info
 	end
 

--- a/tests/config/test_targetinfo.lua
+++ b/tests/config/test_targetinfo.lua
@@ -216,6 +216,7 @@
 		system "MacOSX"
 		i = prepare()
 		test.isequal("bin/Debug/MyProject.app/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
+		test.isequal("", i.extension)
 	end
 
 
@@ -229,6 +230,7 @@
 		system "macosx"
 		i = prepare()
 		test.isequal("bin/Debug/MyProject.bundle/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
+		test.isequal(".dylib", i.extension)
 	end
 
 --
@@ -241,6 +243,7 @@
 		system "macosx"
 		i = prepare()
 		test.isequal("bin/Debug/MyProject.xctest/Contents/MacOS", path.getrelative(os.getcwd(), i.bundlepath))
+		test.isequal(".dylib", i.extension)
 	end
 
 
@@ -254,6 +257,7 @@
 		system "macosx"
 		i = prepare()
 		test.isequal("bin/Debug/MyProject.framework/Versions/A", path.getrelative(os.getcwd(), i.bundlepath))
+		test.isequal(".dylib", i.extension)
 	end
 
 

--- a/website/docs/targetbundleextension.md
+++ b/website/docs/targetbundleextension.md
@@ -1,0 +1,33 @@
+Specifies the bundle extension for the MacOSX bundle.
+
+```lua
+targetbundleextension ("ext")
+```
+
+By default, the project will use the MacOSX's normal naming conventions: .bundle for OSX Bundles, .framework for OSX Framework, and so on. The `targetbundleextension` function allows you to change this default.
+
+### Parameters ###
+
+`ext` is the new bundle extension, including the leading dot.
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0 beta 7 or later.
+
+### Examples ###
+
+```lua
+targetbundleextension ".zmf"
+```
+
+### See Also ###
+
+ * [targetextension](targetextension.md)
+ * [targetname](targetname.md)
+ * [targetdir](targetdir.md)
+ * [targetprefix](targetprefix.md)
+ * [targetsuffix](targetsuffix.md)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -263,6 +263,7 @@ module.exports = {
 						'systemversion',
 						'tags',
 						'tailcalls',
+						'targetbundleextension',
 						'targetdir',
 						'targetextension',
 						'targetname',


### PR DESCRIPTION
**What does this PR do?**

Resolves #2416 by making it so that behavior for bundles does not affect the binary extension, instead providing an API to set the bundle's extension.

**How does this PR change Premake's behavior?**

No changes to XCode functionality, changes gmake's behavior to follow the expected pattern binary target extensions. Bundle extensions API is provided to instead provide functionality to the bundle name and path, rather than the binary itself.

**Anything else we should know?**

No

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
