### PR TITLE
[Fix] - `wholearchive` should not cause multiple symbol definition.

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -59,7 +59,7 @@ jobs:
         name: premake-macosx-${{ matrix.platform }}
         path: bin/${{ matrix.config }}/
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         config: [debug, release]

--- a/modules/gmake/tests/test_gmake_linking.lua
+++ b/modules/gmake/tests/test_gmake_linking.lua
@@ -153,6 +153,27 @@ LDDEPS += build/bin/Debug/libMyProject2.so
 	end
 
 --
+-- Check a linking to a sibling when using wholearchive.
+--
+
+	function suite.links_onSiblingWholeArchiveAndLinks()
+		links "MyProject2"
+		wholearchive "MyProject2"
+
+		test.createproject(wks)
+		kind "SharedLib"
+		location "build"
+
+		prepare { cpp.ldFlags, cpp.libs, cpp.ldDeps }
+		test.capture [[
+ALL_LDFLAGS += $(LDFLAGS) -Wl,-rpath,'$$ORIGIN/../../build/bin/Debug' -s -Wl,--whole-archive build/bin/Debug/libMyProject2.so -Wl,--no-whole-archive
+LIBS +=
+LDDEPS += build/bin/Debug/libMyProject2.so
+		]]
+	end
+
+
+--
 -- Check a linking to a sibling shared library using -l and -L.
 --
 

--- a/modules/ninja/tests/test_ninja_config.lua
+++ b/modules/ninja/tests/test_ninja_config.lua
@@ -371,6 +371,27 @@ target_MyProject_Debug = MyProject
 		]]
 	end
 
+	function suite.configVars_withWholeArchiveAndLinks_Linux()
+		toolset "gcc"
+		_OS = "Linux"
+		kind "ConsoleApp"
+		files { "main.cpp" }
+		links { "m", "pthread" }
+		wholearchive { "m" }
+
+		local cfg = prepare()
+		cpp.configurationVariables(cfg)
+
+		test.capture [[
+ldflags_MyProject_Debug = -s -Wl,--whole-archive m -Wl,--no-whole-archive
+links_MyProject_Debug = -lpthread
+objdir_MyProject_Debug = obj/Debug
+targetdir_MyProject_Debug = bin/Debug
+target_MyProject_Debug = MyProject
+
+		]]
+	end
+
 
 	function suite.configVars_withLinks_Windows()
 		toolset "msc"

--- a/modules/ninja/tests/test_ninja_dependson.lua
+++ b/modules/ninja/tests/test_ninja_dependson.lua
@@ -219,3 +219,34 @@ build obj/Debug/App/data.cpp: custom data.in | bin/Debug/Generator
   customcommand = sh -c 'bin/Debug/Generator data.in'
 		]]
 	end
+
+--
+-- Check that wholearchive and links preserves dependson behavior
+--
+
+	function suite.dependson_wholeArchiveSibling()
+		toolset "gcc"
+		_OS = "Linux"
+
+		project "LibraryA"
+		kind "StaticLib"
+		files { "a.cpp" }
+
+		project "App"
+		kind "ConsoleApp"
+		files { "app.cpp" }
+		links { "LibraryA" }
+		wholearchive { "LibraryA" }
+
+		local prj = test.getproject(wks, 2)  -- Get App
+		local cfg = test.getconfig(prj, "Debug")
+
+		cfg._objectFiles = { "obj/Debug/App/app.o" }
+		cpp.linkTarget(cfg)
+
+		-- Should have LibraryA as an order-only dep (or implicit dep) because it's a sibling
+		test.capture [[
+build bin/Debug/App: link_gcc obj/Debug/App/app.o | bin/Debug/libLibraryA.a
+  ldflags = $ldflags_App_Debug
+		]]
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -4372,11 +4372,11 @@
 
 		-- If we need sibling projects to be listed explicitly, grab them first
 		if explicit then
-			links = config.getlinks(cfg, "siblings", "fullpath")
+			links = config.getlinks(cfg, "siblings", "fullpath", nil, true)
 		end
 
 		-- Then the system libraries, which come undecorated
-		local system = config.getlinks(cfg, "system", "name")
+		local system = config.getlinks(cfg, "system", "name", nil, true)
 		for i = 1, #system do
 			local link = system[i]
 			table.insert(links, link)

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -253,7 +253,7 @@
 --    An array containing the requested link target information.
 --
 
-	function config.getlinks(cfg, kind, part, linkage)
+	function config.getlinks(cfg, kind, part, linkage, drop_wholearchive)
 		local result = {}
 
 		-- If I'm building a list of link directories, include libdirs
@@ -278,66 +278,79 @@
 				name = string.sub(name, 0, -8)
 			end
 
-			-- Sort the links into "sibling" (is another project in this same
-			-- workspace) and "system" (is not part of this workspace) libraries.
+			local is_wholearchive = false
+			if drop_wholearchive and cfg.wholearchive then
+				for _, wa in ipairs(cfg.wholearchive) do
+					if type(wa) == "string" and (wa == name or wa == link) then
+						is_wholearchive = true
+						break
+					end
+				end
+			end
 
-			local prj = p.workspace.findproject(cfg.workspace, name)
-			if prj and kind ~= "system" then
+			if kind == "dependencies" or not is_wholearchive then
 
-				-- Sibling; is there a matching configuration in this project that
-				-- is compatible with linking to me?
+				-- Sort the links into "sibling" (is another project in this same
+				-- workspace) and "system" (is not part of this workspace) libraries.
 
-				local prjcfg = project.getconfig(prj, cfg.buildcfg, cfg.platform)
-				if prjcfg and (kind == "dependencies" or config.canLink(cfg, prjcfg)) then
+				local prj = p.workspace.findproject(cfg.workspace, name)
+				if prj and kind ~= "system" then
 
-					-- Yes; does the caller want the whole project config or only part?
-					if part == "object" then
-						item = prjcfg
-					else
-						item = p.tools.getrelative(cfg.project, prjcfg.linktarget.fullpath)
+					-- Sibling; is there a matching configuration in this project that
+					-- is compatible with linking to me?
+
+					local prjcfg = project.getconfig(prj, cfg.buildcfg, cfg.platform)
+					if prjcfg and (kind == "dependencies" or config.canLink(cfg, prjcfg)) then
+
+						-- Yes; does the caller want the whole project config or only part?
+						if part == "object" then
+							item = prjcfg
+						else
+							item = p.tools.getrelative(cfg.project, prjcfg.linktarget.fullpath)
+						end
+
+					end
+
+				elseif not prj and (kind == "system" or kind == "all") then
+
+					-- Make sure this library makes sense for the requested linkage; don't
+					-- link managed .DLLs into unmanaged code, etc.
+
+					if config.canLink(cfg, link, linkage) then
+						-- if the target is listed via an explicit path (i.e. not a
+						-- system library or assembly), make it project-relative
+						item = link
+						if item:find("/", nil, true) then
+							item = p.tools.getrelative(cfg.project, item)
+						end
 					end
 
 				end
 
-			elseif not prj and (kind == "system" or kind == "all") then
-
-				-- Make sure this library makes sense for the requested linkage; don't
-				-- link managed .DLLs into unmanaged code, etc.
-
-				if config.canLink(cfg, link, linkage) then
-					-- if the target is listed via an explicit path (i.e. not a
-					-- system library or assembly), make it project-relative
-					item = link
-					if item:find("/", nil, true) then
-						item = p.tools.getrelative(cfg.project, item)
+				-- If this is something I can link against, pull out the requested part
+				-- don't link against my self
+				if item and item ~= cfg then
+					if part == "directory" then
+						item = path.getdirectory(item)
+						if item == "." then
+							item = nil
+						end
+					elseif part == "name" then
+						item = path.getname(item)
+					elseif part == "basename" then
+						item = path.getbasename(item)
+					elseif type(part) == "function" then
+						part(link, item)
 					end
 				end
 
-			end
+				-- Add it to the list, skipping duplicates
 
-			-- If this is something I can link against, pull out the requested part
-			-- don't link against my self
-			if item and item ~= cfg then
-				if part == "directory" then
-					item = path.getdirectory(item)
-					if item == "." then
-						item = nil
-					end
-				elseif part == "name" then
-					item = path.getname(item)
-				elseif part == "basename" then
-					item = path.getbasename(item)
-				elseif type(part) == "function" then
-					part(link, item)
+				if item and not table.contains(result, item) then
+					table.insert(result, item)
 				end
+
 			end
-
-			-- Add it to the list, skipping duplicates
-
-			if item and not table.contains(result, item) then
-				table.insert(result, item)
-			end
-
 		end
 
 		return result
@@ -374,7 +387,7 @@
 --
 	function config.getsiblingtargetdirs(cfg)
 		local paths = {}
-		for _, sibling in ipairs(config.getlinks(cfg, "siblings", "object")) do
+		for _, sibling in ipairs(config.getlinks(cfg, "dependencies", "object")) do
 			if (sibling.kind == p.SHAREDLIB) then
 				local p = sibling.linktarget.directory
 				if not (table.contains(paths, p)) then

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -710,7 +710,7 @@
 
 		if not systemonly then
 			if cfg.userelativelinks == p.ON then
-				local libFiles = config.getlinks(cfg, "siblings", "basename")
+				local libFiles = config.getlinks(cfg, "siblings", "basename", nil, true)
 				for _, link in ipairs(libFiles) do
 					if string.startswith(link, "lib") then
 						link = link:sub(4)
@@ -721,12 +721,12 @@
 				-- Don't use the -l form for sibling libraries, since they may have
 				-- custom prefixes or extensions that will confuse the linker. Instead
 				-- just list out the full relative path to the library.
-				result = config.getlinks(cfg, "siblings", "fullpath")
+				result = config.getlinks(cfg, "siblings", "fullpath", nil, true)
 			end
 		end
 
 		-- The "-l" flag is fine for system libraries
-		local links = config.getlinks(cfg, "system", "fullpath")
+		local links = config.getlinks(cfg, "system", "fullpath", nil, true)
 		local static_syslibs = {"-Wl,-Bstatic"}
 		local shared_syslibs = {}
 

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -478,11 +478,11 @@
 
 		-- If we need sibling projects to be listed explicitly, grab them first
 		if not systemonly then
-			links = config.getlinks(cfg, "siblings", "fullpath")
+			links = config.getlinks(cfg, "siblings", "fullpath", nil, true)
 		end
 
 		-- Then the system libraries, which come undecorated
-		local system = config.getlinks(cfg, "system", "fullpath")
+		local system = config.getlinks(cfg, "system", "fullpath", nil, true)
 		for i = 1, #system do
 			-- Add extension if required
 			local link = system[i]

--- a/tests/config/test_links.lua
+++ b/tests/config/test_links.lua
@@ -21,9 +21,9 @@
 		wks, prj = test.createWorkspace()
 	end
 
-	local function prepare(kind, part, linkage)
+	local function prepare(kind, part, linkage, drop_wholearchive)
 		cfg = test.getconfig(prj, "Debug")
-		return config.getlinks(cfg, kind, part, linkage)
+		return config.getlinks(cfg, kind, part, linkage, drop_wholearchive)
 	end
 
 
@@ -264,3 +264,39 @@
 		local r = prepare("all", "fullpath")
 		test.isequal({ "bin/Debug/SiblingLibrary.lib" }, r)
 	end
+
+--
+-- wholearchive
+--
+
+	function suite.skipsWholeArchiveNormalLink_onSystem()
+		links { "SystemLibrary" }
+		wholearchive { "SystemLibrary" }
+		local r = prepare("all", "fullpath", nil, true)
+		test.isequal({}, r)
+	end
+
+	function suite.skipsWholeArchiveNormalLink_onSibling()
+		links { "MyProject2" }
+		wholearchive { "MyProject2" }
+
+		project "MyProject2"
+		kind "StaticLib"
+		language "C++"
+
+		local r = prepare("all", "fullpath", nil, true)
+		test.isequal({}, r)
+	end
+
+	function suite.keepsWholeArchiveNormalLink_onSiblingDependencies()
+		links { "MyProject2" }
+		wholearchive { "MyProject2" }
+
+		project "MyProject2"
+		kind "StaticLib"
+		language "C++"
+
+		local r = prepare("dependencies", "fullpath")
+		test.isequal({ "bin/Debug/MyProject2.lib" }, r)
+	end
+


### PR DESCRIPTION
**What does this PR do?**

In the current iteration of `wholearchive`, if a library is listed both in `links` and `wholearchive`, it may cause multiple symbol definition.

**How does this PR change Premake's behavior?**

If a library (system or sibling projects) is listed in both the `links` and `wholearchive` section, the `wholearchive` specification will take precedence.

Behavior:

* Sibling library in links only -- Build dependency and links library (existing behavior)
* System library in links only -- Links library (existing behavior)
* Sibling library in `wholearchive` only -- Links library, includes all symbols/objects (existing behavior)
* System library in `wholearchive` only -- Links library, includes all symbols/objects (existing behavior)
* Sibling library in both `links` and `wholearchive` -- Build dependency and link library, including all symbols/objects. Only the single `wholearchive` linker input is emitted for the library, dropping the one from `links`.
* System library in both `links` and `wholearchive` -- Link library, including all symbols/objects. Only the single `wholearchive` linker input is emitted for the library, dropping the one from `links`.

**Anything else we should know?**

Other alternatives:
* Provide `wholearchive` with the same dependency generation capability as `links`
* Move `wholearchive` to be similar to `:static` and `:shared` suffixes (discussed in past with initial implementation of API, turned down)

Additionally, pinned the CI actions to windows-2022 to fix CI failures with GH Runner changes to what is `windows-latest`.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
