### PR TITLE
Add dedicated multi-processor compilation API

### DIFF
--- a/modules/vstudio/tests/linux/test_linux_files.lua
+++ b/modules/vstudio/tests/linux/test_linux_files.lua
@@ -46,8 +46,23 @@ local vc2010 = p.vstudio.vc2010
 -- Test multiprocessor compilation.
 --
 
-	function suite.multiProcessorCompile_On()
+	function suite.multiProcessorCompile_On_Flags()
 		flags { "MultiProcessorCompile" }
+		prepareOutputProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
+	<TargetName>MyProject</TargetName>
+	<TargetExt>
+	</TargetExt>
+	<MultiProcNumber>8</MultiProcNumber>
+</PropertyGroup>
+		]]
+	end
+
+	function suite.multiProcessorCompile_On_API()
+		multiprocessorcompile "On"
 		prepareOutputProperties()
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">

--- a/modules/vstudio/tests/vc200x/test_compiler_block.lua
+++ b/modules/vstudio/tests/vc200x/test_compiler_block.lua
@@ -518,8 +518,20 @@
 -- Check handling of the EnableMultiProcessorCompile flag.
 --
 
-	function suite.onMultiProcessorCompile()
+	function suite.onMultiProcessorCompile_Flag()
 		flags { "MultiProcessorCompile" }
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	AdditionalOptions="/MP"
+	Optimization="0"
+	BasicRuntimeChecks="3"
+		]]
+	end
+
+	function suite.onMultiProcessorCompile_API()
+		multiprocessorcompile "On"
 		prepare()
 		test.capture [[
 <Tool

--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -875,8 +875,21 @@
 -- Check handling of the EnableMultiProcessorCompile flag.
 --
 
-	function suite.onMultiProcessorCompile()
+	function suite.onMultiProcessorCompile_Flag()
 		flags { "MultiProcessorCompile" }
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<MinimalRebuild>false</MinimalRebuild>
+	<MultiProcessorCompilation>true</MultiProcessorCompilation>
+		]]
+	end
+
+	function suite.onMultiProcessorCompile_API()
+		multiprocessorcompile "On"
 		prepare()
 		test.capture [[
 <ClCompile>

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -728,7 +728,7 @@
 
 	function m.additionalCompilerOptions(cfg)
 		local opts = cfg.buildoptions
-		if cfg.flags.MultiProcessorCompile then
+		if cfg.multiprocessorcompile == p.ON then
 			table.insert(opts, "/MP")
 		end
 		if #opts > 0 then
@@ -1231,7 +1231,7 @@
 		   cfg.debugformat ~= "c7" and
 		   not cfg.flags.NoMinimalRebuild and
 		   cfg.clr == p.OFF and
-		   not cfg.flags.MultiProcessorCompile
+		   cfg.multiprocessorcompile ~= p.ON
 		then
 			p.w('MinimalRebuild="true"')
 		end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2960,7 +2960,7 @@
 	function m.minimalRebuild(cfg)
 		if config.isOptimizedBuild(cfg) or
 		   cfg.flags.NoMinimalRebuild or
-		   cfg.flags.MultiProcessorCompile or
+		   cfg.multiprocessorcompile == p.ON or
 		   cfg.debugformat == "c7"
 		then
 			m.element("MinimalRebuild", nil, "false")
@@ -2977,7 +2977,7 @@
 
 
 	function m.multiProcessorCompilation(cfg)
-		if cfg.flags.MultiProcessorCompile then
+		if cfg.multiprocessorcompile == p.ON then
 			m.element("MultiProcessorCompilation", nil, "true")
 		end
 	end
@@ -4031,7 +4031,7 @@
 	function m.linuxMultiProcNumber(cfg)
 		-- Linux equivalent of 'MultiProcessorCompilation'
 		-- Default to 8 parallel jobs
-		if cfg.flags.MultiProcessorCompile then
+		if cfg.multiprocessorcompile == p.ON then
 			m.element("MultiProcNumber", nil, "8")
 		end
 	end
@@ -4423,7 +4423,7 @@
 
 	function m.androidUseMultiToolTask(cfg)
 		-- Android equivalent of 'MultiProcessorCompilation'
-		if cfg.flags.MultiProcessorCompile then
+		if cfg.multiprocessorcompile == p.ON then
 			m.element("UseMultiToolTask", nil, "true")
 		end
 	end

--- a/premake5.lua
+++ b/premake5.lua
@@ -221,7 +221,7 @@
 		configurations { "Release", "Debug" }
 		location ( _OPTIONS["to"] )
 
-		flags { "MultiProcessorCompile" }
+		multiprocessorcompile "On"
 		warnings "Extra"
 
 		filter { "options:not zlib-src=none" }

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1206,6 +1206,25 @@
 		mapfile("Default")
 	end)
 
+	api.register {
+		name = "multiprocessorcompile",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off"
+		}
+	}
+
+	api.deprecateValue("flags", "MultiProcessorCompile", "Use `multiprocessorcompile` instead.",
+	function(value)
+		multiprocessorcompile("On")
+	end,
+	function(value)
+		multiprocessorcompile("Default")
+	end)
+
 
 -----------------------------------------------------------------------------
 --

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -65,7 +65,6 @@
 			All = "/WX"
 		},
 		flags = {
-			MultiProcessorCompile = "/MP",
 			NoMinimalRebuild = "/Gm-",
 			OmitDefaultLibrary = "/Zl"
 		},
@@ -92,6 +91,9 @@
 		},
 		linktimeoptimization = {
 			On = "/GL",
+		},
+		multiprocessorcompile = {
+			On = "/MP",
 		},
 		optimize = {
 			Off = "/Od",

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -581,8 +581,14 @@ end
 		test.contains("/Gm-", msc.getcflags(cfg))
 	end
 
-	function suite.cflags_onMultiProcessorCompile()
+	function suite.cflags_onMultiProcessorCompile_Flag()
 		flags "MultiProcessorCompile"
+		prepare()
+		test.contains("/MP", msc.getcflags(cfg))
+	end
+
+	function suite.cflags_onMultiProcessorCompile_API()
+		multiprocessorcompile "On"
 		prepare()
 		test.contains("/MP", msc.getcflags(cfg))
 	end

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -17,7 +17,7 @@ flags { "flag_list" }
 | LinkTimeOptimization  | Enable link-time (i.e. whole program) optimizations. Deprecated in Premake 5.0.0-beta4. Use `linktimeoptimization` API instead. | Removed in Premake 5.0.0-beta8 |
 | Maps                  | Enable Generate Map File for Visual Studio. Deprecated in Premake 5.0.0-beta8. Use `mapfile` API instead. |                          |
 | MFC                   | Enable support for Microsoft Foundation Classes. Deprecated in Premake 5.0.0-beta4. Use `mfc` API instead. | Removed in Premake 5.0.0-beta8 |
-| MultiProcessorCompile | Enable Visual Studio to use multiple compiler processes when building. |
+| MultiProcessorCompile | Enable Visual Studio to use multiple compiler processes when building. Deprecated in Premake 5.0.0-beta8. Use `multiprocessorcompile` API instead. |
 | No64BitChecks         | Disable 64-bit portability warnings.                                |
 | NoBufferSecurityCheck | Turn off stack protection checks.                                   |
 | NoCopyLocal           | Prevent referenced assemblies from being copied to the target directory (C#) |
@@ -61,3 +61,4 @@ flags { "LinkTimeOptimization" }
 * [linktimeoptimization](linktimeoptimization.md)
 * [mfc](mfc.md)
 * [mapfile](mapfile.md)
+* [multiprocessorcompile](multiprocessorcompile.md)

--- a/website/docs/multiprocessorcompile.md
+++ b/website/docs/multiprocessorcompile.md
@@ -1,0 +1,17 @@
+Controls whether multiple processors are used for compilation.
+
+```lua
+multiprocessorcompile ("value")
+```
+
+## Parameters
+`value` is one of:
+* `Default`: Use the compiler's default behavior.
+* `On`: Use multiple processes for compilation.
+* `Off`: Use a single process for compilation.
+
+## Applies To
+The `config` scope.
+
+## Availability
+Premake 5.0.-beta8 or later for the `msc` toolset or in Visual Studio exporters.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -196,6 +196,7 @@ module.exports = {
 						'mapfile',
 						'mapfilepath',
 						'mfc',
+						'multiprocessorcompile',
 						'namespace',
 						'nativewchar',
 						'newaction',


### PR DESCRIPTION
**What does this PR do?**

Deprecates the MultiProcessorCompile flag.

**How does this PR change Premake's behavior?**

No breaking changes.

**Anything else we should know?**

Prep work for Premake 5.0.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
