### PR TITLE
Remove Deprecated Flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Makefile
 *.ninja
 *.ninja_deps
 *.ninja_log
+.vscode/
 
 *.bbprojectsettings
 Scratchpad.txt

--- a/modules/gmakelegacy/tests/cpp/test_clang.lua
+++ b/modules/gmakelegacy/tests/cpp/test_clang.lua
@@ -44,23 +44,6 @@ ifeq ($(config),debug)
 		]]
 	end
 
-	function suite.usesCorrectCompilersAndLinkTimeOptimizationViaFlag()
-		flags { "LinkTimeOptimization" }
-		make.cppConfigs(prj)
-		test.capture [[
-ifeq ($(config),debug)
-  ifeq ($(origin CC), default)
-    CC = clang
-  endif
-  ifeq ($(origin CXX), default)
-    CXX = clang++
-  endif
-  ifeq ($(origin AR), default)
-    AR = llvm-ar
-  endif
-		]]
-	end
-
 	function suite.usesCorrectCompilersAndLinkTimeOptimizationViaAPI()
 		linktimeoptimization "On"
 		make.cppConfigs(prj)

--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -636,14 +636,6 @@
 		}
 	}
 
-	p.api.deprecateValue("flags", "MFC", 'Use `mfc` instead.',
-	function(value)
-		mfc("On")
-	end,
-	function(value)
-		mfc("Off")
-	end)
-
 --
 -- Register Android properties
 --

--- a/modules/vstudio/tests/cs2005/test_compiler_props.lua
+++ b/modules/vstudio/tests/cs2005/test_compiler_props.lua
@@ -71,20 +71,8 @@
 --
 
 
-	function suite.treatWarningsAsErrors_onFatalWarningsFlag()
-		flags { "FatalWarnings" }
-		prepare()
-		test.capture [[
-		<DefineConstants></DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
-		<WarningLevel>4</WarningLevel>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		]]
-	end
-
-
 	function suite.treatWarningsAsErrors_onFatalWarningsAPI()
-		fatalwarnings { "All" }
+		fatalwarnings "All"
 		prepare()
 		test.capture [[
 		<DefineConstants></DefineConstants>

--- a/modules/vstudio/tests/vc200x/test_compiler_block.lua
+++ b/modules/vstudio/tests/vc200x/test_compiler_block.lua
@@ -354,25 +354,6 @@
 -- Verify the correct warnings settings are used when FatalWarnings are enabled.
 --
 
-	function suite.runtimeLibraryIsDebug_onFatalWarningsViaFlag()
-		flags { "FatalWarnings" }
-		prepare()
-		test.capture [[
-<Tool
-	Name="VCCLCompilerTool"
-	Optimization="0"
-	BasicRuntimeChecks="3"
-	RuntimeLibrary="2"
-	EnableFunctionLevelLinking="true"
-	UsePrecompiledHeader="0"
-	WarningLevel="3"
-	WarnAsError="true"
-	DebugInformationFormat="0"
-/>
-		]]
-	end
-
-
 	function suite.runtimeLibraryIsDebug_onFatalWarningsViaAPI()
 		fatalwarnings { "All" }
 		prepare()
@@ -395,25 +376,6 @@
 --
 -- Verify the correct warnings settings are used when no warnings are enabled.
 --
-
-	function suite.runtimeLibraryIsDebug_onNoWarnings_whichDisablesAllOtherWarningsFlagsViaFlag()
-		flags { "FatalWarnings" }
-		warnings "Off"
-		prepare()
-		test.capture [[
-<Tool
-	Name="VCCLCompilerTool"
-	Optimization="0"
-	BasicRuntimeChecks="3"
-	RuntimeLibrary="2"
-	EnableFunctionLevelLinking="true"
-	UsePrecompiledHeader="0"
-	WarningLevel="0"
-	DebugInformationFormat="0"
-/>
-		]]
-	end
-
 
 	function suite.runtimeLibraryIsDebug_onNoWarnings_whichDisablesAllOtherWarningsFlagsViaAPI()
 		fatalwarnings { "All" }
@@ -607,18 +569,6 @@
 --
 -- Check the LinkTimeOptimization flag.
 --
-
-	function suite.flags_onLinkTimeOptimizationViaFlag()
-		flags { "LinkTimeOptimization" }
-		prepare()
-		test.capture [[
-<Tool
-	Name="VCCLCompilerTool"
-	Optimization="0"
-	WholeProgramOptimization="true"
-		]]
-
-	end
 
 	function suite.flags_onLinkTimeOptimization()
 		linktimeoptimization "On"

--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -150,19 +150,6 @@
 -- not be generated.
 --
 
-	function suite.warningLevel_onNoWarningsOverOtherWarningsFlags()
-		flags { "FatalWarnings" }
-		warnings "Off"
-		prepare()
-		test.capture [[
-<ClCompile>
-	<PrecompiledHeader>NotUsing</PrecompiledHeader>
-	<WarningLevel>TurnOffAllWarnings</WarningLevel>
-	<Optimization>Disabled</Optimization>
-		]]
-	end
-
-
 	function suite.warningLevel_onNoWarningsOverOtherWarningsAPI()
 		fatalwarnings { "All" }
 		warnings "Off"
@@ -557,17 +544,6 @@
 --
 -- Add <TreatWarningAsError> if FatalWarnings flag is set.
 --
-
-	function suite.treatWarningsAsError_onFatalWarningsViaFlag()
-		flags { "FatalCompileWarnings" }
-		prepare()
-		test.capture [[
-<ClCompile>
-	<PrecompiledHeader>NotUsing</PrecompiledHeader>
-	<WarningLevel>Level3</WarningLevel>
-	<TreatWarningAsError>true</TreatWarningAsError>
-		]]
-	end
 
 
 	function suite.treatWarningsAsError_onFatalWarningsViaAPI()

--- a/modules/vstudio/tests/vc2010/test_config_props.lua
+++ b/modules/vstudio/tests/vc2010/test_config_props.lua
@@ -184,31 +184,8 @@
 		]]
 	end
 
-	function suite.useOfMfc_onDynamicRuntimeViaFlag()
-		flags { "MFC" }
-		prepare()
-		test.capture [[
-<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-	<ConfigurationType>Application</ConfigurationType>
-	<UseDebugLibraries>false</UseDebugLibraries>
-	<UseOfMfc>Dynamic</UseOfMfc>
-		]]
-	end
-
 	function suite.useOfMfc_onStaticRuntime()
 		mfc "On"
-		staticruntime "On"
-		prepare()
-		test.capture [[
-<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-	<ConfigurationType>Application</ConfigurationType>
-	<UseDebugLibraries>false</UseDebugLibraries>
-	<UseOfMfc>Static</UseOfMfc>
-		]]
-	end
-	
-	function suite.useOfMfc_onStaticRuntimeViaFlag()
-		flags { "MFC" }
 		staticruntime "On"
 		prepare()
 		test.capture [[
@@ -337,19 +314,6 @@
 --
 -- Check the LinkTimeOptimization flag
 --
-
-	function suite.useOfLinkTimeOptimizationViaFlag()
-		flags { "LinkTimeOptimization" }
-		prepare()
-		test.capture [[
-<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-	<ConfigurationType>Application</ConfigurationType>
-	<UseDebugLibraries>false</UseDebugLibraries>
-	<CharacterSet>Unicode</CharacterSet>
-	<PlatformToolset>v100</PlatformToolset>
-	<WholeProgramOptimization>true</WholeProgramOptimization>
-		]]
-	end
 
 	function suite.useOfLinkTimeOptimizationViaAPI()
 		linktimeoptimization "On"

--- a/modules/vstudio/tests/vc2010/test_link.lua
+++ b/modules/vstudio/tests/vc2010/test_link.lua
@@ -651,7 +651,7 @@
 
 	function suite.fatalWarnings_onDynamicLink()
 		kind "ConsoleApp"
-		flags { "FatalLinkWarnings" }
+		linkerfatalwarnings "All"
 		prepare()
 		test.capture [[
 <Link>
@@ -662,7 +662,7 @@
 
 	function suite.fatalWarnings_onStaticLink()
 		kind "StaticLib"
-		flags { "FatalLinkWarnings" }
+		linkerfatalwarnings "All"
 		prepare()
 		test.capture [[
 <Link>

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -2945,32 +2945,6 @@
 	end
 
 
-	function suite.XCBuildConfigurationProject_OnFatalWarningsViaFlag()
-		flags { "FatalWarnings" }
-		prepare()
-		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
-		test.capture [[
-		A14350AC4595EE5E57CE36EC /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
-				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
-				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/Debug;
-				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
-			};
-			name = Debug;
-		};
-		]]
-	end
-
-
 	function suite.XCBuildConfigurationProject_OnFatalWarningsViaAPI()
 		fatalwarnings { "All" }
 		linkerfatalwarnings { "All" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -287,7 +287,7 @@
 
 		-- MinGW AR does not handle LTO out of the box and need a plugin to be setup
 		filter { "system:windows", "configurations:Release", "toolset:not mingw" }
-			flags		{ "LinkTimeOptimization" }
+			linktimeoptimization "On"
 		
 		filter { "system:windows", "configurations:Release", "toolset:clang", "action:not vs*" }
 			linkoptions { "-fuse-ld=lld" }

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -338,12 +338,7 @@
 			"DebugEnvsDontMerge",
 			"DebugEnvsInherit",
 			"ExcludeFromBuild",
-			"FatalCompileWarnings",	-- DEPRECATED
-			"FatalLinkWarnings",	-- DEPRECATED
-			"FatalWarnings",		-- DEPRECATED
-			"LinkTimeOptimization", -- DEPRECATED
 			"Maps",
-			"MFC",
 			"MultiProcessorCompile",
 			"No64BitChecks",
 			"NoCopyLocal",
@@ -1133,15 +1128,6 @@
 		}
 	}
 
-	--27 November 2024
-	api.deprecateValue("flags", "LinkTimeOptimization", "Use `linktimeoptimization` instead.",
-	function(value)
-		linktimeoptimization("On")
-	end,
-	function(value)
-		linktimeoptimization("Default")
-	end)
-
 	--25 November 2024
 	api.deprecateValue("flags", "WPF", 'Use `dotnetsdk "WindowsDesktop"` instead.',
 	function(value)
@@ -1149,29 +1135,6 @@
 	end,
 	function(value)
 		dotnetsdk "Default"
-	end)
-	api.deprecateValue("flags", "FatalWarnings", "Use `fatalwarnings { \"All\" }` instead.",
-	function(value)
-		fatalwarnings({ "All" })
-	end,
-	function(value)
-		removefatalwarnings({ "All" })
-	end)
-
-	api.deprecateValue("flags", "FatalCompileWarnings", "Use `fatalwarnings { \"All\" }` instead.",
-	function(value)
-		fatalwarnings({ "All" })
-	end,
-	function(value)
-		removefatalwarnings({ "All" })
-	end)
-
-	api.deprecateValue("flags", "FatalLinkWarnings", "Use `linkerfatalwarnings { \"All\" }` instead.",
-	function(value)
-		linkerfatalwarnings({ "All" })
-	end,
-	function(value)
-		removelinkerfatalwarnings({ "All" })
 	end)
 
 	premake.filterFatalWarnings = function(tbl)

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -121,12 +121,6 @@
 		test.contains({ "-Weverything" }, gcc.getcflags(cfg))
 	end
 
-	function suite.cflags_onFatalWarningsViaFlag()
-		flags { "FatalWarnings" }
-		prepare()
-		test.contains({ "-Werror" }, gcc.getcflags(cfg))
-	end
-
 	function suite.cflags_onFatalWarningsViaAPI()
 		fatalwarnings { "All" }
 		prepare()
@@ -957,22 +951,10 @@ end
 -- Check handling of link time optimization flag.
 --
 
-	function suite.cflags_onLinkTimeOptimizationViaFlag()
-		flags "LinkTimeOptimization"
-		prepare()
-		test.contains("-flto", gcc.getcflags(cfg))
-	end
-
 	function suite.cflags_onLinkTimeOptimizationViaAPI()
 		linktimeoptimization "On"
 		prepare()
 		test.contains("-flto", gcc.getcflags(cfg))
-	end
-
-	function suite.ldflags_onLinkTimeOptimizationViaFlag()
-		flags "LinkTimeOptimization"
-		prepare()
-		test.contains("-flto", gcc.getldflags(cfg))
 	end
 
 	function suite.ldflags_onLinkTimeOptimizationViaAPI()

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -101,22 +101,10 @@
 		test.excludes("/Oy", msc.getcflags(cfg))
 	end
 
-	function suite.cflags_onLinkTimeOptimizationsViaFlag()
-		flags "LinkTimeOptimization"
-		prepare()
-		test.contains("/GL", msc.getcflags(cfg))
-	end
-
 	function suite.cflags_onLinkTimeOptimizationsViaAPI()
 		linktimeoptimization "On"
 		prepare()
 		test.contains("/GL", msc.getcflags(cfg))
-	end
-
-	function suite.ldflags_onLinkTimeOptimizationsViaFlag()
-		flags "LinkTimeOptimization"
-		prepare()
-		test.contains("/LTCG", msc.getldflags(cfg))
 	end
 
 	function suite.ldflags_onLinkTimeOptimizationsViaAPI()
@@ -294,12 +282,6 @@
 		warnings "Everything"
 		prepare()
 		test.contains("/Wall", msc.getcflags(cfg))
-	end
-
-	function suite.cflags_OnFatalWarningsViaFlag()
-		flags "FatalWarnings"
-		prepare()
-		test.contains("/WX", msc.getcflags(cfg))
 	end
 
 	function suite.cflags_OnFatalWarningsViaAPI()
@@ -816,13 +798,13 @@ end
 --
 
 	function suite.mixedToolFlags_onCFlags()
-		flags { "FatalCompileWarnings" }
+		fatalwarnings "All"
 		prepare()
 		test.isequal({ "/WX", "/MD" }, msc.getcflags(cfg))
 	end
 
 	function suite.mixedToolFlags_onCxxFlags()
-		flags { "FatalCompileWarnings" }
+		fatalwarnings "All"
 		prepare()
 		test.isequal({ "/WX", "/MD", "/EHsc" }, msc.getcxxflags(cfg))
 	end

--- a/tests/tools/test_snc.lua
+++ b/tests/tools/test_snc.lua
@@ -60,13 +60,6 @@
 -- Check the translation of CFLAGS.
 --
 
-	function suite.cflags_onFatalWarningsViaFlag()
-		flags { "FatalWarnings" }
-		prepare()
-		test.isequal({ "-Xquit=2" }, snc.getcflags(cfg))
-	end
-
-
 	function suite.cflag_onFatalWarningsViaAPI()
 		fatalwarnings { "All" }
 		prepare()

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -11,12 +11,12 @@ flags { "flag_list" }
 | Flag                  | Description                                                         | Notes |
 |-----------------------|---------------------------------------------------------------------|----------------|
 | ExcludeFromBuild      | Exclude a source code file from the build, for the current configuration. |
-| FatalCompileWarnings  | Treat compiler warnings as errors. Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. |
-| FatalLinkWarnings     | Treat linker warnings as errors.  Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. |
-| FatalWarnings         | Treat all warnings as errors; equivalent to FatalCompileWarnings, FatalLinkWarnings.  Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. |
-| LinkTimeOptimization  | Enable link-time (i.e. whole program) optimizations. Deprecated in Premake 5.0.0-beta4. Use `linktimeoptimization` API instead. |
+| FatalCompileWarnings  | Treat compiler warnings as errors. Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. | Removed in Premake 5.0.0-beta8 |
+| FatalLinkWarnings     | Treat linker warnings as errors.  Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. | Removed in Premake 5.0.0-beta8 |
+| FatalWarnings         | Treat all warnings as errors; equivalent to FatalCompileWarnings, FatalLinkWarnings.  Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. | Removed in Premake 5.0.0-beta8 |
+| LinkTimeOptimization  | Enable link-time (i.e. whole program) optimizations. Deprecated in Premake 5.0.0-beta4. Use `linktimeoptimization` API instead. | Removed in Premake 5.0.0-beta8 |
 | Maps                  | Enable Generate Map File for Visual Studio                          |
-| MFC                   | Enable support for Microsoft Foundation Classes. Deprecated in Premake 5.0.0-beta4. Use `mfc` API instead. |
+| MFC                   | Enable support for Microsoft Foundation Classes. Deprecated in Premake 5.0.0-beta4. Use `mfc` API instead. | Removed in Premake 5.0.0-beta8 |
 | MultiProcessorCompile | Enable Visual Studio to use multiple compiler processes when building. |
 | No64BitChecks         | Disable 64-bit portability warnings.                                |
 | NoBufferSecurityCheck | Turn off stack protection checks.                                   |


### PR DESCRIPTION
**What does this PR do?**

Removes all prior deprecated flags.

**How does this PR change Premake's behavior?**

Breaks scripts relying on these flags. These flags have been deprecated for over a year.

**Anything else we should know?**

General prep work of removing deprecated flags from 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
