### PR TITLE
Fixed curl type warnings

### DIFF
--- a/src/host/curl_utils.c
+++ b/src/host/curl_utils.c
@@ -10,11 +10,12 @@
 #include <string.h>
 
 #if LIBCURL_VERSION_NUM >= 0x072000
-int curlProgressCallback(curl_state* state, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
+int curlProgressCallback(void* stateptr, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
 #else
 int curlProgressCallback(curl_state* state, double dltotal, double dlnow, double ultotal, double ulnow)
 #endif
 {
+	curl_state* state = ((curl_state*)stateptr);
 	lua_State* L = state->L;
 
 	(void)ultotal;
@@ -90,9 +91,9 @@ CURL* curlRequest(lua_State* L, curl_state* state, int optionsIndex, int progres
 	strcat(agent, PREMAKE_VERSION);
 
 	curl_easy_setopt(curl, CURLOPT_URL, luaL_checkstring(L, 1));
-	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
-	curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1);
-	curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+	curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
+	curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
 	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, state->errorBuffer);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, agent);
 
@@ -102,8 +103,8 @@ CURL* curlRequest(lua_State* L, curl_state* state, int optionsIndex, int progres
 	lua_gettable(L, -2);
 	if (!lua_isnil(L, -1))
 	{
-		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
-		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
 	}
 	lua_pop(L, 2);
 
@@ -184,7 +185,7 @@ CURL* curlRequest(lua_State* L, curl_state* state, int optionsIndex, int progres
 
 	if (state->L != 0)
 	{
-		curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0);
+		curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
 		curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, state);
 #if LIBCURL_VERSION_NUM >= 0x072000
 		curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, curlProgressCallback);

--- a/src/host/curl_utils.h
+++ b/src/host/curl_utils.h
@@ -15,9 +15,7 @@
 #include <lua5.3/lua.h>
 #endif
 
-#define _MPRINTF_REPLACE /* use curl functions only */
 #include <curl/curl.h>
-#include <curl/mprintf.h>
 
 typedef struct
 {
@@ -27,14 +25,6 @@ typedef struct
 	char                errorBuffer[256];
 	struct curl_slist*  headers;
 } curl_state;
-
-
-#if LIBCURL_VERSION_NUM >= 0x072000
-int curlProgressCallback(curl_state* state, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
-#else
-int curlProgressCallback(curl_state* state, double dltotal, double dlnow, double ultotal, double ulnow);
-#endif
-size_t curlWriteCallback(char *ptr, size_t size, size_t nmemb, void* state);
 
 CURL*  curlRequest(lua_State* L, curl_state* state, int optionsIndex, int progressFnIndex, int headersIndex);
 void   curlCleanup(CURL* curl, curl_state* state);

--- a/src/host/http_download.c
+++ b/src/host/http_download.c
@@ -46,7 +46,7 @@ int http_download(lua_State* L)
 
 	if (curl)
 	{
-		curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
+		curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_file_cb);
 

--- a/src/host/http_get.c
+++ b/src/host/http_get.c
@@ -30,7 +30,7 @@ int http_get(lua_State* L)
 
 	if (curl)
 	{
-		curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
+		curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
 
 		code = curl_easy_perform(curl);
 		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);

--- a/src/host/http_post.c
+++ b/src/host/http_post.c
@@ -23,7 +23,7 @@ int http_post(lua_State* L)
 		size_t dataSize;
 		const char* data = luaL_checklstring(L, 2, &dataSize);
 
-		curl_easy_setopt(curl, CURLOPT_POST, 1);
+		curl_easy_setopt(curl, CURLOPT_POST, 1L);
 		if (data && dataSize > 0)
 		{
 			curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)dataSize);


### PR DESCRIPTION
- Removed unnecessary cruft in curl_utils.h

**What does this PR do?**

Fixes warnings with curl. Fixes #2537 

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
