### PR TITLE
Smart Emission of `.exp` file outputs in Ninja Rules

### DIFF
--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -1150,10 +1150,21 @@ function m.linkTarget(cfg)
 	-- for the .lib file
 	-- If this is on windows and building a shared library, emit a exp file as an implicit output
 	if cfg.system == p.WINDOWS and cfg.kind == p.SHAREDLIB then
-		local expFileName = cfg.buildtarget.name:gsub("%..-$", "") .. ".exp"
-		if expFileName then
-			local expFilePath = path.getrelative(cfg.workspace.location, cfg.buildtarget.directory) .. "/" .. expFileName
-			table.insert(implicitoutputs, expFilePath)
+		-- exp files are only required with link.exe
+		-- If using MSVC or clang with link as the linker, emit the exp file
+		local shouldEmitExp = false
+		if toolset == p.tools.msc then
+			shouldEmitExp = true
+		elseif toolset == p.tools.clang and toolset.linker == "link" then
+			shouldEmitExp = true
+		end
+
+		if shouldEmitExp then
+			local expFileName = cfg.buildtarget.name:gsub("%..-$", "") .. ".exp"
+			if expFileName then
+				local expFilePath = path.getrelative(cfg.workspace.location, cfg.buildtarget.directory) .. "/" .. expFileName
+				table.insert(implicitoutputs, expFilePath)
+			end
 		end
 
 		if cfg.useimportlib ~= p.OFF then

--- a/modules/ninja/tests/test_ninja_project.lua
+++ b/modules/ninja/tests/test_ninja_project.lua
@@ -210,7 +210,37 @@ build bin/Debug/%s: link_gcc obj/Debug/main.o
 		ninja.cpp.linkTarget(cfg)
 
 		test.capture [[
-build bin/Debug/MyProject2.dll | bin/Debug/MyProject2.exp bin/Debug/MyProject2.lib: link_gcc obj/Debug/main.o
+build bin/Debug/MyProject2.dll | bin/Debug/MyProject2.lib: link_gcc obj/Debug/main.o
+  ldflags = $ldflags_MyProject2_Debug
+		]]
+	end
+
+
+--
+-- Test that shared library on Windows with default importlib setting works correctly with Clang
+--
+	function suite.sharedLibWindowsClang()
+		local wks = test.createWorkspace()
+		configurations { "Debug" }
+		toolset "clang"
+		_OS = "windows"
+
+		local prj = test.createProject(wks)
+		kind "SharedLib"
+		language "C++"
+		files { "main.cpp" }
+		toolset "gcc"
+
+		local cfg = test.getconfig(prj, "Debug")
+
+		-- Set up object files list (normally done by buildFiles)
+		cfg._objectFiles = { "obj/Debug/main.o" }
+
+		-- Call linkTarget and check output
+		ninja.cpp.linkTarget(cfg)
+
+		test.capture [[
+build bin/Debug/MyProject2.dll | bin/Debug/MyProject2.lib: link_gcc obj/Debug/main.o
   ldflags = $ldflags_MyProject2_Debug
 		]]
 	end
@@ -273,7 +303,7 @@ build bin/Debug/MyProject2.dll | bin/Debug/MyProject2.exp bin/Debug/MyProject2.l
 		ninja.cpp.linkTarget(cfg)
 
 		test.capture [[
-build bin/Debug/MyProject2.dll | bin/Debug/MyProject2.exp: link_gcc obj/Debug/main.o
+build bin/Debug/MyProject2.dll: link_gcc obj/Debug/main.o
   ldflags = $ldflags_MyProject2_Debug
 		]]
 	end


### PR DESCRIPTION
**What does this PR do?**

Ninja currently always emits `.exp` file outputs for shared libraries on Windows. This should only happen if using the `msc` toolset or Clang with `link.exe`. `lld` may or may not write an `.exp` file, so we shouldn't rely on this behavior.

**How does this PR change Premake's behavior?**

`.exp` files are only emitted when toolset is `msc` or  when using the `link.exe` linker on Windows.

**Anything else we should know?**

No

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
