### PR TITLE
Handle `fatalwarnings` for specific warnings (not 'All') for visual studio with clang

### DIFF
--- a/modules/vstudio/tests/vc2019/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2019/test_compile_settings.lua
@@ -209,3 +209,20 @@
 	<AdditionalOptions>-Wno-disable %(AdditionalOptions)</AdditionalOptions>
 		]]
 	end
+
+--
+-- Fatal specific warnings.
+--
+
+	function suite.fatalSpecificWarningsWithClang()
+		fatalwarnings { "disable" }
+		toolset "clang"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<AdditionalOptions>-Werror=disable %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2162,6 +2162,7 @@
 				table.insert(opts, 1, '/Zp' .. tostring(cfg.structmemberalign))
 			end
 			opts = table.join(opts, table.translate(cfg.disablewarnings, function(disable) return '-Wno-' .. disable end))
+			opts = table.join(opts, table.translate(p.filterFatalWarnings(cfg.fatalwarnings), function(disable) return '-Werror=' .. disable end))
 		end
 
 		if #opts > 0 then
@@ -3568,7 +3569,7 @@
 	function m.treatSpecificWarningsAsErrors(cfg, condition)
 		local filteredWarnings = p.filterFatalWarnings(cfg.fatalwarnings)
 
-		if #filteredWarnings > 0 then
+		if #filteredWarnings > 0 and cfg.toolset ~= "clang" then
 			local fatal = table.concat(filteredWarnings, ";")
 			fatal = fatal .. ";%%(TreatSpecificWarningsAsErrors)"
 			m.element('TreatSpecificWarningsAsErrors', condition, fatal)


### PR DESCRIPTION
**What does this PR do?**

Handle `fatalwarnings` for specific warnings (not 'All') for visual studio with clang

**How does this PR change Premake's behavior?**

change vs action to handle `fatalwarnings` with clang toolset

**Anything else we should know?**

Tested with https://github.com/Jarod42/premake-sample-projects/actions/runs/19131565364
on https://github.com/Jarod42/premake-sample-projects/tree/master/projects/fatalwarnings

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ x Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

