### PR TITLE
Allow for absolute runpath directories

### DIFF
--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -439,19 +439,29 @@
 		end
 
 		for _, fullpath in ipairs(dirs) do
+			-- Try to make rpath relative to target dir
 			local rpath = path.getrelative(cfg.buildtarget.directory, fullpath)
-			if table.contains(os.getSystemTags(cfg.system), "darwin") then
-				rpath = "@loader_path/" .. rpath
-			elseif (cfg.system == p.LINUX) then
-				rpath = iif(rpath == ".", "", "/" .. rpath)
-				rpath = "$$ORIGIN" .. rpath
-			end
 
-			if mode == "linker" then
-				rpath = "-Wl,-rpath,'" .. rpath .. "'"
-			end
+			if path.isabsolute(rpath) then				
+				if mode == "linker" then
+					rpath = "-Wl,-rpath,'" .. rpath .. "'"
+				end
 
-			table.insert(result, rpath)
+				table.insert(result, rpath)
+			else
+				if table.contains(os.getSystemTags(cfg.system), "darwin") then
+					rpath = "@loader_path/" .. rpath
+				elseif (cfg.system == p.LINUX) then
+					rpath = iif(rpath == ".", "", "/" .. rpath)
+					rpath = "$$ORIGIN" .. rpath
+				end
+
+				if mode == "linker" then
+					rpath = "-Wl,-rpath,'" .. rpath .. "'"
+				end
+
+				table.insert(result, rpath)
+			end
 		end
 
 		return result

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -1400,3 +1400,36 @@ end
 		test.contains({ "-pg" }, gcc.getcxxflags(cfg))
 		test.contains({ "-pg" }, gcc.getldflags(cfg))
 	end
+
+--
+-- Test runpath dirs
+--
+
+	function suite.runpathdirs_onRelativeDir()	
+		local paths = { "libs" }
+		
+		runpathdirs(paths)
+		prepare()
+    
+		test.contains({ "-Wl,-rpath,'$$ORIGIN/libs'" }, gcc.getrunpathdirs(cfg, paths))
+	end
+
+
+	function suite.runpathdirs_onRelativeDir_macosx()	
+		local paths = { "libs" }
+		
+		system("MacOSX")
+		runpathdirs(paths)
+		prepare()
+	
+		test.contains({ "-Wl,-rpath,'@loader_path/libs'" }, gcc.getrunpathdirs(cfg, paths))
+	end
+
+	function suite.runpathdirs_onAbsoluteDir()	
+		local paths = { "/usr/local/lib/mylibs" }
+		
+		runpathdirs(paths)
+		prepare()
+	
+		test.contains({ "-Wl,-rpath,'/usr/local/lib/mylibs'" }, gcc.getrunpathdirs(cfg, paths))
+	end


### PR DESCRIPTION
**What does this PR do?**

Adds support for absolute rpath directories in Premake.

**How does this PR change Premake's behavior?**

Breaks any reliance on (incorrect) absolute directories referencing `$$ORIGIN` or `@loader_path`.

**Anything else we should know?**

Closes #2578 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
