### PR TITLE
feat: added registries to community section

### DIFF
--- a/website/community/registries.md
+++ b/website/community/registries.md
@@ -2,11 +2,29 @@
 title: Registries
 ---
 
-These Registries are available from other developers; follow the links for more information. If you've created a registry you would like to share with others, feel free to [add a link](https://github.com/premake/premake-core/edit/master/website/community/registries.md) to the list!
+These registries are available from other developers for managing Premake modules and libraries. If you have created a registry you would like to share, feel free to [add a link](https://github.com/premake/premake-core/edit/master/website/community/registries.md) to the list!
 
 ## Premake Manager
 
-The following registries are integrated with **premake manager**
+The following registries are fully integrated with **premake-manager**.
 
-- [Public Registry](https://premake-registry-ywxg.onrender.com/)
-- [Common Registry](https://github.com/lolrobbe2/premake-common-registry)
+### [Common Registry](https://github.com/lolrobbe2/premake-common-registry)
+
+A collection of public and popular libraries designed to integrate seamlessly with **premake**.
+
+* **Dependency Management:** Libraries can declare dependencies, version ranges, and more.
+* **Version Matching:** The `premake-manager-cli` automatically matches and installs the correct versions.
+* **Customizable:** These registries are created via GitHub repositories and premake manager; users can create their own common registries and add them to their specific workflows via **premake-manager-cli** and derived extensions.
+
+### [Public Registry](https://premake-registry-ywxg.onrender.com/)
+
+The public registry is a hub for individual Premake users who want to share their libraries and modules with the community.
+
+* **Easy Registration:** Modules can be registered via a web UI using GitHub login.
+* **Flexible Integration:** While they integrate with `premake-manager-cli`, they are also designed to be used standalone (e.g., as Git submodules).
+* **Search API:** Provides a public API dedicated to searching for available modules and libraries, allowing for integration into external tools and scripts.
+
+---
+
+> [!NOTE]
+> Developers are encouraged to create their own common registries to manage internal dependencies within their team's specific Premake workflow.

--- a/website/community/registries.md
+++ b/website/community/registries.md
@@ -1,0 +1,12 @@
+---
+title: Registries
+---
+
+These Registries are available from other developers; follow the links for more information. If you've created a registry you would like to share with others, feel free to [add a link](https://github.com/premake/premake-core/edit/master/website/community/registries.md) to the list!
+
+## Premake Manager
+
+The following registries are integrated with **premake manager**
+
+- [Public Registry](https://premake-registry-ywxg.onrender.com/)
+- [Common Registry](https://github.com/lolrobbe2/premake-common-registry)

--- a/website/sidebars-community.js
+++ b/website/sidebars-community.js
@@ -3,6 +3,7 @@ module.exports = {
 		'support',
 		'showcase',
 		'extensions',
-		'modules'
+		'modules',
+		'registries'
 	]
 };


### PR DESCRIPTION
**What does this PR do?**

This creates a new registries page (did no know where to put these otherwise?)

**Anything else we should know?**

Any Modules are welcome to be registered!

There is a public rate limited search api available if other projects wan't to integrate the public registry

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
