### PR TITLE
[feature] Add `wholearchive`

### DIFF
--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -288,15 +288,7 @@ function m.configurationVariables(cfg)
 	
 	local links = toolset.getlinks(cfg)
 	if #links > 0 then
-		local wksLinks = {}
-		for _, link in ipairs(links) do
-			if not path.isabsolute(link) and link:match('[/\\]') then
-				local absPath = path.join(cfg.project.location, link)
-				link = path.getrelative(cfg.workspace.location, absPath)
-			end
-			table.insert(wksLinks, link)
-		end
-		_p("links_%s = %s", ninja.key(cfg), table.concat(wksLinks, " "))
+		_p("links_%s = %s", ninja.key(cfg), table.concat(links, " "))
 	end
 	
 	_p("objdir_%s = %s", ninja.key(cfg), project.getrelative(cfg.project, cfg.objdir))
@@ -1131,13 +1123,7 @@ function m.linkTarget(cfg)
 	local deps = config.getlinks(cfg, "siblings", "fullpath")
 	local implicitDeps = ""
 	if #deps > 0 then
-		local wksRelDeps = {}
-		for _, dep in ipairs(deps) do
-			local absPath = path.join(cfg.project.location, dep)
-			local relDep = path.getrelative(cfg.workspace.location, absPath)
-			table.insert(wksRelDeps, relDep)
-		end
-		implicitDeps = " | " .. table.concat(wksRelDeps, " ")
+		implicitDeps = " | " .. table.concat(deps, " ")
 	end
 	
 	-- Use pre-computed dependency targets if available, otherwise compute them inline

--- a/modules/vstudio/tests/vc2010/test_link.lua
+++ b/modules/vstudio/tests/vc2010/test_link.lua
@@ -7,7 +7,6 @@
 	local p = premake
 	local suite = test.declare("vs2010_link")
 	local vc2010 = p.vstudio.vc2010
-	local project = p.project
 
 
 --
@@ -877,6 +876,26 @@
 <Link>
 	<SubSystem>Windows</SubSystem>
 	<AdditionalDependencies>kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
+</Link>
+		]]
+	end
+
+
+--
+-- Whole archive should be listed in additional dependencies.
+--
+
+	function suite.wholearchive()
+		links { "MyProject2" }
+		wholearchive { "kernel32", "MyProject2" }
+		project "MyProject2"
+		kind "StaticLib"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<AdditionalDependencies>/WHOLEARCHIVE:kernel32;/WHOLEARCHIVE:bin\Debug\MyProject2.lib;%(AdditionalDependencies)</AdditionalDependencies>
 	<ImportLibrary>bin\Debug\MyProject.lib</ImportLibrary>
 </Link>
 		]]

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -1961,6 +1961,10 @@
 	function m.additionalDependencies(cfg, explicit)
 		local links
 
+		local toolgetrelative = p.tools.getrelative
+		p.tools.getrelative = function(...)
+			return path.translate(toolgetrelative(...))
+		end
 		-- check to see if this project uses an external toolset. If so, let the
 		-- toolset define the format of the links
 		local toolset = config.toolset(cfg)
@@ -1969,8 +1973,10 @@
 		else
 			links = vstudio.getLinks(cfg, explicit)
 		end
+		links = table.join(links, p.tools.msc.wholearchive(cfg))
+		p.tools.getrelative = toolgetrelative
 
-		links = path.translate(table.concat(links, ";"))
+		links = table.concat(links, ";")
 
 		local additional = ";%(AdditionalDependencies)"
 		if cfg.inheritdependencies ~= nil then

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1609,7 +1609,7 @@
 			end
 		end
 
-		settings['OTHER_LDFLAGS'] = table.join(flags, cfg.linkoptions)
+		settings['OTHER_LDFLAGS'] = table.join(flags, cfg.linkoptions, toolset.wholearchive(cfg))
 
 		if cfg.staticruntime == "On" then
 			settings['STANDARD_C_PLUS_PLUS_LIBRARY_TYPE'] = 'static'

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1026,6 +1026,12 @@
 	}
 
 	api.register {
+		name = "wholearchive",
+		scope = "config",
+		kind = "list:string"
+	}
+
+	api.register {
 		name = "editorintegration",
 		scope = "workspace",
 		kind = "boolean",

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -260,7 +260,7 @@
 
 		if part == "directory" then
 			table.foreachi(cfg.libdirs, function(dir)
-				table.insert(result, project.getrelative(cfg.project, dir))
+				table.insert(result, p.tools.getrelative(cfg.project, dir))
 			end)
 		end
 
@@ -294,7 +294,7 @@
 					if part == "object" then
 						item = prjcfg
 					else
-						item = project.getrelative(cfg.project, prjcfg.linktarget.fullpath)
+						item = p.tools.getrelative(cfg.project, prjcfg.linktarget.fullpath)
 					end
 
 				end
@@ -309,7 +309,7 @@
 					-- system library or assembly), make it project-relative
 					item = link
 					if item:find("/", nil, true) then
-						item = project.getrelative(cfg.project, item)
+						item = p.tools.getrelative(cfg.project, item)
 					end
 				end
 
@@ -343,6 +343,26 @@
 		return result
 	end
 
+--
+-- Return list of (non-decorated) wholearchive fullpath
+--
+
+	function config.getwholearchive(cfg)
+		local getfullpath = function(libraryname)
+			local prj = p.workspace.findproject(cfg.workspace, libraryname)
+			local prjcfg = prj and project.getconfig(prj, cfg.buildcfg, cfg.platform)
+			if prj and config.canLink(cfg, prjcfg) then -- is sibling project
+				return p.tools.getrelative(cfg.project, prjcfg.linktarget.fullpath)
+			else
+				if path.isabsolute(libraryname) then
+					return libraryname
+				else
+					return p.tools.getrelative(cfg.project, libraryname)
+				end
+			end
+		end
+		return table.translate(cfg.wholearchive, getfullpath)
+	end
 
 --
 -- Returns the list of sibling target directories

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -293,8 +293,13 @@
 		}
 	}
 
+	clang.wholearchive = gcc.wholearchive
+
 	function clang.getldflags(cfg)
 		local flags = config.mapFlags(cfg, clang.ldflags)
+
+		flags = table.join(flags, gcc.wholearchive(cfg))
+
 		return flags
 	end
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -609,8 +609,22 @@
 		}
 	}
 
+	function gcc.wholearchive(cfg)
+		if cfg.system == p.MACOSX then
+			return table.translate(config.getwholearchive(cfg), function(libraryname) return "-force_load " .. libraryname end)
+		else
+			if #cfg.wholearchive == 0 then
+				return {}
+			end
+			return table.join({ "-Wl,--whole-archive" }, config.getwholearchive(cfg), { "-Wl,--no-whole-archive" })
+		end
+	end
+
 	function gcc.getldflags(cfg)
 		local flags = config.mapFlags(cfg, gcc.ldflags)
+
+		flags = table.join(flags, gcc.wholearchive(cfg))
+
 		return flags
 	end
 

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -394,6 +394,10 @@
 		}
 	}
 
+	function msc.wholearchive(cfg)
+		return table.translate(config.getwholearchive(cfg), function(libraryname) return "/WHOLEARCHIVE:" .. libraryname end)
+	end
+
 	function msc.getldflags(cfg)
 		local map = iif(cfg.kind ~= p.STATICLIB, msc.linkerFlags, msc.librarianFlags)
 		local flags = config.mapFlags(cfg, map)
@@ -424,6 +428,8 @@
 				table.insert(flags, "/PROFILE")
 			end
 		end
+
+		flags = table.join(flags, msc.wholearchive(cfg))
 
 		return flags
 	end

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -8,7 +8,6 @@
 	local suite = test.declare("tools_gcc")
 
 	local gcc = p.tools.gcc
-	local project = p.project
 
 
 --
@@ -498,6 +497,27 @@
 		test.contains({ "-shared" }, gcc.getldflags(cfg))
 	end
 
+	function suite.ldflags_onWindows_onWholeArchive()
+		system "windows"
+		links { "MyProject2" }
+		wholearchive { "ole32", "MyProject2" }
+		project "MyProject2"
+		kind "StaticLib"
+		system "windows"
+		prepare()
+		test.isequal({ "-s", "-Wl,--whole-archive", "ole32", "bin/Debug/MyProject2.lib", "-Wl,--no-whole-archive" }, gcc.getldflags(cfg))
+	end
+
+	function suite.ldflags_onLinux_onWholeArchive()
+		system "linux"
+		links { "MyProject2" }
+		wholearchive { "ole32", "MyProject2" }
+		project "MyProject2"
+		kind "StaticLib"
+		system "linux"
+		prepare()
+		test.isequal({ "-s", "-Wl,--whole-archive", "ole32", "bin/Debug/libMyProject2.a", "-Wl,--no-whole-archive" }, gcc.getldflags(cfg))
+	end
 --
 -- Check Mac OS X variants on LDFLAGS.
 --
@@ -537,6 +557,17 @@
 		kind "SharedLib"
 		prepare()
 		test.contains({ "-dynamiclib" }, gcc.getldflags(cfg))
+	end
+
+	function suite.ldflags_onMacOSX_onWholeArchive()
+		system "MacOSX"
+		links { "MyProject2" }
+		wholearchive { "ole32", "MyProject2" }
+		project "MyProject2"
+		kind "StaticLib"
+		system "MacOSX"
+		prepare()
+		test.isequal({"-Wl,-x", "-force_load ole32", "-force_load bin/Debug/libMyProject2.a" }, gcc.getldflags(cfg))
 	end
 
 --

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -745,6 +745,17 @@ end
 		test.missing("/PROFILE", msc.getldflags(cfg))
 	end
 
+	function suite.ldflags_wholearchive()
+		system "windows"
+		links { "MyProject2" }
+		wholearchive { "kernel32", "MyProject2" }
+		project "MyProject2"
+		system "windows"
+		kind "StaticLib"
+		prepare()
+		test.isequal({"/NOLOGO", "/DLL", "/WHOLEARCHIVE:kernel32", "/WHOLEARCHIVE:bin/Debug/MyProject2.lib"}, msc.getldflags(cfg))
+	end
+
 --
 -- Check handling of CLR settings.
 --

--- a/website/docs/Project-API.md
+++ b/website/docs/Project-API.md
@@ -160,6 +160,7 @@
 | [vectorextensions](vectorextensions.md)                   | Enable hardware vector extensions |
 | [vpaths](vpaths.md)                                       |  |
 | [warnings](warnings.md)                                   |  |
+| [wholearchive](wholearchive.md)                           |  |
 | [workspace](workspace.md)                                 |  |
 
 ### Builtin Extension APIs ###

--- a/website/docs/wholearchive.md
+++ b/website/docs/wholearchive.md
@@ -1,0 +1,32 @@
+Command linker to include all objects of given libraries.
+
+```lua
+wholearchive { "libraries" }
+```
+
+### Parameters ###
+
+`libraries` is the list of static libraries for which to include all their symbols.
+
+### Availability ###
+
+Premake 5.0 or later.
+
+### Examples ###
+
+```lua
+project 'some_library'
+    kind 'StaticLib'
+    defines { 'MAKING_DLL_LIB' } -- for dllexport
+-- ..
+project 'some_dll'
+    kind 'SharedLib'
+    defines { 'MAKING_DLL_LIB' } -- for dllexport
+    links { 'some_library' }
+    wholearchive { 'some_library' }
+-- ..
+```
+
+### See Also ###
+
+* [links](links.md)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -299,6 +299,7 @@ module.exports = {
 						'vpaths',
 						'vsprops',
 						'warnings',
+						'wholearchive',
 						'workspace',
 						'wpf',
 						'xcodebuildresources',


### PR DESCRIPTION
**What does this PR do?**

Add `wholearchive` API which correspond to link option
- [`/WHOLEARCHIVE`](https://learn.microsoft.com/en-us/cpp/build/reference/wholearchive-include-all-library-object-files)
- `--whole-archive` of [ld](https://linux.die.net/man/1/ld)
- [`-force_load`](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang2-force_load)

**How does this PR change Premake's behavior?**

Add an API

**Anything else we should know?**

Tested with https://github.com/Jarod42/premake-sample-projects/tree/wholearchive/projects/wholearchive

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
