### PR TITLE
fix return value of os.writefile_ifnotequal()

### DIFF
--- a/src/host/os_writefile_ifnotequal.c
+++ b/src/host/os_writefile_ifnotequal.c
@@ -105,7 +105,7 @@ int os_writefile_ifnotequal(lua_State* L)
 
 		if (!error)
 		{
-			lua_pushinteger(L, error ? -1 : 0);
+			lua_pushinteger(L, 1);
 			return 1;
 		}
 	}

--- a/website/docs/os/os.writefile_ifnotequal.md
+++ b/website/docs/os/os.writefile_ifnotequal.md
@@ -13,7 +13,15 @@ ok, err = os.writefile_ifnotequal("text", "filename")
 
 ### Return Value ###
 
-True if successful, otherwise nil and an error message.
+The first return value:
+
+| Value | Explanation                                          |
+|-------|------------------------------------------------------|
+| 1     | The string was written to the file                   |
+| 0     | The string is identical to the current file contents |
+| -1    | An error occurred                                    |
+
+The second return value is an error message if the first return value is -1, otherwise nil.
 
 
 ### Availability ###


### PR DESCRIPTION
**What does this PR do?**

- fix return value of os.writefile_ifnotequal()
- update the document for that function

**How does this PR change Premake's behavior?**

Before #2654 , os.writefile_ifnotequal() returns `1` if successful, `0` if the string is identical to the current file contents, otherwise `-1` and an error message. #2654 seems to changed this behavior accidentally, return `0` on success too. This PR change the behavior back.

**Anything else we should know?**

@jkriegshauser

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
