### PR TITLE
Fix dynamic deoptimization in optimized builds

### DIFF
--- a/modules/vstudio/tests/vc2022/test_link.lua
+++ b/modules/vstudio/tests/vc2022/test_link.lua
@@ -38,3 +38,54 @@ local project = p.project
 	<AdditionalOptions>/wx:4123,4124 %(AdditionalOptions)</AdditionalOptions>
 		]]
 	end
+
+
+	function suite.dynamicDebugging_On()
+		kind "StaticLib"
+		dynamicdebugging "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<UseDynamicDebugging>true</UseDynamicDebugging>
+</Link>
+<Lib>
+	<UseDynamicDebugging>true</UseDynamicDebugging>
+</Lib>
+	]]
+	end
+
+
+	function suite.dynamicDebugging_On_WithOpts()
+		kind "StaticLib"
+		dynamicdebugging "On"
+		optimize "On"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<EnableCOMDATFolding>false</EnableCOMDATFolding>
+	<OptimizeReferences>true</OptimizeReferences>
+	<UseDynamicDebugging>true</UseDynamicDebugging>
+</Link>
+<Lib>
+	<UseDynamicDebugging>true</UseDynamicDebugging>
+</Lib>
+	]]
+	end
+
+
+	function suite.dynamicDebugging_Off()
+		kind "StaticLib"
+		dynamicdebugging "Off"
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<UseDynamicDebugging>false</UseDynamicDebugging>
+</Link>
+<Lib>
+	<UseDynamicDebugging>false</UseDynamicDebugging>
+</Lib>
+	]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -885,6 +885,7 @@
 				m.treatLinkerWarningAsErrors,
 				m.targetMachine,
 				m.additionalLinkOptions,
+				m.useDynamicDebugging,
 			}
 		else
 			return {}
@@ -3088,7 +3089,11 @@
 
 	function m.optimizeReferences(cfg)
 		if config.isOptimizedBuild(cfg) then
-			m.element("EnableCOMDATFolding", nil, "true")
+			if cfg.dynamicdebugging == p.ON then
+				m.element("EnableCOMDATFolding", nil, "false")
+			else
+				m.element("EnableCOMDATFolding", nil, "true")
+			end
 			m.element("OptimizeReferences", nil, "true")
 		end
 	end


### PR DESCRIPTION
**What does this PR do?**

Fixes an issue with optimized builds enabling COMDAT folding, but this isn't supported with dynamic deoptimization.

**How does this PR change Premake's behavior?**

No breaking changes.

**Anything else we should know?**

No

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
