### PR TITLE
Fix: GCC ninja module pchheader generation

### DIFF
--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -607,8 +607,8 @@ function m.buildPch(cfg)
 		local relPath
 		
 		if pch then
-			local headerPath = path.getabsolute(path.join(cfg.project.location, pch))
-			relPath = path.getrelative(cfg.workspace.location, headerPath)
+			-- pch is workspace-relative because ninja.getrelative is active when this runs
+			relPath = pch
 		else
 			relPath = cfg.pchheader
 		end
@@ -858,8 +858,15 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 			else
 				local pch = toolset.getpch(cfg)
 				if pch then
-					local objdir = path.getrelative(cfg.project.location, cfg.objdir)
+					local objdir = path.getrelative(cfg.workspace.location, cfg.objdir)
 					local pchPlaceholder = objdir .. "/" .. path.getname(pch)
+					-- Add the directory containing the PCH header to the search path so
+					-- #include "pch.h" in source files can be resolved when building from
+					-- the workspace root (where the project subdirectory is not in the path).
+					local pchDir = path.getdirectory(pch)
+					if pchDir and pchDir ~= "" and pchDir ~= "." then
+						table.insert(extraFlags, "-I " .. pchDir)
+					end
 					table.insert(extraFlags, "-include " .. pchPlaceholder)
 				end
 			end

--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -853,7 +853,8 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 				table.insert(extraFlags, "/Yu" .. cfg.pchheader)
 				local pchPath = m.getPchPath(cfg)
 				if pchPath then
-					table.insert(extraFlags, "/Fp" .. pchPath)
+					local wksRelPchPath = path.getrelative(cfg.workspace.location, path.join(cfg.project.location, pchPath))
+					table.insert(extraFlags, "/Fp" .. wksRelPchPath)
 				end
 			else
 				local pch = toolset.getpch(cfg)

--- a/modules/ninja/tests/test_ninja_pch.lua
+++ b/modules/ninja/tests/test_ninja_pch.lua
@@ -18,10 +18,21 @@
 --
 
 	local wks, prj
+	local _originalGetRelative
 
+	-- gcc.getpch() internally calls p.tools.getrelative(), which in production
+	-- gets overridden by ninja.getrelative (inside the onProject callback in _preload.lua)
+	-- to return workspace-relative paths. ninja_cpp.lua correctly assumes getpch
+	-- returns workspace-relative paths. But the test suite also needs to activate that override.
 	function suite.setup()
 		p.action.set("ninja")
 		wks, prj = test.createWorkspace()
+		_originalGetRelative = p.tools.getrelative
+		p.tools.getrelative = p.modules.ninja.getrelative
+	end
+
+	function suite.teardown()
+		p.tools.getrelative = _originalGetRelative
 	end
 
 	local function prepare()
@@ -423,11 +434,129 @@ build obj/Debug/main.obj: cxx_msc main.cpp | obj/Debug/stdafx.pch
 		language "C++"
 		pchheader "stdafx.h"
 		files { "stdafx.h", "main.cpp" }
-		
+
 		local cfg = prepare()
 		local pchFile = cpp.buildPch(cfg)
-		
+
 		-- MSVC requires pchsource, so this should return nil
 		test.isnil(pchFile)
+	end
+
+
+---
+-- PCH with project in a subdirectory (workspace location != project location)
+--
+-- When a project lives in a subdirectory relative to the workspace, ninja runs
+-- from the workspace root so all paths in the generated .ninja file must be
+-- workspace-relative. The tests below cover three bugs that caused incorrect
+-- paths in this scenario.
+---
+
+
+--
+-- The PCH source path in the build rule must not be doubled when the project
+-- is in a subdirectory. Previously, buildPch incorrectly joined the already
+-- workspace-relative path returned by ninja.getrelative with cfg.project.location,
+-- producing "MyProject/MyProject/pch.h" instead of "MyProject/pch.h".
+--
+-- Setup note: pchheader uses an explicit workspace-relative path to simulate
+-- what gcc.getpch returns when it locates the header in the project basedir.
+--
+
+	function suite.buildPch_sourcePathNotDoubled_inSubdirectory()
+		toolset "gcc"
+		language "C++"
+		location "MyProject"
+		pchheader "MyProject/pch.h"
+		files { "MyProject/pch.h", "MyProject/main.cpp" }
+
+		local cfg = test.getconfig(prj, "Debug")
+		local pchFile = cpp.buildPch(cfg)
+
+		test.isequal("MyProject/obj/Debug/pch.h.gch", pchFile)
+		test.capture [[
+build MyProject/obj/Debug/pch.h.gch | MyProject/obj/Debug/pch.h.gch.d: pch_gcc MyProject/pch.h
+  cflags = $cxxflags_MyProject_Debug
+		]]
+	end
+
+
+--
+-- Source files in a subdirectory project must receive two flags:
+--   -I <pch-header-dir>   so #include "pch.h" resolves from the workspace root
+--   -include <workspace-relative-objdir>/pch.h  (not project-relative)
+--
+-- Previously the -include path used project-relative objdir ("obj/Debug/pch.h")
+-- and the -I flag was absent entirely, causing GCC to fail to find pch.h.
+--
+
+	function suite.buildFile_pchFlags_inSubdirectory()
+		toolset "gcc"
+		language "C++"
+		location "MyProject"
+		pchheader "MyProject/pch.h"
+		files { "MyProject/pch.h", "MyProject/main.cpp" }
+
+		local cfg = test.getconfig(prj, "Debug")
+		local tr = p.project.getsourcetree(cfg.project)
+		local pchFile = "MyProject/obj/Debug/pch.h.gch"
+
+		local mainNode = nil
+		p.tree.traverse(tr, {
+			onleaf = function(node, depth)
+				if node.name == "main.cpp" then
+					mainNode = node
+				end
+			end
+		}, false, 1)
+
+		test.isnotnil(mainNode)
+		local filecfg = p.fileconfig.getconfig(mainNode, cfg)
+		local objFile = cpp.objectFile(cfg, mainNode, filecfg)
+
+		cpp.buildFile(cfg, mainNode, filecfg, objFile, pchFile, nil)
+
+		test.capture [[
+build MyProject/obj/Debug/main.o: cxx_gcc MyProject/main.cpp | MyProject/obj/Debug/pch.h.gch
+  cxxflags = $cxxflags_MyProject_Debug -I MyProject -include MyProject/obj/Debug/pch.h
+		]]
+	end
+
+
+--
+-- When the project and workspace are in the same directory (the common case),
+-- no -I flag should be added since pch.h is already findable without it.
+-- This ensures the subdirectory fix does not regress the co-located case.
+--
+
+	function suite.buildFile_noExtraIncludeDir_whenSameDir()
+		toolset "gcc"
+		language "C++"
+		pchheader "pch.h"
+		files { "pch.h", "main.cpp" }
+
+		local cfg = prepare()
+		local tr = p.project.getsourcetree(cfg.project)
+		local pchFile = "obj/Debug/pch.h.gch"
+
+		local mainNode = nil
+		p.tree.traverse(tr, {
+			onleaf = function(node, depth)
+				if node.name == "main.cpp" then
+					mainNode = node
+				end
+			end
+		}, false, 1)
+
+		test.isnotnil(mainNode)
+		local filecfg = p.fileconfig.getconfig(mainNode, cfg)
+		local objFile = cpp.objectFile(cfg, mainNode, filecfg)
+
+		cpp.buildFile(cfg, mainNode, filecfg, objFile, pchFile, nil)
+
+		test.capture [[
+build obj/Debug/main.o: cxx_gcc main.cpp | obj/Debug/pch.h.gch
+  cxxflags = $cxxflags_MyProject_Debug -include obj/Debug/pch.h
+		]]
 	end
 

--- a/modules/ninja/tests/test_ninja_pch.lua
+++ b/modules/ninja/tests/test_ninja_pch.lua
@@ -53,10 +53,10 @@
 		toolset "gcc"
 		language "C++"
 		pchheader "pch.h"
-		
+
 		local cfg = prepare()
 		local pchPath = cpp.getPchPath(cfg)
-		
+
 		test.isequal("obj/Debug/pch.h.gch", pchPath)
 	end
 
@@ -69,10 +69,10 @@
 		toolset "msc"
 		language "C++"
 		pchheader "stdafx.h"
-		
+
 		local cfg = prepare()
 		local pchPath = cpp.getPchPath(cfg)
-		
+
 		test.isequal("obj/Debug/stdafx.pch", pchPath)
 	end
 
@@ -83,10 +83,10 @@
 
 	function suite.getPchPath_onNoPCH()
 		toolset "gcc"
-		
+
 		local cfg = prepare()
 		local pchPath = cpp.getPchPath(cfg)
-		
+
 		test.isnil(pchPath)
 	end
 
@@ -99,10 +99,10 @@
 		toolset "gcc"
 		pchheader "pch.h"
 		enablepch "Off"
-		
+
 		local cfg = prepare()
 		local pchPath = cpp.getPchPath(cfg)
-		
+
 		test.isnil(pchPath)
 	end
 
@@ -120,10 +120,10 @@
 		language "C++"
 		pchheader "pch.h"
 		files { "pch.h", "main.cpp" }
-		
+
 		local cfg = prepare()
 		local pchFile = cpp.buildPch(cfg)
-		
+
 		test.isequal("obj/Debug/pch.h.gch", pchFile)
 		test.capture [[
 build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
@@ -141,10 +141,10 @@ build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
 		language "C++"
 		pchheader "precompile.h"
 		files { "precompile.h", "main.cpp" }
-		
+
 		local cfg = prepare()
 		local pchFile = cpp.buildPch(cfg)
-		
+
 		test.isequal("obj/Debug/precompile.h.gch", pchFile)
 		test.capture [[
 build obj/Debug/precompile.h.gch | obj/Debug/precompile.h.gch.d: pch_clang precompile.h
@@ -162,10 +162,10 @@ build obj/Debug/precompile.h.gch | obj/Debug/precompile.h.gch.d: pch_clang preco
 		language "C"
 		pchheader "pch.h"
 		files { "pch.h", "main.c" }
-		
+
 		local cfg = prepare()
 		local pchFile = cpp.buildPch(cfg)
-		
+
 		test.isequal("obj/Debug/pch.h.gch", pchFile)
 		test.capture [[
 build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
@@ -181,10 +181,10 @@ build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
 	function suite.buildPch_onNoPCH()
 		toolset "gcc"
 		language "C++"
-		
+
 		local cfg = prepare()
 		local pchFile = cpp.buildPch(cfg)
-		
+
 		test.isnil(pchFile)
 	end
 
@@ -199,10 +199,10 @@ build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
 		pchheader "pch.h"
 		enablepch "Off"
 		files { "pch.h", "main.cpp" }
-		
+
 		local cfg = prepare()
 		local pchFile = cpp.buildPch(cfg)
-		
+
 		test.isnil(pchFile)
 	end
 
@@ -216,152 +216,16 @@ build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
 		language "C++"
 		pchheader "include/pch.h"
 		files { "include/pch.h", "main.cpp" }
-		
+
 		local cfg = prepare()
 		local pchFile = cpp.buildPch(cfg)
-		
+
 		test.isequal("obj/Debug/pch.h.gch", pchFile)
 	end
 
 
 ---
--- Integration tests - PCH with source files
----
-
---
--- Verify that source files depend on the PCH.
---
-
-	function suite.sourceFileDependsOnPCH()
-		toolset "gcc"
-		language "C++"
-		pchheader "pch.h"
-		files { "pch.h", "main.cpp", "utils.cpp" }
-		
-		local cfg = prepare()
-		
-		test.isnotnil(cfg.pchheader)
-	end
-
-
---
--- Verify that source files get the -include flag for GCC.
---
-
-	function suite.sourceFile_hasIncludeFlag_GCC()
-		toolset "gcc"
-		language "C++"
-		pchheader "pch.h"
-		files { "pch.h", "main.cpp" }
-		
-		local cfg = prepare()
-		cpp.buildPch(cfg)
-		
-		test.capture [[
-build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
-  cflags = $cxxflags_MyProject_Debug
-		]]
-	end
-
-
---
--- Verify that per-file EnablePCH Off is respected - file without PCH.
---
-
-	function suite.perFileNoPCH_noInclude()
-		toolset "gcc"
-		language "C++"
-		pchheader "pch.h"
-		files { "pch.h", "nopch.cpp" }
-		
-		filter "files:nopch.cpp"
-			enablepch "Off"
-		
-		local cfg = prepare()
-		local tr = p.project.getsourcetree(cfg.project)
-		local pchFile = "obj/Debug/pch.h.gch"  -- Just use the path directly
-		
-		-- Find the nopch.cpp file node
-		local nopchNode = nil
-		p.tree.traverse(tr, {
-			onleaf = function(node, depth)
-				if node.name == "nopch.cpp" then
-					nopchNode = node
-				end
-			end
-		}, false, 1)
-		
-		test.isnotnil(nopchNode)
-		local filecfg = p.fileconfig.getconfig(nopchNode, cfg)
-		local objFile = cpp.objectFile(cfg, nopchNode, filecfg)
-		
-		cpp.buildFile(cfg, nopchNode, filecfg, objFile, pchFile, nil)
-		
-		-- Should NOT have -include flag because of NoPCH
-		test.capture [[
-build obj/Debug/nopch.o: cxx_gcc nopch.cpp
-  cxxflags = $cxxflags_MyProject_Debug
-		]]
-	end
-
-
---
--- Verify that regular files get the -include flag for GCC.
---
-
-	function suite.perFileWithPCH_hasInclude()
-		toolset "gcc"
-		language "C++"
-		pchheader "pch.h"
-		files { "pch.h", "main.cpp" }
-		
-		local cfg = prepare()
-		local tr = p.project.getsourcetree(cfg.project)
-		local pchFile = "obj/Debug/pch.h.gch"  -- Just use the path directly
-		
-		-- Find the main.cpp file node
-		local mainNode = nil
-		p.tree.traverse(tr, {
-			onleaf = function(node, depth)
-				if node.name == "main.cpp" then
-					mainNode = node
-				end
-			end
-		}, false, 1)
-		
-		test.isnotnil(mainNode)
-		local filecfg = p.fileconfig.getconfig(mainNode, cfg)
-		local objFile = cpp.objectFile(cfg, mainNode, filecfg)
-		
-		cpp.buildFile(cfg, mainNode, filecfg, objFile, pchFile, nil)
-		
-		-- Should have -include flag with PCH placeholder
-		test.capture [[
-build obj/Debug/main.o: cxx_gcc main.cpp | obj/Debug/pch.h.gch
-  cxxflags = $cxxflags_MyProject_Debug -include obj/Debug/pch.h
-		]]
-	end
-
-
---
--- Verify PCH header is found in includedirs.
---
-
-	function suite.pchInIncludedir()
-		toolset "gcc"
-		language "C++"
-		pchheader "pch.h"
-		includedirs { "include" }
-		files { "include/pch.h", "main.cpp" }
-		
-		local cfg = prepare()
-		local pchFile = cpp.buildPch(cfg)
-		
-		-- Should still build the PCH even if header is in subdirectory
-		test.isnotnil(pchFile)
-	end
-
-
+-- PCH build rule generation (buildPch) — MSVC
 --
 -- Verify MSVC PCH source compilation.
 --
@@ -372,55 +236,16 @@ build obj/Debug/main.o: cxx_gcc main.cpp | obj/Debug/pch.h.gch
 		pchheader "stdafx.h"
 		pchsource "stdafx.cpp"
 		files { "stdafx.h", "stdafx.cpp", "main.cpp" }
-		
+
 		local cfg = prepare()
 		local pchFile = cpp.buildPch(cfg)
-		
+
 		test.isequal("obj/Debug/stdafx.pch", pchFile)
 		test.capture [[
 build obj/Debug/stdafx.pch | obj/Debug/stdafx.obj: pch_msc stdafx.cpp
   pchheader = stdafx.h
   objdir = obj/Debug
   cflags = $cxxflags_MyProject_Debug
-		]]
-	end
-
-
---
--- Verify MSVC source files get the /Yu flag.
---
-
-	function suite.sourceFile_hasYuFlag_MSVC()
-		toolset "msc"
-		language "C++"
-		pchheader "stdafx.h"
-		pchsource "stdafx.cpp"
-		files { "stdafx.h", "stdafx.cpp", "main.cpp" }
-		
-		local cfg = prepare()
-		local tr = p.project.getsourcetree(cfg.project)
-		local pchFile = "obj/Debug/stdafx.pch"  -- Just use the path directly
-		
-		-- Find the main.cpp file node
-		local mainNode = nil
-		p.tree.traverse(tr, {
-			onleaf = function(node, depth)
-				if node.name == "main.cpp" then
-					mainNode = node
-				end
-			end
-		}, false, 1)
-		
-		test.isnotnil(mainNode)
-		local filecfg = p.fileconfig.getconfig(mainNode, cfg)
-		local objFile = cpp.objectFile(cfg, mainNode, filecfg)
-		
-		cpp.buildFile(cfg, mainNode, filecfg, objFile, pchFile, nil)
-		
-		-- Should have /Yu flag with PCH
-		test.capture [[
-build obj/Debug/main.obj: cxx_msc main.cpp | obj/Debug/stdafx.pch
-  cxxflags = $cxxflags_MyProject_Debug /Yustdafx.h /Fpobj/Debug/stdafx.pch
 		]]
 	end
 
@@ -444,11 +269,270 @@ build obj/Debug/main.obj: cxx_msc main.cpp | obj/Debug/stdafx.pch
 
 
 ---
+-- Source file flag generation (buildFile) — GCC, co-located project
+---
+
+--
+-- Verify that source files depend on the PCH.
+--
+
+	function suite.sourceFileDependsOnPCH()
+		toolset "gcc"
+		language "C++"
+		pchheader "pch.h"
+		files { "pch.h", "main.cpp", "utils.cpp" }
+
+		local cfg = prepare()
+
+		test.isnotnil(cfg.pchheader)
+	end
+
+
+--
+-- Verify that source files get the -include flag for GCC.
+--
+
+	function suite.sourceFile_hasIncludeFlag_GCC()
+		toolset "gcc"
+		language "C++"
+		pchheader "pch.h"
+		files { "pch.h", "main.cpp" }
+
+		local cfg = prepare()
+		cpp.buildPch(cfg)
+
+		test.capture [[
+build obj/Debug/pch.h.gch | obj/Debug/pch.h.gch.d: pch_gcc pch.h
+  cflags = $cxxflags_MyProject_Debug
+		]]
+	end
+
+
+--
+-- Verify that per-file EnablePCH Off is respected - file without PCH.
+--
+
+	function suite.perFileNoPCH_noInclude()
+		toolset "gcc"
+		language "C++"
+		pchheader "pch.h"
+		files { "pch.h", "nopch.cpp" }
+
+		filter "files:nopch.cpp"
+			enablepch "Off"
+
+		local cfg = prepare()
+		local tr = p.project.getsourcetree(cfg.project)
+		local pchFile = "obj/Debug/pch.h.gch"  -- Just use the path directly
+
+		-- Find the nopch.cpp file node
+		local nopchNode = nil
+		p.tree.traverse(tr, {
+			onleaf = function(node, depth)
+				if node.name == "nopch.cpp" then
+					nopchNode = node
+				end
+			end
+		}, false, 1)
+
+		test.isnotnil(nopchNode)
+		local filecfg = p.fileconfig.getconfig(nopchNode, cfg)
+		local objFile = cpp.objectFile(cfg, nopchNode, filecfg)
+
+		cpp.buildFile(cfg, nopchNode, filecfg, objFile, pchFile, nil)
+
+		-- Should NOT have -include flag because of NoPCH
+		test.capture [[
+build obj/Debug/nopch.o: cxx_gcc nopch.cpp
+  cxxflags = $cxxflags_MyProject_Debug
+		]]
+	end
+
+
+--
+-- Verify that regular files get the -include flag for GCC.
+--
+
+	function suite.perFileWithPCH_hasInclude()
+		toolset "gcc"
+		language "C++"
+		pchheader "pch.h"
+		files { "pch.h", "main.cpp" }
+
+		local cfg = prepare()
+		local tr = p.project.getsourcetree(cfg.project)
+		local pchFile = "obj/Debug/pch.h.gch"  -- Just use the path directly
+
+		-- Find the main.cpp file node
+		local mainNode = nil
+		p.tree.traverse(tr, {
+			onleaf = function(node, depth)
+				if node.name == "main.cpp" then
+					mainNode = node
+				end
+			end
+		}, false, 1)
+
+		test.isnotnil(mainNode)
+		local filecfg = p.fileconfig.getconfig(mainNode, cfg)
+		local objFile = cpp.objectFile(cfg, mainNode, filecfg)
+
+		cpp.buildFile(cfg, mainNode, filecfg, objFile, pchFile, nil)
+
+		-- Should have -include flag with PCH placeholder
+		test.capture [[
+build obj/Debug/main.o: cxx_gcc main.cpp | obj/Debug/pch.h.gch
+  cxxflags = $cxxflags_MyProject_Debug -include obj/Debug/pch.h
+		]]
+	end
+
+
+--
+-- Verify PCH header is found in includedirs.
+--
+
+	function suite.pchInIncludedir()
+		toolset "gcc"
+		language "C++"
+		pchheader "pch.h"
+		includedirs { "include" }
+		files { "include/pch.h", "main.cpp" }
+
+		local cfg = prepare()
+		local pchFile = cpp.buildPch(cfg)
+
+		-- Should still build the PCH even if header is in subdirectory
+		test.isnotnil(pchFile)
+	end
+
+
+--
+-- When pchheader is specified at the project root ("pch.h"), no -I flag is
+-- needed since the file is already findable from the workspace root.
+--
+
+	function suite.buildFile_noExtraIncludeDir_whenSameDir()
+		toolset "gcc"
+		language "C++"
+		pchheader "pch.h"
+		files { "pch.h", "main.cpp" }
+
+		local cfg = prepare()
+		local tr = p.project.getsourcetree(cfg.project)
+		local pchFile = "obj/Debug/pch.h.gch"
+
+		local mainNode = nil
+		p.tree.traverse(tr, {
+			onleaf = function(node, depth)
+				if node.name == "main.cpp" then
+					mainNode = node
+				end
+			end
+		}, false, 1)
+
+		test.isnotnil(mainNode)
+		local filecfg = p.fileconfig.getconfig(mainNode, cfg)
+		local objFile = cpp.objectFile(cfg, mainNode, filecfg)
+
+		cpp.buildFile(cfg, mainNode, filecfg, objFile, pchFile, nil)
+
+		test.capture [[
+build obj/Debug/main.o: cxx_gcc main.cpp | obj/Debug/pch.h.gch
+  cxxflags = $cxxflags_MyProject_Debug -include obj/Debug/pch.h
+		]]
+	end
+
+
+--
+-- When the PCH header has a directory prefix (e.g. "include/pch.h") in a
+-- co-located project, source files must receive an -I flag for that directory
+-- so GCC can resolve the header when processing the -include placeholder.
+-- (gcc.getpch uses os.isfile to search includedirs at build time; in unit tests
+-- files don't exist on disk, so we exercise this path via an explicit directory
+-- prefix in pchheader instead.)
+--
+
+	function suite.buildFile_hasIncludeDirFlag_whenPchFoundInIncludedir()
+		toolset "gcc"
+		language "C++"
+		pchheader "include/pch.h"
+		files { "include/pch.h", "main.cpp" }
+
+		local cfg = prepare()
+		local tr = p.project.getsourcetree(cfg.project)
+		local pchFile = "obj/Debug/pch.h.gch"
+
+		local mainNode = nil
+		p.tree.traverse(tr, {
+			onleaf = function(node, depth)
+				if node.name == "main.cpp" then
+					mainNode = node
+				end
+			end
+		}, false, 1)
+
+		test.isnotnil(mainNode)
+		local filecfg = p.fileconfig.getconfig(mainNode, cfg)
+		local objFile = cpp.objectFile(cfg, mainNode, filecfg)
+
+		cpp.buildFile(cfg, mainNode, filecfg, objFile, pchFile, nil)
+
+		test.capture [[
+build obj/Debug/main.o: cxx_gcc main.cpp | obj/Debug/pch.h.gch
+  cxxflags = $cxxflags_MyProject_Debug -I include -include obj/Debug/pch.h
+		]]
+	end
+
+
+---
+-- Source file flag generation (buildFile) — MSVC, co-located project
+---
+
+--
+-- Verify MSVC source files get the /Yu and /Fp flags.
+--
+
+	function suite.sourceFile_hasYuFlag_MSVC()
+		toolset "msc"
+		language "C++"
+		pchheader "stdafx.h"
+		pchsource "stdafx.cpp"
+		files { "stdafx.h", "stdafx.cpp", "main.cpp" }
+
+		local cfg = prepare()
+		local tr = p.project.getsourcetree(cfg.project)
+		local pchFile = "obj/Debug/stdafx.pch"  -- Just use the path directly
+
+		-- Find the main.cpp file node
+		local mainNode = nil
+		p.tree.traverse(tr, {
+			onleaf = function(node, depth)
+				if node.name == "main.cpp" then
+					mainNode = node
+				end
+			end
+		}, false, 1)
+
+		test.isnotnil(mainNode)
+		local filecfg = p.fileconfig.getconfig(mainNode, cfg)
+		local objFile = cpp.objectFile(cfg, mainNode, filecfg)
+
+		cpp.buildFile(cfg, mainNode, filecfg, objFile, pchFile, nil)
+
+		-- Should have /Yu flag with PCH
+		test.capture [[
+build obj/Debug/main.obj: cxx_msc main.cpp | obj/Debug/stdafx.pch
+  cxxflags = $cxxflags_MyProject_Debug /Yustdafx.h /Fpobj/Debug/stdafx.pch
+		]]
+	end
+
+
+---
 -- PCH with project in a subdirectory (workspace location != project location)
 --
 -- When a project lives in a subdirectory relative to the workspace, ninja runs
 -- from the workspace root so all paths in the generated .ninja file must be
--- workspace-relative. The tests below cover three bugs that caused incorrect
+-- workspace-relative. The tests below cover the bugs that caused incorrect
 -- paths in this scenario.
 ---
 
@@ -524,20 +608,22 @@ build MyProject/obj/Debug/main.o: cxx_gcc MyProject/main.cpp | MyProject/obj/Deb
 
 
 --
--- When the project and workspace are in the same directory (the common case),
--- no -I flag should be added since pch.h is already findable without it.
--- This ensures the subdirectory fix does not regress the co-located case.
+-- When an MSVC project lives in a subdirectory, the /Fp flag must use a
+-- workspace-relative path so ninja can locate the PCH from the workspace root.
+-- Previously /Fp used the project-relative path ("obj/Debug/stdafx.pch")
+-- instead of the correct workspace-relative path ("MyProject/obj/Debug/stdafx.pch").
 --
 
-	function suite.buildFile_noExtraIncludeDir_whenSameDir()
-		toolset "gcc"
+	function suite.sourceFile_hasWorkspaceRelativeFpFlag_MSVC_inSubdirectory()
+		toolset "msc"
 		language "C++"
-		pchheader "pch.h"
-		files { "pch.h", "main.cpp" }
+		location "MyProject"
+		pchheader "stdafx.h"
+		files { "MyProject/stdafx.h", "MyProject/main.cpp" }
 
-		local cfg = prepare()
+		local cfg = test.getconfig(prj, "Debug")
 		local tr = p.project.getsourcetree(cfg.project)
-		local pchFile = "obj/Debug/pch.h.gch"
+		local pchFile = "MyProject/obj/Debug/stdafx.pch"
 
 		local mainNode = nil
 		p.tree.traverse(tr, {
@@ -555,8 +641,7 @@ build MyProject/obj/Debug/main.o: cxx_gcc MyProject/main.cpp | MyProject/obj/Deb
 		cpp.buildFile(cfg, mainNode, filecfg, objFile, pchFile, nil)
 
 		test.capture [[
-build obj/Debug/main.o: cxx_gcc main.cpp | obj/Debug/pch.h.gch
-  cxxflags = $cxxflags_MyProject_Debug -include obj/Debug/pch.h
+build MyProject/obj/Debug/main.obj: cxx_msc MyProject/main.cpp | MyProject/obj/Debug/stdafx.pch
+  cxxflags = $cxxflags_MyProject_Debug /Yustdafx.h /FpMyProject/obj/Debug/stdafx.pch
 		]]
 	end
-


### PR DESCRIPTION
**What does this PR do?**

- fixes Clang/GCC `pchheader` command to remove path duplication in generated build.ninja files

**How does this PR change Premake's behavior?**

- writes correct ninja rules on clang for Unix machines

**Anything else we should know?**

given a dummy project with the following structure:
```bash
$ tree
.
├── build.ninja
├── HostApp
│   ├── HostApp.ninja
│   ├── include
│   │   └── pch.h
│   ├── premake5.lua
│   └── src
│       └── main.cc
├── premake5.lua
├── provision.sh
├── README.md
├── run-tests
└── Vagrantfile

4 directories, 11 files
$ cat HostApp/premake5.lua 
project "HostApp"
    kind "ConsoleApp"
    language "C++"
    cppdialect "C++17"

    files { "src/*.cc" }
    includedirs { "include" }
    pchheader "pch.h"%   
```

premake v5.0.0-beta8 generated `build.ninja`:
```
$ cat HostApp/HostApp.ninja
...
build HostApp/obj/Debug/pch.h.gch | HostApp/obj/Debug/pch.h.gch.d: pch_clang HostApp/HostApp/include/pch.h # <- pch.h doesn't exist here
  cflags = $cxxflags_HostApp_Debug
  depfile = HostApp/obj/Debug/pch.h.gch.d
build HostApp/obj/Debug/main.o: cxx_clang HostApp/src/main.cc | HostApp/obj/Debug/pch.h.gch
  cxxflags = $cxxflags_HostApp_Debug -include obj/Debug/pch.h # <- pch.h doesn't exist here
build HostApp/bin/Debug/HostApp: link_clang HostApp/obj/Debug/main.o
  ldflags = $ldflags_HostApp_Debug

$ ninja
ninja: error: 'HostApp/HostApp/include/pch.h', needed by 'HostApp/obj/Debug/pch.h.gch', missing and no known rule to make it
```

post-changes output:
```
$ cat HostApp/HostApp.ninja
...
build HostApp/obj/Debug/pch.h.gch | HostApp/obj/Debug/pch.h.gch.d: pch_gcc HostApp/include/pch.h
  cflags = $cxxflags_HostApp_Debug
  depfile = HostApp/obj/Debug/pch.h.gch.d
build HostApp/obj/Debug/main.o: cxx_gcc HostApp/src/main.cc | HostApp/obj/Debug/pch.h.gch
  cxxflags = $cxxflags_HostApp_Debug -I HostApp/include -include HostApp/obj/Debug/pch.h
build HostApp/bin/Debug/HostApp: link_gcc HostApp/obj/Debug/main.o
  ldflags = $ldflags_HostApp_Debug

$ ninja
[1/3] Generating precompiled header HostApp/include/pch.h
[2/3] Compiling C++ source HostApp/src/main.cc
[3/3] Linking target HostApp/bin/Debug/HostApp
```

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

