### PR TITLE
[fix] Use same interface and behavior (escaping) across toolsets for `getdefines`/`getundefines`

### DIFF
--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -146,10 +146,10 @@
 --    An array of symbols with the appropriate flag decorations.
 --
 
-	function clang.getdefines(defines)
+	function clang.getdefines(defines, cfg)
 
 		-- Just pass through to GCC for now
-		local flags = gcc.getdefines(defines)
+		local flags = gcc.getdefines(defines, cfg)
 		return flags
 
 	end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -287,7 +287,7 @@
 -- Decorate defines for the GCC command line.
 --
 
-	function gcc.getdefines(defines)
+	function gcc.getdefines(defines, cfg)
 		local result = {}
 		for _, define in ipairs(defines) do
 			table.insert(result, '-D' .. p.esc(define))

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -239,9 +239,9 @@
 
 	msc.defines = {
 		characterset = {
-			Default = { '/D"_UNICODE"', '/D"UNICODE"' },
-			MBCS = '/D"_MBCS"',
-			Unicode = { '/D"_UNICODE"', '/D"UNICODE"' },
+			Default = { '/D_UNICODE', '/DUNICODE' },
+			MBCS = '/D_MBCS',
+			Unicode = { '/D_UNICODE', '/DUNICODE' },
 			ASCII = { },
 		}
 	}
@@ -260,7 +260,7 @@
 		end
 
 		for _, define in ipairs(defines) do
-			table.insert(result, '/D"' .. define .. '"')
+			table.insert(result, '/D' .. p.esc(define))
 		end
 
 		if cfg and cfg.exceptionhandling == p.OFF then
@@ -271,11 +271,7 @@
 	end
 
 	function msc.getundefines(undefines)
-		local result = {}
-		for _, undefine in ipairs(undefines) do
-			table.insert(result, '/U"' .. undefine .. '"')
-		end
-		return result
+		return table.translate(undefines, function (undefine) return '/U' .. p.esc(undefine) end)
 	end
 
 

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -328,13 +328,37 @@
 	function suite.defines()
 		defines "DEF"
 		prepare()
-		test.contains({ "-DDEF" }, gcc.getdefines(cfg.defines))
+		p.escaper(p.quote)
+		test.contains({ '-D"DEF"' }, gcc.getdefines(cfg.defines, cfg))
+		p.escaper()
+		test.contains({ '-DDEF' }, gcc.getdefines(cfg.defines, cfg))
+	end
+
+	function suite.definesVar()
+		defines "DEF=42"
+		prepare()
+		p.escaper(p.quote)
+		test.contains({ '-D"DEF=42"' }, gcc.getdefines(cfg.defines, cfg))
+		p.escaper()
+		test.contains({ '-DDEF=42' }, gcc.getdefines(cfg.defines, cfg))
+	end
+
+	function suite.definesStringVar()
+		defines 'DEF="Hello world"'
+		prepare()
+		p.escaper(p.quote)
+		test.contains({ '-D"DEF=\\"Hello world\\""' }, gcc.getdefines(cfg.defines, cfg))
+		p.escaper()
+		test.contains({ '-DDEF="Hello world"' }, gcc.getdefines(cfg.defines, cfg))
 	end
 
 	function suite.undefines()
 		undefines "UNDEF"
 		prepare()
-		test.contains({ "-UUNDEF" }, gcc.getundefines(cfg.undefines))
+		p.escaper(p.quote)
+		test.contains({ '-U"UNDEF"' }, gcc.getundefines(cfg.undefines))
+		p.escaper()
+		test.contains({ '-UUNDEF' }, gcc.getundefines(cfg.undefines))
 	end
 
 

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -532,13 +532,37 @@ end
 	function suite.defines()
 		defines "DEF"
 		prepare()
+		p.escaper(p.quote)
 		test.contains({ '/D"DEF"' }, msc.getdefines(cfg.defines, cfg))
+		p.escaper()
+		test.contains({ '/DDEF' }, msc.getdefines(cfg.defines, cfg))
+	end
+
+	function suite.definesVar()
+		defines "DEF=42"
+		prepare()
+		p.escaper(p.quote)
+		test.contains({ '/D"DEF=42"' }, msc.getdefines(cfg.defines, cfg))
+		p.escaper()
+		test.contains({ '/DDEF=42' }, msc.getdefines(cfg.defines, cfg))
+	end
+
+	function suite.definesStringVar()
+		defines 'DEF="Hello world"'
+		prepare()
+		p.escaper(p.quote)
+		test.contains({ '/D"DEF=\\"Hello world\\""' }, msc.getdefines(cfg.defines, cfg))
+		p.escaper()
+		test.contains({ '/DDEF="Hello world"' }, msc.getdefines(cfg.defines, cfg))
 	end
 
 	function suite.undefines()
 		undefines "UNDEF"
 		prepare()
+		p.escaper(p.quote)
 		test.contains({ '/U"UNDEF"' }, msc.getundefines(cfg.undefines))
+		p.escaper()
+		test.contains({ '/UUNDEF' }, msc.getundefines(cfg.undefines))
 	end
 
 
@@ -715,25 +739,25 @@ end
 
 	function suite.cflags_onCharSetDefault()
 		prepare()
-		test.contains('/D"_UNICODE"', msc.getdefines(cfg.defines, cfg))
+		test.contains('/D_UNICODE', msc.getdefines(cfg.defines, cfg))
 	end
 
 	function suite.cflags_onCharSetUnicode()
 		characterset "Unicode"
 		prepare()
-		test.contains('/D"_UNICODE"', msc.getdefines(cfg.defines, cfg))
+		test.contains('/D_UNICODE', msc.getdefines(cfg.defines, cfg))
 	end
 
 	function suite.cflags_onCharSetMBCS()
 		characterset "MBCS"
 		prepare()
-		test.contains('/D"_MBCS"', msc.getdefines(cfg.defines, cfg))
+		test.contains('/D_MBCS', msc.getdefines(cfg.defines, cfg))
 	end
 
 	function suite.cflags_onCharSetASCII()
 		characterset "ASCII"
 		prepare()
-		test.excludes({'/D"_MBCS"', '/D"_UNICODE"'}, msc.getdefines(cfg.defines, cfg))
+		test.excludes({'/D_MBCS', '/D_UNICODE'}, msc.getdefines(cfg.defines, cfg))
 	end
 
 


### PR DESCRIPTION
**What does this PR do?**

Use same interface and behavior for msc and `gcc.getdefines`
i.e both take `cfg`, both use `p.esc`

**How does this PR change Premake's behavior?**

No changes in premake-core itself, as `msc.getdefines` is never used.

**Anything else we should know?**

That allow to fix generator using `msc` (i.e premake-ninja with msc)
see https://github.com/Jarod42/premake-sample-projects/actions/runs/15797731153

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
