### PR TITLE
Explicit separation between excludefrombuild and buildaction None

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -133,7 +133,7 @@
 				for cfg in project.eachconfig(prj) do
 					local cfgname = codelite.cfgname(cfg)
 					local fcfg = p.fileconfig.getconfig(node, cfg)
-					if not fcfg or fcfg.buildaction == "None" then
+					if not fcfg or fcfg.excludefrombuild or fcfg.buildaction == "None" then
 						table.insert(excludesFromBuild, cfgname)
 					end
 				end

--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -160,7 +160,7 @@
 
 	function cpp.addFile(cfg, node)
 		local filecfg = fileconfig.getconfig(node, cfg)
-		if not filecfg or filecfg.buildaction == "None" then
+		if not filecfg or filecfg.buildaction == "None" or filecfg.excludefrombuild then
 			return
 		end
 

--- a/modules/gmake/gmake_utility.lua
+++ b/modules/gmake/gmake_utility.lua
@@ -88,7 +88,7 @@
 
 	function utility.addFile(cfg, node, prj)
 		local filecfg = fileconfig.getconfig(node, cfg)
-		if not filecfg or filecfg.buildaction == "None" then
+		if not filecfg or filecfg.buildaction == "None" or filecfg.excludefrombuild then
 			return
 		end
 

--- a/modules/gmakelegacy/gmakelegacy_cpp.lua
+++ b/modules/gmakelegacy/gmakelegacy_cpp.lua
@@ -292,7 +292,7 @@ end
 				local custom = false
 				for cfg in project.eachconfig(prj) do
 					local filecfg = fileconfig.getconfig(node, cfg)
-					if filecfg and filecfg.buildaction ~= "None" then
+					if filecfg and filecfg.buildaction ~= "None" and not filecfg.excludefrombuild then
 						incfg[cfg] = filecfg
 						custom = fileconfig.hasCustomBuildRule(filecfg)
 					else

--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -641,7 +641,7 @@ function m.buildFiles(cfg)
 		onleaf = function(node, depth)
 			local filecfg = fileconfig.getconfig(node, cfg)
 			if filecfg then
-				if filecfg.buildaction == "None" then
+				if filecfg.buildaction == "None" or filecfg.excludefrombuild then
 					return
 				end
 				
@@ -687,7 +687,7 @@ function m.buildFiles(cfg)
 		onleaf = function(node, depth)
 			local filecfg = fileconfig.getconfig(node, cfg)
 			if filecfg then
-				if filecfg.buildaction == "None" then
+				if filecfg.buildaction == "None" or filecfg.excludefrombuild then
 					return
 				end
 				

--- a/modules/vstudio/tests/vc200x/test_files.lua
+++ b/modules/vstudio/tests/vc200x/test_files.lua
@@ -434,10 +434,10 @@
 		]]
 	end
 
-	function suite.excludedFromBuild_onBuildActionNone()
+	function suite.excludedFromBuild_onExcludeAPI()
 		files { "hello.cpp" }
 		filter "files:hello.cpp"
-		buildaction "None"
+		excludefrombuild "On"
 		prepare()
 		test.capture [[
 <Files>
@@ -521,12 +521,12 @@
 	end
 
 	
-	function suite.excludedFromBuild_onCustomBuildRule_buildActionNone()
+	function suite.excludedFromBuild_onCustomBuildRule_excludeAPI()
 		files { "hello.cg" }
 		filter "files:**.cg"
 			buildcommands { "cgc $(InputFile)" }
 			buildoutputs { "$(InputName).obj" }
-			buildaction "None"
+			excludefrombuild "On"
 		prepare()
 		test.capture [[
 <Files>

--- a/modules/vstudio/tests/vc2010/test_files.lua
+++ b/modules/vstudio/tests/vc2010/test_files.lua
@@ -256,7 +256,9 @@
 		prepare()
 		test.capture [[
 <ItemGroup>
-	<None Include="hello.cpp" />
+	<ClCompile Include="hello.cpp">
+		<ExcludedFromBuild>true</ExcludedFromBuild>
+	</ClCompile>
 </ItemGroup>
 		]]
 	end
@@ -273,19 +275,20 @@
 		]]
 	end
 
-	function suite.excludedFromBuild_onBuildActionNone_Filtered()
+	function suite.excludedFromBuild_onAPI()
 		files { "hello.cpp" }
-		filter { "files:hello.cpp", "configurations:Debug" }
-		buildaction "None"
+		filter "files:hello.cpp"
+		excludefrombuild "On"
 		prepare()
 		test.capture [[
 <ItemGroup>
 	<ClCompile Include="hello.cpp">
-		<ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+		<ExcludedFromBuild>true</ExcludedFromBuild>
 	</ClCompile>
 </ItemGroup>
 		]]
 	end
+
 
 	function suite.excludedFromBuild_onResourceFile_excludedFile()
 		files { "hello.rc" }
@@ -308,7 +311,9 @@
 		prepare()
 		test.capture [[
 <ItemGroup>
-	<None Include="hello.rc" />
+	<ResourceCompile Include="hello.rc">
+		<ExcludedFromBuild>true</ExcludedFromBuild>
+	</ResourceCompile>
 </ItemGroup>
 		]]
 	end
@@ -325,15 +330,15 @@
 		]]
 	end
 
-	function suite.excludedFromBuild_onResourceFile_buildActionNone_Filtered()
+	function suite.excludedFromBuild_onResourceFile_viaAPI()
 		files { "hello.rc" }
-		filter { "files:hello.rc", "configurations:Debug" }
-		buildaction "None"
+		filter "files:hello.rc"
+		excludefrombuild "On"
 		prepare()
 		test.capture [[
 <ItemGroup>
 	<ResourceCompile Include="hello.rc">
-		<ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+		<ExcludedFromBuild>true</ExcludedFromBuild>
 	</ResourceCompile>
 </ItemGroup>
 		]]
@@ -347,34 +352,23 @@
 		prepare()
 		test.capture [[
 <ItemGroup>
-	<None Include="hello.rc" />
+	<ResourceCompile Include="hello.rc">
+		<ExcludedFromBuild>true</ExcludedFromBuild>
+	</ResourceCompile>
 </ItemGroup>
 		]]
 	end
 
-	function suite.excludedFromBuild_onResourceFile_buildActionNone_nonWindows()
+	function suite.excludedFromBuild_onResourceFile_viaAPI_nonWindows()
 		files { "hello.rc" }
 		system "Linux"
 		filter "files:hello.rc"
-		buildaction "None"
-		prepare()
-		test.capture [[
-<ItemGroup>
-	<None Include="hello.rc" />
-</ItemGroup>
-		]]
-	end
-
-	function suite.excludedFromBuild_onResourceFile_buildActionNone_nonWindows_Filtered()
-		files { "hello.rc" }
-		system "Linux"
-		filter { "files:hello.rc", "configurations:Debug" }
-		buildaction "None"
+		excludefrombuild "On"
 		prepare()
 		test.capture [[
 <ItemGroup>
 	<ResourceCompile Include="hello.rc">
-		<ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">true</ExcludedFromBuild>
+		<ExcludedFromBuild>true</ExcludedFromBuild>
 	</ResourceCompile>
 </ItemGroup>
 		]]
@@ -429,25 +423,6 @@
 		]]
 	end
 
-	function suite.excludedFromBuild_onCustomBuildRule_buildActionNone()
-		files { "hello.cg" }
-		filter "files:**.cg"
-			buildcommands { "cgc $(InputFile)" }
-			buildoutputs { "$(InputName).obj" }
-			buildaction "None"
-		prepare()
-		test.capture [[
-<ItemGroup>
-	<CustomBuild Include="hello.cg">
-		<FileType>Document</FileType>
-		<ExcludedFromBuild>true</ExcludedFromBuild>
-		<Command>cgc $(InputFile)</Command>
-		<Outputs>$(InputName).obj</Outputs>
-	</CustomBuild>
-</ItemGroup>
-		]]
-	end
-
 	function suite.excludedFromBuild_onCustomBuildRule_withNoCommands_excludeViaFlag()
 		files { "hello.cg" }
 		filter { "files:**.cg", "Debug" }
@@ -468,13 +443,13 @@
 		]]
 	end
 
-	function suite.excludedFromBuild_onCustomBuildRule_withNoCommands_buildActionNone()
+	function suite.excludedFromBuild_onCustomBuildRule_withNoCommands_excludeViaAPI()
 		files { "hello.cg" }
 		filter { "files:**.cg", "Debug" }
 			buildcommands { "cgc $(InputFile)" }
 			buildoutputs { "$(InputName).obj" }
 		filter { "files:**.cg" }
-			buildaction "None"
+			excludefrombuild "On"
 		prepare()
 		test.capture [[
 <ItemGroup>

--- a/modules/vstudio/vs200x_vcproj.lua
+++ b/modules/vstudio/vs200x_vcproj.lua
@@ -1086,7 +1086,7 @@
 
 
 	function m.excludedFromBuild(filecfg)
-		if not filecfg or filecfg.buildaction == "None" then
+		if not filecfg or filecfg.excludefrombuild then
 			p.w('ExcludedFromBuild="true"')
 		end
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1653,9 +1653,6 @@
 			end
 
 		else
-			local allNone = nil
-			local foundAction = nil
-
 			for cfg in project.eachconfig(prj) do
 				local fcfg = fileconfig.getconfig(file, cfg)
 				if fcfg then
@@ -1666,29 +1663,13 @@
 
 					-- also check for buildaction
 					if fcfg.buildaction then
-						if fcfg.buildaction ~= "None" then
-							allNone = false
-							foundAction = m.categories[fcfg.buildaction] or m.categories.None
-						else
-							allNone = foundAction == nil
-						end
-					else
-						-- If no buildaction is defined for this file config, it's not "None"
-						allNone = false
+						return m.categories[fcfg.buildaction] or m.categories.None
 					end
 
 					if fcfg.compileas ~= nil and fcfg.compileas ~= "Default" then
 						return m.categories.ClCompile
 					end
 				end
-			end
-
-			if not foundAction and allNone == true then
-				return m.categories.None
-			end
-
-			if foundAction then
-				return foundAction
 			end
 
 			-- If there is a custom rule associated with it, use that
@@ -2499,7 +2480,7 @@
 
 
 	function m.excludedFromBuild(filecfg, condition)
-		if not filecfg or filecfg.buildaction == "None" then
+		if not filecfg or filecfg.excludefrombuild then
 			m.element("ExcludedFromBuild", condition, "true")
 		end
 	end

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1303,7 +1303,7 @@
 						-- ms this seems to work on visual studio !!!
 						-- why not in xcode ??
 						local filecfg = fileconfig.getconfig(node, cfg)
-						if not filecfg or filecfg.buildaction == "None" then
+						if not filecfg or filecfg.buildaction == "None" or filecfg.excludefrombuild then
 						--fileNameList = fileNameList .. " " ..filecfg.name
 							table.insert(fileNameList, xcode.escapeArg(node.name))
 						end

--- a/modules/xcode/xcode_project.lua
+++ b/modules/xcode/xcode_project.lua
@@ -36,7 +36,7 @@
 		for cfg in premake.project.eachconfig(prj) do
 			local filecfg = premake.fileconfig.getconfig(node, cfg)
 			if filecfg then
-				local newValue = filecfg.buildaction == "None"
+				local newValue = filecfg.buildaction == "None" or filecfg.excludefrombuild
 				if value == nil then
 					value = newValue
 				elseif value ~= newValue then

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1457,44 +1457,12 @@
 		kind = "boolean",
 	}
 
-	api.deprecateValue("flags", "ExcludeFromBuild", "Use `excludefrombuild` to exclude projects or use `buildaction 'None'` to exclude files from compilation instead.",
+	api.deprecateValue("flags", "ExcludeFromBuild", "Use `excludefrombuild` API instead.",
 	function(value)
-		local currentscope = api.scope.current
-		local csetblocks = currentscope.blocks
-
-		local isfilefiltered = false
-		for _, block in ipairs(csetblocks) do
-			local crit = block._criteria
-			if crit and criteria.hasFilter(crit, "files") then
-				isfilefiltered = true
-				break
-			end
-		end
-
-		if isfilefiltered then
-			buildaction("None")
-		else
-			excludefrombuild("On")
-		end
+		excludefrombuild("On")
 	end,
 	function(value)
-		local currentscope = api.scope.current
-		local csetblocks = currentscope.blocks
-
-		local isfilefiltered = false
-		for _, block in ipairs(csetblocks) do
-			local crit = block._criteria
-			if crit and criteria.hasFilter(crit, "files") then
-				isfilefiltered = true
-				break
-			end
-		end
-
-		if isfilefiltered then
-			removebuildaction("None")
-		else
-			excludefrombuild("Off")
-		end
+		excludefrombuild("Off")
 	end)
 
 -----------------------------------------------------------------------------

--- a/src/base/criteria.lua
+++ b/src/base/criteria.lua
@@ -190,25 +190,3 @@
 		criteria._validPrefixes[prefix:lower()] = true
 	end
 
-	
----
--- Checks if a given criteria has a filter of the specified type.
---
--- @param crit
---    The criteria object to check.
--- @param type
---    The filter type to look for.
--- @return
---    True if the criteria has a filter of the specified type.
----
-
-	function criteria.hasFilter(crit, type)
-		for _, term in ipairs(crit.terms) do
-			if term:startswith(type .. ":") then
-				return true
-			end
-		end
-
-		return false
-	end
-

--- a/src/base/oven.lua
+++ b/src/base/oven.lua
@@ -168,7 +168,7 @@
 
 		local function addFile(cfg, node)
 			local filecfg = p.fileconfig.getconfig(node, cfg)
-			if not filecfg or filecfg.buildaction == "None" or not filecfg.compilebuildoutputs then
+			if not filecfg or filecfg.excludefrombuild or not filecfg.compilebuildoutputs then
 				return
 			end
 
@@ -850,7 +850,7 @@
 
 			for cfg in p.project.eachconfig(prj) do
 				local fcfg = p.fileconfig.getconfig(file, cfg)
-				if fcfg ~= nil and fcfg.buildaction ~= "None" then
+				if fcfg ~= nil and not fcfg.excludefrombuild then
 					oven.uniqueSequence(fcfg, cfg, sequences, bases)
 				end
 			end

--- a/website/docs/excludefrombuild.md
+++ b/website/docs/excludefrombuild.md
@@ -1,4 +1,4 @@
-Excludes a project from the build.
+Excludes a project from the build or a source file from a configuration.
 
 ```lua
 excludefrombuild "On"
@@ -6,7 +6,7 @@ excludefrombuild "On"
 
 ### Parameters ###
 
-*value* specifies whether to exclude project from build:
+*value* specifies whether to exclude project or source file from build:
 
 | Value       | Description                                  |
 |-------------|----------------------------------------------|
@@ -15,7 +15,7 @@ excludefrombuild "On"
 
 ### Applies To ###
 
-Project configurations.
+Project and file configurations.
 
 ### Availability ###
 

--- a/website/docs/flags.md
+++ b/website/docs/flags.md
@@ -10,7 +10,7 @@ flags { "flag_list" }
 
 | Flag                  | Description                                                         | Notes |
 |-----------------------|---------------------------------------------------------------------|----------------|
-| ExcludeFromBuild      | Exclude a source code file from the build, for the current configuration. Deprecated in Premake 5.0.0-beta8. Use `excludefrombuld` API to exclude a project from the build or `buildaction "None"` to exclude a file from the build instead. |
+| ExcludeFromBuild      | Exclude a source code file from the build, for the current configuration. Deprecated in Premake 5.0.0-beta8. Use `excludefrombuild` API instead. |
 | FatalCompileWarnings  | Treat compiler warnings as errors. Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. | Removed in Premake 5.0.0-beta8 |
 | FatalLinkWarnings     | Treat linker warnings as errors.  Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. | Removed in Premake 5.0.0-beta8 |
 | FatalWarnings         | Treat all warnings as errors; equivalent to FatalCompileWarnings, FatalLinkWarnings.  Deprecated in Premake 5.0.0-beta4. Use `fatalwarnings` API instead. | Removed in Premake 5.0.0-beta8 |
@@ -59,7 +59,6 @@ flags { "LinkTimeOptimization" }
 
 * [allowcopylocal](allowcopylocal.md)
 * [buffersecuritycheck](buffersecuritycheck.md)
-* [buildaction](buildaction.md)
 * [copylocal](copylocal.md)
 * [debugenvsinherit](debugenvsinherit.md)
 * [debugenvsmerge](debugenvsmerge.md)


### PR DESCRIPTION
**What does this PR do?**

Restores the behavior of the ExcludeFromBuild flag, but as part of the dedicated API.

**How does this PR change Premake's behavior?**

None

**Anything else we should know?**

Preparation for 5.0

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
