### PR TITLE
Add folder.iconcomposer.icon type to Xcode generator #2680

### DIFF
--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -44,6 +44,7 @@
 			[".swift"] = "Sources",
 			[".metal"] = "Resources",
 			[".xcprivacy"] = "Resources",
+			[".icon"] = "Resources",
 		}
 		if node.isResource then
 			return "Resources"
@@ -149,6 +150,7 @@
 			[".metal"]     = "sourcecode.metal",
 			[".dylib"]     = "compiled.mach-o.dylib",
 			[".xcprivacy"] = "PrivacyInfo.xcprivacy",
+			[".icon"]	   = "folder.iconcomposer.icon",
 		}
 		return types[path.getextension(node.path)] or "text"
 	end


### PR DESCRIPTION
**What does this PR do?**

Closes #2680.

**How does this PR change Premake's behavior?**

Adds  folder.iconcomposer.icon type to the Xcode generator.

**Anything else we should know?**

I think I did it correctly and added it to all the correct locations, please double check.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ -] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [-] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
