### PR TITLE
Add support for CYGWIN.

### DIFF
--- a/contrib/curl/lib/config-linux.h
+++ b/contrib/curl/lib/config-linux.h
@@ -185,7 +185,7 @@
 #define HAVE_GETHOSTBYNAME 1
 
 /* Define to 1 if you have the gethostbyname_r function. */
-#if !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__sun__)
+#if !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__sun__) && !defined(__CYGWIN__)
 #define HAVE_GETHOSTBYNAME_R 1
 #endif
 

--- a/contrib/curl/lib/curl_setup.h
+++ b/contrib/curl/lib/curl_setup.h
@@ -170,6 +170,10 @@
 #  include "config-linux.h"
 #endif
 
+#ifdef __CYGWIN__
+#  include "config-linux.h"
+#endif
+
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #  include "config-linux.h"
 #endif

--- a/contrib/lua/premake5.lua
+++ b/contrib/lua/premake5.lua
@@ -18,7 +18,7 @@ project "lua-lib"
 		"src/print.c",
 	}
 
-	filter "system:linux or bsd or hurd or aix or solaris or haiku"
+	filter "system:linux or bsd or hurd or aix or solaris or haiku or cygwin"
 		defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }
 
 	filter "system:macosx"

--- a/contrib/lua/src/luaconf.h
+++ b/contrib/lua/src/luaconf.h
@@ -198,6 +198,18 @@
 		LUA_CDIR"..\\lib\\lua\\" LUA_VDIR "\\?.dll;" \
 		LUA_CDIR"loadall.dll;" ".\\?.dll"
 
+#elif defined(__CYGWIN__)		/* }{ */
+
+#define LUA_ROOT	"/usr/"
+#define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
+#define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
+#define LUA_PATH_DEFAULT  \
+		LUA_LDIR"?.lua;"  LUA_LDIR"?/init.lua;" \
+		LUA_CDIR"?.lua;"  LUA_CDIR"?/init.lua;" \
+		"./?.lua;" "./?/init.lua"
+#define LUA_CPATH_DEFAULT \
+		LUA_CDIR"?.dll;" LUA_CDIR"loadall.dll;" "./?.dll"
+
 #else			/* }{ */
 
 #define LUA_ROOT	"/usr/local/"

--- a/contrib/luashim/premake5.lua
+++ b/contrib/luashim/premake5.lua
@@ -13,7 +13,7 @@ project "luashim-lib"
 		"*.lua"
 	}
 
-	filter "system:linux or bsd or hurd or aix or haiku"
+	filter "system:linux or bsd or hurd or aix or haiku or cygwin"
 		defines      { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }
 
 	filter "system:macosx"

--- a/premake4.lua
+++ b/premake4.lua
@@ -77,7 +77,7 @@
 		configuration { "solaris" }
 			links       { "m", "socket", "nsl" }
 
-		configuration "aix"
+		configuration "aix or cygwin"
 			defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }
 			links       { "m" }
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -386,7 +386,7 @@
 		filter { "system:solaris" }
 			links       { "m", "socket", "nsl" }
 
-		filter "system:aix"
+		filter "system:aix or cygwin"
 			defines     { "LUA_USE_POSIX", "LUA_USE_DLOPEN" }
 			links       { "m" }
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -861,6 +861,7 @@
 		allowed = {
 			"aix",
 			"bsd",
+			"cygwin",
 			"emscripten",
 			"haiku",
 			"hurd",
@@ -1606,6 +1607,7 @@
 		allowed = {
 			{ "aix",        "IBM AIX" },
 			{ "bsd",        "OpenBSD, NetBSD, or FreeBSD" },
+			{ "cygwin",     "CYGWIN" },
 			{ "emscripten", "Emscripten" },
 			{ "haiku",      "Haiku" },
 			{ "hurd",       "GNU/Hurd" },
@@ -1725,6 +1727,16 @@
 		targetprefix ""
 		targetbundleextension ".xctest"
 
+	-- CYGWIN specific.
+
+	filter { "system:cygwin", "kind:ConsoleApp or WindowedApp" }
+		targetextension ".exe"
+
+	filter { "system:cygwin", "kind:SharedLib" }
+		targetprefix "cyg"
+		targetextension ".dll"
+		implibextension ".dll.a"
+
 	-- Windows and friends.
 
 	filter { "system:Windows or language:C# or language:F#", "kind:ConsoleApp or WindowedApp" }
@@ -1744,7 +1756,7 @@
 		targetextension ".dll"
 		implibextension ".dll"
 
-	filter { "kind:SharedLib", "system:not Windows" }
+	filter { "kind:SharedLib", "system:not Windows and not cygwin" }
 		pic "On"
 
 	filter { "system:darwin" }

--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -65,6 +65,8 @@
 	local function get_library_search_path()
 		if os.istarget("windows") then
 			return (os.getenv("PATH") or ""):explode(";")
+		elseif os.istarget("cygwin") then
+			return (os.getenv("PATH") or ""):explode(":")
 		elseif os.istarget("haiku") then
 			return (os.getenv("LIBRARY_PATH") or ""):explode(":")
 		else
@@ -84,7 +86,7 @@
 
 			local archpaths = {"/lib", "/usr/lib", "/usr/local/lib"}
 			if os.is64bit() and not (os.istarget("darwin")) then
-				archpaths = table.join({"/lib64", "/usr/lib64/", "usr/local/lib64"}, archpaths)
+				archpaths = table.join({"/lib64", "/usr/lib64", "usr/local/lib64"}, archpaths)
 			end
 			return table.join(paths, archpaths)
 		end
@@ -116,6 +118,8 @@
 		-- assemble a search path, depending on the platform
 		if os.istarget("windows") then
 			formats = { "%s.dll", "%s" }
+		elseif os.istarget("cygwin") then
+			formats = { "cyg%s.dll", "%s.dll", "%s" }
 		elseif os.istarget("haiku") then
 			formats = { "lib%s.so", "%s.so" }
 		else
@@ -868,6 +872,7 @@
 		["aix"]        = { "aix",     "posix", "desktop" },
 		["android"]    = { "android", "mobile" },
 		["bsd"]        = { "bsd",     "posix", "desktop" },
+		["cygwin"]     = { "cygwin",  "posix", "desktop" },
 		["emscripten"] = { "emscripten", "web" },
 		["haiku"]      = { "haiku",   "posix", "desktop" },
 		["ios"]        = { "ios",     "darwin", "posix", "mobile" },

--- a/src/host/os_getnumcpus.c
+++ b/src/host/os_getnumcpus.c
@@ -16,14 +16,15 @@
 #include <sys/sysctl.h>
 #elif PLATFORM_SOLARIS
 #include <unistd.h>
-#elif PLATFORM_WINDOWS
+#elif PLATFORM_WINDOWS | PLATFORM_CYGWIN
 #define WIN32_LEAN_AND_MEAN
+#define NOGDI
 #include <windows.h>
 #endif
 
 int do_getnumcpus()
 {
-#if PLATFORM_WINDOWS
+#if PLATFORM_WINDOWS | PLATFORM_CYGWIN
 	SYSTEM_INFO sysinfo;
 	GetSystemInfo(&sysinfo);
 	return sysinfo.dwNumberOfProcessors;

--- a/src/host/os_getversion.c
+++ b/src/host/os_getversion.c
@@ -272,7 +272,7 @@ getversion_macosx_cleanup:
 
 /*************************************************************/
 
-#elif defined(PLATFORM_BSD) || defined(PLATFORM_LINUX) || defined(PLATFORM_SOLARIS) || defined(PLATFORM_HURD) || defined(PLATFORM_HAIKU) || defined(PLATFORM_COSMO)
+#elif defined(PLATFORM_BSD) || defined(PLATFORM_LINUX) || defined(PLATFORM_SOLARIS) || defined(PLATFORM_HURD) || defined(PLATFORM_HAIKU) || defined(PLATFORM_COSMO) || defined(__CYGWIN__)
 
 #include <string.h>
 #include <sys/utsname.h>

--- a/src/host/premake.h
+++ b/src/host/premake.h
@@ -52,11 +52,14 @@
 #elif defined(_WIN32) || defined(_WIN64)
 #define PLATFORM_WINDOWS  (1)
 #define PLATFORM_OS   "windows"
+#elif defined (__CYGWIN__)
+#define PLATFORM_CYGWIN  (1)
+#define PLATFORM_OS  "cygwin"
 #else
 #error Unknown platform detected
 #endif
 
-#define PLATFORM_POSIX  (PLATFORM_LINUX || PLATFORM_BSD || PLATFORM_MACOSX || PLATFORM_SOLARIS || PLATFORM_HAIKU || PLATFORM_HURD || PLATFORM_COSMO)
+#define PLATFORM_POSIX  (PLATFORM_LINUX || PLATFORM_BSD || PLATFORM_MACOSX || PLATFORM_SOLARIS || PLATFORM_HAIKU || PLATFORM_HURD || PLATFORM_COSMO || PLATFORM_CYGWIN)
 
 #if defined(__x86_64__) || defined(__x86_64) || defined(__amd64__) || defined(__amd64) || \
     defined(_M_X64) || defined(_M_AMD64)

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -22,7 +22,7 @@
 	end
 
 	local function get_LD_PATH_variable_name()
-		if os.istarget("windows") then
+		if os.istarget("windows") or os.istarget("cygwin") then
 			return 'PATH'
 		elseif os.istarget("haiku") then
 			return 'LIBRARY_PATH'
@@ -51,6 +51,8 @@
 			-- https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes
 		elseif os.istarget("windows") then
 			test.istrue(os.findlib("user32"))
+		elseif os.istarget("cygwin") then
+			test.istrue(os.findlib("cygwin1"))
 		elseif os.istarget("haiku") then
 			test.istrue(os.findlib("root"))
 		elseif os.istarget("bsd") and os.getversion().description == "OpenBSD" then

--- a/website/docs/system.md
+++ b/website/docs/system.md
@@ -15,6 +15,7 @@ If no system is specified, Premake will identify and target the current operatin
 | aix | IBM AIX |
 | android | Android Platform |
 | bsd | BSD Variants |
+| cygwin | CYGWIN |
 | emscripten | Emscripten targets |
 | haiku | Haiku OS |
 | hurd | GNU Hurd |


### PR DESCRIPTION
**What does this PR do?**

This PR adds support for CYGWIN.
After these few fixes, premake can be compiled and used for this new platform.

**How does this PR change Premake's behavior?**

These changes won't affect support for existing plaftorms and targets.

During my debug, I discovered that into `src/base/os.lua` there was a tiny mistake because it was adding `"/usr/lib64/"` instead of `"/usr/lib64"` (note the final `"/"` at the end of the string), so I fixed it. However, this is a minimal and safe fix, as you can see.

**Anything else we should know?**

CYGWIN follows much more BSD than Linux.
This allows to avoid duplications of code into the makefile.
So, once you get the sources fixed by this PR, you can build premake for CYGWIN by using this command:
```
make -f Bootstrap.mak bsd
```
After that, you will find the executable of premake under the `bin/release` directory.
The new port also passed all tests successfully.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [X] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
