### PR TITLE
Generate folders for compilecommands on action

### DIFF
--- a/modules/compilecommands/_preload.lua
+++ b/modules/compilecommands/_preload.lua
@@ -88,6 +88,23 @@ newaction {
 		elseif f ~= 0 then
 			printf("Generated %s...", path.getrelative(os.getcwd(), output_path))
 		end
+
+		-- clangd relies on the "directory" entries in compile_commands.json to exist in order to properly
+		-- resolve relative paths. This is to ensure that the compilecommands action generates them.
+		local paths_to_generate = {}
+		for _, cmd in ipairs(all_commands) do
+			local dir = cmd.directory
+			if dir and not os.isdir(dir) then
+				paths_to_generate[dir] = true
+			end
+		end
+
+		for dir, _ in pairs(paths_to_generate) do
+			local ok, err = os.mkdir(dir)
+			if not ok then
+				error(err, 0)
+			end
+		end
 	end
 }
 


### PR DESCRIPTION
**What does this PR do?**

On generating the compilation database, this will generate the folders specified by the "location" of the projects. This fixes an issue with clangd where it does not handle if a directory does not exist when resolving relative paths.

Potential Alternatives:
1. Re-root the commands to the location of the compilation database. Decided against because this breaks pattern of Premake, as well as causes different commands to be generated for the compilation database and the exporters (ninja, gmake)

**How does this PR change Premake's behavior?**

Generates folders that are potentially empty.

**Anything else we should know?**

Fixes #2665

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
