### PR TITLE
Prep for migrating premake-ninja into core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ Makefile
 .settings
 .buildpath
 *.vs
+*.ninja
+*.ninja_deps
+*.ninja_log
 
 *.bbprojectsettings
 Scratchpad.txt

--- a/contrib/libzip/premake5.lua
+++ b/contrib/libzip/premake5.lua
@@ -11,7 +11,7 @@ project "zip-lib"
 		"**.c"
 	}
 
-	filter "toolset:gcc or clang or cosmocc"
+	filter { "toolset:gcc or clang or cosmocc", "system:not windows" }
 		defines { "HAVE_SSIZE_T_LIBZIP", "HAVE_CONFIG_H" }
 		forceincludes { "unistd.h" }
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -267,7 +267,7 @@
 		filter { "system:windows", "options:arch=x86_64 or arch=x64" }
 			platforms { "x64" }
 
-		filter { "system:windows", "options:not arch" }
+		filter { "system:windows", "options:arch=" }
 			platforms { "x86", "x64" }
 
 		filter "configurations:Debug"
@@ -288,6 +288,9 @@
 		-- MinGW AR does not handle LTO out of the box and need a plugin to be setup
 		filter { "system:windows", "configurations:Release", "toolset:not mingw" }
 			flags		{ "LinkTimeOptimization" }
+		
+		filter { "system:windows", "configurations:Release", "toolset:clang", "action:not vs*" }
+			linkoptions { "-fuse-ld=lld" }
 
 		filter { "system:uwp" }
 			systemversion "latest:latest"
@@ -350,6 +353,9 @@
 			files { "src/**.rc" }
 
 		filter "toolset:mingw"
+			links		{ "crypt32", "bcrypt" }
+
+		filter { "system:windows", "toolset:clang", "action:not vs*" }
 			links		{ "crypt32", "bcrypt" }
 
 		filter "system:linux or bsd or hurd"


### PR DESCRIPTION
**What does this PR do?**

Lays the ground work to get premake-core ready for bringing the third-party Ninja module (https://github.com/jimon/premake-ninja) into core.

**How does this PR change Premake's behavior?**

No behavior changes.

**Anything else we should know?**

It appears that `options:not XYZ` does not work as expected for testing if an option is not set. Using `options:XYZ=` does test for empty/unset as expected. May be worth opening an issue, either to update docs or to fix the underlying issue.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
