### PR TITLE
Remove NoFramePointer from docs

### DIFF
--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -21,7 +21,6 @@ flags { "flag_list" }
 | No64BitChecks         | Disable 64-bit portability warnings.                                |
 | NoBufferSecurityCheck | Turn off stack protection checks.                                   |
 | NoCopyLocal           | Prevent referenced assemblies from being copied to the target directory (C#) |
-| NoFramePointer        | Disable the generation of stack frame pointers.                     |
 | NoImplicitLink        | Disable Visual Studio's default behavior of automatically linking dependent projects. |
 | NoImportLib           | Prevent the generation of an import library for a Windows DLL.      |
 | NoIncrementalLink     | Disable support for Visual Studio's incremental linking feature.    |


### PR DESCRIPTION
**What does this PR do?**

Documentation was out of date. This flag was removed in the past.

**How does this PR change Premake's behavior?**

No breaking changes, just updating docs.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
