### PR TITLE
Skip CI builds when making changes to docs

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,12 @@
 name: CI Workflow
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'website/**'
+  pull_request:
+    paths-ignore:
+      - 'website/**'
 
 jobs:
   linux:


### PR DESCRIPTION

**What does this PR do?**

This change should make CI not trigger when PRs only make changes to files inside the website folder.

Triggering CI for website changes can cause unnecessary delay due to waiting for jobs to complete or jobs being canceled due to no runners being available.

**How does this PR change Premake's behavior?**

This should not affect the behaviour of Premake itself. Only CI.

**Anything else we should know?**

I'm not 100% confident in this change since I don't use Github Actions all that often.

It could also be the case that there is some reason to trigger the builds on website changes that I'm not aware of?

The motivation for this change came from submitting this [PR](https://github.com/premake/premake-core/pull/2517), however it looks like that PR failed some CI jobs for reasons that aren't clear to me?

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
