### PR TITLE
Add StartWorkingDirectory output to csproj.user file

### DIFF
--- a/modules/vstudio/vs2005_csproj_user.lua
+++ b/modules/vstudio/vs2005_csproj_user.lua
@@ -16,6 +16,7 @@
 	m.elements.userProjectPropertyGroup = function()
 		return {
 			m.referencePath,
+			m.startWorkingDir,
 		}
 	end
 
@@ -82,7 +83,14 @@
 		end
 	end
 
-
+	function m.startWorkingDir(prj)
+		-- Per-configuration reference paths aren't supported (are they?) so just
+		-- use the first configuration in the project
+		local cfg = p.project.getfirstconfig(prj)
+		if cfg.debugdir then
+			p.x('<StartWorkingDirectory>%s</StartWorkingDirectory>', cfg.debugdir)
+		end
+	end
 
 	function m.localDebuggerCommandArguments(cfg)
 		if #cfg.debugargs > 0 then


### PR DESCRIPTION
**What does this PR do?**

Emits `debugdir` to StartWorkingDirectory in `.csproj.user` file 
Closes #1339

**How does this PR change Premake's behavior?**

Premake should now correctly set-up the working directory when starting from within the IDE 

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes (n/a, documentation for debugdir already suggests this works)

So not all of them, but can't find any relevant tests to copy from.
