### PR TITLE
Updated gmake and gmakelegacy generators so that GCC dependency flags come from the toolset

### DIFF
--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -60,13 +60,13 @@
 			fileExtension { ".cc", ".cpp", ".cxx", ".mm" }
 			buildoutputs  { "$(OBJDIR)/%{file.objname}.o" }
 			buildmessage  '$(notdir $<)'
-			buildcommands {'$(CXX) %{premake.modules.gmake.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"'}
+			buildcommands {'$(CXX) %{premake.modules.gmake.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) -o "$@" -c "$<"'}
 
 		rule 'cc'
 			fileExtension {".c", ".s", ".m"}
 			buildoutputs  { "$(OBJDIR)/%{file.objname}.o" }
 			buildmessage  '$(notdir $<)'
-			buildcommands {'$(CC) %{premake.modules.gmake.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"'}
+			buildcommands {'$(CC) %{premake.modules.gmake.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) -o "$@" -c "$<"'}
 
 		rule 'resource'
 			fileExtension ".rc"
@@ -703,7 +703,7 @@
 		_p('$(GCH): $(PCH) | prebuild')
 		_p('\t@echo $(notdir $<)')
 		local cmd = iif(p.languages.isc(cfg.language), "$(CC) -x c-header $(ALL_CFLAGS)", "$(CXX) -x c++-header $(ALL_CXXFLAGS)")
-		_p('\t$(SILENT) %s -o "$@" -MF "$(@:%%.gch=%%.d)" -c "$<"', cmd)
+		_p('\t$(SILENT) %s -o "$@" -c "$<"', cmd)
 		_p('$(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)')
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) touch "$@"')

--- a/modules/gmake/tests/test_gmake_file_rules.lua
+++ b/modules/gmake/tests/test_gmake_file_rules.lua
@@ -94,10 +94,10 @@
 
 $(OBJDIR)/hello.o: src/greetings/hello.cpp
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 $(OBJDIR)/hello1.o: src/hello.cpp
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 
 		]]
 	end
@@ -116,10 +116,10 @@ $(OBJDIR)/hello1.o: src/hello.cpp
 
 $(OBJDIR)/hello.o: src/hello.c
 	@echo "$(notdir $<)"
-	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 $(OBJDIR)/test.o: src/test.cpp
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 
 		]]
 	end
@@ -139,10 +139,10 @@ $(OBJDIR)/test.o: src/test.cpp
 
 $(OBJDIR)/hello.o: src/hello.c
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 $(OBJDIR)/test.o: src/test.c
 	@echo "$(notdir $<)"
-	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 		]]
 	end
 
@@ -161,17 +161,17 @@ $(OBJDIR)/test.o: src/test.c
 
 $(OBJDIR)/test.o: src/test.c
 	@echo "$(notdir $<)"
-	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 
 ifeq ($(config),debug)
 $(OBJDIR)/hello.o: src/hello.c
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 
 else ifeq ($(config),release)
 $(OBJDIR)/hello.o: src/hello.c
 	@echo "$(notdir $<)"
-	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 
 endif
 		]]

--- a/modules/gmake/tests/test_gmake_flags.lua
+++ b/modules/gmake/tests/test_gmake_flags.lua
@@ -43,6 +43,26 @@ INCLUDES += -Isrc/include -I../include
 	end
 
 --
+-- Dependency flags in ALL_CPPFLAGS shouldn't appear for MSC
+--
+
+	function suite.dependencyFlags_onDefault()
+		local cfg = test.getconfig(prj, "Debug")
+		local res = cpp.cppFlags(cfg, p.tools.gcc)
+		test.capture [[
+ALL_CPPFLAGS += $(CPPFLAGS) -MD -MP -MF "$(@:%.o=%.d)" $(DEFINES) $(INCLUDES)
+]]
+	end
+
+	function suite.dependencyFlags_onMSC()
+		local cfg = test.getconfig(prj, "Debug")
+		cpp.cppFlags(cfg, p.tools.msc)
+		test.capture [[
+ALL_CPPFLAGS += $(CPPFLAGS) $(DEFINES) $(INCLUDES)
+]]
+	end
+
+--
 -- symbols "on" should produce -g
 --
 	function suite.symbols_on()

--- a/modules/gmake/tests/test_gmake_pch.lua
+++ b/modules/gmake/tests/test_gmake_pch.lua
@@ -69,10 +69,10 @@
 
 $(OBJDIR)/a.o: a.cpp
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 $(OBJDIR)/b.o: b.cpp
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 ]]
 	end
 
@@ -134,7 +134,7 @@ ifneq (,$(PCH))
 $(OBJECTS): $(GCH) | $(PCH_PLACEHOLDER)
 $(GCH): $(PCH) | prebuild
 	@echo $(notdir $<)
-	$(SILENT) $(CXX) -x c++-header $(ALL_CXXFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
+	$(SILENT) $(CXX) -x c++-header $(ALL_CXXFLAGS) -o "$@" -c "$<"
 $(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) touch "$@"
@@ -161,7 +161,7 @@ ifneq (,$(PCH))
 $(OBJECTS): $(GCH) | $(PCH_PLACEHOLDER)
 $(GCH): $(PCH) | prebuild
 	@echo $(notdir $<)
-	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
+	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -c "$<"
 $(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) touch "$@"
@@ -191,10 +191,10 @@ endif
 
 $(OBJDIR)/a.o: a.cpp
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 $(OBJDIR)/b.o: b.cpp
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 ]]
 	end
 
@@ -213,9 +213,9 @@ $(OBJDIR)/b.o: b.cpp
 
 $(OBJDIR)/a.o: a.cpp
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 $(OBJDIR)/b.o: b.cpp
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) -include $(PCH_PLACEHOLDER) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 ]]
 	end

--- a/modules/gmakelegacy/gmakelegacy_cpp.lua
+++ b/modules/gmakelegacy/gmakelegacy_cpp.lua
@@ -184,7 +184,7 @@
 			local iscfile = node and path.iscfile(node.abspath) or false
 			flags = iif(prj.language == "C" or iscfile, '$(CC) $(ALL_CFLAGS)', '$(CXX) $(ALL_CXXFLAGS)')
 		end
-		_p('\t$(SILENT) %s $(FORCE_INCLUDE) -o "$@" -MF "$(@:%%.%s=%%.d)" -c "$<"', flags, objext)
+		_p('\t$(SILENT) %s $(FORCE_INCLUDE) -o "$@" -c "$<"', flags, objext)
 	end
 
 
@@ -584,7 +584,7 @@ end
 		_p('\t@echo $(notdir $<)')
 
 		local cmd = iif(prj.language == "C", "$(CC) -x c-header $(ALL_CFLAGS)", "$(CXX) -x c++-header $(ALL_CXXFLAGS)")
-		_p('\t$(SILENT) %s -o "$@" -MF "$(@:%%.gch=%%.d)" -c "$<"', cmd)
+		_p('\t$(SILENT) %s -o "$@" -c "$<"', cmd)
 
 		_p('else')
 		_p('$(OBJECTS): | $(OBJDIR)')

--- a/modules/gmakelegacy/tests/cpp/test_file_rules.lua
+++ b/modules/gmakelegacy/tests/cpp/test_file_rules.lua
@@ -37,10 +37,10 @@
 		test.capture [[
 $(OBJDIR)/hello.o: src/greetings/hello.cpp
 	@echo $(notdir $<)
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 $(OBJDIR)/hello1.o: src/hello.cpp
 	@echo $(notdir $<)
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 
 		]]
 	end
@@ -56,10 +56,10 @@ $(OBJDIR)/hello1.o: src/hello.cpp
 		test.capture [[
 $(OBJDIR)/hello.o: src/hello.c
 	@echo $(notdir $<)
-	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 $(OBJDIR)/test.o: src/test.cpp
 	@echo $(notdir $<)
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 
 		]]
 	end
@@ -77,14 +77,14 @@ $(OBJDIR)/test.o: src/test.cpp
 $(OBJDIR)/hello.o: src/hello.c
 	@echo $(notdir $<)
 ifeq ($(config),debug)
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 endif
 ifeq ($(config),release)
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 endif
 $(OBJDIR)/test.o: src/test.c
 	@echo $(notdir $<)
-	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 		]]
 	end
 
@@ -101,14 +101,14 @@ $(OBJDIR)/test.o: src/test.c
 $(OBJDIR)/hello.o: src/hello.c
 	@echo $(notdir $<)
 ifeq ($(config),debug)
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 endif
 ifeq ($(config),release)
-	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 endif
 $(OBJDIR)/test.o: src/test.c
 	@echo $(notdir $<)
-	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -c "$<"
 		]]
 	end
 

--- a/modules/gmakelegacy/tests/cpp/test_make_pch.lua
+++ b/modules/gmakelegacy/tests/cpp/test_make_pch.lua
@@ -112,7 +112,7 @@ ifneq (,$(PCH))
 $(OBJECTS): $(GCH) $(PCH) | $(OBJDIR)
 $(GCH): $(PCH) | $(OBJDIR)
 	@echo $(notdir $<)
-	$(SILENT) $(CXX) -x c++-header $(ALL_CXXFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
+	$(SILENT) $(CXX) -x c++-header $(ALL_CXXFLAGS) -o "$@" -c "$<"
 else
 $(OBJECTS): | $(OBJDIR)
 endif
@@ -133,7 +133,7 @@ ifneq (,$(PCH))
 $(OBJECTS): $(GCH) $(PCH) | $(OBJDIR)
 $(GCH): $(PCH) | $(OBJDIR)
 	@echo $(notdir $<)
-	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
+	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -c "$<"
 else
 $(OBJECTS): | $(OBJDIR)
 endif

--- a/modules/gmakelegacy/tests/cpp/test_wiidev.lua
+++ b/modules/gmakelegacy/tests/cpp/test_wiidev.lua
@@ -31,7 +31,7 @@
 	function suite.writesCorrectCppFlags()
 		make.cppFlags(cfg, p.tools.gcc)
 		test.capture [[
-  ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP -I$(LIBOGC_INC) $(MACHDEP) $(DEFINES) $(INCLUDES)
+  ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP -I$(LIBOGC_INC) $(MACHDEP) -MF "$(@:%.o=%.d)" $(DEFINES) $(INCLUDES)
 		]]
 	end
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -33,6 +33,10 @@
 
 	function gcc.getcppflags(cfg)
 		local flags = config.mapFlags(cfg, gcc.cppflags)
+
+		-- Request that dependencies be written out
+		table.insert(flags, '-MF "$(@:%.o=%.d)"')
+
 		return flags
 	end
 


### PR DESCRIPTION
**What does this PR do?**

Updated gmake and gmakelegacy generators so that GCC dependency flags come from the toolset.

**How does this PR change Premake's behavior?**

gmake and gmakelegacy will no longer emit the GCC dependency flag. GCC and Clang emit it. This may cause issues for modules that add new C and C++ toolsets and don't return the GCC/Clang cppflags.

**Anything else we should know?**

N/A.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
