### PR TITLE
test: safe removal of symlink directory

### DIFF
--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -572,6 +572,31 @@
 -- os.remove() tests.
 --
 
+	function suite.remove_OnSymlink_RemovesLinkNotTarget()
+		-- Create a real file with content
+		local realfile = tmpfile()
+
+		-- Create a symlink pointing to the real file
+		local linkpath = tmpname()
+		os.linkfile(realfile, linkpath)
+
+		-- Verify setup
+		test.istrue(os.islink(linkpath))
+		test.istrue(os.isfile(realfile))
+
+		-- Remove the symlink - should remove only the link, not the target
+		test.istrue(os.remove(linkpath))
+
+		-- Symlink must be gone
+		test.isfalse(os.islink(linkpath))
+
+		-- Target file must still exist (link was not followed)
+		test.istrue(os.isfile(realfile))
+
+		-- Cleanup
+		os.remove(realfile)
+	end
+
 	function suite.remove_ReturnsError_OnNonExistingPath()
 		local ok, err, exitcode = os.remove(tmpname())
 		test.isnil(ok)
@@ -599,6 +624,26 @@
 --
 -- os.rmdir() tests.
 --
+
+	function suite.rmdir_OnSymlink_RemovesLinkNotTarget()
+		-- Create a symlink pointing to folder/subfolder (which contains hello.txt)
+		test.istrue(os.linkdir("folder/subfolder", "folder/symlink_nofollow"))
+
+		-- Verify setup
+		test.istrue(os.islink("folder/symlink_nofollow"))
+		test.istrue(os.isfile("folder/subfolder/hello.txt"))
+
+		-- Remove the symlink - should remove only the link, not the target
+		test.istrue(os.rmdir("folder/symlink_nofollow"))
+
+		-- Symlink must be gone
+		test.isfalse(os.islink("folder/symlink_nofollow"))
+		test.isfalse(os.isdir("folder/symlink_nofollow"))
+
+		-- Target directory and its contents must still exist (link was not followed)
+		test.istrue(os.isdir("folder/subfolder"))
+		test.istrue(os.isfile("folder/subfolder/hello.txt"))
+	end
 
 	function suite.rmdir_ReturnsError_OnNonExistingPath()
 		local ok, err = os.rmdir(tmpname())


### PR DESCRIPTION
**What does this PR do?**

Adds the ability to safely remove symlinks without following it. This case was previously skipped, leaving the file behind.

**How does this PR change Premake's behavior?**

Symlinks to directories are now properly cleaned up.

**Anything else we should know?**

On Windows, symlink-related tests assume proper permissions are set up so that `SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE` is accepted by the OS.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
