### PR TITLE
fix Unicode path error messages in file operations

### DIFF
--- a/src/host/os_copyfile.c
+++ b/src/host/os_copyfile.c
@@ -35,11 +35,11 @@ int os_copyfile(lua_State* L)
 		if (FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, NULL, ec,
 			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buf, 256, NULL) && (err = luaL_convertwstring(L, buf, NULL)) != NULL)
 		{
-			lua_pushfstring(L, "unable to copy file to '%s', reason: '%s' (%lu)", dst, err, ec);
+			lua_pushfstring(L, "unable to copy file to '%s', reason: '%s' (%I)", lua_tostring(L, 2), err, (lua_Integer)ec);
 			lua_remove(L, -2); /* converted string */
 		}
 		else
-			lua_pushfstring(L, "unable to copy file to '%s', error code: %lu", dst, ec);
+			lua_pushfstring(L, "unable to copy file to '%s', error code: %I", lua_tostring(L, 2), (lua_Integer)ec);
 #else
 		lua_pushfstring(L, "unable to copy file to '%s'", dst);
 #endif

--- a/src/host/os_remove.c
+++ b/src/host/os_remove.c
@@ -29,7 +29,7 @@ int os_remove(lua_State* L)
 			LocalFree(messageBuffer);
 		}
 
-		lua_pushfstring(L, "%s: %s (%lu)", filename, pushed ? lua_tostring(L, -1) : "<failed to get error message>", err);
+		lua_pushfstring(L, "%s: %s (%I)", lua_tostring(L, 1), pushed ? lua_tostring(L, -1) : "<failed to get error message>", (lua_Integer)err);
 		if (pushed) lua_remove(L, -2);
 		lua_pushinteger(L, err);
 		return 3;

--- a/src/host/os_rename.c
+++ b/src/host/os_rename.c
@@ -14,15 +14,17 @@ int os_rename(lua_State* L)
 	const wchar_t *fromname = luaL_checkconvertstring(L, 1);
 
 	BOOL b = MoveFileExW(fromname, toname, MOVEFILE_COPY_ALLOWED);
-	lua_pop(L, 2);
 	if (b)
 	{
+		lua_pop(L, 2);
 		lua_pushboolean(L, 1);
 		return 1;
 	}
 	else
 	{
 		DWORD err = GetLastError();
+		const char *fromname_utf8 = lua_tostring(L, 1); /* get original UTF-8 before popping converted strings */
+		lua_pop(L, 2);
 
 		LPWSTR messageBuffer = NULL;
 		int pushed = 0;
@@ -33,7 +35,7 @@ int os_rename(lua_State* L)
 			LocalFree(messageBuffer);
 		}
 
-		lua_pushfstring(L, "%s: %s (%I)", fromname, pushed ? lua_tostring(L, -1) : "<failed to get error message>", (lua_Integer)err);
+		lua_pushfstring(L, "%s: %s (%I)", fromname_utf8, pushed ? lua_tostring(L, -1) : "<failed to get error message>", (lua_Integer)err);
 		if (pushed) lua_remove(L, -2); /* remove converted string */
 		lua_pushinteger(L, err);
 		return 3;

--- a/src/host/os_stat.c
+++ b/src/host/os_stat.c
@@ -13,10 +13,11 @@ int os_stat(lua_State* L)
 {
 
 #if PLATFORM_WINDOWS
-	const wchar_t *filename = luaL_checkconvertstring(L, 1);
+	const wchar_t *wfilename = luaL_checkconvertstring(L, 1);
+	const char *filename = lua_tostring(L, 1); /* save original path before popping converted string */
 	struct _stat s;
 
-	int failed = (_wstat(filename, &s) != 0);
+	int failed = (_wstat(wfilename, &s) != 0);
 	lua_pop(L, 1);
 #else
 	const char* filename = luaL_checkstring(L, 1);

--- a/tests/base/test_os_unicode.lua
+++ b/tests/base/test_os_unicode.lua
@@ -59,11 +59,15 @@ end
 	end
 
 	function suite.remove_ReturnsError_OnNonExistingUnicodePath()
-		local ok, err, exitcode = os.remove(tmpname() .. "_café")
+		local p = tmpname() .. "_café"
+		local ok, err, exitcode = os.remove(p)
 		test.isnil(ok)
 		test.isequal("string", type(err))
 		test.isequal("number", type(exitcode))
 		test.istrue(0 ~= exitcode)
+		if os.ishost("windows") then
+			test.istrue(err:find(p, 1, true) ~= nil)
+		end
 	end
 
 
@@ -81,9 +85,13 @@ end
 	end
 
 	function suite.rename_ReturnsError_OnNonExistingSource()
-		local ok, err = os.rename(tmpname(), tmpname())
+		local src = tmpname() .. "_café"
+		local ok, err = os.rename(src, tmpname())
 		test.isnil(ok)
 		test.isequal("string", type(err))
+		if os.ishost("windows") then
+			test.istrue(err:find(src, 1, true) ~= nil)
+		end
 	end
 
 	function suite.rename_ReturnsTrue_OnUnicodeSrc()
@@ -316,6 +324,17 @@ end
 		test.istrue(os.isfile(dst))
 		os.remove(src)
 		os.remove(dst)
+	end
+
+	function suite.copyfile_ReturnsError_OnNonExistingSource()
+		local src = tmpname() .. "_café"
+		local dst = tmpname() .. "_naïve"
+		local ok, err = os.copyfile(src, dst)
+		test.isnil(ok)
+		test.isequal("string", type(err))
+		if os.ishost("windows") then
+			test.istrue(err:find(dst, 1, true) ~= nil)
+		end
 	end
 
 


### PR DESCRIPTION
**What does this PR do?**

- Use lua_tostring() for UTF-8 error messages instead of wide char pointers
- Fix premature lua_pop() in os.rename and os.stat that invalidated path pointer
- Replace %lu with %I + lua_Integer cast for 64-bit compatibility
- Update tests to verify error messages contain original Unicode paths

**How does this PR change Premake's behavior?**

Those error messages didn't work before.

**Anything else we should know?**

Addressed by AI, I just did some quick test.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
