### PR TITLE
Added ability for toolsets to specify tool output extensions

### DIFF
--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -58,25 +58,33 @@
 	function cpp.initialize()
 		rule 'cpp'
 			fileExtension { ".cc", ".cpp", ".cxx", ".mm" }
-			buildoutputs  { "$(OBJDIR)/%{file.objname}.o" }
+			buildoutputs  { "$(OBJDIR)/%{file.objname}.%{premake.modules.gmake.cpp.gettooloutputext('cxx', cfg)}" }
 			buildmessage  '$(notdir $<)'
 			buildcommands {'$(CXX) %{premake.modules.gmake.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"'}
 
 		rule 'cc'
 			fileExtension {".c", ".s", ".m"}
-			buildoutputs  { "$(OBJDIR)/%{file.objname}.o" }
+			buildoutputs  { "$(OBJDIR)/%{file.objname}.%{premake.modules.gmake.cpp.gettooloutputext('cc', cfg)}" }
 			buildmessage  '$(notdir $<)'
 			buildcommands {'$(CC) %{premake.modules.gmake.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"'}
 
 		rule 'resource'
 			fileExtension ".rc"
-			buildoutputs  { "$(OBJDIR)/%{file.objname}.res" }
+			buildoutputs  { "$(OBJDIR)/%{file.objname}.%{premake.modules.gmake.cpp.gettooloutputext('rc', cfg)}" }
 			buildmessage  '$(notdir $<)'
 			buildcommands {'$(RESCOMP) $< -O coff -o "$@" $(ALL_RESFLAGS)'}
 
 		global(nil)
 	end
 
+	function cpp.gettooloutputext(tool, cfg)
+		local toolset = gmake.getToolSet(cfg)
+		if toolset.gettooloutputext ~= nil then
+			return toolset.gettooloutputext(tool)
+		end
+
+		return iif(tool == "rc", "res", "o")
+	end
 
 	function cpp.createRuleTable(prj)
 		local rules = {}

--- a/modules/gmake/tests/test_gmake_file_rules.lua
+++ b/modules/gmake/tests/test_gmake_file_rules.lua
@@ -82,6 +82,46 @@
 
 
 --
+-- Object filenames use correct extension based on toolset
+--
+
+	function suite.objectNameExtensions_onDefault()
+		files { "src/hello.cpp", "src/test.c" }
+		prepare()
+		test.capture [[
+# File Rules
+# #############################################
+
+$(OBJDIR)/hello.o: src/hello.cpp
+	@echo "$(notdir $<)"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/test.o: src/test.c
+	@echo "$(notdir $<)"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+
+]]
+	end
+
+	function suite.objectNameExtensions_onMSC()
+		toolset "msc"
+		files { "src/hello.cpp", "src/test.c" }
+		prepare()
+		test.capture [[
+# File Rules
+# #############################################
+
+$(OBJDIR)/hello.obj: src/hello.cpp
+	@echo "$(notdir $<)"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/test.obj: src/test.c
+	@echo "$(notdir $<)"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+
+]]
+	end
+
+
+--
 -- Two files with the same base name should have different object files.
 --
 

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -432,6 +432,14 @@
 	end
 
 --
+-- Return tool output extension
+--
+
+	function msc.gettooloutputext(tool)
+		return iif(tool == "rc", "res", "obj")
+	end
+
+--
 -- Return the list of libraries to link, decorated with flags as needed.
 --
 


### PR DESCRIPTION
**What does this PR do?**

Adds ability for toolsets to specify tool output extensions.

**How does this PR change Premake's behavior?**

The gmake generator will now correctly use `.obj` when using the msc toolset.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
