### PR TITLE
Handle `structmemberalign` for non-visual studio actions

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -423,19 +423,6 @@
 	}
 
 	p.api.register {
-		name = "structmemberalign",
-		scope = "config",
-		kind = "integer",
-		allowed = {
-			"1",
-			"2",
-			"4",
-			"8",
-			"16",
-		}
-	}
-
-	p.api.register {
 		name = "symbolspath",
 		scope = "config",
 		kind = "path",

--- a/modules/vstudio/tests/vc2019/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_compile_settings.lua
@@ -94,6 +94,24 @@
 	end
 
 --
+-- Check StructMemberAlignment
+--
+
+	function suite.structMemberAlignmentWithClang()
+		toolset "clang"
+		structmemberalign(2)
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<AdditionalOptions>/Zp2 %(AdditionalOptions)</AdditionalOptions>
+	<StructMemberAlignment>2Bytes</StructMemberAlignment>
+]]
+	end
+
+--
 -- Check ClCompile for ScanForModuleDependencies
 --
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2157,6 +2157,10 @@
 			if cfg.openmp == "On" then
 				table.insert(opts, 1, '/openmp')
 			end
+			-- <StructMemberAlignment>N</StructMemberAlignment> is unfortunately partially ignored with clang toolset
+			if cfg.structmemberalign then
+				table.insert(opts, 1, '/Zp' .. tostring(cfg.structmemberalign))
+			end
 		end
 
 		if #opts > 0 then

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -3214,6 +3214,32 @@
 		]]
 	end
 
+	function suite.XCBuildConfigurationProject_OnStructmemberalign()
+		structmemberalign(2)
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		A14350AC4595EE5E57CE36EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = (
+					"-fpack-struct=2",
+				);
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
 
 	function suite.XCBuildConfigurationProject_OnNoPCH()
 		pchheader "MyProject_Prefix.pch"

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1588,6 +1588,10 @@
 
 		settings['OTHER_CFLAGS'] = table.join(flags, cfg.buildoptions)
 
+		if cfg.structmemberalign then
+			table.insert(settings['OTHER_CFLAGS'], "-fpack-struct=" .. tostring(cfg.structmemberalign))
+		end
+
 		-- build list of "other" linked flags.
 		flags = { }
 		for _, lib in ipairs(config.getlinks(cfg, "system")) do

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -823,6 +823,19 @@
 	}
 
 	api.register {
+		name = "structmemberalign",
+		scope = "config",
+		kind = "integer",
+		allowed = {
+			"1",
+			"2",
+			"4",
+			"8",
+			"16",
+		}
+	}
+
+	api.register {
 		name = "symbols",
 		scope = "config",
 		kind = "string",

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -575,7 +575,7 @@
 				-- result if the corresponding value is not present
 
 				for key, replacement in pairs(map) do
-					if #key > 1 and key:startswith("_") then
+					if type(key) == "string" and #key > 1 and key:startswith("_") then
 						key = key:sub(2)
 						if values[key] == nil then
 							add(replacement)

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -65,6 +65,7 @@
 		sanitize = table.merge(gcc.shared.sanitize, {
 			Fuzzer = "-fsanitize=fuzzer",
 		}),
+		structmemberalign = gcc.shared.structmemberalign,
 		visibility = gcc.shared.visibility,
 		inlinesvisibility = gcc.shared.inlinesvisibility,
 		linktimeoptimization = gcc.shared.linktimeoptimization,

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -154,6 +154,13 @@
 			Thread = "-fsanitize=thread",
 			UndefinedBehavior = "-fsanitize=undefined",
 		},
+		structmemberalign = {
+			[1] = "-fpack-struct=1",
+			[2] = "-fpack-struct=2",
+			[4] = "-fpack-struct=4",
+			[8] = "-fpack-struct=8",
+			[16] = "-fpack-struct=16",
+		},
 		visibility = {
 			Default = "-fvisibility=default",
 			Hidden = "-fvisibility=hidden",

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -139,6 +139,13 @@
 			On = "/GF",
 			Off = "/GF-",
 		},
+		structmemberalign = {
+			[1] = "/Zp1",
+			[2] = "/Zp2",
+			[4] = "/Zp4",
+			[8] = "/Zp8",
+			[16] = "/Zp16",
+		},
 		symbols = {
 			On = "/Z7"
 		},

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -183,6 +183,32 @@
 		test.contains({ "-ffloat-store" }, gcc.getcflags(cfg))
 	end
 
+	function suite.cflags_onStructmemberalign1()
+		structmemberalign(1)
+		prepare()
+		test.contains({ "-fpack-struct=1" }, gcc.getcflags(cfg))
+	end
+	function suite.cflags_onStructmemberalign2()
+		structmemberalign(2)
+		prepare()
+		test.contains({ "-fpack-struct=2" }, gcc.getcflags(cfg))
+	end
+	function suite.cflags_onStructmemberalign4()
+		structmemberalign(4)
+		prepare()
+		test.contains({ "-fpack-struct=4" }, gcc.getcflags(cfg))
+	end
+	function suite.cflags_onStructmemberalign8()
+		structmemberalign(8)
+		prepare()
+		test.contains({ "-fpack-struct=8" }, gcc.getcflags(cfg))
+	end
+	function suite.cflags_onStructmemberalign16()
+		structmemberalign(16)
+		prepare()
+		test.contains({ "-fpack-struct=16" }, gcc.getcflags(cfg))
+	end
+
 	function suite.cflags_onSSE()
 		vectorextensions "SSE"
 		prepare()

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -120,6 +120,37 @@
 		test.excludes("/GF-", msc.getcflags(cfg))
 	end
 
+	function suite.cflags_onStructmemberalign1()
+		structmemberalign(1)
+		prepare()
+		test.contains("/Zp1", msc.getcflags(cfg))
+		test.contains("/Zp1", msc.getcflags(cfg))
+	end
+	function suite.cflags_onStructmemberalign2()
+		structmemberalign(2)
+		prepare()
+		test.contains("/Zp2", msc.getcflags(cfg))
+		test.contains("/Zp2", msc.getcflags(cfg))
+	end
+	function suite.cflags_onStructmemberalign4()
+		structmemberalign(4)
+		prepare()
+		test.contains("/Zp4", msc.getcflags(cfg))
+		test.contains("/Zp4", msc.getcflags(cfg))
+	end
+	function suite.cflags_onStructmemberalign8()
+		structmemberalign(8)
+		prepare()
+		test.contains("/Zp8", msc.getcflags(cfg))
+		test.contains("/Zp8", msc.getcflags(cfg))
+	end
+	function suite.cflags_onStructmemberalign16()
+		structmemberalign(16)
+		prepare()
+		test.contains("/Zp16", msc.getcflags(cfg))
+		test.contains("/Zp16", msc.getcflags(cfg))
+	end
+
 	function suite.cflags_onFloatingPointExceptionsOn()
 		floatingpointexceptions "On"
 		prepare()

--- a/website/docs/structmemberalign.md
+++ b/website/docs/structmemberalign.md
@@ -1,4 +1,4 @@
-structmemberalign - This page was auto-generated. Feel free to help us improve the documentation by creating a pull request.
+structmemberalign - Specifies 1, 2, 4, 8, 16-byte boundary for struct member alignment.
 
 ```lua
 structmemberalign (value)
@@ -8,11 +8,11 @@ structmemberalign (value)
 
 `value` is one of:
 
-* `1`: needs documentation
-* `2`: needs documentation
-* `4`: needs documentation
-* `8`: needs documentation
-* `16`: needs documentation
+* `1`
+* `2`
+* `4`
+* `8`
+* `16`
 
 ## Applies To ###
 
@@ -20,11 +20,12 @@ The `config` scope.
 
 ### Availability ###
 
-Premake 5.0.0 alpha 14 or later.
+Premake 5.0.0 alpha 14 or later for visual studio (non-clang).
+Premake 5.0.0 beta 7 for others
 
 ### Examples ###
 
 ```lua
-structmemberalign (value)
+structmemberalign (1)
 ```
 


### PR DESCRIPTION
**What does this PR do?**

Handle `structmemberalign` for non-visual studio actions

**How does this PR change Premake's behavior?**

None, except new support

**Anything else we should know?**

Tested with https://github.com/Jarod42/premake-sample-projects/tree/test_structmemberalign

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
