### PR TITLE
Deprecate NoBufferSecurityCheck Flag

### DIFF
--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -59,7 +59,26 @@
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="-Og;-fPIC;-g;-std=c++11;-fno-exceptions;-fno-stack-protector;-fno-rtti;-include forced_include1.h;-include forced_include2.h;-opt1;-opt2" C_Options="-Og;-fPIC;-g;-include forced_include1.h;-include forced_include2.h;-opt1;-opt2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
+      <Compiler Options="-Og;-fPIC;-g;-fno-stack-protector;-std=c++11;-fno-exceptions;-fno-rtti;-include forced_include1.h;-include forced_include2.h;-opt1;-opt2" C_Options="-Og;-fPIC;-g;-include forced_include1.h;-include forced_include2.h;-opt1;-opt2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
+      </Compiler>
+		]]
+	end
+
+	function suite.OnProjectCfg_BufferSecurityCheckAPI()
+		optimize "Debug"
+		exceptionhandling "Off"
+		rtti "Off"
+		pic "On"
+		symbols "On"
+		language "C++"
+		cppdialect "C++11"
+		buffersecuritycheck "Off"
+		forceincludes { "forced_include1.h", "forced_include2.h" }
+		buildoptions { "-opt1", "-opt2" }
+		prepare()
+		codelite.project.compiler(cfg)
+		test.capture [[
+      <Compiler Options="-Og;-fPIC;-g;-fno-stack-protector;-std=c++11;-fno-exceptions;-fno-rtti;-include forced_include1.h;-include forced_include2.h;-opt1;-opt2" C_Options="-Og;-fPIC;-g;-include forced_include1.h;-include forced_include2.h;-opt1;-opt2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
       </Compiler>
 		]]
 	end

--- a/modules/vstudio/tests/vc200x/test_compiler_block.lua
+++ b/modules/vstudio/tests/vc200x/test_compiler_block.lua
@@ -247,7 +247,7 @@
 -- Check that the "no buffer security check" flag is applied correctly.
 --
 
-	function suite.noBufferSecurityFlagSet_onBufferSecurityCheck()
+	function suite.noBufferSecurityFlagSet_onBufferSecurityCheck_ViaFlag()
 		flags { "NoBufferSecurityCheck" }
 		prepare()
 		test.capture [[
@@ -256,6 +256,42 @@
 	Optimization="0"
 	BasicRuntimeChecks="3"
 	BufferSecurityCheck="false"
+	RuntimeLibrary="2"
+	EnableFunctionLevelLinking="true"
+	UsePrecompiledHeader="0"
+	WarningLevel="3"
+	DebugInformationFormat="0"
+/>
+		]]
+	end
+
+	function suite.noBufferSecurityFlagSet_onBufferSecurityCheck_ViaAPI()
+		buffersecuritycheck "Off"
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	Optimization="0"
+	BasicRuntimeChecks="3"
+	BufferSecurityCheck="false"
+	RuntimeLibrary="2"
+	EnableFunctionLevelLinking="true"
+	UsePrecompiledHeader="0"
+	WarningLevel="3"
+	DebugInformationFormat="0"
+/>
+		]]
+	end
+
+	function suite.bufferSecurityFlagSet_onBufferSecurityCheck_ViaAPI()
+		buffersecuritycheck "On"
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	Optimization="0"
+	BasicRuntimeChecks="3"
+	BufferSecurityCheck="true"
 	RuntimeLibrary="2"
 	EnableFunctionLevelLinking="true"
 	UsePrecompiledHeader="0"

--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -713,7 +713,7 @@
 		]]
 	end
 
-	function suite.runtimeTypeInfo_onNoBufferSecurityCheck()
+	function suite.runtimeTypeInfo_onNoBufferSecurityCheck_ViaFlag()
 		flags "NoBufferSecurityCheck"
 		prepare()
 		test.capture [[
@@ -725,6 +725,29 @@
 		]]
 	end
 
+	function suite.runtimeTypeInfo_onNoBufferSecurityCheck_ViaAPI()
+		buffersecuritycheck "Off"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<BufferSecurityCheck>false</BufferSecurityCheck>
+		]]
+	end
+
+	function suite.runtimeTypeInfo_onBufferSecurityCheck_ViaAPI()
+		buffersecuritycheck "On"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<BufferSecurityCheck>true</BufferSecurityCheck>
+		]]
+	end
 
 --
 -- On Win32 builds, use the Edit-and-Continue debug information format.

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -879,8 +879,10 @@
 
 
 	function m.bufferSecurityCheck(cfg)
-		if cfg.flags.NoBufferSecurityCheck then
+		if cfg.buffersecuritycheck == p.OFF then
 			p.w('BufferSecurityCheck="false"')
+		elseif cfg.buffersecuritycheck == p.ON then
+			p.w('BufferSecurityCheck="true"')
 		end
 	end
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -3379,8 +3379,10 @@
 
 	function m.bufferSecurityCheck(cfg)
 		local tool, toolVersion = p.config.toolset(cfg)
-		if cfg.flags.NoBufferSecurityCheck or (toolVersion and toolVersion:startswith("LLVM-vs")) then
+		if cfg.buffersecuritycheck == p.OFF or (toolVersion and toolVersion:startswith("LLVM-vs")) then
 			m.element("BufferSecurityCheck", nil, "false")
+		elseif cfg.buffersecuritycheck == p.ON then
+			m.element("BufferSecurityCheck", nil, "true")
 		end
 	end
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -277,7 +277,8 @@
 		filter "configurations:Release"
 			defines     "NDEBUG"
 			optimize    "Full"
-			flags       { "NoBufferSecurityCheck", "NoRuntimeChecks" }
+			flags       { "NoRuntimeChecks" }
+			buffersecuritycheck "Off"
 
 		filter "action:vs*"
 			defines     { "_CRT_SECURE_NO_DEPRECATE", "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_WARNINGS" }

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1245,6 +1245,24 @@
 		multiprocessorcompile("Default")
 	end)
 
+	api.register {
+		name = "buffersecuritycheck",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off"
+		}
+	}
+
+	api.deprecateValue("flags", "NoBufferSecurityCheck", "Use `buffersecuritycheck` instead.",
+	function(value)
+		buffersecuritycheck("Off")
+	end,
+	function(value)
+		buffersecuritycheck("Default")
+	end)
 
 -----------------------------------------------------------------------------
 --

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -243,9 +243,6 @@
 		exceptionhandling = {
 			Off = "-fno-exceptions"
 		},
-		flags = {
-			NoBufferSecurityCheck = "-fno-stack-protector",
-		},
 		cppdialect = {
 			["C++98"] = "-std=c++98",
 			["C++0x"] = "-std=c++0x",
@@ -270,6 +267,10 @@
 			["gnu++2b"] = "-std=gnu++2b",
 			["gnu++23"] = "-std=gnu++23",
 			["C++latest"] = "-std=c++23",
+		},
+		buffersecuritycheck = {
+			Off = "-fno-stack-protector",
+			On = "-fstack-protector"
 		},
 		rtti = {
 			Off = "-fno-rtti"

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -429,10 +429,22 @@
 		test.contains({ "-fno-exceptions" }, gcc.getcxxflags(cfg))
 	end
 
-	function suite.cxxflags_onNoBufferSecurityCheck()
+	function suite.cxxflags_onNoBufferSecurityCheck_ViaFlag()
 		flags { "NoBufferSecurityCheck" }
 		prepare()
 		test.contains({ "-fno-stack-protector" }, gcc.getcxxflags(cfg))
+	end
+
+	function suite.cxxflags_onNoBufferSecurityCheck_ViaAPI()
+		buffersecuritycheck "Off"
+		prepare()
+		test.contains({ "-fno-stack-protector" }, gcc.getcxxflags(cfg))
+	end
+
+	function suite.cxxflags_onBufferSecurityCheck_ViaAPI()
+		buffersecuritycheck "On"
+		prepare()
+		test.contains({ "-fstack-protector" }, gcc.getcxxflags(cfg))
 	end
 
 	function suite.cxxflags_onSanitizeAddress()

--- a/website/docs/buffersecuritycheck.md
+++ b/website/docs/buffersecuritycheck.md
@@ -1,0 +1,32 @@
+Specifies whether to use stack and buffer protections.
+
+```lua
+buffersecuritycheck "value"
+```
+
+### Parameters ###
+
+*value* specifies if buffer security checks should be enabled.
+
+| Value   | Description                                            |
+|---------|--------------------------------------------------------|
+| Off     | Disable buffer security checks.                        |
+| On      | Enable buffer security checks.                         |
+| Default | Use the default buffer security checks.                |
+
+### Applies To ###
+
+The `config` scope.
+
+### Availability ###
+
+Premake 5.0-beta8 or later.
+
+### Examples ###
+
+```lua
+buffersecuritycheck "On"
+```
+
+[1]: https://learn.microsoft.com/en-us/cpp/build/reference/gs-buffer-security-check?view=msvc-170
+[2]: https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/Instrumentation-Options.html#Instrumentation-Options

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -19,7 +19,7 @@ flags { "flag_list" }
 | MFC                   | Enable support for Microsoft Foundation Classes. Deprecated in Premake 5.0.0-beta4. Use `mfc` API instead. | Removed in Premake 5.0.0-beta8 |
 | MultiProcessorCompile | Enable Visual Studio to use multiple compiler processes when building. Deprecated in Premake 5.0.0-beta8. Use `multiprocessorcompile` API instead. |
 | No64BitChecks         | Disable 64-bit portability warnings. Deprecated in Premake 5.0.0-beta8. Use `enable64bitchecks` API instead. |
-| NoBufferSecurityCheck | Turn off stack protection checks.                                   |
+| NoBufferSecurityCheck | Turn off stack protection checks. Deprecated in Premake 5.0.0-beta8. Use `buffersecuritycheck` API instead. |
 | NoCopyLocal           | Prevent referenced assemblies from being copied to the target directory (C#) |
 | NoImplicitLink        | Disable Visual Studio's default behavior of automatically linking dependent projects. |
 | NoImportLib           | Prevent the generation of an import library for a Windows DLL.      |
@@ -57,6 +57,7 @@ flags { "LinkTimeOptimization" }
 
 ### See Also ###
 
+* [buffersecuritycheck](buffersecuritycheck.md)
 * [fatalwarnings](fatalwarnings.md)
 * [linktimeoptimization](linktimeoptimization.md)
 * [mfc](mfc.md)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -70,6 +70,7 @@ module.exports = {
 						'atl',
 						'basedir',
 						'bindirs',
+						'buffersecuritycheck',
 						'buildaction',
 						'buildcommands',
 						'buildcustomizations',


### PR DESCRIPTION
**What does this PR do?**

Deprecates the existing `NoBufferSecurityCheck` Flag and adds a dedicated `buffersecuritycheck` API.

**How does this PR change Premake's behavior?**

No breaking changes.

**Anything else we should know?**

Preparation for 5.0

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
