### PR TITLE
feat: print [New] or [Updated] in generation output

### DIFF
--- a/src/base/premake.lua
+++ b/src/base/premake.lua
@@ -168,6 +168,7 @@
 			error(err, 0)
 		end
 
+		local fileexists = os.isfile(fn)
 		local f, err = os.writefile_ifnotequal(output, fn);
 
 		if (f == 0) then
@@ -175,7 +176,11 @@
 		elseif (f < 0) then
 			error(err, 0)
 		elseif (f > 0) then
-			printf("Generated %s...", path.getrelative(os.getcwd(), fn))
+			if fileexists then
+				printf("Generated %s... [Updated]", path.getrelative(_WORKING_DIR, fn))
+			else
+				printf("Generated %s... [New]", path.getrelative(_WORKING_DIR, fn))
+			end
 			return true -- file modified
 		end
 	end


### PR DESCRIPTION
**What does this PR do?**

Prints [New] or [Updated] next to the generated files when they have been touched on the filesystem.

**How does this PR change Premake's behavior?**

Adds extra info to pre-exiting output.
Uses global `_WORKING_DIR` instead of calling `os.getcwd()` as a minor optimization.
Adds a filesystem access to determine if the file existed prior.

**Anything else we should know?**

Useful to know when files are new vs updated

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
