### PR TITLE
Utilize existing tool version functionality for toolchainversion

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -638,7 +638,17 @@
 		"3.5",
 		"3.6",
 		"3.8",
-		"5.0", })
+		"5.0",
+	})
+
+	p.api.deprecateField("toolchainversion", "Use `toolchain 'gcc-<version>'` or `toolchain 'clang-<version>'` instead.",
+	function(value)
+		if value == "4.6" or value == "4.8" or value == "4.9" then
+			toolset("gcc-" .. value)
+		elseif value == "3.4" or value == "3.5" or value == "3.6" or value == "3.8" or value == "5.0" then
+			toolset("clang-" .. value)
+		end
+	end)
 
 	p.api.register {
 		name = "floatabi",

--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -119,9 +119,11 @@ return {
 	"android/test_android_build_settings.lua",
 	"android/test_android_files.lua",
 	"android/test_android_project.lua",
+	"android/test_android_toolset.lua",
 
 	-- Linux projects
 	"linux/test_linux_files.lua",
+	"linux/test_linux_toolchains.lua",
 
 	-- Visual Studio 2026+ Solutions
 	"sln2026/test_configurations.lua",

--- a/modules/vstudio/tests/android/test_android_toolset.lua
+++ b/modules/vstudio/tests/android/test_android_toolset.lua
@@ -1,0 +1,229 @@
+--
+-- tests/android/test_android_toolset.lua
+-- Unit tests for Visual Studio Android toolset handling.
+-- Author: Nick Clark
+-- Copyright (c) 2026 Jess Perkins and the Premake project
+--
+
+local p = premake
+local suite = test.declare("test_android_toolset")
+local vc2010 = p.vstudio.vc2010
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2015")
+		system "android"
+		architecture "ARM"
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepareConfigProperties()
+		system "android"
+		local cfg = test.getconfig(prj, "Debug", platform)
+		vc2010.configurationProperties(cfg)
+	end
+
+--
+-- Test Android GCC 4.6 toolchain mapping.
+--
+
+	function suite.androidGcc46Toolchain()
+		toolset "gcc-4.6"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>GCC_4_6</PlatformToolset>
+	]]
+	end
+
+	function suite.androidGcc46ToolsetVersion()
+		toolset "gcc"
+		toolchainversion "4.6"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>GCC_4_6</PlatformToolset>
+	]]
+	end
+
+--
+-- Test Android GCC 4.8 toolchain mapping.
+--
+
+	function suite.androidGcc48Toolchain()
+		toolset "gcc-4.8"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>GCC_4_8</PlatformToolset>
+	]]
+	end
+
+	function suite.androidGcc48ToolsetVersion()
+		toolset "gcc"
+		toolchainversion "4.8"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>GCC_4_8</PlatformToolset>
+	]]
+	end
+
+--
+-- Test Android GCC 4.9 toolchain mapping.
+--
+
+	function suite.androidGcc49Toolchain()
+		toolset "gcc-4.9"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>GCC_4_9</PlatformToolset>
+	]]
+	end
+
+	function suite.androidGcc49ToolsetVersion()
+		toolset "gcc"
+		toolchainversion "4.9"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>GCC_4_9</PlatformToolset>
+	]]
+	end
+
+--
+-- Test Android Clang 3.4 toolchain mapping.
+--
+	function suite.androidClang34Toolchain()
+		toolset "clang-3.4"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Clang_3_4</PlatformToolset>
+	]]
+	end
+
+	function suite.androidClang34ToolsetVersion()
+		toolset "clang"
+		toolchainversion "3.4"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Clang_3_4</PlatformToolset>
+	]]
+	end
+
+--
+-- Test Android Clang 3.5 toolchain mapping.
+--
+
+	function suite.androidClang35Toolchain()
+		toolset "clang-3.5"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Clang_3_5</PlatformToolset>
+	]]
+	end
+
+	function suite.androidClang35ToolsetVersion()
+		toolset "clang"
+		toolchainversion "3.5"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Clang_3_5</PlatformToolset>
+	]]
+	end
+
+--
+-- Test Android Clang 3.6 toolchain mapping.
+--
+
+	function suite.androidClang36Toolchain()
+		toolset "clang-3.6"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Clang_3_6</PlatformToolset>
+	]]
+	end
+
+	function suite.androidClang36ToolsetVersion()
+		toolset "clang"
+		toolchainversion "3.6"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Clang_3_6</PlatformToolset>
+	]]
+	end
+
+--
+-- Test Android Clang 3.8 toolchain mapping.
+--
+
+	function suite.androidClang38Toolchain()
+		toolset "clang-3.8"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Clang_3_8</PlatformToolset>
+	]]
+	end
+
+	function suite.androidClang38ToolsetVersion()
+		toolset "clang"
+		toolchainversion "3.8"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Clang_3_8</PlatformToolset>
+	]]
+	end
+
+--
+-- Test Android Clang 5.0 toolchain mapping.
+--
+
+	function suite.androidClang50Toolchain()
+		toolset "clang-5.0"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Clang_5_0</PlatformToolset>
+	]]
+	end
+
+	function suite.androidClang50ToolsetVersion()
+		toolset "clang"
+		toolchainversion "5.0"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Clang_5_0</PlatformToolset>
+	]]
+	end

--- a/modules/vstudio/tests/linux/test_linux_files.lua
+++ b/modules/vstudio/tests/linux/test_linux_files.lua
@@ -32,11 +32,12 @@ local vc2010 = p.vstudio.vc2010
 
 	function suite.linkTimeOptimization_On()
 		linktimeoptimization('on')
+		toolset('gcc-remote')
 		prepareConfigProperties()
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
 	<ConfigurationType>Application</ConfigurationType>
-	<PlatformToolset>v142</PlatformToolset>
+	<PlatformToolset>Remote_GCC_1_0</PlatformToolset>
 	<LinkTimeOptimization>true</LinkTimeOptimization>
 </PropertyGroup>
 		]]
@@ -48,11 +49,12 @@ local vc2010 = p.vstudio.vc2010
 
 	function suite.linkTimeOptimization_Fast()
 		linktimeoptimization('fast')
+		toolset('gcc-remote')
 		prepareConfigProperties()
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
 	<ConfigurationType>Application</ConfigurationType>
-	<PlatformToolset>v142</PlatformToolset>
+	<PlatformToolset>Remote_GCC_1_0</PlatformToolset>
 	<LinkTimeOptimization>true</LinkTimeOptimization>
 </PropertyGroup>
 		]]

--- a/modules/vstudio/tests/linux/test_linux_toolchains.lua
+++ b/modules/vstudio/tests/linux/test_linux_toolchains.lua
@@ -1,0 +1,184 @@
+--
+-- tests/vstudio/test_linux_toolchains.lua
+-- Unit tests for Visual Studio Linux toolchain handling.
+-- Author: Nick Clark
+-- Copyright (c) 2026 Jess Perkins and the Premake project
+--
+
+local p = premake
+local suite = test.declare("test_linux_toolchains")
+local vc2010 = p.vstudio.vc2010
+
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2019")
+		wks, prj = test.createWorkspace()
+	end
+
+	local function prepareOutputProperties()
+		system "linux"
+		local cfg = test.getconfig(prj, "Debug")
+		vc2010.outputProperties(cfg)
+	end
+
+	local function prepareConfigProperties()
+		system "linux"
+		local cfg = test.getconfig(prj, "Debug", platform)
+		vc2010.configurationProperties(cfg)
+	end
+
+--
+-- Test GCC toolchain remote mapping.
+--
+
+	function suite.remoteGccToolchain()
+		toolset "gcc-remote"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Remote_GCC_1_0</PlatformToolset>
+		]]
+	end
+
+	function suite.remoteGccToolsetVersion()
+		toolset "gcc"
+		toolchainversion "Remote"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Remote_GCC_1_0</PlatformToolset>
+		]]
+	end
+
+--
+-- Test WSL GCC toolchain mapping.
+--
+
+	function suite.wslGccToolchain()
+		toolset "gcc-wsl"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>WSL_1_0</PlatformToolset>
+		]]
+	end
+
+	function suite.wslGccToolsetVersion()
+		toolset "gcc"
+		toolchainversion "WSL"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>WSL_1_0</PlatformToolset>
+		]]
+	end
+
+--
+-- Test WSL2 GCC toolchain mapping.
+--
+
+	function suite.wsl2GccToolchain()
+		toolset "gcc-wsl2"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>WSL2_1_0</PlatformToolset>
+		]]
+	end
+
+	function suite.wsl2GccToolsetVersion()
+		toolset "gcc"
+		toolchainversion "WSL2"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>WSL2_1_0</PlatformToolset>
+		]]
+	end
+
+--
+-- Test Clang toolchain remote mapping.
+--
+
+	function suite.remoteClangToolchain()
+		toolset "clang-remote"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Remote_Clang_1_0</PlatformToolset>
+		]]
+	end
+
+	function suite.remoteClangToolsetVersion()
+		toolset "clang"
+		toolchainversion "Remote"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>Remote_Clang_1_0</PlatformToolset>
+		]]
+	end
+
+--
+-- Test WSL Clang toolchain mapping.
+--
+
+	function suite.wslClangToolchain()
+		toolset "clang-wsl"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>WSL_Clang_1_0</PlatformToolset>
+		]]
+	end
+
+	function suite.wslClangToolsetVersion()
+		toolset "clang"
+		toolchainversion "WSL"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>WSL_Clang_1_0</PlatformToolset>
+		]]
+	end
+
+--
+-- Test WSL2 Clang toolchain mapping.
+--
+
+	function suite.wsl2ClangToolchain()
+		toolset "clang-wsl2"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>WSL2_Clang_1_0</PlatformToolset>
+		]]
+	end
+
+	function suite.wsl2ClangToolsetVersion()
+		toolset "clang"
+		toolchainversion "WSL2"
+		prepareConfigProperties()
+		test.capture [[
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+	<ConfigurationType>Application</ConfigurationType>
+	<PlatformToolset>WSL2_Clang_1_0</PlatformToolset>
+		]]
+	end

--- a/website/docs/toolchainversion.md
+++ b/website/docs/toolchainversion.md
@@ -37,6 +37,7 @@ Project configurations.
 
 Premake 5.0.0-alpha14 or later, only applies to Android projects.
 Premake 5.0.0-beta3 or later, only applies to Visual Studio Linux projects.
+Deprecated in 5.0.0-beta8. Use `toolset` API with version instead, such as `toolset 'gcc-4.6'` or `toolset 'clang-wsl2'`.
 
 ### Examples ###
 

--- a/website/docs/toolset.md
+++ b/website/docs/toolset.md
@@ -46,3 +46,9 @@ Use the toolset for Windows XP
 ```lua
 toolset "v140_xp"
 ```
+
+Specify version 4.8 of GCC for Android
+```lua
+filter { "system:android" }
+   toolset "gcc-4.8"
+```


### PR DESCRIPTION
**What does this PR do?**

Merges `toolchainversion` functionality with `toolset`. Deprecates `toolchainversion` in favor of a single way to specify tooling versions. This also makes it clearer how versions get specified.

```lua
-- Old
toolset "gcc"
toolchainversion "4.8"

-- New
toolset "gcc-4.8"
```

**How does this PR change Premake's behavior?**

No behavior changes.

**Anything else we should know?**

Preparation for 5.0

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
