### PR TITLE
Update Coding-Conventions.md

### DIFF
--- a/website/docs/Coding-Conventions.md
+++ b/website/docs/Coding-Conventions.md
@@ -29,7 +29,7 @@ local project = p.project
 local m = p.vstudio.vc2010
 ```
 
-The alias `p` is used conventionally  as a shortcut for the `premake` namespace. The alias `m` is conventially used to represent the module being implemented.
+The alias `p` is used conventionally  as a shortcut for the `premake` namespace. The alias `m` is conventionally used to represent the module being implemented.
 
 Using aliases saves some keystrokes when coding. And since Premake embeds all of its scripts into the release executables, it saves on the final download size as well.
 


### PR DESCRIPTION
Corrected the 2nd spelling of _conventionally_ on line 32 of the **Coding Conventions** page of the documentation.

[](https://premake.github.io/docs/Coding-Conventions/)