### PR TITLE
Add support for MIPS (64-bit, Little Endian)

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -34,7 +34,8 @@
 			p.PPC64,
 			p.WASM32,
 			p.WASM64,
-			p.E2K
+			p.E2K,
+			p.MIPS64EL
 		},
 		aliases = {
 			i386  = p.X86,

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -71,6 +71,7 @@
 	premake.WASM32 = "wasm32"
 	premake.WASM64 = "wasm64"
 	premake.E2K = "e2k"
+	premake.MIPS64EL = "mips64el"
 
 
 ---

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -79,6 +79,10 @@
 #define PLATFORM_ARCHITECTURE "ppc64"
 #elif defined(__ppc__) || defined(__powerpc__)
 #define PLATFORM_ARCHITECTURE "ppc"
+#elif (defined(__mips) && defined (_ABI64) && \
+       defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+       (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+#define PLATFORM_ARCHITECTURE "mips64el"
 #elif !defined(RC_INVOKED)
 #error Unknown architecture detected
 #endif

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -20,6 +20,7 @@ architecture ("value")
 * `wasm32`,
 * `wasm64`,
 * `e2k`,
+* `mips64el`,
 * `armv5`: Only supported in VSAndroid projects
 * `armv7`: Only supported in VSAndroid projects
 * `aarch64`: Only supported in VSAndroid projects


### PR DESCRIPTION
Add support for MIPS (64-bit, Little Endian), or mips64el, commonly found on pre-LoongArch Loongson hardware.

**What does this PR do?**

Thanks for the contribution! Please provide a concise description of the problem this request solves.

**How does this PR change Premake's behavior?**

Are there any breaking changes? Will any existing behavior change?

**Anything else we should know?**

Add any other context about your changes here.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
