### PR TITLE
Normalize floatabi field values

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -655,11 +655,20 @@
 		scope = "config",
 		kind = "string",
 		allowed = {
-			"soft",
-			"softfp",
-			"hard",
+			"Soft",
+			"SoftFP",
+			"Hard",
 		},
+		aliases = {
+			[ "soft" ] = "Soft",
+			[ "softfp" ] = "SoftFP",
+			[ "hard" ] = "Hard",
+		}
 	}
+
+	p.api.deprecateAlias("floatabi", "soft", "Use `Soft` instead.")
+	p.api.deprecateAlias("floatabi", "softfp", "Use `SoftFP` instead.")
+	p.api.deprecateAlias("floatabi", "hard", "Use `Hard` instead.")
 
 	p.api.register {
 		name = "androidapilevel",
@@ -718,8 +727,13 @@
 		kind = "string"
 	}
 
+	p.ARMv5 = "ARMv5"
+	p.ARMv7 = "ARMv7"
+	p.MIPS   = "MIPS"
+	p.MIPS64 = "MIPS64"
+
 	p.api.addAllowed("system", p.ANDROID)
-	p.api.addAllowed("architecture", { "armv5", "armv7", "mips", "mips64" })
+	p.api.addAllowed("architecture", { p.ARMv5, p.ARMv7, p.MIPS, p.MIPS64 })
 	p.api.addAllowed("vectorextensions", { "NEON", "MXU" })
 	p.api.addAllowed("exceptionhandling", {"UnwindTables"})
 	p.api.addAllowed("kind", p.PACKAGING)
@@ -782,6 +796,19 @@
 	function(value)
 		runtimechecks("Default")
 	end)
+
+	-- Deprecate lower case versions of some architectures for consistency
+	p.api.addAliases("architecture", {
+		[ "armv5" ] = p.ARMv5,
+		[ "armv7" ] = p.ARMv7,
+		[ "mips" ] = p.MIPS,
+		[ "mips64" ] = p.MIPS64,
+	})
+
+	p.api.deprecateAlias("architecture", "armv5", "Use `ARMv5` instead.")
+	p.api.deprecateAlias("architecture", "armv7", "Use `ARMv7` instead.")
+	p.api.deprecateAlias("architecture", "mips", "Use `MIPS` instead.")
+	p.api.deprecateAlias("architecture", "mips64", "Use `MIPS64` instead.")
 
 --
 -- Decide when the full module should be loaded.

--- a/modules/vstudio/tests/_tests.lua
+++ b/modules/vstudio/tests/_tests.lua
@@ -118,6 +118,7 @@ return {
 	-- Android projects
 	"android/test_android_build_settings.lua",
 	"android/test_android_files.lua",
+	"android/test_android_floats.lua",
 	"android/test_android_project.lua",
 	"android/test_android_toolset.lua",
 

--- a/modules/vstudio/tests/android/test_android_floats.lua
+++ b/modules/vstudio/tests/android/test_android_floats.lua
@@ -1,0 +1,182 @@
+--
+-- test_android_floats.lua
+-- Test Android float settings
+-- Author: Nick Clark
+-- Copyright (c) 2026 Jess Perkins and the Premake project
+--
+
+local p = premake
+local suite = test.declare("test_android_floats")
+local vc2010 = p.vstudio.vc2010
+
+--
+-- Setup
+--
+
+	local wks, prj
+
+	function suite.setup()
+		p.action.set("vs2013")
+		wks = test.createWorkspace()
+	end
+
+	local function prepare()
+		prj = test.getproject(wks, 1)
+		system "android"
+		local cfg = test.getconfig(prj, "Debug", platform)
+		vc2010.androidAdditionalCompileOptions(cfg)
+		vc2010.gccClangAdditionalCompileOptions(cfg)
+	end
+
+
+--
+-- Test software floating point ABI on ARM
+--
+
+
+	function suite.softFloatingPoint_ARM()
+		floatabi "Soft"
+		architecture "ARM"
+		prepare()
+		test.capture [[
+<AdditionalOptions>-mfloat-abi=soft %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end
+
+
+--
+-- Test softfp floating point ABI on ARM
+--
+
+
+	function suite.softfpFloatingPoint_ARM()
+		floatabi "SoftFP"
+		architecture "ARM"
+		prepare()
+		test.capture [[
+<AdditionalOptions>-mfpu=vfp -mfloat-abi=softfp %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end
+
+
+--
+-- Test hard floating point ABI on ARM
+--
+
+
+	function suite.hardFloatingPoint_ARM()
+		floatabi "Hard"
+		architecture "ARM"
+		prepare()
+		test.capture [[
+<AdditionalOptions>-mfpu=vfp -mfloat-abi=hard %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end
+
+
+--
+-- Test software floating point ABI on ARMv7
+--
+
+
+	function suite.softFloatingPoint_ARMv7()
+		floatabi "Soft"
+		architecture "ARMv7"
+		prepare()
+		test.capture [[
+<AdditionalOptions>-mfloat-abi=soft %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end
+
+
+--
+-- Test softfp floating point ABI on ARMv7
+--
+
+
+	function suite.softfpFloatingPoint_ARMv7()
+		floatabi "SoftFP"
+		architecture "ARMv7"
+		prepare()
+		test.capture [[
+<AdditionalOptions>-mfpu=vfpv3-d16 -mfloat-abi=softfp %(AdditionalOptions)</AdditionalOptions>
+		]]
+
+	end
+
+
+--
+-- Test hard floating point ABI on ARMv7
+--
+
+
+	function suite.hardFloatingPoint_ARMv7()
+		floatabi "Hard"
+		architecture "ARMv7"
+		prepare()
+		test.capture [[
+<AdditionalOptions>-mfpu=vfpv3-d16 -mfloat-abi=hard %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end
+
+
+--
+-- Test soft floating point ABI on ARMv7 with Neon vector extensions
+--
+
+
+	function suite.softFloatingPoint_ARMv7_Neon()
+		floatabi "Soft"
+		architecture "ARMv7"
+		vectorextensions "Neon"
+		prepare()
+		test.capture [[
+<AdditionalOptions>-mfloat-abi=soft %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end
+	
+
+--
+-- Test softfp floating point ABI on ARMv7 with Neon vector extensions
+--
+
+	function suite.softfpFloatingPoint_ARMv7_Neon()
+		floatabi "SoftFP"
+		architecture "ARMv7"
+		vectorextensions "Neon"
+		prepare()
+		test.capture [[
+<AdditionalOptions>-mfpu=neon -mfloat-abi=softfp %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end
+
+
+--
+-- Test hard floating point ABI on ARMv7 with Neon vector extensions
+--
+
+	function suite.hardFloatingPoint_ARMv7_Neon()
+		floatabi "Hard"
+		architecture "ARMv7"
+		vectorextensions "Neon"
+		prepare()
+		test.capture [[
+<AdditionalOptions>-mfpu=neon -mfloat-abi=hard %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end
+
+
+--
+-- Test MIPS architecture with MXU vector extensions
+--
+
+
+function suite.mips_Mxu()
+		floatabi "Soft"
+		architecture "MIPS"
+		vectorextensions "MXU"
+		prepare()
+		test.capture [[
+<AdditionalOptions>-mmxu %(AdditionalOptions)</AdditionalOptions>
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -4216,7 +4216,7 @@
 				return false
 			end
 
-			if not cfg.architecture or string.startswith(cfg.architecture, "arm") then
+			if not cfg.architecture or string.startswith(cfg.architecture, p.ARM) then
 				-- we might want to define the arch to generate better code
 --				if not alreadyHas(cfg.buildoptions, "-march=") then
 --					if cfg.architecture == "armv6" then
@@ -4227,22 +4227,22 @@
 --				end
 
 				-- ARM has a comprehensive set of floating point options
-				if cfg.fpu ~= "Software" and cfg.floatabi ~= "soft" then
+				if cfg.fpu ~= "Software" and cfg.floatabi ~= "Soft" then
 
-					if cfg.architecture == "armv7" then
+					if cfg.architecture == p.ARMv7 then
 
 						-- armv7 always has VFP, may not have NEON
 
 						if not alreadyHas(cfg.buildoptions, "-mfpu=") then
 							if cfg.vectorextensions == "NEON" then
 								table.insert(cfg.buildoptions, "-mfpu=neon")
-							elseif cfg.fpu == "Hardware" or cfg.floatabi == "softfp" or cfg.floatabi == "hard" then
+							elseif cfg.fpu == "Hardware" or cfg.floatabi == "SoftFP" or cfg.floatabi == "Hard" then
 								table.insert(cfg.buildoptions, "-mfpu=vfpv3-d16") -- d16 is the lowest common denominator
 							end
 						end
 
 						if not alreadyHas(cfg.buildoptions, "-mfloat-abi=") then
-							if cfg.floatabi == "hard" then
+							if cfg.floatabi == "Hard" then
 								table.insert(cfg.buildoptions, "-mfloat-abi=hard")
 							else
 								-- Android should probably use softfp by default for compatibility
@@ -4255,22 +4255,22 @@
 						-- armv5/6 may not have VFP
 
 						if not alreadyHas(cfg.buildoptions, "-mfpu=") then
-							if cfg.fpu == "Hardware" or cfg.floatabi == "softfp" or cfg.floatabi == "hard" then
+							if cfg.fpu == "Hardware" or cfg.floatabi == "SoftFP" or cfg.floatabi == "Hard" then
 								table.insert(cfg.buildoptions, "-mfpu=vfp")
 							end
 						end
 
 						if not alreadyHas(cfg.buildoptions, "-mfloat-abi=") then
-							if cfg.floatabi == "softfp" then
+							if cfg.floatabi == "SoftFP" then
 								table.insert(cfg.buildoptions, "-mfloat-abi=softfp")
-							elseif cfg.floatabi == "hard" then
+							elseif cfg.floatabi == "Hard" then
 								table.insert(cfg.buildoptions, "-mfloat-abi=hard")
 							end
 						end
 
 					end
 
-				elseif cfg.floatabi == "soft" then
+				elseif cfg.floatabi == "Soft" then
 
 					table.insert(cfg.buildoptions, "-mfloat-abi=soft")
 
@@ -4282,7 +4282,7 @@
 					table.insert(cfg.buildoptions, "-mbig-endian")
 				end
 
-			elseif cfg.architecture == "mips" then
+			elseif cfg.architecture == p.MIPS then
 
 				-- TODO...
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -23,10 +23,10 @@ architecture ("value")
 | wasm64      | 64-bit WASM Architecture |
 | e2k         | Elbrus-2000 Architecture |
 | mips64el    | 64-bit MIPS (Little Endian) Architecture |
-| armv5       | ARMv5 Architecture | Only supported in VSAndroid projects |
-| armv7       | ARMv7 Architecture | Only supported in VSAndroid projects |
-| mips        | 32-bit MIPS Architecture | Only supported in VSAndroid projects |
-| mips64      | 64-bit MIPS Architecture | Only supported in VSAndroid projects |
+| ARMv5       | ARMv5 Architecture | Only supported in VSAndroid projects |
+| ARMv7       | ARMv7 Architecture | Only supported in VSAndroid projects |
+| MIPS        | 32-bit MIPS Architecture | Only supported in VSAndroid projects |
+| MIPS64      | 64-bit MIPS Architecture | Only supported in VSAndroid projects |
 
 Additional values that are aliases for the above:
 

--- a/website/docs/floatabi.md
+++ b/website/docs/floatabi.md
@@ -10,9 +10,9 @@ floatabi ("value")
 
 | Value | Description |
 |-------|-------------|
-| soft  | Compiler will generate software library calls for floating-point operations. |
-| softfp | Compiler will generate hardware floating-point instructions, but will still use software float calling conventions. |
-| hard | Compiler will generate floating-point instructions using FPU-specific calling conventions. |
+| Soft  | Compiler will generate software library calls for floating-point operations. |
+| SoftFP | Compiler will generate hardware floating-point instructions, but will still use software float calling conventions. |
+| Hard | Compiler will generate floating-point instructions using FPU-specific calling conventions. |
 
 ## Applies To ###
 


### PR DESCRIPTION
**What does this PR do?**

Clean up for 5.0, normalizes the `floatabi` valid values to be capitalized in a similar way to the rest of the APIs. Cleans up some surrounding capitalization issues with `architecture` that were exposed with this. Adds tests.

**How does this PR change Premake's behavior?**

No breaking changes. Deprecates the "lower" versions of the inputs.

**Anything else we should know?**

Preparation for 5.0. A follow up with normalize the rest of the architecture values.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
