### PR TITLE
Deprecate NoRuntimeChecks, add dedicated API

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -727,7 +727,7 @@
 	p.api.addAllowed("vectorextensions", { "NEON", "MXU" })
 	p.api.addAllowed("exceptionhandling", {"UnwindTables"})
 	p.api.addAllowed("kind", p.PACKAGING)
-	p.api.addAllowed("flags", { "NoImplicitLink", "NoCopyLocal" })
+	p.api.addAllowed("flags", { "NoImplicitLink", "NoCopyLocal", "NoRuntimeChecks" })
 
 	p.api.register {
 		name = "implicitlink",
@@ -764,6 +764,27 @@
 	end,
 	function(value)
 		allowcopylocal("Default")
+	end)
+
+	p.api.register {
+		name = "runtimechecks",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"Off",
+			"StackFrames",
+			"UninitializedVariables",
+			"FastChecks",
+		}
+	}
+
+	p.api.deprecateValue("flags", "NoRuntimeChecks", "Use `runtimechecks` instead.",
+	function(value)
+		runtimechecks("Off")
+	end,
+	function(value)
+		runtimechecks("Default")
 	end)
 
 --

--- a/modules/vstudio/tests/vc200x/test_compiler_block.lua
+++ b/modules/vstudio/tests/vc200x/test_compiler_block.lua
@@ -601,10 +601,78 @@
 <Tool
 	Name="VCCLCompilerTool"
 	Optimization="0"
+	BasicRuntimeChecks="0"
 	RuntimeLibrary="2"
 		]]
 	end
 
+
+--
+-- Check handling of the runtimechecks API with "Off" value.
+--
+
+	function suite.onRuntimeChecks_Off()
+		runtimechecks "Off"
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	Optimization="0"
+	BasicRuntimeChecks="0"
+	RuntimeLibrary="2"
+		]]
+	end
+
+
+--
+-- Check handling of the runtimechecks API with "StackFrames" value.
+--
+
+	function suite.onRuntimeChecks_StackFrames()
+		runtimechecks "StackFrames"
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	Optimization="0"
+	BasicRuntimeChecks="1"
+	RuntimeLibrary="2"
+		]]
+	end
+
+
+--
+-- Check handling of the runtimechecks API with "UninitializedVariables" value.
+--
+
+	function suite.onRuntimeChecks_UninitializedVariables()
+		runtimechecks "UninitializedVariables"
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	Optimization="0"
+	BasicRuntimeChecks="2"
+	RuntimeLibrary="2"
+		]]
+	end
+
+
+--
+-- Check handling of the runtimechecks API with "FastChecks" value.
+--
+
+	function suite.onRuntimeChecks_FastChecks()
+		runtimechecks "FastChecks"
+		prepare()
+		test.capture [[
+<Tool
+	Name="VCCLCompilerTool"
+	Optimization="0"
+	BasicRuntimeChecks="3"
+	RuntimeLibrary="2"
+		]]
+	end
 
 
 --

--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -895,6 +895,54 @@
 
 
 --
+-- Check handling of the runtimechecks API with "Off" value.
+--
+
+	function suite.onRuntimeChecks_Off()
+		runtimechecks "Off"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<BasicRuntimeChecks>Default</BasicRuntimeChecks>
+		]]
+	end
+
+
+--
+-- Check handling of the runtimechecks API with "FastChecks" value.
+--
+
+	function suite.onRuntimeChecks_FastChecks()
+		runtimechecks "FastChecks"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+		]]
+	end
+
+
+--
+-- Check handling of the runtimechecks API with "Default" value.
+--
+
+	function suite.onRuntimeChecks_Default()
+		runtimechecks "Default"
+		prepare()
+		test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+		]]
+	end
+
+
+--
 -- Check handling of the EnableMultiProcessorCompile flag.
 --
 

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -870,9 +870,17 @@
 		if not filecfg
 			and not config.isOptimizedBuild(cfg)
 			and cfg.clr == p.OFF
-			and not cfg.flags.NoRuntimeChecks
 		then
-			p.w('BasicRuntimeChecks="3"')
+			local runtimechecks = cfg.runtimechecks or "Default"
+			local map = {
+				Off = 0,
+				StackFrames = 1,
+				UninitializedVariables = 2,
+				FastChecks = 3,
+				Default = 3
+			}
+
+			p.w('BasicRuntimeChecks="%s"', map[runtimechecks])
 		end
 	end
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2218,15 +2218,23 @@
 
 	function m.basicRuntimeChecks(cfg, condition)
 		local prjcfg, filecfg = p.config.normalize(cfg)
-		local runtime = config.getruntime(prjcfg) or iif(config.isDebugBuild(cfg), "Debug", "Release")
-		if filecfg then
-			if filecfg.flags.NoRuntimeChecks or (config.isOptimizedBuild(filecfg) and runtime:endswith("Debug")) then
-				m.element("BasicRuntimeChecks", condition, "Default")
-			end
-		else
-			if prjcfg.flags.NoRuntimeChecks or (config.isOptimizedBuild(prjcfg) and runtime:endswith("Debug")) then
-				m.element("BasicRuntimeChecks", nil, "Default")
-			end
+
+		local function getruntimecheck(c)
+			local checks = {
+				Off = "Default", -- Per MSVC SDK docs, "Default" means no runtime checks
+				StackFrames = "StackFrameRuntimeCheck",
+				UninitializedVariables = "UninitializedLocalUsageCheck",
+				FastChecks = "EnableFastChecks",
+			}
+
+			local runtimecheck = c.runtimechecks
+			return checks[runtimecheck]
+			
+		end
+
+		local check = getruntimecheck(filecfg or prjcfg)
+		if check then
+			m.element("BasicRuntimeChecks", condition, check)
 		end
 	end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -346,7 +346,6 @@
 			"NoManifest",
 			"NoMinimalRebuild",
 			"NoPCH",
-			"NoRuntimeChecks",
 			"NoBufferSecurityCheck",
 			"OmitDefaultLibrary",
 			"RelativeLinks",

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -27,7 +27,7 @@ flags { "flag_list" }
 | NoManifest            | Prevent the generation of a manifest for Windows executables and shared libraries. Deprecated in Premake 5.0.0-beta8. Use `manifest` API instead. |
 | NoMinimalRebuild      | Disable Visual Studio's [minimal rebuild feature][1]. Deprecated in Premake 5.0.0-beta8. Use `minimalrebuild` API instead. | Visual Studio has deprecated this feature as of vs2015.|
 | NoPCH                 | Disable precompiled header support. If not specified, the toolset default behavior will be used. Deprecated in Premake 5.0.0-beta8. Use `enablepch` API instead. |
-| NoRuntimeChecks       | Disable Visual Studio's [default stack frame and uninitialized variable checks][2] on debug builds. |
+| NoRuntimeChecks       | Disable Visual Studio's [default stack frame and uninitialized variable checks][2] on debug builds. Deprecated in Premake 5.0.0-beta8. Use `runtimechecks` API instead. |
 | OmitDefaultLibrary    | Omit the specification of a runtime library in object files. Deprecated in Premake 5.0.0-beta8. Use `nodefaultlib` API instead. |
 | RelativeLinks         | Forces the linker to use relative paths to libraries instead of absolute paths. Deprecated in Premake 5.0.0-beta8. Use `userelativelinks` API instead. |
 | ShadowedVariables     | Warn when a variable, type declaration, or function is shadowed. Deprecated in Premake 5.0.0-beta8. Use `buildoptions` API instead to add compile warnings. |

--- a/website/docs/runtimechecks.md
+++ b/website/docs/runtimechecks.md
@@ -1,0 +1,43 @@
+Controls whether runtime error checking is enabled for Visual Studio C/C++ projects.
+
+```lua
+runtimechecks ("value")
+```
+
+If no value is set for a configuration, the toolset's default behavior will be used. By default, runtime checks are enabled for debug builds.
+
+### Parameters ###
+
+`value` specifies the desired behavior:
+
+| Value                  | Description                                          |
+|------------------------|------------------------------------------------------|
+| Off                    | Turns off runtime error checking                     | 
+| Default                | Use the toolset default behavior (Default value)     |
+| StackFrames            | Enables runtime checks for stack frames              |
+| UninitializedVariables | Enables runtime checks for uninitialized variables   |
+| FastChecks             | Enables all fast runtime checks                      |
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0.0-beta8 or later in Visual Studio only.
+
+### Examples ###
+
+Disable runtime checks:
+
+```lua
+runtimechecks "Off"
+```
+
+Enable runtime checks even in optimized builds:
+
+```lua
+filter { "configurations:Release" }
+	optimize "On"
+	runtimechecks "FastChecks"
+```

--- a/website/docs/userelativelinks.md
+++ b/website/docs/userelativelinks.md
@@ -22,7 +22,7 @@ Project configurations.
 
 ### Availability ###
 
-Premake 5.0.0-beta8 or later. Replaces the deprecated `RelativeLinks` flag.
+Premake 5.0.0-beta8 or later.
 
 ### Examples ###
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -247,6 +247,7 @@ module.exports = {
 						'runcodeanalysis',
 						'runpathdirs',
 						'runtime',
+						'runtimechecks',
 						'sanitize',
 						'scanformoduledependencies',
 						'shaderassembler',


### PR DESCRIPTION
**What does this PR do?**

Deprecates the NoRuntimeChecks flag. Adds a new API for `runtimechecks with the following fields:
* Default (uses exporter defaults)
* Off (performs no checks, maps to "Default" in IDE, maps to NoRuntimeChecks flag behavior)
* StackFrame (stack frame checks)
* UninitializedVariables (uninit variable checks)
* FastChecks (all fast checks)

**How does this PR change Premake's behavior?**

No breaking changes

**Anything else we should know?**

Prep for 5.0

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
