### PR TITLE
Implements C++23 for Visual Studio non-makefile projects

### DIFF
--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -1439,7 +1439,7 @@
 	<PrecompiledHeader>NotUsing</PrecompiledHeader>
 	<WarningLevel>Level3</WarningLevel>
 	<Optimization>Disabled</Optimization>
-	<LanguageStandard>stdcpplatest</LanguageStandard>
+	<LanguageStandard>stdcpp23</LanguageStandard>
 	<ExternalWarningLevel>Level3</ExternalWarningLevel>
 </ClCompile>
 		]]

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2053,7 +2053,7 @@
 			elseif (cfg.cppdialect == "C++20") then
 				m.element("LanguageStandard", condition, iif(_ACTION <= "vs2017", 'stdcpplatest', 'stdcpp20'))
 			elseif (cfg.cppdialect == "C++23") then
-				m.element("LanguageStandard", condition, 'stdcpplatest')
+				m.element("LanguageStandard", condition, iif(_ACTION <= "vs2019", 'stdcpplatest', 'stdcpp23'))
 			elseif (cfg.cppdialect == "C++latest") then
 				m.element("LanguageStandard", condition, 'stdcpplatest')
 			end
@@ -2141,8 +2141,8 @@
 			elseif (cfg.cppdialect == "C++17") then
 				table.insert(opts, "/std:c++17")
 			elseif (cfg.cppdialect == "C++20") then
-				table.insert(opts, "/std:c++latest")
-			elseif (cfg.cppdialect == "C++latest") then
+				table.insert(opts, iif(_ACTION <= "vs2017", "/std:c++latest", "/std:c++20"))
+			elseif (cfg.cppdialect == "C++latest" or cfg.cppdialect == "C++23") then
 				table.insert(opts, "/std:c++latest")
 			end
 		end


### PR DESCRIPTION
**What does this PR do?**

Adds C++23 for non-makefile VS projects.

**How does this PR change Premake's behavior?**

For non-makefile projects, uses the `stdcpp23` value in the vcxproj files. For makefile projects, this causes `/std:c++latest` to be used.

**Anything else we should know?**

The value `/std:c++23preview` does exist, but it is a temporary flag that will go away with the full release of `/std:c++23`. I have opted to use `/std:c++latest`, as that flag will be around for the foreseeable future. Once `/std:c++23` is in full release, another PR will be needed to use it in `msc.lua` and in the makefile project configuration of `vs2010_vcxproj.lua`.
