### PR TITLE
Fixed tools output of MSC in the gmake generator

### DIFF
--- a/modules/gmake/tests/test_gmake_tools.lua
+++ b/modules/gmake/tests/test_gmake_tools.lua
@@ -59,3 +59,19 @@ endif
 RESCOMP = windres
 		]]
 	end
+
+	function suite.usesCorrectTools_msc()
+		gmake.cpp.tools(cfg, p.tools.msc)
+		test.capture [[
+ifeq ($(origin CC), default)
+  CC = cl
+endif
+ifeq ($(origin CXX), default)
+  CXX = cl
+endif
+ifeq ($(origin AR), default)
+  AR = lib
+endif
+RESCOMP = rc
+		]]
+	end

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -41,6 +41,7 @@
 	premake.MACOSX      = "macosx"
 	premake.MAKEFILE    = "Makefile"
 	premake.MBCS        = "MBCS"
+	premake.MSC         = "msc"
 	premake.NONE        = "None"
 	premake.DEFAULT     = "Default"
 	premake.OBJECTIVEC   = "Objective-C"

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -481,8 +481,17 @@
 --    default value should be used.
 --
 
+	msc.tools = {
+		cc = "cl",
+		cxx = "cl",
+		ar = "lib",
+		rc = "rc"
+	}
+
 	function msc.gettoolname(cfg, tool)
-		return nil
+		local toolset, version = p.tools.canonical(cfg.toolset or p.MSC)
+		-- TODO: Support versioning?
+		return msc.tools[tool]
 	end
 
 

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -27,6 +27,29 @@
 
 
 --
+-- Check the selection of tools.
+--
+
+	function suite.tools_onDefaults()
+		prepare()
+		test.isequal("cl", msc.gettoolname(cfg, "cc"))
+		test.isequal("cl", msc.gettoolname(cfg, "cxx"))
+		test.isequal("lib", msc.gettoolname(cfg, "ar"))
+		test.isequal("rc", msc.gettoolname(cfg, "rc"))
+	end
+
+	function suite.tools_withMsc()
+		toolset "msc"
+		prepare()
+		test.isequal("cl", msc.gettoolname(cfg, "cc"))
+		test.isequal("cl", msc.gettoolname(cfg, "cxx"))
+		test.isequal("lib", msc.gettoolname(cfg, "ar"))
+		test.isequal("rc", msc.gettoolname(cfg, "rc"))
+	end
+
+
+
+--
 -- Check the optimization flags.
 --
 


### PR DESCRIPTION
**What does this PR do?**

Provides the MSC tools for the gmake generator, and any other generators that might use this information.

**How does this PR change Premake's behavior?**

MSC will now have tools names.

**Anything else we should know?**

N/A.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
