### PR TITLE
add "Fast" option to LinkTimeOptimization API which enables LTCG:incremental for vs2010, and behaves as "On" for other toolsets

### DIFF
--- a/modules/gmakelegacy/tests/cpp/test_clang.lua
+++ b/modules/gmakelegacy/tests/cpp/test_clang.lua
@@ -61,3 +61,20 @@ ifeq ($(config),debug)
 		]]
 	end
 
+	function suite.usesCorrectCompilersAndFastLinkTimeOptimizationViaAPI()
+		linktimeoptimization "Fast"
+		make.cppConfigs(prj)
+		test.capture [[
+ifeq ($(config),debug)
+  ifeq ($(origin CC), default)
+    CC = clang
+  endif
+  ifeq ($(origin CXX), default)
+    CXX = clang++
+  endif
+  ifeq ($(origin AR), default)
+    AR = llvm-ar
+  endif
+		]]
+	end
+

--- a/modules/vstudio/tests/linux/test_linux_files.lua
+++ b/modules/vstudio/tests/linux/test_linux_files.lua
@@ -43,6 +43,22 @@ local vc2010 = p.vstudio.vc2010
 	end
 
 --
+-- Test fast link time optimization being equivalent to on. 
+--
+
+	function suite.linkTimeOptimization_Fast()
+		linktimeoptimization('fast')
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>v142</PlatformToolset>
+	<LinkTimeOptimization>true</LinkTimeOptimization>
+</PropertyGroup>
+		]]
+	end
+
+--
 -- Test multiprocessor compilation.
 --
 

--- a/modules/vstudio/tests/vc200x/test_compiler_block.lua
+++ b/modules/vstudio/tests/vc200x/test_compiler_block.lua
@@ -594,6 +594,18 @@
 
 	end
 
+	function suite.flags_onLinkTimeOptimizationFast()
+		linktimeoptimization "Fast"
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	Optimization="0"
+	WholeProgramOptimization="true"
+		]]
+
+	end
+
 
 --
 -- Check the optimization flags.

--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -328,6 +328,19 @@
 		]]
 	end
 
+	function suite.useOfLinkTimeOptimizationViaAPI_Fast()
+		linktimeoptimization "Fast"
+		prepare()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<UseDebugLibraries>false</UseDebugLibraries>
+	<CharacterSet>Unicode</CharacterSet>
+	<PlatformToolset>v100</PlatformToolset>
+	<WholeProgramOptimization>true</WholeProgramOptimization>
+		]]
+	end
+
 
 --
 -- Check the WindowsSDKDesktopARMSupport element

--- a/modules/vstudio/tests/vc2010/test_link.lua
+++ b/modules/vstudio/tests/vc2010/test_link.lua
@@ -615,6 +615,31 @@
 
 
 --
+-- Test if LinkTimeOptimization API correctly specifies LinkTimeCodeGeneration
+--
+
+	function suite.linkTimeOptimization_onEnableLinkTimeOptimization()
+		linktimeoptimization "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+		]]
+	end
+
+	function suite.linkTimeOptimization_onFastLinkTimeOptimization()
+		linktimeoptimization "Fast"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+		]]
+	end
+
+
+--
 -- Correctly handle module definition (.def) files.
 --
 

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -1614,7 +1614,7 @@
 
 
 	function m.wholeProgramOptimization(cfg)
-		if cfg.linktimeoptimization == "On" then
+		if cfg.linktimeoptimization == "On" or cfg.linktimeoptimization == "Fast" then
 			p.x('WholeProgramOptimization="true"')
 		elseif cfg.linktimeoptimization == "Off" then
 			p.x('WholeProgramOptimization="false"')

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2298,7 +2298,7 @@
 
 
 	function m.wholeProgramOptimization(cfg)
-		if cfg.linktimeoptimization == "On" then
+		if cfg.linktimeoptimization == "On" or cfg.linktimeoptimization == "Fast" then
 			m.element("WholeProgramOptimization", nil, "true")
 		elseif cfg.linktimeoptimization == "Off" then
 			m.element("WholeProgramOptimization", nil, "false")
@@ -3085,6 +3085,8 @@
 	function m.linkTimeCodeGeneration(cfg)
 		if cfg.linktimeoptimization == "On" then
 			m.element("LinkTimeCodeGeneration", nil, "UseLinkTimeCodeGeneration")
+		elseif cfg.linktimeoptimization == "Fast" then
+			m.element("LinkTimeCodeGeneration", nil, "UseFastLinkTimeCodeGeneration")
 		end
 	end
 
@@ -4021,7 +4023,7 @@
 	end
 
 	function m.linuxWholeProgramOptimization(cfg)
-		if cfg.linktimeoptimization == "On" then
+		if cfg.linktimeoptimization == "On" or cfg.linktimeoptimization == "Fast" then
 			m.element("LinkTimeOptimization", nil, "true")
 		elseif cfg.linktimeoptimization == "Off" then
 			m.element("LinkTimeOptimization", nil, "false")
@@ -4037,7 +4039,7 @@
 	end
 
 	function m.linuxLinkTimeCodeGeneration(cfg)
-		if cfg.linktimeoptimization == "On" then
+		if cfg.linktimeoptimization == "On" or cfg.linktimeoptimization == "Fast" then
 			m.element("LinkTimeOptimization", nil, "true")
 		end
 	end

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1124,6 +1124,7 @@
 		allowed = {
 			"Default",
 			"On",
+			"Fast",
 			"Off"
 		}
 	}

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -155,7 +155,8 @@
 		if cfg.kind == "StaticLib"
 				or config.isOptimizedBuild(cfg)
 				or cfg.flags.NoIncrementalLink
-				or cfg.linktimeoptimization == "On" then
+				or cfg.linktimeoptimization == "On"
+				or cfg.linktimeoptimization == "Fast" then
 			return false
 		end
 		return true

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -68,7 +68,10 @@
 		structmemberalign = gcc.shared.structmemberalign,
 		visibility = gcc.shared.visibility,
 		inlinesvisibility = gcc.shared.inlinesvisibility,
-		linktimeoptimization = gcc.shared.linktimeoptimization,
+		linktimeoptimization = {
+			On = "-flto",
+			Fast = "-flto=thin",
+		},
 		profile = gcc.shared.profile,
 	}
 
@@ -368,7 +371,7 @@
 	clang.tools = {
 		cc = "clang",
 		cxx = "clang++",
-		ar = function(cfg) return iif(cfg.linktimeoptimization == "On", "llvm-ar", "ar") end,
+		ar = function(cfg) return iif(cfg.linktimeoptimization == "On" or cfg.linktimeoptimization == "Fast", "llvm-ar", "ar") end,
 		rc = "windres"
 	}
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -71,6 +71,7 @@
 		},
 		linktimeoptimization = {
 			On = "-flto",
+			Fast = "-flto",
 		},
 		strictaliasing = {
 			Off = "-fno-strict-aliasing",

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -91,6 +91,7 @@
 		},
 		linktimeoptimization = {
 			On = "/GL",
+			Fast = "/GL",
 		},
 		multiprocessorcompile = {
 			On = "/MP",
@@ -353,7 +354,8 @@
 			WindowedApp = "/SUBSYSTEM:WINDOWS"
 		},
 		linktimeoptimization = {
-			On = "/LTCG"
+			On = "/LTCG",
+			Fast = "/LTCG:incremental",
 		},
 		symbols = {
 			On = "/DEBUG"

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -39,12 +39,50 @@
 		test.isequal("windres", clang.gettoolname(cfg, "rc"))
 	end
 
+	function suite.tools_onLinkTimeOptimizationViaAPI()
+		linktimeoptimization "On"
+		prepare()
+		test.isequal("clang", clang.gettoolname(cfg, "cc"))
+		test.isequal("clang++", clang.gettoolname(cfg, "cxx"))
+		test.isequal("llvm-ar", clang.gettoolname(cfg, "ar"))
+		test.isequal("windres", clang.gettoolname(cfg, "rc"))
+	end
+
+	function suite.tools_onFastLinkTimeOptimizationViaAPI()
+		linktimeoptimization "Fast"
+		prepare()
+		test.isequal("clang", clang.gettoolname(cfg, "cc"))
+		test.isequal("clang++", clang.gettoolname(cfg, "cxx"))
+		test.isequal("llvm-ar", clang.gettoolname(cfg, "ar"))
+		test.isequal("windres", clang.gettoolname(cfg, "rc"))
+	end
+
 	function suite.tools_forVersion()
 		toolset "clang-16"
 		prepare()
 		test.isequal("clang-16", clang.gettoolname(cfg, "cc"))
 		test.isequal("clang++-16", clang.gettoolname(cfg, "cxx"))
 		test.isequal("ar-16", clang.gettoolname(cfg, "ar"))
+		test.isequal("windres-16", clang.gettoolname(cfg, "rc"))
+	end
+
+	function suite.tools_forVersion_onLinkTimeOptimizationViaAPI()
+		toolset "clang-16"
+		linktimeoptimization "On"
+		prepare()
+		test.isequal("clang-16", clang.gettoolname(cfg, "cc"))
+		test.isequal("clang++-16", clang.gettoolname(cfg, "cxx"))
+		test.isequal("llvm-ar-16", clang.gettoolname(cfg, "ar"))
+		test.isequal("windres-16", clang.gettoolname(cfg, "rc"))
+	end
+
+	function suite.tools_forVersion_onFastLinkTimeOptimizationViaAPI()
+		toolset "clang-16"
+		linktimeoptimization "Fast"
+		prepare()
+		test.isequal("clang-16", clang.gettoolname(cfg, "cc"))
+		test.isequal("clang++-16", clang.gettoolname(cfg, "cxx"))
+		test.isequal("llvm-ar-16", clang.gettoolname(cfg, "ar"))
 		test.isequal("windres-16", clang.gettoolname(cfg, "rc"))
 	end
 
@@ -132,6 +170,34 @@ end
 		linker "LLD"
 		prepare()
 		test.contains("-fuse-ld=lld", clang.getldflags(cfg))
+	end
+
+--
+-- Check handling of link time optimization flag.
+--
+
+	function suite.cflags_onLinkTimeOptimizationViaAPI()
+		linktimeoptimization "On"
+		prepare()
+		test.contains("-flto", clang.getcflags(cfg))
+	end
+
+	function suite.cflags_onFastLinkTimeOptimizationViaAPI()
+		linktimeoptimization "Fast"
+		prepare()
+		test.contains("-flto=thin", clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_onLinkTimeOptimizationViaAPI()
+		linktimeoptimization "On"
+		prepare()
+		test.contains("-flto", clang.getldflags(cfg))
+	end
+
+	function suite.ldflags_onFastLinkTimeOptimizationViaAPI()
+		linktimeoptimization "Fast"
+		prepare()
+		test.contains("-flto=thin", clang.getldflags(cfg))
 	end
 
 --

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -957,8 +957,20 @@ end
 		test.contains("-flto", gcc.getcflags(cfg))
 	end
 
+	function suite.cflags_onFastLinkTimeOptimizationViaAPI()
+		linktimeoptimization "Fast"
+		prepare()
+		test.contains("-flto", gcc.getcflags(cfg))
+	end
+
 	function suite.ldflags_onLinkTimeOptimizationViaAPI()
 		linktimeoptimization "On"
+		prepare()
+		test.contains("-flto", gcc.getldflags(cfg))
+	end
+
+	function suite.ldflags_onFastLinkTimeOptimizationViaAPI()
+		linktimeoptimization "Fast"
 		prepare()
 		test.contains("-flto", gcc.getldflags(cfg))
 	end

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -107,10 +107,22 @@
 		test.contains("/GL", msc.getcflags(cfg))
 	end
 
+	function suite.cflags_onFastLinkTimeOptimizationsViaAPI()
+		linktimeoptimization "Fast"
+		prepare()
+		test.contains("/GL", msc.getcflags(cfg))
+	end
+
 	function suite.ldflags_onLinkTimeOptimizationsViaAPI()
 		linktimeoptimization "On"
 		prepare()
 		test.contains("/LTCG", msc.getldflags(cfg))
+	end
+
+	function suite.ldflags_onFastLinkTimeOptimizationsViaAPI()
+		linktimeoptimization "Fast"
+		prepare()
+		test.contains("/LTCG:incremental", msc.getldflags(cfg))
 	end
 
 	function suite.cflags_onStringPoolingOn()

--- a/website/docs/linktimeoptimization.md
+++ b/website/docs/linktimeoptimization.md
@@ -8,11 +8,12 @@ linktimeoptimization "value"
 
 *value* specifies whether or not to use link time optimization, if the toolset and exporter support it.
 
-| Value   | Description                                            |
-|---------|--------------------------------------------------------|
+| Value   | Description                                            | Notes |
+|---------|--------------------------------------------------------| ---------------- |
 | Off     | No LTO to be performed.                                |
-| On      | LTO optimization enabled.                              |
-| Default | Default LTO optimizations for the toolset or exporter. |
+| On      | LTO enabled.                                           |
+| Fast    | Incremental/Fast LTO enabled.                          | Visual Studio & Clang only, available from Premake 5.0-beta8 or later |
+| Default | Default LTO setting for the toolset or exporter.       |
 
 ### Applies To ###
 


### PR DESCRIPTION
add "Fast" option to LinkTimeOptimization API which enables LTCG:incremental for vs2010, and behaves as "On" for other toolsets

**What does this PR do?**

^ see commit description

**How does this PR change Premake's behavior?**

This adds a "Fast" option to the LinkTimeOptimiation for vs2010 projects.

**Anything else we should know?**

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
