### PR TITLE
Handle `disablewarnings` for visual studio with clang

### DIFF
--- a/modules/vstudio/tests/vc2019/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_compile_settings.lua
@@ -192,3 +192,20 @@
 	<EnableModules>true</EnableModules>
 		]]
 	end
+
+--
+-- Disable specific warnings.
+--
+
+	function suite.disableSpecificWarningsWithClang()
+		disablewarnings { "disable" }
+		toolset "clang"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<AdditionalOptions>-Wno-disable %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2161,6 +2161,7 @@
 			if cfg.structmemberalign then
 				table.insert(opts, 1, '/Zp' .. tostring(cfg.structmemberalign))
 			end
+			opts = table.join(opts, table.translate(cfg.disablewarnings, function(disable) return '-Wno-' .. disable end))
 		end
 
 		if #opts > 0 then
@@ -3556,7 +3557,7 @@
 
 
 	function m.disableSpecificWarnings(cfg, condition)
-		if #cfg.disablewarnings > 0 then
+		if #cfg.disablewarnings > 0 and cfg.toolset ~= "clang" then
 			local warnings = table.concat(cfg.disablewarnings, ";")
 			warnings = warnings .. ";%%(DisableSpecificWarnings)"
 			m.element('DisableSpecificWarnings', condition, warnings)


### PR DESCRIPTION
**What does this PR do?**

close #2522

**How does this PR change Premake's behavior?**

visual project with clang now handle `disablewarnings`

**Anything else we should know?**

Also tested on my sample-test-project

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
