### PR TITLE
fix zip extract missing pop for wpath pushed in luaL_convertlstring

### DIFF
--- a/src/host/zip_extract.c
+++ b/src/host/zip_extract.c
@@ -200,6 +200,7 @@ static int extract(lua_State *L, const char* src, const char* destination)
 						return -1;
 					}
 					fp = _wfopen(wpath, L"wb");
+					lua_pop(L, 1); /* pop converted wide path */
 				}
 #else
 				fp = fopen(appended_full_name, "wb");


### PR DESCRIPTION
**What does this PR do?**

fix zip extract missing pop for wpath pushed in luaL_convertlstring

**How does this PR change Premake's behavior?**

Nothing.

**Anything else we should know?**

Addressed by AI, not fully tested.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
