### PR TITLE
Add dynamic debugging support for MSC (VS, Ninja)

### DIFF
--- a/modules/vstudio/tests/vc2022/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2022/test_compile_settings.lua
@@ -186,3 +186,29 @@ function suite.BuildStlModulesOn()
 	<BuildStlModules>true</BuildStlModules>
 	]]
 end
+
+function suite.DynamicDebuggingOn()
+	dynamicdebugging 'On'
+	prepare()
+	test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
+	<UseDynamicDebugging>true</UseDynamicDebugging>
+	]]
+end
+
+function suite.DynamicDebuggingOff()
+	dynamicdebugging 'Off'
+	prepare()
+	test.capture [[
+<ClCompile>
+	<PrecompiledHeader>NotUsing</PrecompiledHeader>
+	<WarningLevel>Level3</WarningLevel>
+	<Optimization>Disabled</Optimization>
+	<ExternalWarningLevel>Level3</ExternalWarningLevel>
+	<UseDynamicDebugging>false</UseDynamicDebugging>
+	]]
+end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -597,6 +597,7 @@
 			m.useStandardPreprocessor,
 			m.enableModules,
 			m.buildStlModules,
+			m.useDynamicDebugging,
 		}
 
 		if cfg.kind == p.STATICLIB then
@@ -795,6 +796,7 @@
 				m.generateDebugInformation,
 				m.optimizeReferences,
 				m.linkTimeCodeGeneration,
+				m.useDynamicDebugging,
 			}
 		else
 			return {
@@ -804,6 +806,7 @@
 				m.optimizeReferences,
 				m.linkTimeCodeGeneration,
 				m.additionalDependencies,
+				m.useDynamicDebugging,
 				m.additionalLibraryDirectories,
 				m.importLibrary,
 				m.entryPointSymbol,
@@ -1978,6 +1981,17 @@
 		-- If there are no links and dependencies should be inherited, the tag doesn't have to be generated.
 		if #links > 0 or additional == "" then
 			m.element("AdditionalDependencies", nil, "%s%s", links, additional)
+		end
+	end
+
+
+	function m.useDynamicDebugging(cfg, explicit)
+		if cfg.dynamicdebugging and _ACTION >= "vs2022" then
+			if cfg.dynamicdebugging == p.ON then
+				m.element("UseDynamicDebugging", nil, "true")
+			elseif cfg.dynamicdebugging == p.OFF then
+				m.element("UseDynamicDebugging", nil, "false")
+			end
 		end
 	end
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1485,6 +1485,17 @@
 	function(value)
 	end)
 
+	api.register {
+		name = "dynamicdebugging",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off"
+		}
+	}
+
 -----------------------------------------------------------------------------
 --
 -- Field name aliases for backward compatibility

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -83,6 +83,9 @@
 			StdCall = "/Gz",
 			VectorCall = "/Gv",
 		},
+		dynamicdebugging = {
+			On = "/dynamicdeopt",
+		},
 		intrinsics = {
 			On = "/Oi",
 		},
@@ -366,7 +369,10 @@
 		},
 		symbols = {
 			On = "/DEBUG"
-		}
+		},
+		dynamicdebugging = {
+			On = "/dynamicdeopt",
+		},
 	}
 
 	msc.librarianFlags = {

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -879,3 +879,39 @@ end
 		prepare()
 		test.isequal({ "/MD", "/Z7" }, msc.getcflags(cfg))
 	end
+
+	function suite.cflags_onDynamicDebuggingOn()
+		dynamicdebugging "On"
+		prepare()
+		test.contains("/dynamicdeopt", msc.getcflags(cfg))
+	end
+
+	function suite.cxxflags_onDynamicDebuggingOn()
+		dynamicdebugging "On"
+		prepare()
+		test.contains("/dynamicdeopt", msc.getcxxflags(cfg))
+	end
+
+	function suite.cflags_onDynamicDebuggingOff()
+		dynamicdebugging "Off"
+		prepare()
+		test.excludes("/dynamicdeopt", msc.getcflags(cfg))
+	end
+
+	function suite.cxxflags_onDynamicDebuggingOff()
+		dynamicdebugging "Off"
+		prepare()
+		test.excludes("/dynamicdeopt", msc.getcxxflags(cfg))
+	end
+
+	function suite.linkerflags_onDynamicDebuggingOn()
+		dynamicdebugging "On"
+		prepare()
+		test.contains("/dynamicdeopt", msc.getldflags(cfg))
+	end
+
+	function suite.linkerflags_onDynamicDebuggingOff()
+		dynamicdebugging "Off"
+		prepare()
+		test.excludes("/dynamicdeopt", msc.getldflags(cfg))
+	end

--- a/website/docs/dynamicdebugging.md
+++ b/website/docs/dynamicdebugging.md
@@ -1,0 +1,33 @@
+Specifies if the binary has dynamic debugging support.
+
+```lua
+dynamicdebugging ("value")
+```
+
+### Parameters ###
+
+`value` is one of:
+
+| Value | Description | Notes |
+|-------|-------------|-------|
+| Default | Uses the default dynamic debugging behavior. | |
+| On | Allows dynamic debugging of source code. | For MSVC, debug [symbols](symbols.md) must be present. [Edit and Continue](editandcontinue.md) is not allowed. For a full list of flags that are required, see the [Microsoft Docs](https://learn.microsoft.com/en-us/cpp/build/reference/dynamic-deopt?view=msvc-170). |
+| Off | Disallows dynamic debugging of source code. | |
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0.0 or later for Visual Studio 2022 and later or MSC toolsets.
+
+### Examples ###
+
+```lua
+dynamicdebugging "On"
+```
+
+### See Also ###
+
+- [C++ Dynamic Debugging](https://devblogs.microsoft.com/cppblog/cpp-dynamic-debugging-full-debuggability-for-optimized-builds/)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -127,6 +127,7 @@ module.exports = {
 						'dotnetframework',
 						'dotnetsdk',
 						'dpiawareness',
+						'dynamicdebugging',
 						'editandcontinue',
 						'editorintegration',
 						'embed',


### PR DESCRIPTION
**What does this PR do?**

Adds support for Dynamic Debugging (/dynamicdeopt) for Visual Studio and MSC via Ninja.

**How does this PR change Premake's behavior?**

No breaking changes. Adds new API.

**Anything else we should know?**

Context: https://devblogs.microsoft.com/cppblog/cpp-dynamic-debugging-full-debuggability-for-optimized-builds/

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
