### PR TITLE
Link library dependencies respect exporter defaults

### DIFF
--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2943,7 +2943,9 @@
 		-- that has been excluded from the build. As a workaround, disable dependency
 		-- linking and list all siblings explicitly
 		p.push('<ProjectReference>')
-		m.element("LinkLibraryDependencies", nil, iif(explicit, "false", "true"))
+		if explicit or cfg.implicitlink ~= nil then
+			m.element("LinkLibraryDependencies", nil, iif(explicit, "false", "true"))
+		end
 		p.pop('</ProjectReference>')
 	end
 


### PR DESCRIPTION
**What does this PR do?**

Respect VS exporter defaults for `implicitlinks`.

**How does this PR change Premake's behavior?**

No breaking changes from prior premake releases.

**Anything else we should know?**

Fixes small bug from #2568 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
