### PR TITLE
Add support of `nugetsource` for local directory.

### DIFF
--- a/src/host/premake.c
+++ b/src/host/premake.c
@@ -145,6 +145,7 @@ static const luaL_Reg http_functions[] = {
 #ifdef PREMAKE_COMPRESSION
 static const luaL_Reg zip_functions[] = {
 	{ "extract",  zip_extract },
+	{ "list", zip_list},
 	{ NULL, NULL }
 };
 #endif

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -213,6 +213,7 @@ int http_download(lua_State* L);
 
 #ifdef PREMAKE_COMPRESSION
 int zip_extract(lua_State* L);
+int zip_list(lua_State* L);
 #endif
 
 /* Engine interface */

--- a/src/host/zip_list.c
+++ b/src/host/zip_list.c
@@ -1,0 +1,33 @@
+#include "premake.h"
+
+#ifdef PREMAKE_COMPRESSION
+
+#include "zip.h"
+
+int zip_list(lua_State* L)
+{
+    const char* src = luaL_checkstring(L, 1);
+
+    int err = 0;
+    struct zip* z_archive = zip_open(src, 0, &err);
+
+    if(!z_archive)
+    {
+        lua_newtable(L);
+        lua_pushstring(L, "Cannot open file");
+        return 2;
+    }
+    const zip_int64_t entries_count = zip_get_num_entries(z_archive, 0);
+    lua_createtable(L, entries_count, 0);
+    for(zip_int64_t i = 0; i != entries_count; ++i)
+    {
+        const char* full_name = zip_get_name(z_archive, i, 0);
+        lua_pushstring(L, full_name);
+        lua_rawseti(L, -2, i);
+    }
+    zip_close(z_archive);
+    lua_pushnil(L);
+    return 2;
+}
+
+#endif

--- a/website/docs/nugetsource.md
+++ b/website/docs/nugetsource.md
@@ -6,7 +6,7 @@ nugetsource ("url")
 
 ### Parameters ###
 
-`url` is the NuGet v3 feed URL.
+`url` is the NuGet v3 feed URL or local directory.
 
 ### Applies To ###
 
@@ -14,14 +14,22 @@ Project configurations.
 
 ### Availability ###
 
-Premake 5.0.0-alpha12 or later.
+Nuget "galleries" since Premake 5.0.0-alpha12 or later.
+Local directory since Premake 5.0.0 or later.
 
 ### Examples ###
+
+Set source to NuGet gallery.
 
 ```lua
 nugetsource "https://api.nuget.org/v3/index.json"
 ```
 
+Set source to local directory.
+
+```lua
+nugetsource "c:/my_nuget_packages/"
+```
 ### See Also ###
 
 * [nuget](nuget.md)

--- a/website/docs/zip/zip.list.md
+++ b/website/docs/zip/zip.list.md
@@ -1,0 +1,17 @@
+Get list of file paths contained in an archive.
+
+```lua
+local entries, err = zip.list(sourceZip)
+```
+
+### Parameters ###
+- `sourceZip` is the zip file which has to be extracted
+
+### Return Value ###
+
+A new table containing the path of files contained in the archive, following with error string.
+
+### Availability ###
+
+Premake 5.0.0 or later.
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -511,7 +511,8 @@ module.exports = {
 					type: 'category',
 					label: 'zip',
 					items: [
-						'zip/zip.extract'
+						'zip/zip.extract',
+						'zip/zip.list'
 					]
 				}
 			],


### PR DESCRIPTION
Add `zip.list` to get list of files from a zip file.

**What does this PR do?**

Add support for nugetsource to use local directory

**How does this PR change Premake's behavior?**

No changes of previous script expected, just new behavior

**Anything else we should know?**

I need to get list of files from zip/nupkg file,
So I also added `zip.list`

Testing with https://github.com/Jarod42/wxWidgets_nuget_test

Not sure best way to add UTs for that.
Adding dummy zip file nuget package seems not really good.

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
