### PR TITLE
fix: add Precise to msc floatingpoint

### DIFF
--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -342,6 +342,7 @@
 			"Default",
 			"Fast",
 			"Strict",
+			"Precise"
 		}
 	}
 

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -50,6 +50,8 @@
 		flags = gcc.shared.flags,
 		floatingpoint = {
 			Fast = "-ffast-math",
+			Strict = "-ffp-model=strict",
+			Precise = "-ffp-model=precise"
 		},
 		strictaliasing = gcc.shared.strictaliasing,
 		openmp = gcc.shared.openmp,

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -68,6 +68,7 @@
 		floatingpoint = {
 			Fast = "/fp:fast",
 			Strict = "/fp:strict",
+			Precise = "/fp:precise",
 		},
 		floatingpointexceptions = {
 			On  = "/fp:except",

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -307,6 +307,28 @@ end
 	end
 
 --
+-- Check handling of floating point modifiers.
+--
+
+	function suite.cflags_onFloatingPointFast()
+		floatingpoint "Fast"
+		prepare()
+		test.contains({ "-ffast-math" }, clang.getcflags(cfg))
+	end
+
+	function suite.cflags_onFloatingPointStrict()
+		floatingpoint "Strict"
+		prepare()
+		test.contains({ "-ffp-model=strict" }, clang.getcflags(cfg))
+	end
+
+	function suite.cflags_onFloatingPointPrecise()
+		floatingpoint "Precise"
+		prepare()
+		test.contains({ "-ffp-model=precise" }, clang.getcflags(cfg))
+	end
+
+--
 -- Test profiling flag
 --
 

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -534,6 +534,12 @@ end
 		test.contains("/fp:strict", msc.getcflags(cfg))
 	end
 
+	function suite.cflags_onFloatingPointPrecise()
+		floatingpoint "Precise"
+		prepare()
+		test.contains("/fp:precise", msc.getcflags(cfg))
+	end
+
 	function suite.cflags_onSSE()
 		vectorextensions "SSE"
 		prepare()

--- a/website/docs/floatingpoint.md
+++ b/website/docs/floatingpoint.md
@@ -10,11 +10,12 @@ If no value is set for a configuration, the toolset's default floating point set
 
 `value` specifies the desired style of floating point math:
 
-| Value       | Description                                                       |
-|-------------|-------------------------------------------------------------------|
-| Default     | Use the toolset's floating point settings.                        |
-| Fast        | Enable floating point optimizations at the expense of accuracy.   |
-| Strict      | Improve floating point consistency at the expense of performance. |
+| Value       | Description                                                                             |
+|-------------|-----------------------------------------------------------------------------------------|
+| Default     | Use the toolset's floating point settings.                                              |
+| Fast        | Enable floating point optimizations at the expense of accuracy.                         |
+| Strict      | Improve floating point consistency at the expense of performance.                       |
+| Precise     | Preserves the source expression ordering and rounding properties of the target machine. |
 
 ### Applies To ###
 


### PR DESCRIPTION
**What does this PR do?**

Adds explicit /fp:precise entry as Precise in the msc floatingpoint list of supported values.

**How does this PR change Premake's behavior?**

Simple one-liner to be able to explicitly set it.

**Anything else we should know?**

Nope

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
