### PR TITLE
Unify Architectures, Fix Aliases

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -709,7 +709,7 @@
 	}
 
 	p.api.addAllowed("system", p.ANDROID)
-	p.api.addAllowed("architecture", { "armv5", "armv7", "aarch64", "mips", "mips64", "arm" })
+	p.api.addAllowed("architecture", { "armv5", "armv7", "mips", "mips64" })
 	p.api.addAllowed("vectorextensions", { "NEON", "MXU" })
 	p.api.addAllowed("exceptionhandling", {"UnwindTables"})
 	p.api.addAllowed("kind", p.PACKAGING)

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -3033,8 +3033,7 @@
 		if cfg.system == p.WINDOWS then
 			if cfg.architecture == p.ARM then
 				p.w('<WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>')
-			end
-			if cfg.architecture == p.ARM64 then
+			elseif cfg.architecture == p.AARCH64 then
 				p.w('<WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>')
 			end
 		end
@@ -4349,10 +4348,10 @@
 
 			if (cfg.architecture ~= nil or cfg.toolchainversion ~= nil) and archMap[arch] ~= nil then
 				local defaultToolsetMap = {
-					arm = "arm-linux-androideabi-",
+					[ p.ARM ] = "arm-linux-androideabi-",
 					armv5 = "arm-linux-androideabi-",
 					armv7 = "arm-linux-androideabi-",
-					aarch64 = "aarch64-linux-android-",
+					[ p.AARCH64 ] = "aarch64-linux-android-",
 					mips = "mipsel-linux-android-",
 					mips64 = "mips64el-linux-android-",
 					x86 = "x86-",

--- a/modules/vstudio/vstudio.lua
+++ b/modules/vstudio/vstudio.lua
@@ -24,11 +24,11 @@
 
 	vstudio.vs200x_architectures =
 	{
-		win32   = "x86",
-		x86     = "x86",
-		x86_64  = "x64",
-		ARM     = "ARM",
-		ARM64   = "ARM64",
+		win32     = "x86",
+		x86       = "x86",
+		x86_64    = "x64",
+		ARM       = "ARM",
+		AARCH64   = "ARM64",
 	}
 
 	vstudio.vs2010_architectures =

--- a/premake5.lua
+++ b/premake5.lua
@@ -169,7 +169,7 @@
 		description = "Set the architecture of the binary to be built.",
 		allowed = {
 			{ "ARM", "ARM (On macOS, same as ARM64.)" },
-			{ "ARM64", "ARM64" },
+			{ "AARCH64", "AARCH64" },
 			{ "x86", "x86 (On macOS, same as x86_64.)" },
 			{ "x86_64", "x86_64" },
 			{ "ppc", "PowerPC 32-bit" },
@@ -178,6 +178,7 @@
 			--
 			{ "Win32", "Same as x86" },
 			{ "x64", "Same as x86_64" },
+			{ "ARM64", "Same as AARCH64" },
 		},
 		-- "Generates default platforms for targets, x86 and x86_64 projects for Windows." }
 		default = nil,
@@ -235,7 +236,7 @@
 		filter { "options:lua-src=contrib" }
 			defines { "LUA_STATICLIB" }
 
-		filter { "system:macosx", "options:arch=ARM or arch=ARM64" }
+		filter { "system:macosx", "options:arch=ARM or arch=AARCH64" }
 			buildoptions { "-arch arm64" }
 			linkoptions { "-arch arm64" }
 
@@ -258,7 +259,7 @@
 		filter { "system:windows", "options:arch=ARM" }
 			platforms { "ARM" }
 
-		filter { "system:windows", "options:arch=ARM64" }
+		filter { "system:windows", "options:arch=AARCH64" }
 			platforms { "ARM64" }
 
 		filter { "system:windows", "options:arch=x86 or arch=Win32" }

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -27,7 +27,7 @@
 			p.X86,
 			p.X86_64,
 			p.ARM,
-			p.ARM64,
+			p.AARCH64,
 			p.RISCV64,
 			p.LOONGARCH64,
 			p.PPC,
@@ -38,12 +38,16 @@
 			p.MIPS64EL
 		},
 		aliases = {
-			i386  = p.X86,
-			amd64 = p.X86_64,
-			x32   = p.X86,	-- these should be DEPRECATED
-			x64   = p.X86_64,
+			i386    = p.X86,
+			amd64   = p.X86_64,
+			x32     = p.X86,
+			x64     = p.X86_64,
+			ARM64   = p.AARCH64,
 		},
 	}
+
+	api.deprecateAlias("architecture", "i386", "Use 'x86' instead with `buildoptions { '-march=i386' }`.")
+	api.deprecateAlias("architecture", "x32", "Use 'x86' instead. There is no x32 ABI support currently.")
 
 	api.register {
 		name = "basedir",

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -63,7 +63,7 @@
 	premake.X86         = "x86"
 	premake.X86_64      = "x86_64"
 	premake.ARM         = "ARM"
-	premake.ARM64       = "ARM64"
+	premake.AARCH64     = "AARCH64"
 	premake.RISCV64     = "RISCV64"
 	premake.LOONGARCH64 = "loongarch64"
 	premake.PPC         = "ppc"

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -56,7 +56,7 @@
 		architecture = {
 			x86 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch i386", "-m32") end,
 			x86_64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch x86_64", "-m64") end,
-			ARM64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch arm64", nil) end,
+			AARCH64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch arm64", nil) end,
 		},
 		fatalwarnings = {
 			All = "-Werror",
@@ -504,7 +504,7 @@
 		architecture = {
 			x86 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch i386", "-m32") end,
 			x86_64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch x86_64", "-m64") end,
-			ARM64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch arm64", nil) end,
+			AARCH64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch arm64", nil) end,
 		},
 		linkerfatalwarnings = {
 			All = "-Wl,--fatal-warnings",

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -645,6 +645,6 @@ function suite.targetarch()
 	test.isequal(_TARGET_ARCH, os.targetarch())
 
 	-- --arch has priority over _TARGET_ARCH
-	_OPTIONS["arch"] = "arm64"
+	_OPTIONS["arch"] = "AARCH64"
 	test.isequal(_OPTIONS["arch"], os.targetarch())
 end

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -364,11 +364,25 @@ end
 		test.contains({ "-arch x86_64" }, clang.getldflags(cfg))
 	end
 
+	function suite.cflags_macosx_onAARCH64()
+		system "macosx"
+		architecture "AARCH64"
+		prepare()
+		test.contains({ "-arch arm64" }, clang.getcflags(cfg))
+	end
+
 	function suite.cflags_macosx_onarm64()
 		system "macosx"
 		architecture "arm64"
 		prepare()
 		test.contains({ "-arch arm64" }, clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_macosx_onAARCH64()
+		system "macosx"
+		architecture "AARCH64"
+		prepare()
+		test.contains({ "-arch arm64" }, clang.getldflags(cfg))
 	end
 
 	function suite.ldflags_macosx_onarm64()

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -644,16 +644,30 @@
 		test.contains({ "-arch x86_64" }, gcc.getldflags(cfg))
 	end
 
-	function suite.cflags_macosx_onarm64()
+	function suite.cflags_macosx_onAARCH64()
 		system "macosx"
-		architecture "arm64"
+		architecture "AARCH64"
 		prepare()
 		test.contains({ "-arch arm64" }, gcc.getcflags(cfg))
 	end
 
-	function suite.ldflags_macosx_onarm64()
+	function suite.cflags_macosx_onARM64()
 		system "macosx"
-		architecture "arm64"
+		architecture "ARM64"
+		prepare()
+		test.contains({ "-arch arm64" }, gcc.getcflags(cfg))
+	end
+
+	function suite.ldflags_macosx_onAARCH64()
+		system "macosx"
+		architecture "AARCH64"
+		prepare()
+		test.contains({ "-arch arm64" }, gcc.getldflags(cfg))
+	end
+
+	function suite.ldflags_macosx_onARM64()
+		system "macosx"
+		architecture "ARM64"
 		prepare()
 		test.contains({ "-arch arm64" }, gcc.getldflags(cfg))
 	end

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -14,7 +14,7 @@ architecture ("value")
 | x86         | x86 Architecture |
 | x86_64      | x86_64 Architecture |
 | ARM         | 32-bit ARM Architecture |
-| ARM64       | 64-bit ARM Architecture |
+| AARCH64     | 64-bit ARM Architecture |
 | RISCV64     | 64-bit RISCV Architecture |
 | loongarch64 | 64-bit LoongArch Architecture |
 | ppc         | 32-bit PowerPC Architecture |
@@ -25,7 +25,6 @@ architecture ("value")
 | mips64el    | 64-bit MIPS (Little Endian) Architecture |
 | armv5       | ARMv5 Architecture | Only supported in VSAndroid projects |
 | armv7       | ARMv7 Architecture | Only supported in VSAndroid projects |
-| aarch64     | 64-bit ARM Architecture | Only supported in VSAndroid projects |
 | mips        | 32-bit MIPS Architecture | Only supported in VSAndroid projects |
 | mips64      | 64-bit MIPS Architecture | Only supported in VSAndroid projects |
 
@@ -33,10 +32,11 @@ Additional values that are aliases for the above:
 
 | Value | Description |
 |-------|-------------|
-| i386 | Alias for `x86` |
+| ARM64 | Alias for `AARCH64` |
 | amd64 | Alias for `x86_64` |
-| x32 | Alias for `x86`. There is intent to deprecate this |
-| x64 | Alias for `x86_64`. There is intent to deprecate this |
+| i386  | Alias for `x86` | Deprecated in Premake 5.0.0-beta8. Use `x86` with `buildoptions { '-march=i386' }`. |
+| x32   | Alias for `x86`. | Deprecated in Premake 5.0.0-beta8. There is currently no support for `x32` ABI. |
+| x64   | Alias for `x86_64`. |
 
 ### Applies To ###
 


### PR DESCRIPTION
**What does this PR do?**

1. Uses AARCH64 for all 64 bit ARM architectures
2. Makes ARM64 an alias of AARCH64
3. Deprecates i386 and x32
  * `i386` - This should strictly be the original x86 architecture and mean `-m32 -march=i386` instead of an alias to `-m32`. This can be reintroduced as its own architecture in the future after deprecation period.
  * `x32` - This should be `-mx32` for the x32 ABI. Currently, this maps to `-m32` which is the x86 ABI, and thus is incorrect.

**How does this PR change Premake's behavior?**

No breaking changes to core. Third party libraries relying on `ARM64` rather than `AARCH64` will break.

**Anything else we should know?**

Preparation for 5.0

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
