### PR TITLE
fix: sort workspace configs and projects alphabetically for deterministic output

### DIFF
--- a/modules/codelite/tests/test_codelite_workspace.lua
+++ b/modules/codelite/tests/test_codelite_workspace.lua
@@ -206,17 +206,17 @@
 <CodeLite_Workspace Name="MyWorkspace" Database="" Version="10000">
   <Project Name="MyProject" Path="MyProject.project"/>
   <BuildMatrix>
-    <WorkspaceConfiguration Name="x86_64-Debug" Selected="yes">
-      <Project Name="MyProject" ConfigName="x86_64-Debug"/>
-    </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="x86-Debug" Selected="no">
+    <WorkspaceConfiguration Name="x86-Debug" Selected="yes">
       <Project Name="MyProject" ConfigName="x86-Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="x86_64-Release" Selected="no">
-      <Project Name="MyProject" ConfigName="x86_64-Release"/>
+    <WorkspaceConfiguration Name="x86_64-Debug" Selected="no">
+      <Project Name="MyProject" ConfigName="x86_64-Debug"/>
     </WorkspaceConfiguration>
     <WorkspaceConfiguration Name="x86-Release" Selected="no">
       <Project Name="MyProject" ConfigName="x86-Release"/>
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="x86_64-Release" Selected="no">
+      <Project Name="MyProject" ConfigName="x86_64-Release"/>
     </WorkspaceConfiguration>
   </BuildMatrix>
 </CodeLite_Workspace>

--- a/modules/ninja/tests/test_ninja_workspace.lua
+++ b/modules/ninja/tests/test_ninja_workspace.lua
@@ -261,7 +261,7 @@ default TestProject_Debug
 		test.capture [[
 
 # Default build target
-default TestProject_Debug_x86
+default TestProject_Debug_x64
 		]]
 	end
 
@@ -294,5 +294,3 @@ build all: phony
   build ProjectB: phony
 		]]
 	end
-
-

--- a/src/base/workspace.lua
+++ b/src/base/workspace.lua
@@ -50,13 +50,19 @@
 	function workspace.eachconfig(self)
 		self = p.oven.bakeWorkspace(self)
 
+		local sorted = {}
+		for _, item in ipairs(self.configs) do
+			table.insert(sorted, item)
+		end
+		table.sort(sorted, function(a,b) return a.name < b.name end)
+
 		local i = 0
 		return function()
 			i = i + 1
-			if i > #self.configs then
+			if i > #sorted then
 				return nil
 			else
-				return self.configs[i]
+				return sorted[i]
 			end
 		end
 	end
@@ -70,11 +76,17 @@
 --
 
 	function workspace.eachproject(self)
+		local sorted = {}
+		for id, _ in ipairs(self.projects) do
+			table.insert(sorted, p.workspace.getproject(self, id))
+		end
+		table.sort(sorted, function(a,b) return a.name < b.name end)
+
 		local i = 0
 		return function ()
 			i = i + 1
-			if i <= #self.projects then
-				return p.workspace.getproject(self, i)
+			if i <= #sorted then
+				return sorted[i]
 			end
 		end
 	end


### PR DESCRIPTION
**What does this PR do?**

It patches iterators (eachconfig/eachproject) to sort by name, so that any users of these can produce deterministic output even when insertion order changes, which could differ depending on the client code (e.g., order of options, reflection from filesystem, etc).

**How does this PR change Premake's behavior?**

Since this only changes the order without modifying the actual config or project elements, there is no behavior we're aware of that could result from this change. If there was an assumption by client code of the order of configs or projects, this could be changed, but Premake already makes no guarantee on the order.

**Anything else we should know?**

The test in test_codelite_workspace.lua covers this change: project order and config orders are set in the captured output that's being validated and is already in the expected alphabetical ordering.
Note that I would still not make any promised in doc about the ordering returned by these functions, this is just a convenient way to drive baking output to be deterministic.

Been using this in production for years at this point, glad to contribute!

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
