### PR TITLE
Deprecate NoLocalCopy flag

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -727,7 +727,7 @@
 	p.api.addAllowed("vectorextensions", { "NEON", "MXU" })
 	p.api.addAllowed("exceptionhandling", {"UnwindTables"})
 	p.api.addAllowed("kind", p.PACKAGING)
-	p.api.addAllowed("flags", { "NoImplicitLink" })
+	p.api.addAllowed("flags", { "NoImplicitLink", "NoCopyLocal" })
 
 	p.api.register {
 		name = "implicitlink",
@@ -746,6 +746,24 @@
 	end,
 	function(value)
 		implicitlink("Default")
+	end)
+
+	p.api.register {
+		name = "allowcopylocal",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off"
+		}
+	}
+
+	p.api.deprecateValue("flags", "NoCopyLocal", "Use `allowcopylocal {}` instead.", function(value)
+		allowcopylocal("Off")
+	end,
+	function(value)
+		allowcopylocal("Default")
 	end)
 
 --

--- a/modules/vstudio/tests/cs2005/test_assembly_refs.lua
+++ b/modules/vstudio/tests/cs2005/test_assembly_refs.lua
@@ -133,9 +133,29 @@
 -- NoCopyLocal flag has been set for the configuration.
 --
 
-	function suite.markedPrivate_onNoCopyLocal()
+	function suite.markedPrivate_onNoCopyLocal_ViaFlag()
 		links { "../Libraries/nunit.framework" }
 		flags { "NoCopyLocal" }
+		prepare()
+		test.capture [[
+	<ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<Reference Include="nunit.framework">
+			<HintPath>..\Libraries\nunit.framework.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+	</ItemGroup>
+	<ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<Reference Include="nunit.framework">
+			<HintPath>..\Libraries\nunit.framework.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+	</ItemGroup>
+		]]
+	end
+
+	function suite.markedPrivate_onNoCopyLocal_ViaAPI()
+		links { "../Libraries/nunit.framework" }
+		allowcopylocal "Off"
 		prepare()
 		test.capture [[
 	<ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -286,10 +306,39 @@ end
 --
 
 if http ~= nil and _OPTIONS["test-all"] then
-	function suite.nugetPackages_onNoCopyLocal()
+	function suite.nugetPackages_onNoCopyLocal_ViaFlag()
 		dotnetframework "2.0"
 		nuget { "NUnit:3.6.1" }
 		flags { "NoCopyLocal" }
+		prepare()
+		test.capture [[
+	<ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<Reference Include="nunit.framework">
+			<HintPath>packages\NUnit.3.6.1\lib\net20\nunit.framework.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="NUnit.System.Linq">
+			<HintPath>packages\NUnit.3.6.1\lib\net20\NUnit.System.Linq.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+	</ItemGroup>
+	<ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<Reference Include="nunit.framework">
+			<HintPath>packages\NUnit.3.6.1\lib\net20\nunit.framework.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="NUnit.System.Linq">
+			<HintPath>packages\NUnit.3.6.1\lib\net20\NUnit.System.Linq.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+	</ItemGroup>
+		]]
+	end
+
+	function suite.nugetPackages_onNoCopyLocal_ViaAPI()
+		dotnetframework "2.0"
+		nuget { "NUnit:3.6.1" }
+		allowcopylocal "Off"
 		prepare()
 		test.capture [[
 	<ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/modules/vstudio/tests/cs2005/test_project_refs.lua
+++ b/modules/vstudio/tests/cs2005/test_project_refs.lua
@@ -96,9 +96,24 @@
 -- NoCopyLocal flag has been set for the configuration.
 --
 
-	function suite.markedPrivate_onNoCopyLocal()
+	function suite.markedPrivate_onNoCopyLocal_ViaFlag()
 		links { "MyProject" }
 		flags { "NoCopyLocal" }
+		prepare()
+		test.capture [[
+	<ItemGroup>
+		<ProjectReference Include="MyProject.vcproj">
+			<Project>{00112233-4455-6677-8888-99AABBCCDDEE}</Project>
+			<Name>MyProject</Name>
+			<Private>False</Private>
+		</ProjectReference>
+	</ItemGroup>
+		]]
+	end
+
+	function suite.markedPrivate_onNoLocalCopy_ViaAPI()
+		links { "MyProject" }
+		allowcopylocal "Off"
 		prepare()
 		test.capture [[
 	<ItemGroup>

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -341,7 +341,6 @@
 			"Maps",
 			"MultiProcessorCompile",
 			"No64BitChecks",
-			"NoCopyLocal",
 			"NoImportLib",         -- DEPRECATED
 			"NoIncrementalLink",
 			"NoManifest",

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -446,7 +446,7 @@
 --
 
 	function config.isCopyLocal(cfg, linkname, default)
-		if cfg.flags.NoCopyLocal then
+		if cfg.allowcopylocal == p.OFF then
 			return false
 		end
 

--- a/website/docs/allowcopylocal.md
+++ b/website/docs/allowcopylocal.md
@@ -1,0 +1,27 @@
+Specifies whether or not to allow for copy local of assemblies.
+
+```lua
+allowcopylocal "value"
+```
+
+### Parameters ###
+
+`value` specifies the desired copy mode:
+
+| Value       | Description                                                       |
+|-------------|-------------------------------------------------------------------|
+| Default     | Perform the default copy local mechanism for the exporter.        |
+| Off         | Do not copy local assemblies to the output directory.             |
+| On          | Allow the local assemblies to be copied to the output directory.  |
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0-beta8 or later for Visual Studio C# Projects.
+
+### See Also ###
+
+* [copylocal](copylocal.md)

--- a/website/docs/copylocal.md
+++ b/website/docs/copylocal.md
@@ -6,7 +6,7 @@ copylocal { "libraries" }
 
 If a project includes multiple calls to `copylocal` the lists are concatenated, in the order in which they appear in the script.
 
-Note that, by default, all referenced non-system assemblies in a C# project are copied. This function only needs to called when a subset of the referenced assemblies should be copied. To disable copying of *all* references, use the `NoLocalCopy` build flag instead (see Examples, below).
+Note that, by default, all referenced non-system assemblies in a C# project are copied. This function only needs to called when a subset of the referenced assemblies should be copied. To disable copying of *all* references, use the `allowcopylocal` API.
 
 ### Parameters ###
 
@@ -36,8 +36,8 @@ links { "Renderer", "../ThirdParty/nunit.framework" }
 copylocal { "../ThirdParty/nunit.framework" }
 ```
 
-If you want to prevent any assemblies from being copied, use the **NoLocalCopy** flag instead.
+If you want to prevent any assemblies from being copied, use the **allowcopylocal** API instead.
 
 ```lua
-flags { "NoCopyLocal" }
+allowcopylocal "Off"
 ```

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -20,7 +20,7 @@ flags { "flag_list" }
 | MultiProcessorCompile | Enable Visual Studio to use multiple compiler processes when building. Deprecated in Premake 5.0.0-beta8. Use `multiprocessorcompile` API instead. |
 | No64BitChecks         | Disable 64-bit portability warnings. Deprecated in Premake 5.0.0-beta8. Use `enable64bitchecks` API instead. |
 | NoBufferSecurityCheck | Turn off stack protection checks. Deprecated in Premake 5.0.0-beta8. Use `buffersecuritycheck` API instead. |
-| NoCopyLocal           | Prevent referenced assemblies from being copied to the target directory (C#) |
+| NoCopyLocal           | Prevent referenced assemblies from being copied to the target directory (C#). Deprecated in Premake 5.0.0-beta8. Use `allowcopylocal` API instead. |
 | NoImplicitLink        | Disable Visual Studio's default behavior of automatically linking dependent projects. Deprecated in Premake 5.0.0-beta8. Use `implicitlink` API instead. |
 | NoImportLib           | Prevent the generation of an import library for a Windows DLL.      |
 | NoIncrementalLink     | Disable support for Visual Studio's incremental linking feature.    |
@@ -57,7 +57,9 @@ flags { "LinkTimeOptimization" }
 
 ### See Also ###
 
+* [allowcopylocal](allowcopylocal.md)
 * [buffersecuritycheck](buffersecuritycheck.md)
+* [copylocal](copylocal.md)
 * [fatalwarnings](fatalwarnings.md)
 * [implicitlink](implicitlink.md)
 * [linktimeoptimization](linktimeoptimization.md)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -63,6 +63,7 @@ module.exports = {
 					label: 'Project Settings',
 					items: [
 						'allmodulespublic',
+						'allowcopylocal',
 						'androidapilevel',
 						'androidapplibname',
 						'architecture',


### PR DESCRIPTION
**What does this PR do?**

Deprecates the `NoCopyLocal` flag in favor of a dedicated API, `allowcopylocal`.

**How does this PR change Premake's behavior?**

No breaking changes, just deprecation.

**Anything else we should know?**

Preparation for 5.0

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
