### PR TITLE
Added macOS arch support to GCC and Clang for gmake and gmakelegacy

### DIFF
--- a/modules/gmake/tests/test_gmake_ldflags.lua
+++ b/modules/gmake/tests/test_gmake_ldflags.lua
@@ -74,6 +74,6 @@ ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib32 -m32
 		system (p.MACOSX)
 		prepare()
 		test.capture [[
-ALL_LDFLAGS += $(LDFLAGS) -m64
+ALL_LDFLAGS += $(LDFLAGS) -arch x86_64
 		]]
 	end

--- a/modules/gmakelegacy/tests/cpp/test_ldflags.lua
+++ b/modules/gmakelegacy/tests/cpp/test_ldflags.lua
@@ -73,6 +73,6 @@
 		system (p.MACOSX)
 		prepare()
 		test.capture [[
-  ALL_LDFLAGS += $(LDFLAGS) -m64
+  ALL_LDFLAGS += $(LDFLAGS) -arch x86_64
 		]]
 	end

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -233,12 +233,10 @@
 --
 
 	clang.ldflags = {
-		architecture = {
-			x86 = "-m32",
-			x86_64 = "-m64",
+		architecture = table.merge(gcc.ldflags.architecture, {
 			WASM32 = "-m32",
 			WASM64 = "-m64",
-		},
+		}),
 		linkerfatalwarnings = {
 			All = "-Wl,--fatal-warnings",
 		},

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -54,8 +54,9 @@
 --
 	gcc.shared = {
 		architecture = {
-			x86 = "-m32",
-			x86_64 = "-m64",
+			x86 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch i386", "-m32") end,
+			x86_64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch x86_64", "-m64") end,
+			ARM64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch arm64", nil) end,
 		},
 		fatalwarnings = {
 			All = "-Werror",
@@ -485,8 +486,9 @@
 
 	gcc.ldflags = {
 		architecture = {
-			x86 = "-m32",
-			x86_64 = "-m64",
+			x86 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch i386", "-m32") end,
+			x86_64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch x86_64", "-m64") end,
+			ARM64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch arm64", nil) end,
 		},
 		linkerfatalwarnings = {
 			All = "-Wl,--fatal-warnings",

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -237,3 +237,77 @@ end
 		test.contains({ "-pg" }, clang.getcxxflags(cfg))
 		test.contains({ "-pg" }, clang.getldflags(cfg))
 	end
+
+--
+-- Make sure system or architecture flags are added properly.
+--
+
+	function suite.cflags_onX86()
+		architecture "x86"
+		prepare()
+		test.contains({ "-m32" }, clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_onX86()
+		architecture "x86"
+		prepare()
+		test.contains({ "-m32" }, clang.getldflags(cfg))
+	end
+
+	function suite.cflags_onX86_64()
+		architecture "x86_64"
+		prepare()
+		test.contains({ "-m64" }, clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_onX86_64()
+		architecture "x86_64"
+		prepare()
+		test.contains({ "-m64" }, clang.getldflags(cfg))
+	end
+
+	function suite.cflags_macosx_onX86()
+		system "macosx"
+		architecture "x86"
+		prepare()
+		test.excludes({ "-m32" }, clang.getcflags(cfg))
+		test.contains({ "-arch i386" }, clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_macosx_onX86()
+		system "macosx"
+		architecture "x86"
+		prepare()
+		test.excludes({ "-m32" }, clang.getldflags(cfg))
+		test.contains({ "-arch i386" }, clang.getldflags(cfg))
+	end
+
+	function suite.cflags_macosx_onX86_64()
+		system "macosx"
+		architecture "x86_64"
+		prepare()
+		test.excludes({ "-m64" }, clang.getcflags(cfg))
+		test.contains({ "-arch x86_64" }, clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_macosx_onX86_64()
+		system "macosx"
+		architecture "x86_64"
+		prepare()
+		test.excludes({ "-m64" }, clang.getldflags(cfg))
+		test.contains({ "-arch x86_64" }, clang.getldflags(cfg))
+	end
+
+	function suite.cflags_macosx_onarm64()
+		system "macosx"
+		architecture "arm64"
+		prepare()
+		test.contains({ "-arch arm64" }, clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_macosx_onarm64()
+		system "macosx"
+		architecture "arm64"
+		prepare()
+		test.contains({ "-arch arm64" }, clang.getldflags(cfg))
+	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -606,6 +606,52 @@
 		test.contains({ "-m64" }, gcc.getldflags(cfg))
 	end
 
+	function suite.cflags_macosx_onX86()
+		system "macosx"
+		architecture "x86"
+		prepare()
+		test.excludes({ "-m32" }, gcc.getcflags(cfg))
+		test.contains({ "-arch i386" }, gcc.getcflags(cfg))
+	end
+
+	function suite.ldflags_macosx_onX86()
+		system "macosx"
+		architecture "x86"
+		prepare()
+		test.excludes({ "-m32" }, gcc.getldflags(cfg))
+		test.contains({ "-arch i386" }, gcc.getldflags(cfg))
+	end
+
+	function suite.cflags_macosx_onX86_64()
+		system "macosx"
+		architecture "x86_64"
+		prepare()
+		test.excludes({ "-m64" }, gcc.getcflags(cfg))
+		test.contains({ "-arch x86_64" }, gcc.getcflags(cfg))
+	end
+
+	function suite.ldflags_macosx_onX86_64()
+		system "macosx"
+		architecture "x86_64"
+		prepare()
+		test.excludes({ "-m64" }, gcc.getldflags(cfg))
+		test.contains({ "-arch x86_64" }, gcc.getldflags(cfg))
+	end
+
+	function suite.cflags_macosx_onarm64()
+		system "macosx"
+		architecture "arm64"
+		prepare()
+		test.contains({ "-arch arm64" }, gcc.getcflags(cfg))
+	end
+
+	function suite.ldflags_macosx_onarm64()
+		system "macosx"
+		architecture "arm64"
+		prepare()
+		test.contains({ "-arch arm64" }, gcc.getldflags(cfg))
+	end
+
 
 --
 -- Non-Windows shared libraries should marked as position independent.


### PR DESCRIPTION
**What does this PR do?**

Adds macOS arch support to GCC and Clang for gmake and gmakelegacy.

**How does this PR change Premake's behavior?**

Fixes #1568.

**Anything else we should know?**

N/A.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
