### PR TITLE
Fix search order in `premake.findProjectScript`

### DIFF
--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -227,8 +227,22 @@
 			table.insert(filenames, path.getabsolute(fname, _SCRIPT_DIR))
 		end
 
-		local compiled_chunk
-		local res = os.locate(table.unpack(filenames))
+		local compiled_chunk = nil
+		local res = nil
+
+		-- First try to find the file directly on file system.
+		for _, candidate in ipairs(filenames) do
+			if os.isfile(candidate) then
+				res = path.getabsolute(candidate)
+				break
+			end
+		end
+
+		-- If that fails, try to find the file using the search paths.
+		if res == nil then
+			res = os.locate(table.unpack(filenames))
+		end
+
 		if res == nil then
 			local caller = filelineinfo(3)
 			premake.error(caller .. ": Cannot find neither " .. table.implode(filenames, "", "", " nor "))

--- a/tests/base/test_include.lua
+++ b/tests/base/test_include.lua
@@ -65,3 +65,54 @@
 		includeexternal (_TESTS_DIR .. "/folder/premake5.lua")
 		test.isequal("okokok", p.captured())
 	end
+
+
+--
+-- Tests for local-first search priority (fix for issue #1783):
+-- Local files must be found before identically-named files in premake.path.
+--
+
+	-- Helper: run fn with CWD and premake.path temporarily overridden.
+	local function withLocalPriority(cwd, searchPath, fn)
+		local savedPath = premake.path
+		local savedCwd  = os.getcwd()
+		premake.path = searchPath
+		os.chdir(cwd)
+		local ok, err = pcall(fn)
+		os.chdir(savedCwd)
+		premake.path = savedPath
+		if not ok then error(err, 2) end
+	end
+
+	-- A local "name/premake5.lua" must be preferred over a plain file named
+	-- "name" that lives only in a premake.path search directory.
+	function suite.findProjectScript_prefersLocalSubdir_overPathDecoy()
+		local folder = _TESTS_DIR .. "/folder"
+		withLocalPriority(folder, folder .. "/subfolder", function()
+			local res, _ = premake.findProjectScript("shadowlib")
+			test.isequal(
+				path.normalize(folder .. "/shadowlib/premake5.lua"),
+				path.normalize(res))
+		end)
+	end
+
+	-- A local "name.lua" must be preferred over a plain file named "name"
+	-- (no extension) that lives only in a premake.path search directory.
+	function suite.findProjectScript_prefersLocalLuaFile_overPathDecoy()
+		local folder = _TESTS_DIR .. "/folder"
+		withLocalPriority(folder, folder .. "/subfolder", function()
+			local res, _ = premake.findProjectScript("ok")
+			test.isequal(
+				path.normalize(folder .. "/ok.lua"),
+				path.normalize(res))
+		end)
+	end
+
+	-- Verify the full include() call for the subdir-priority scenario.
+	function suite.include_prefersLocalSubdir_overPathDecoy()
+		local folder = _TESTS_DIR .. "/folder"
+		withLocalPriority(folder, folder .. "/subfolder", function()
+			include("shadowlib")
+		end)
+		test.isequal("shadowlocal", p.captured())
+	end

--- a/tests/folder/shadowlib/premake5.lua
+++ b/tests/folder/shadowlib/premake5.lua
@@ -1,0 +1,1 @@
+premake.out("shadowlocal")

--- a/tests/folder/subfolder/ok
+++ b/tests/folder/subfolder/ok
@@ -1,0 +1,1 @@
+-- decoy: this file should NOT be loaded by include("ok") when a local ok.lua exists

--- a/tests/folder/subfolder/shadowlib
+++ b/tests/folder/subfolder/shadowlib
@@ -1,0 +1,1 @@
+-- decoy: this file should NOT be loaded by include("shadowlib") when a local shadowlib/ directory exists

--- a/website/docs/globals/include.md
+++ b/website/docs/globals/include.md
@@ -6,7 +6,9 @@ include("path")
 
 ### Parameters ###
 
-`path` is the file system path to a script file or a directory. If a directory is specified, Premake looks for a file named `premake5.lua` in that directory and runs it if found.
+`path` is the file system path to a script file or a directory. If a directory is specified, Premake looks for a file named `premake5.lua` in that directory and runs it if found. If the `.lua` extension is omitted from the file name, Premake will also look for a file with that extension.
+
+See [Locating Scripts](Locating-Scripts.md) for more information about how script files are located.
 
 If the file or directory specified has already been included previously, the call is ignored. If you want to execute the same script multiple times, use Lua's [dofile()](http://www.lua.org/manual/5.1/manual.html#pdf-dofile) instead.
 


### PR DESCRIPTION
**What does this PR do?**

fix #1783

Current problem:

When `include("abc")` is called, Premake looks for those files under each directory in `premake.path`:

- A file named `abc`
- A file named `abc.lua`
  - This behavior is not mentioned in the documentation
- Files named premake5.lua and premake4.lua inside an `abc` subdirectory

`premake.path` includes the directory of the currently executing script, paths specified via command-line arguments or environment variables, `~/.premake`, `/usr/local/share/premake`, the directory containing the Premake executable, etc.

The concrete search order is: for each candidate filename, search through all these path entries in order, stopping when a match is found.

This creates a problem: entries toward the end of `premake.path` are supposed to serve as fallback locations, yet the first candidate filename may match against them. For example, `include("bitmap")` intends to load `./bitmap/premake5.lua`, but if the Premake executable lives in `/usr/bin` and that directory happens to contain a file named `bitmap`, that file is returned, even though it is a binary executable.

Fix:

Perform a local file-system pass over all candidate filenames first, before delegating to `os.locate` for path-based search.  
Update the documentation to describe the search order and the automatic `.lua` extension behavior.

**How does this PR change Premake's behavior?**

Before this change, a file in an external search path whose name matches the first candidate for `include("bitmap")` would be loaded in preference to a local `./bitmap/premake5.lua`. After this change, `./bitmap/premake5.lua` is loaded first.  
This is unlikely to break existing users: anyone loading a shared lua script from an external path would not normally also have a same-named lua script in the working directory, and would not normally omit the `.lua` extension.

**Anything else we should know?**

This fix mitigates the most common manifestation of the problem. The underlying ordering issue remains. 

`os.isfile` is affected by `do_chdir` in `lua_auxlib.c`, so it also operates relative to the directory of the currently executing script.
 
The current implementation intermingles the code paths for searching embedded scripts and file-system scripts, making it harder to maintain and potentially introducing subtle bugs. Further refactoring may be warranted.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
