### PR TITLE
Fixed visibility flag output for VS Android projects

### DIFF
--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -114,6 +114,7 @@ return {
 	"vc2022/test_toolset_settings.lua",
 	
 	-- Android projects
+	"android/test_android_build_settings.lua",
 	"android/test_android_files.lua",
 	"android/test_android_project.lua",
 

--- a/modules/vstudio/tests/android/test_android_build_settings.lua
+++ b/modules/vstudio/tests/android/test_android_build_settings.lua
@@ -1,0 +1,36 @@
+local p = premake
+local suite = test.declare("vstudio_vs2010_android_compile_settings")
+local vc2010 = p.vstudio.vc2010
+local project = p.project
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2015")
+		system "android"
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepare(platform)
+		local cfg = test.getconfig(prj, "Debug", platform)
+		vc2010.clCompile(cfg)
+	end
+
+--
+-- Visibility settings should go into AdditionalOptions
+--
+
+	function suite.additionalOptions_onVisibility()
+		visibility "Default"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<Optimization>Disabled</Optimization>
+	<AdditionalOptions>-fvisibility=default %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -4474,7 +4474,7 @@
 
 		-- -fvisibility=<>
 		if cfg.visibility ~= nil then
-			table.insert(opts, p.tools.gcc.cxxflags.visibility[cfg.visibility])
+			table.insert(opts, p.tools.gcc.shared.visibility[cfg.visibility])
 		end
 
 		if #opts > 0 then


### PR DESCRIPTION
- Added test for flag output

**What does this PR do?**

Fixes bug with visibility flag in VS Android projects.

**How does this PR change Premake's behavior?**

Stops Premake from crashing when using the visibility flag when generating VS Android projects.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
