### PR TITLE
Fix return value of os.writefile_ifnotequal()

### DIFF
--- a/src/host/os_writefile_ifnotequal.c
+++ b/src/host/os_writefile_ifnotequal.c
@@ -105,7 +105,7 @@ int os_writefile_ifnotequal(lua_State* L)
 
 		if (!error)
 		{
-			lua_pushinteger(L, error ? -1 : 0);
+			lua_pushinteger(L, 1);
 			return 1;
 		}
 	}

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -542,6 +542,18 @@
 -- Helpers
 --
 
+	-- Save the real functions before test runner installs its stubs.
+	local real_writefile_ifnotequal = os.writefile_ifnotequal
+	local real_io_open = io.open
+
+	local function real_readfile(filepath)
+		local f = real_io_open(filepath, "rb")
+		if not f then return nil end
+		local content = f:read("*a")
+		f:close()
+		return content
+	end
+
 	local tmpname = function()
 		local p = os.tmpname()
         if p:startswith("\\") then
@@ -567,6 +579,52 @@
 		return p
 	end
 
+
+--
+-- os.writefile_ifnotequal() tests.
+--
+
+	function suite.writefile_ifnotequal_WritesNewFile()
+		local filepath = tmpname()
+		local content = "Hello, World!"
+		local ok, err = real_writefile_ifnotequal(content, filepath)
+		test.isequal(1, ok)
+		test.isnil(err)
+		test.istrue(os.isfile(filepath))
+		test.isequal(content, real_readfile(filepath))
+		os.remove(filepath)
+	end
+
+	function suite.writefile_ifnotequal_SkipsIdenticalContent()
+		local filepath = tmpname()
+		local content = "Identical content"
+		-- Write the file first
+		local ok1, err1 = real_writefile_ifnotequal(content, filepath)
+		test.isequal(1, ok1)
+		test.isnil(err1)
+		-- Try to write identical content
+		local ok2, err2 = real_writefile_ifnotequal(content, filepath)
+		test.isequal(0, ok2)
+		test.isnil(err2)
+		test.isequal(content, real_readfile(filepath))
+		os.remove(filepath)
+	end
+
+	function suite.writefile_ifnotequal_UpdatesWhenContentDiffers()
+		local filepath = tmpname()
+		local content1 = "First content"
+		local content2 = "Second content"
+		-- Write the file first
+		local ok1, err1 = real_writefile_ifnotequal(content1, filepath)
+		test.isequal(1, ok1)
+		test.isnil(err1)
+		-- Write different content
+		local ok2, err2 = real_writefile_ifnotequal(content2, filepath)
+		test.isequal(1, ok2)
+		test.isnil(err2)
+		test.isequal(content2, real_readfile(filepath))
+		os.remove(filepath)
+	end
 
 --
 -- os.remove() tests.

--- a/website/docs/os/os.writefile_ifnotequal.md
+++ b/website/docs/os/os.writefile_ifnotequal.md
@@ -13,7 +13,15 @@ ok, err = os.writefile_ifnotequal("text", "filename")
 
 ### Return Value ###
 
-True if successful, otherwise nil and an error message.
+The first return value:
+
+| Value | Explanation                                          |
+|-------|------------------------------------------------------|
+| 1     | The string was written to the file                   |
+| 0     | The string is identical to the current file contents |
+| -1    | An error occurred                                    |
+
+The second return value is an error message if the first return value is -1, otherwise nil.
 
 
 ### Availability ###


### PR DESCRIPTION
## NOTE
This combines two of @mercury233 's PRs: #2667 and #2682 (since i can't push to their branch)

**What does this PR do?**

- fix return value of os.writefile_ifnotequal()
- update the document for that function

**How does this PR change Premake's behavior?**

Before #2654 , os.writefile_ifnotequal() returns `1` if successful, `0` if the string is identical to the current file contents, otherwise `-1` and an error message. #2654 seems to changed this behavior accidentally, return `0` on success too. This PR change the behavior back.

**Anything else we should know?**

@jkriegshauser

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*

