### PR TITLE
Remove remaining usages of flags in Premake

### DIFF
--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -563,7 +563,7 @@
 		local fcfg = fileconfig.getconfig(file, cfg)
 		local flags = {}
 
-		if cfg.pchheader and not cfg.flags.NoPCH and (not fcfg or not fcfg.flags.NoPCH) then
+		if cfg.pchheader and cfg.enablepch ~= p.OFF and (not fcfg or fcfg.enablepch ~= p.OFF) then
 			table.insert(flags, "-include $(PCH_PLACEHOLDER)")
 		end
 

--- a/modules/gmakelegacy/gmakelegacy_cpp.lua
+++ b/modules/gmakelegacy/gmakelegacy_cpp.lua
@@ -513,7 +513,7 @@ end
 
 	function make.forceInclude(cfg, toolset)
 		local includes = toolset.getforceincludes(cfg)
-		if not cfg.flags.NoPCH and cfg.pchheader then
+		if cfg.enablepch ~= p.OFF and cfg.pchheader then
 			table.insert(includes, 1, "-include $(OBJDIR)/$(notdir $(PCH))")
 		end
 		_x('  FORCE_INCLUDE +=%s', make.list(includes))

--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -532,7 +532,7 @@ function m.getLdFlags(cfg, toolset)
 end
 
 function m.getPchPath(cfg)
-	if not cfg.pchheader or cfg.flags.NoPCH then
+	if not cfg.pchheader or cfg.enablepch == p.OFF then
 		return nil
 	end
 	
@@ -552,7 +552,7 @@ function m.getPchPath(cfg)
 end
 
 function m.buildPch(cfg)
-	if not cfg.pchheader or cfg.flags.NoPCH then
+	if not cfg.pchheader or cfg.enablepch == p.OFF then
 		return nil
 	end
 	
@@ -806,7 +806,7 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 		local relPath = path.getrelative(cfg.workspace.location, node.abspath)
 		local implicitDeps = ""
 		
-		local usePch = cfg.pchheader and not cfg.flags.NoPCH and (not filecfg or not filecfg.flags.NoPCH)
+		local usePch = cfg.pchheader and cfg.enablepch ~= p.OFF and (not filecfg or filecfg.enablepch ~= p.OFF)
 		if pchFile and usePch then
 			implicitDeps = implicitDeps .. " | " .. pchFile
 		end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -4416,8 +4416,8 @@
 	end
 
 	function m.androidShortEnums(cfg)
-		if cfg.flags.UseShortEnums ~= nil then
-			m.element(UseShortEnums, nil, "true")
+		if cfg.useshortenums then
+			m.element("UseShortEnums", nil, iif(cfg.useshortenums == "On", "true", "false"))
 		end
 	end
 
@@ -4450,7 +4450,7 @@
 	end
 
 	function m.androidGenerateMapFile(cfg)
-		if cfg.flags.Maps then
+		if cfg.mapfile == p.ON then
 			-- Android specifies a name. Other platforms use the project name
 			-- so we do the same thing here
 			m.element("GenerateMapFile", nil, cfg.project.name..".map")

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1502,7 +1502,7 @@
 		local optimizeMap = { On = 3, Size = 's', Speed = 3, Full = 'fast', Debug = 'g' }
 		settings['GCC_OPTIMIZATION_LEVEL'] = optimizeMap[cfg.optimize] or 0
 
-		if cfg.pchheader and not cfg.flags.NoPCH then
+		if cfg.pchheader and cfg.enablepch ~= p.OFF then
 			settings['GCC_PRECOMPILE_PREFIX_HEADER'] = 'YES'
 			settings['GCC_PREFIX_HEADER'] = cfg.pchheader
 		end

--- a/premake5.lua
+++ b/premake5.lua
@@ -275,16 +275,16 @@
 			symbols	    "On"
 
 		filter "configurations:Release"
-			defines     "NDEBUG"
-			optimize    "Full"
-			flags       { "NoRuntimeChecks" }
+			defines             "NDEBUG"
+			optimize            "Full"
+			runtimechecks       "Off"
 			buffersecuritycheck "Off"
 
 		filter "action:vs*"
 			defines     { "_CRT_SECURE_NO_DEPRECATE", "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_WARNINGS" }
 
 		filter { "system:windows", "configurations:Release" }
-			flags       { "NoIncrementalLink" }
+			incrementallink "Off"
 
 		-- MinGW AR does not handle LTO out of the box and need a plugin to be setup
 		filter { "system:windows", "configurations:Release", "toolset:not gcc" }

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1465,6 +1465,21 @@
 		excludefrombuild("Off")
 	end)
 
+	api.register {
+		name = "useshortenums",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off"
+		}
+	}
+
+	api.deprecateField("flags", "Use dedicated APIs instead.",
+	function(value)
+	end)
+
 -----------------------------------------------------------------------------
 --
 -- Field name aliases for backward compatibility

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -445,8 +445,8 @@
 			end
 		else
 			local field = p.fields[name]
-			field.deprecated = field.deprecated or {}
-			field.deprecated[value] = {
+			field.deprecatedvalues = field.deprecatedvalues or {}
+			field.deprecatedvalues[value] = {
 				add = addHandler,
 				remove = removeHandler,
 				message = message
@@ -548,7 +548,7 @@
 			error(err, 3)
 		end
 
-		local hasDeprecatedValues = (type(field.deprecated) == "table")
+		local hasDeprecatedValues = (type(field.deprecatedvalues) == "table")
 
 		-- Build a list of values to be removed. If this field has deprecated
 		-- values, check to see if any of those are going to be removed by this
@@ -558,8 +558,8 @@
 		local removes = {}
 
 		local function check(value)
-			if field.deprecated[value] then
-				local handler = field.deprecated[value]
+			if field.deprecatedvalues[value] then
+				local handler = field.deprecatedvalues[value]
 				if handler.remove then handler.remove(value) end
 				if handler.message and api._deprecations ~= "off" then
 					local caller = filelineinfo(8)
@@ -597,7 +597,7 @@
 					error { msg=err }
 				end
 
-				if field.deprecated then
+				if field.deprecatedvalues then
 					check(value)
 				end
 
@@ -681,8 +681,8 @@
 				return nil, "invalid value '" .. value .. "' for " .. field.name
 			end
 
-			if field.deprecated and field.deprecated[canonical] then
-				local handler = field.deprecated[canonical]
+			if field.deprecatedvalues and field.deprecatedvalues[canonical] then
+				local handler = field.deprecatedvalues[canonical]
 				handler.add(canonical)
 				if handler.message and api._deprecations ~= "off" then
 					local caller =  filelineinfo(9)

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -73,6 +73,7 @@
 			Fast = "-flto=thin",
 		},
 		profile = gcc.shared.profile,
+		useshortenums = gcc.shared.useshortenums,
 	}
 
 	clang.cflags = table.merge(gcc.cflags, {

--- a/src/tools/dotnet.lua
+++ b/src/tools/dotnet.lua
@@ -149,11 +149,6 @@
 				info.SubType = fcfg.buildaction
 			end
 
-			-- This flag is deprecated, will remove eventually
-			if fcfg.flags and fcfg.flags.Component then
-				info.SubType = "Component"
-			end
-
 		end
 
 		if info.action == "Content" then

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -175,6 +175,10 @@
 		},
 		profile = {
 			On = "-pg",
+		},
+		useshortenums = {
+			On = "-fshort-enums",
+			Off = "-fno-short-enums",
 		}
 	}
 
@@ -381,7 +385,7 @@
 	-- relative pch file path if any
 	function gcc.getpch(cfg)
 		-- If there is no header, or if PCH has been disabled, I can early out
-		if not cfg.pchheader or cfg.flags.NoPCH then
+		if not cfg.pchheader or cfg.enablepch == p.OFF then
 			return nil
 		end
 

--- a/website/docs/useshortenums.md
+++ b/website/docs/useshortenums.md
@@ -1,0 +1,25 @@
+Specifies if short enums should be used.
+
+```lua
+useshortenums ("value")
+```
+
+If no value is set for a configuration, the toolset's default option will be used.
+
+### Parameters ###
+
+`value` specifies the desired wpf setting:
+
+| Value      | Description                                       | Notes |
+|------------|---------------------------------------------------|
+| Default    | Use the default behavior                          |
+| On         | Enums are backed by the smallest legal integral.  | Binaries compiled with short enums may not be ABI compatible with those without. It is recommended to compile all projects with the same setting. |
+| Off        | Enums are backed by the default integral.         |
+
+### Applies To ###
+
+Android projects in Visual Studio or any GCC/Clang project.
+
+### Availability ###
+
+Premake 5.0.0-beta8 or later.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -294,6 +294,7 @@ module.exports = {
 						'usefullpaths',
 						'useimportlib',
 						'uses',
+						'useshortenums',
 						'usestandardpreprocessor',
 						'usingdirs',
 						'uuid',


### PR DESCRIPTION
**What does this PR do?**

Deprecates flags, removes remaining usages of `flags`, and adds an API for missing flag (`useshortenums`).

**How does this PR change Premake's behavior?**

No breaking changes

**Anything else we should know?**

Preparation for 5.0

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
