### PR TITLE
add {COPYFILEIFNEWER} token

### DIFF
--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -361,6 +361,37 @@
 	end
 
 --
+-- os.translateCommand() COPYFILEIFNEWER tests
+--
+	function suite.translateCommand_windowsCopyFileIfNewer()
+		test.isequal('xcopy /D /Y a b*', os.translateCommands('{COPYFILEIFNEWER} a b', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyFileIfNewerWithSpaces()
+		test.isequal('xcopy /D /Y "a a" "b b*"', os.translateCommands('{COPYFILEIFNEWER} "a a" "b b"', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyFileIfNewerWithPaths()
+		test.isequal('xcopy /D /Y "src\\dir\\file.txt" "dst\\dir\\file.txt*"', os.translateCommandsAndPaths('{COPYFILEIFNEWER} %[src/dir/file.txt] %[dst/dir/file.txt]', '.', '.', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyFileIfNewerDirDst()
+		test.isequal('xcopy /D /Y "src\\Core.dll" "dst\\outdir\\Core.dll*"', os.translateCommandsAndPaths('{COPYFILEIFNEWER} %[src/Core.dll] %[dst/outdir/]', '.', '.', "windows"))
+	end
+
+	function suite.translateCommand_windowsCopyFileIfNewerDirDstQuoted()
+		test.isequal('xcopy /D /Y "src dir\\Core.dll" "dst dir\\Core.dll*"', os.translateCommandsAndPaths('{COPYFILEIFNEWER} %[src dir/Core.dll] %[dst dir/]', '.', '.', "windows"))
+	end
+
+	function suite.translateCommand_posixCopyFileIfNewer()
+		test.isequal('cp -u a b', os.translateCommands('{COPYFILEIFNEWER} a b', "posix"))
+	end
+
+	function suite.translateCommand_posixCopyFileIfNewerWithSpaces()
+		test.isequal('cp -u "a a" "b b"', os.translateCommands('{COPYFILEIFNEWER} "a a" "b b"', "posix"))
+	end
+
+--
 -- os.translateCommand() LINKDIR/LINKFILE tests
 --
 	function suite.translateCommand_windowsLinkDir()

--- a/website/docs/Tokens.md
+++ b/website/docs/Tokens.md
@@ -103,6 +103,7 @@ The available tokens, and their replacements:
 |------------|---------------------------------------------|-----------------------|
 | {CHDIR}    | chdir {args}                                | cd {args}             |
 | {COPYFILE} | copy /B /Y {args}                           | cp -f {args}          |
+| {COPYFILEIFNEWER} | xcopy /D /Y {args}*                   | cp -u {args}          |
 | {COPYDIR}  | xcopy /Q /E /Y /I {args}                    | cp -rf {args}         |
 | {DELETE}   | del {args}                                  | rm -rf {args}         |
 | {ECHO}     | echo {args}                                 | echo {args}           |


### PR DESCRIPTION
What does this PR do?**

Adds a `{COPYIFNEWER}` command token that copies a file only if the source is newer than the destination, or the destination doesn't exist.

**How does this PR change Premake's behavior?**

No breaking changes. Existing behavior is untouched. This just adds a new `{COPYIFNEWER}` token alongside the existing `{COPY}`, `{COPYFILE}`, etc.

**Anything else we should know?**

Nothing.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any related issues
- [X] Follow our coding conventions
- [X] Minimize the number of commits
- [X] Align documentation to your changes