### PR TITLE
Updated Bootstrap.bat and Bootstrap.mak to support VS2026

### DIFF
--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -47,6 +47,9 @@ IF "%vsversion%" == "vs2010" (
 ) ELSE IF "%vsversion%" == "vs2022" (
 	CALL :VsWhereVisualBootstrap "%vsversion%" "17.0" "18.0"
 
+) ELSE IF "%vsversion%" == "vs18" (
+	CALL :VsWhereVisualBootstrap "vs2026" "18.0" "19.0"
+
 ) ELSE (
 	ECHO Unrecognized Visual Studio version %vsversion%
 	EXIT /B 2

--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -40,6 +40,25 @@ SRC		= src/host/*.c			\
 		$(LUA_DIR)/lvm.c		\
 		$(LUA_DIR)/lzio.c		\
 
+ifdef MAKEDIR:
+!ifdef MAKEDIR
+
+# NMAKE
+
+!if "$(MSDEV)" == "vs2010" || "$(MSDEV)" == "vs2012" || "$(MSDEV)" == "vs2013" || "$(MSDEV)" == "vs2015" || "$(MSDEV)" == "vs2017" || "$(MSDEV)" == "vs2019" || "$(MSDEV)" == "vs2022"
+SLN_EXT = sln
+!else
+SLN_EXT = slnx
+!endif
+
+!else
+else
+
+# make
+
+endif
+!endif : # !endif has to be last to work in make
+
 HOST_PLATFORM= none
 
 .PHONY: default none clean nix-clean windows-clean \
@@ -148,11 +167,11 @@ windows-base: windows-clean
 	.\build\bootstrap\premake_bootstrap --arch=$(PLATFORM) --to=build/bootstrap $(PREMAKE_OPTS) $(MSDEV)
 
 windows: windows-base
-	devenv .\build\bootstrap\Premake5.sln /Upgrade
-	devenv .\build\bootstrap\Premake5.sln /Build "$(CONFIG)|$(PLATFORM:x86=win32)"
+	devenv .\build\bootstrap\Premake5.$(SLN_EXT) /Upgrade
+	devenv .\build\bootstrap\Premake5.$(SLN_EXT) /Build "$(CONFIG)|$(PLATFORM:x86=win32)"
 
 windows-msbuild: windows-base
-	msbuild /p:Configuration=$(CONFIG) /p:Platform=$(PLATFORM:x86=win32) .\build\bootstrap\Premake5.sln
+	msbuild /p:Configuration=$(CONFIG) /p:Platform=$(PLATFORM:x86=win32) .\build\bootstrap\Premake5.$(SLN_EXT)
 
 cosmo-clean: nix-clean
 


### PR DESCRIPTION
**What does this PR do?**

Updates Bootstrap.bat and Bootstrap.mak to support VS2026

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

We should probably consider splitting Bootstrap.mak to avoid weird hacks like this PR introduces.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
