### PR TITLE
feat: add support for toolset-provided extensions in msc.getlinks

### DIFF
--- a/modules/vstudio/tests/vc2010/test_link.lua
+++ b/modules/vstudio/tests/vc2010/test_link.lua
@@ -489,6 +489,55 @@
 
 
 --
+-- When using a non-MSC toolset (e.g. clang or gcc), links with native
+-- extensions (.a, .so) should be passed through as-is without .lib appended.
+--
+
+	function suite.additionalDependencies_dotA_onClangToolset()
+		toolset "clang"
+		links { "mylib.a" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<AdditionalDependencies>mylib.a;%(AdditionalDependencies)</AdditionalDependencies>
+		]]
+	end
+
+	function suite.additionalDependencies_dotSo_onClangToolset()
+		toolset "clang"
+		links { "mylib.so" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<AdditionalDependencies>mylib.so;%(AdditionalDependencies)</AdditionalDependencies>
+		]]
+	end
+
+	function suite.additionalDependencies_dotA_onGccToolset()
+		toolset "gcc"
+		links { "mylib.a" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<AdditionalDependencies>mylib.a;%(AdditionalDependencies)</AdditionalDependencies>
+		]]
+	end
+
+	function suite.additionalDependencies_dotSo_onGccToolset()
+		toolset "gcc"
+		links { "mylib.so" }
+		prepare()
+		test.capture [[
+<Link>
+	<SubSystem>Windows</SubSystem>
+	<AdditionalDependencies>mylib.so;%(AdditionalDependencies)</AdditionalDependencies>
+		]]
+	end
+
+--
 -- Additional library directories should be specified, relative to the project.
 --
 

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -402,3 +402,10 @@
 	function clang.gettooloutputext(tool)
 		return gcc.gettooloutputext(tool)
 	end
+
+	function clang.getLibraryExtensions()
+		return {
+			["a"] = true,
+			["so"] = true,
+		}
+	end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -824,3 +824,10 @@
 	function gcc.gettooloutputext(tool)
 		return iif(tool == "rc", ".res", ".o")
 	end
+
+	function gcc.getLibraryExtensions()
+		return {
+			["a"] = true,
+			["so"] = true,
+		}
+	end

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -483,10 +483,15 @@
 
 		-- Then the system libraries, which come undecorated
 		local system = config.getlinks(cfg, "system", "fullpath")
+
+		local toolset = config.toolset(cfg)
+		local toolsetExts = toolset and toolset.getLibraryExtensions and toolset.getLibraryExtensions() or {}
+		local libExts = table.merge(p.tools.msc.getLibraryExtensions(), toolsetExts)
+
 		for i = 1, #system do
 			-- Add extension if required
 			local link = system[i]
-			if not p.tools.msc.getLibraryExtensions()[link:match("[^.]+$")] then
+			if not libExts[link:match("[^.]+$")] then
 				link = path.appendextension(link, ".lib")
 			end
 


### PR DESCRIPTION
**What does this PR do?**

When using clang or gcc as a native toolset in Visual Studio as a cross-compiler, libraries may have .a or .so as extensions, but currently .lib is appended to the lib's name in the linker arguments list, which results in e.g., Foo.a.lib, Bar.so.lib for Foo.a and Bar.so, respectively.

**How does this PR change Premake's behavior?**

We add the support for extensions that are typical of the toolsets on corresponding platforms and use them specifically in `msc.getlinks` to supplement the list of extensions when the active toolset defines some.
This only has an impact in the special case of a msc generated output with a non-msc toolset, typically for cross-compilation scenarios. Because we just add new extensions, it should not impact usages with clang-cl.

**Anything else we should know?**

Nope.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
