### PR TITLE
Fix PCH deps for Ninja incremental builds

### DIFF
--- a/modules/ninja/tests/test_ninja_build_rules.lua
+++ b/modules/ninja/tests/test_ninja_build_rules.lua
@@ -47,7 +47,6 @@ rule cc_msc
   command = cl $cflags /nologo /showIncludes -c /Tc$in /Fo$out
   deps = msvc
   description = Compiling C source $in
-  depfile = $out.d
 
 		]]
 	end
@@ -66,8 +65,8 @@ rule cc_msc
 rule cc_gcc
   command = gcc $cflags -c $in -o $out
   deps = gcc
-  description = Compiling C source $in
   depfile = $out.d
+  description = Compiling C source $in
 
 		]]
 	end
@@ -86,8 +85,8 @@ rule cc_gcc
 rule cc_clang
   command = clang $cflags -c $in -o $out
   deps = gcc
-  description = Compiling C source $in
   depfile = $out.d
+  description = Compiling C source $in
 
 		]]
 	end
@@ -111,7 +110,6 @@ rule cxx_msc
   command = cl $cxxflags /nologo /showIncludes -c /Tp$in /Fo$out
   deps = msvc
   description = Compiling C++ source $in
-  depfile = $out.d
 
 		]]
 	end
@@ -130,8 +128,8 @@ rule cxx_msc
 rule cxx_gcc
   command = g++ $cxxflags -c $in -o $out
   deps = gcc
-  description = Compiling C++ source $in
   depfile = $out.d
+  description = Compiling C++ source $in
 
 		]]
 	end
@@ -150,8 +148,8 @@ rule cxx_gcc
 rule cxx_clang
   command = clang++ $cxxflags -c $in -o $out
   deps = gcc
-  description = Compiling C++ source $in
   depfile = $out.d
+  description = Compiling C++ source $in
 
 		]]
 	end
@@ -327,7 +325,7 @@ rule ar_gcc
 		cpp.pchrule(cfg)
 		test.capture [[
 rule pch_gcc
-  command = g++ -x c++-header $cflags -o $out -MD -c $in
+  command = g++ -x c++-header $cflags -o $out -MD -MF $out.d -c $in
   description = Generating precompiled header $in
   depfile = $out.d
 
@@ -346,7 +344,7 @@ rule pch_gcc
 		cpp.pchrule(cfg)
 		test.capture [[
 rule pch_clang
-  command = clang++ -x c++-header $cflags -o $out -MD -c $in
+  command = clang++ -x c++-header $cflags -o $out -MD -MF $out.d -c $in
   description = Generating precompiled header $in
   depfile = $out.d
 

--- a/modules/ninja/tests/test_ninja_pch.lua
+++ b/modules/ninja/tests/test_ninja_pch.lua
@@ -115,7 +115,7 @@
 		
 		test.isequal("obj/Debug/pch.h.gch", pchFile)
 		test.capture [[
-build obj/Debug/pch.h.gch: pch_gcc pch.h
+build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
   cflags = $cxxflags_MyProject_Debug
 		]]
 	end
@@ -136,7 +136,7 @@ build obj/Debug/pch.h.gch: pch_gcc pch.h
 		
 		test.isequal("obj/Debug/precompile.h.gch", pchFile)
 		test.capture [[
-build obj/Debug/precompile.h.gch: pch_clang precompile.h
+build obj/Debug/precompile.h.gch | obj/Debug/precompile.h.gch.d: pch_clang precompile.h
   cflags = $cxxflags_MyProject_Debug
 		]]
 	end
@@ -157,7 +157,7 @@ build obj/Debug/precompile.h.gch: pch_clang precompile.h
 		
 		test.isequal("obj/Debug/pch.h.gch", pchFile)
 		test.capture [[
-build obj/Debug/pch.h.gch: pch_gcc pch.h
+build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
   cflags = $cflags_MyProject_Debug
 		]]
 	end
@@ -247,7 +247,7 @@ build obj/Debug/pch.h.gch: pch_gcc pch.h
 		cpp.buildPch(cfg)
 		
 		test.capture [[
-build obj/Debug/pch.h.gch: pch_gcc pch.h
+build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
   cflags = $cxxflags_MyProject_Debug
 		]]
 	end


### PR DESCRIPTION
**What does this PR do?**

Fixes Ninja PCH dep file generation on GCC-like compiler drivers.

**How does this PR change Premake's behavior?**

No breaking changes

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
