### PR TITLE
Fix build deps for all build steps

### DIFF
--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -222,6 +222,10 @@ function m.customrule(cfg, toolset, prj)
 	end
 end
 
+local function kindHasOutputFile(kind)
+	return kind == p.STATICLIB or kind == p.SHAREDLIB or kind == p.CONSOLEAPP or kind == p.WINDOWSAPP
+end
+
 local function gatherDepTargets(cfg)
 	local depTargets = {}
 	for _, depname in ipairs(cfg.dependson) do
@@ -229,23 +233,22 @@ local function gatherDepTargets(cfg)
 		if depprj then
 			local depcfg = project.getconfig(depprj, cfg.buildcfg, cfg.platform)
 			if depcfg then
-				local depTarget = path.getrelative(cfg.workspace.location, depcfg.buildtarget.directory) .. "/" .. depcfg.buildtarget.name
-				table.insert(depTargets, depTarget)
-
+				-- Dependency hierarchy is as follows:
+				-- 1) If the dependent config has post-build commands, depend on the post-build target
+				-- 2) If the dependent config produces an output file (exe/dll/lib), depend on that
+				-- 3) If the dependent config has pre-link commands, depend on the pre-link target
+				-- 4) If the dependent config has pre-build commands, depend on the pre-build target
+				
 				local depTargetEventRoot = path.getrelative(cfg.workspace.location, depcfg.objdir) .. "/" .. depcfg.project.name
-
-				-- Check if the dependency has a prebuild command, postbuild command, or prelink command
-				-- If so, add the outputs of those commands as dependencies as well
-				if depcfg.prebuildcommands and #depcfg.prebuildcommands > 0 then
-					table.insert(depTargets, depTargetEventRoot .. ".prebuild")
-				end
-
 				if depcfg.postbuildcommands and #depcfg.postbuildcommands > 0 then
 					table.insert(depTargets, depTargetEventRoot .. ".postbuild")
-				end
-
-				if depcfg.prelinkcommands and #depcfg.prelinkcommands > 0 then
+				elseif kindHasOutputFile(depcfg.kind) then
+					local depTarget = path.getrelative(cfg.workspace.location, depcfg.buildtarget.directory) .. "/" .. depcfg.buildtarget.name
+					table.insert(depTargets, depTarget)
+				elseif depcfg.prelinkcommands and #depcfg.prelinkcommands > 0 then
 					table.insert(depTargets, depTargetEventRoot .. ".prelinkevents")
+				elseif depcfg.prebuildcommands and #depcfg.prebuildcommands > 0 then
+					table.insert(depTargets, depTargetEventRoot .. ".prebuild")
 				end
 			end
 		end
@@ -573,8 +576,8 @@ function m.buildPch(cfg)
 	end
 	
 	local implicitDeps = ""
-	if cfg._dependsOnTarget then
-		implicitDeps = " | " .. cfg._dependsOnTarget
+	if cfg._dependsOnTargets then
+		implicitDeps = " | " .. table.concat(cfg._dependsOnTargets, " ")
 	end
 	
 	if toolset == p.tools.msc then
@@ -834,6 +837,14 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 				implicitDeps = implicitDeps .. " " .. output
 			end
 		end
+
+		-- Check if there are any dependson targets and add them as implicit dependencies
+		if cfg._dependsOnTargets then
+			if implicitDeps == "" then
+				implicitDeps = " |"
+			end
+			implicitDeps = implicitDeps .. " " .. table.concat(cfg._dependsOnTargets, " ")
+		end
 		
 		_p("build %s: %s_%s %s%s", objFile, rule, cfg.toolset, relPath, implicitDeps)
 		
@@ -971,11 +982,11 @@ function m.checkCustomRuleFile(cfg, node, filecfg, outputTracking)
 		end
 	end
 	
-	if cfg._dependsOnTarget and not cfg._hasPrebuild then
+	if cfg._dependsOnTargets and not cfg._hasPrebuild then
 		if deps == "" then
 			deps = " |"
 		end
-		deps = deps .. " " .. cfg._dependsOnTarget
+		deps = deps .. " " .. table.concat(cfg._dependsOnTargets, " ")
 	end
 	
 	local commands = {}
@@ -1227,8 +1238,8 @@ function m.buildPreBuildEvents(cfg)
 	local prebuildTarget = path.getrelative(cfg.workspace.location, cfg.objdir) .. "/" .. cfg.project.name .. ".prebuild"
 
 	local implicitDeps = ""
-	if cfg._dependsOnTarget then
-		implicitDeps = " | " .. cfg._dependsOnTarget
+	if cfg._dependsOnTargets then
+		implicitDeps = " | " .. table.concat(cfg._dependsOnTargets, " ")
 	end
 	
 	if hasMessage and not hasCommands then

--- a/modules/ninja/tests/test_ninja_buildaction.lua
+++ b/modules/ninja/tests/test_ninja_buildaction.lua
@@ -477,3 +477,254 @@ build bin/Debug/MyProject.exe: link_gcc obj/Debug/test.o | bin/Debug/prebuilt.o
 		]]
 	end
 
+
+--
+-- Check that a build with a dependency on a prebuild action correctly tracks the prebuild output as an implicit dependency of the link step.
+--
+
+	function suite.buildaction_PrebuildAction_ImplicitDependency_GCC()
+		toolset "gcc"
+
+		project "MyProject"
+			language "C++"
+			files { "main.cpp" }
+			dependson { "Project2" }
+
+		project "Project2"
+			kind "Utility"
+			files { "src/dummy.cpp" }
+			prebuildmessage "Generating code..."
+			prebuildcommands { "echo Prebuilding..." }
+		project "*"
+
+		local cfg = prepare()
+		cfg._dependsOnTargets = cpp.buildDependsOnTarget(cfg)
+		cpp.buildFiles(cfg)
+	
+		test.capture [[
+build obj/Debug/MyProject/main.o: cxx_gcc main.cpp | obj/Debug/Project2/Project2.prebuild
+		]]
+	end
+
+
+--
+-- Check that a build with a dependency on a postbuild action correctly tracks the postbuild output as an implicit dependency of the link step.
+--
+
+	function suite.buildaction_PostbuildAction_ImplicitDependency_GCC()
+		toolset "gcc"
+
+		project "MyProject"
+			language "C++"
+			files { "main.cpp" }
+			dependson { "Project2" }
+
+		project "Project2"
+			kind "Utility"
+			files { "src/dummy.cpp" }
+			postbuildmessage "Generating code..."
+			postbuildcommands { "echo Postbuilding..." }
+		project "*"
+
+		local cfg = prepare()
+		cfg._dependsOnTargets = cpp.buildDependsOnTarget(cfg)
+		cpp.buildFiles(cfg)
+	
+		test.capture [[
+build obj/Debug/MyProject/main.o: cxx_gcc main.cpp | obj/Debug/Project2/Project2.postbuild
+		]]
+	end
+
+
+--
+-- Check that a build with a dependency on a prelink action correctly tracks the prelink output as an implicit dependency of the link step.
+--
+
+	function suite.buildaction_PrelinkAction_ImplicitDependency_GCC()
+		toolset "gcc"
+
+		project "MyProject"
+			language "C++"
+			files { "main.cpp" }
+			dependson { "Project2" }
+
+		project "Project2"
+			kind "Utility"
+			files { "src/dummy.cpp" }
+			prelinkmessage "Generating code..."
+			prelinkcommands { "echo Prelinking..." }
+		project "*"
+
+		local cfg = prepare()
+		cfg._dependsOnTargets = cpp.buildDependsOnTarget(cfg)
+		cpp.buildFiles(cfg)
+	
+		test.capture [[
+build obj/Debug/MyProject/main.o: cxx_gcc main.cpp | obj/Debug/Project2/Project2.prelinkevents
+		]]
+	end
+
+
+--
+-- Test that postbuild commands take priority over prelink and prebuild for implicit dependencies.
+--
+
+	function suite.buildaction_PostbuildTakesPriority_GCC()
+		toolset "gcc"
+
+		project "MyProject"
+			language "C++"
+			files { "main.cpp" }
+			dependson { "Project2" }
+
+		project "Project2"
+			kind "Utility"
+			files { "src/dummy.cpp" }
+			prebuildmessage "Generating code..."
+			prebuildcommands { "echo Prebuilding..." }
+			prelinkmessage "Generating code..."
+			prelinkcommands { "echo Prelinking..." }
+			postbuildmessage "Generating code..."
+			postbuildcommands { "echo Postbuilding..." }
+		project "*"
+
+		local cfg = prepare()
+		cfg._dependsOnTargets = cpp.buildDependsOnTarget(cfg)
+		cpp.buildFiles(cfg)
+	
+		test.capture [[
+build obj/Debug/MyProject/main.o: cxx_gcc main.cpp | obj/Debug/Project2/Project2.postbuild
+		]]
+	end
+
+
+--
+-- Test that the postbuild commands takes priority over build type with output
+--
+
+	function suite.buildaction_PostbuildTakesPriorityOverOutput_GCC()
+		toolset "gcc"
+
+		project "MyProject"
+			language "C++"
+			files { "main.cpp" }
+			dependson { "Project2" }
+
+		project "Project2"
+			kind "ConsoleApp"
+			files { "src/dummy.cpp" }
+			prebuildmessage "Generating code..."
+			prebuildcommands { "echo Prebuilding..." }
+			prelinkmessage "Generating code..."
+			prelinkcommands { "echo Prelinking..." }
+			postbuildmessage "Generating code..."
+			postbuildcommands { "echo Postbuilding..." }
+		project "*"
+
+		local cfg = prepare()
+		cfg._dependsOnTargets = cpp.buildDependsOnTarget(cfg)
+		cpp.buildFiles(cfg)
+	
+		test.capture [[
+build obj/Debug/MyProject/main.o: cxx_gcc main.cpp | obj/Debug/Project2/Project2.postbuild
+		]]
+	end
+
+
+--
+-- Test that the output file of a dependent project takes priority over prebuild and prelink commands for implicit dependencies.
+--
+	
+	function suite.buildaction_OutputTakesPriorityOverPrebuildPrelink_GCC()
+		toolset "gcc"
+		_OS = "linux"
+
+		project "MyProject"
+			language "C++"
+			files { "main.cpp" }
+			dependson { "Project2" }
+
+		project "Project2"
+			kind "ConsoleApp"
+			files { "src/dummy.cpp" }
+			prebuildmessage "Generating code..."
+			prebuildcommands { "echo Prebuilding..." }
+			prelinkmessage "Generating code..."
+			prelinkcommands { "echo Prelinking..." }
+		project "*"
+
+		local cfg = prepare()
+		cfg._dependsOnTargets = cpp.buildDependsOnTarget(cfg)
+		cpp.buildFiles(cfg)
+	
+		test.capture [[
+build obj/Debug/MyProject/main.o: cxx_gcc main.cpp | bin/Debug/Project2
+		]]
+	end
+
+
+--
+-- Test that the prelink commands takes priority over prebuild commands for implicit dependencies.
+--
+
+	function suite.buildaction_PrelinkTakesPriorityOverPrebuild_GCC()
+		toolset "gcc"
+
+		project "MyProject"
+			language "C++"
+			files { "main.cpp" }
+			dependson { "Project2" }
+
+		project "Project2"
+			kind "Utility"
+			files { "src/dummy.cpp" }
+			prebuildmessage "Generating code..."
+			prebuildcommands { "echo Prebuilding..." }
+			prelinkmessage "Generating code..."
+			prelinkcommands { "echo Prelinking..." }
+		project "*"
+
+		local cfg = prepare()
+		cfg._dependsOnTargets = cpp.buildDependsOnTarget(cfg)
+		cpp.buildFiles(cfg)
+	
+		test.capture [[
+build obj/Debug/MyProject/main.o: cxx_gcc main.cpp | obj/Debug/Project2/Project2.prelinkevents
+		]]
+	end
+
+
+--
+-- Test that the link depends on the events of the dependent project, not the main build step, when both are present.
+--
+
+	function suite.buildaction_LinkDependsOnEvents_GCC()
+		toolset "gcc"
+		_OS = "linux"
+
+		project "MyProject"
+			language "C++"
+			files { "main.cpp" }
+			dependson { "Project2" }
+
+		project "Project2"
+			kind "Utility"
+			files { "src/dummy.cpp" }
+			prebuildmessage "Generating code..."
+			prebuildcommands { "echo Prebuilding..." }
+			prelinkmessage "Generating code..."
+			prelinkcommands { "echo Prelinking..." }
+			postbuildmessage "Generating code..."
+			postbuildcommands { "echo Postbuilding..." }
+		project "*"
+
+		local cfg = prepare()
+		cfg._dependsOnTargets = cpp.buildDependsOnTarget(cfg)
+		cfg._objectFiles = { "obj/Debug/MyProject/main.o" }
+		cpp.linkTarget(cfg)
+	
+		test.capture [[
+build bin/Debug/MyProject: link_gcc obj/Debug/MyProject/main.o | obj/Debug/Project2/Project2.postbuild
+  ldflags = $ldflags_MyProject_Debug
+		]]
+	end


### PR DESCRIPTION
**What does this PR do?**

Fixes more issues with missing dependencies between prebuild/prelink/postbuild steps.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

Follow on to #2689

Future work needed: For projects that are only custom build steps, we need to make sure those are properly tracked as dependencies for consumers of those projects.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
