### PR TITLE
Ninja fix broken build dependencies

### DIFF
--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -231,6 +231,22 @@ local function gatherDepTargets(cfg)
 			if depcfg then
 				local depTarget = path.getrelative(cfg.workspace.location, depcfg.buildtarget.directory) .. "/" .. depcfg.buildtarget.name
 				table.insert(depTargets, depTarget)
+
+				local depTargetEventRoot = path.getrelative(cfg.workspace.location, depcfg.objdir) .. "/" .. depcfg.project.name
+
+				-- Check if the dependency has a prebuild command, postbuild command, or prelink command
+				-- If so, add the outputs of those commands as dependencies as well
+				if depcfg.prebuildcommands and #depcfg.prebuildcommands > 0 then
+					table.insert(depTargets, depTargetEventRoot .. ".prebuild")
+				end
+
+				if depcfg.postbuildcommands and #depcfg.postbuildcommands > 0 then
+					table.insert(depTargets, depTargetEventRoot .. ".postbuild")
+				end
+
+				if depcfg.prelinkcommands and #depcfg.prelinkcommands > 0 then
+					table.insert(depTargets, depTargetEventRoot .. ".prelinkevents")
+				end
 			end
 		end
 	end
@@ -1002,7 +1018,7 @@ local function buildCommandString(cmds, message, touchFile)
 	elseif shell == "cmd" then
 		local joined = table.concat(allcmds, " && ")
 		-- Escape double quotes
-		joined = joined:gsub('"', '\\"')
+		joined = joined:gsub('"', '^"')
 		return "cmd /C \"" .. joined .. "\""
 	else
 		return table.concat(allcmds, " && ")
@@ -1302,7 +1318,7 @@ function m.projectPhonies(prj)
 		
 		local hasPostBuild = #firstCfg.postbuildcommands > 0 or firstCfg.postbuildmessage
 		if hasPostBuild then
-			local postbuildTarget = path.getrelative(firstCfg.workspace.location, firstCfg.buildtarget.directory) .. "/" .. firstCfg.project.name .. ".postbuild"
+			local postbuildTarget = path.getrelative(firstCfg.workspace.location, firstCfg.objdir) .. "/" .. firstCfg.project.name .. ".postbuild"
 			_p("build %s: phony %s", prj.name, postbuildTarget)
 		else
 			_p("build %s: phony %s", prj.name, targetPath)

--- a/modules/ninja/tests/test_ninja_config.lua
+++ b/modules/ninja/tests/test_ninja_config.lua
@@ -673,7 +673,7 @@ target_MyProject_Debug = MyProject
 		test.isnotnil(result)
 		test.capture [[
 build obj/Debug/MyProject.prebuild: prebuild
-  prebuildcommands = cmd /C "echo Building && type nul >> \"obj\Debug\MyProject.prebuild\" && copy /b \"obj\Debug\MyProject.prebuild\"+,, \"obj\Debug\MyProject.prebuild\""
+  prebuildcommands = cmd /C "echo Building && type nul >> ^"obj\Debug\MyProject.prebuild^" && copy /b ^"obj\Debug\MyProject.prebuild^"+,, ^"obj\Debug\MyProject.prebuild^""
 		]]
 	end
 
@@ -716,7 +716,7 @@ function suite.prebuildEvents_onMessage_Windows()
 		test.isnotnil(result)
 		test.capture [[
 build obj/Debug/MyProject.prebuild: prebuild
-  prebuildcommands = cmd /C "echo \"Building project\" && type nul >> \"obj\Debug\MyProject.prebuild\" && copy /b \"obj\Debug\MyProject.prebuild\"+,, \"obj\Debug\MyProject.prebuild\""
+  prebuildcommands = cmd /C "echo ^"Building project^" && type nul >> ^"obj\Debug\MyProject.prebuild^" && copy /b ^"obj\Debug\MyProject.prebuild^"+,, ^"obj\Debug\MyProject.prebuild^""
 		]]
 	end
 
@@ -761,7 +761,7 @@ build obj/Debug/MyProject.prebuild: prebuild
 		test.isnotnil(result)
 		test.capture [[
 build obj/Debug/MyProject.prebuild: prebuild
-  prebuildcommands = cmd /C "echo \"Building project\" && mkdir -p build && cp file.txt build/ && type nul >> \"obj\Debug\MyProject.prebuild\" && copy /b \"obj\Debug\MyProject.prebuild\"+,, \"obj\Debug\MyProject.prebuild\""
+  prebuildcommands = cmd /C "echo ^"Building project^" && mkdir -p build && cp file.txt build/ && type nul >> ^"obj\Debug\MyProject.prebuild^" && copy /b ^"obj\Debug\MyProject.prebuild^"+,, ^"obj\Debug\MyProject.prebuild^""
 		]]
 	end
 
@@ -827,7 +827,7 @@ build obj/Debug/MyProject.prebuild: prebuild
 		test.isnotnil(result)
 		test.capture [[
 build obj/Debug/MyProject.prelinkevents: prelink obj/Debug/main.o
-  prelinkcommands = cmd /C "echo Linking && type nul >> \"obj\Debug\MyProject.prelinkevents\" && copy /b \"obj\Debug\MyProject.prelinkevents\"+,, \"obj\Debug\MyProject.prelinkevents\""
+  prelinkcommands = cmd /C "echo Linking && type nul >> ^"obj\Debug\MyProject.prelinkevents^" && copy /b ^"obj\Debug\MyProject.prelinkevents^"+,, ^"obj\Debug\MyProject.prelinkevents^""
 		]]
 	end
 
@@ -873,7 +873,7 @@ build obj/Debug/MyProject.prelinkevents: prelink obj/Debug/main.o
 		test.isnotnil(result)
 		test.capture [[
 build obj/Debug/MyProject.prelinkevents: prelink obj/Debug/main.o
-  prelinkcommands = cmd /C "echo \"Linking project\" && type nul >> \"obj\Debug\MyProject.prelinkevents\" && copy /b \"obj\Debug\MyProject.prelinkevents\"+,, \"obj\Debug\MyProject.prelinkevents\""
+  prelinkcommands = cmd /C "echo ^"Linking project^" && type nul >> ^"obj\Debug\MyProject.prelinkevents^" && copy /b ^"obj\Debug\MyProject.prelinkevents^"+,, ^"obj\Debug\MyProject.prelinkevents^""
 		]]
 	end
 
@@ -919,7 +919,7 @@ build obj/Debug/MyProject.prelinkevents: prelink obj/Debug/main.o
 		test.isnotnil(result)
 		test.capture [[
 build obj/Debug/MyProject.prelinkevents: prelink obj/Debug/main.o
-  prelinkcommands = cmd /C "echo \"Preparing link\" && echo prelinking && ls -la && type nul >> \"obj\Debug\MyProject.prelinkevents\" && copy /b \"obj\Debug\MyProject.prelinkevents\"+,, \"obj\Debug\MyProject.prelinkevents\""
+  prelinkcommands = cmd /C "echo ^"Preparing link^" && echo prelinking && ls -la && type nul >> ^"obj\Debug\MyProject.prelinkevents^" && copy /b ^"obj\Debug\MyProject.prelinkevents^"+,, ^"obj\Debug\MyProject.prelinkevents^""
 		]]
 	end
 
@@ -1005,7 +1005,7 @@ build obj/Debug/MyProject.prelinkevents: prelink obj/Debug/main.o obj/Debug/foo.
 
 		test.capture [[
 build obj/Debug/MyProject.postbuild: postbuild | bin/Debug/MyProject
-  postbuildcommands = cmd /C "echo Done && type nul >> \"obj\Debug\MyProject.postbuild\" && copy /b \"obj\Debug\MyProject.postbuild\"+,, \"obj\Debug\MyProject.postbuild\""
+  postbuildcommands = cmd /C "echo Done && type nul >> ^"obj\Debug\MyProject.postbuild^" && copy /b ^"obj\Debug\MyProject.postbuild^"+,, ^"obj\Debug\MyProject.postbuild^""
 		]]
 	end
 
@@ -1045,7 +1045,7 @@ build obj/Debug/MyProject.postbuild: postbuild | bin/Debug/MyProject
 
 		test.capture [[
 build obj/Debug/MyProject.postbuild: postbuild | bin/Debug/MyProject
-  postbuildcommands = cmd /C "echo \"Build complete\" && type nul >> \"obj\Debug\MyProject.postbuild\" && copy /b \"obj\Debug\MyProject.postbuild\"+,, \"obj\Debug\MyProject.postbuild\""
+  postbuildcommands = cmd /C "echo ^"Build complete^" && type nul >> ^"obj\Debug\MyProject.postbuild^" && copy /b ^"obj\Debug\MyProject.postbuild^"+,, ^"obj\Debug\MyProject.postbuild^""
 		]]
 	end
 
@@ -1087,7 +1087,7 @@ build obj/Debug/MyProject.postbuild: postbuild | bin/Debug/MyProject
 
 		test.capture [[
 build obj/Debug/MyProject.postbuild: postbuild | bin/Debug/MyProject
-  postbuildcommands = cmd /C "echo \"Finishing build\" && cp bin/Debug/MyProject /usr/local/bin/ && chmod +x /usr/local/bin/MyProject && type nul >> \"obj\Debug\MyProject.postbuild\" && copy /b \"obj\Debug\MyProject.postbuild\"+,, \"obj\Debug\MyProject.postbuild\""
+  postbuildcommands = cmd /C "echo ^"Finishing build^" && cp bin/Debug/MyProject /usr/local/bin/ && chmod +x /usr/local/bin/MyProject && type nul >> ^"obj\Debug\MyProject.postbuild^" && copy /b ^"obj\Debug\MyProject.postbuild^"+,, ^"obj\Debug\MyProject.postbuild^""
 		]]
 	end
 


### PR DESCRIPTION
**What does this PR do?**

Fixes dependson only actions that affect subsequent builds via prebuild/postbuild/prelink events.

**How does this PR change Premake's behavior?**

Fixes project phonies on postbuilds, adds dependencies for build events that rely on prebuild/postbuild/prelink events of depended upon projects.

**Anything else we should know?**

No

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
