### PR TITLE
Add support for C# Implicit Usings

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -159,6 +159,17 @@
 	}
 
 	p.api.register {
+		name = "enableimplicitusings",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Off"
+		}
+	}
+
+	p.api.register {
 		name = "externalanglebrackets",
 		scope = "config",
 		kind = "string",

--- a/modules/vstudio/tests/cs2005/test_netcore.lua
+++ b/modules/vstudio/tests/cs2005/test_netcore.lua
@@ -138,6 +138,40 @@ function suite.allowUnsafeProperty_core()
     ]]
 end
 
+function suite.implicitUsings_on()
+    p.action.set("vs2022")
+    dotnetframework "net10.0"
+    enableimplicitusings "On"
+    prepareProjectProperties()
+    test.capture [[
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<TargetFramework>net10.0</TargetFramework>
+		<Configurations>Debug;Release;Distribution</Configurations>
+		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+		<ImplicitUsings>true</ImplicitUsings>
+	</PropertyGroup>
+    ]]
+end
+
+function suite.implicitUsings_off()
+    p.action.set("vs2022")
+    dotnetframework "net10.0"
+    enableimplicitusings "Off"
+    prepareProjectProperties()
+    test.capture [[
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<TargetFramework>net10.0</TargetFramework>
+		<Configurations>Debug;Release;Distribution</Configurations>
+		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+		<ImplicitUsings>false</ImplicitUsings>
+	</PropertyGroup>
+    ]]
+end
+
 function suite.project_element_configurations()
 	p.action.set("vs2022")
 	dotnetframework "net8.0"

--- a/modules/vstudio/vs2005_csproj.lua
+++ b/modules/vstudio/vs2005_csproj.lua
@@ -54,6 +54,7 @@
 				dotnetbase.csversion,
 				dotnetbase.projectConfigurations,
 				dotnetbase.netcore.enableDefaultCompileItems,
+				dotnetbase.netcore.enableImplicitUsings,
 				dotnetbase.netcore.dotnetsdk
 			}
 		else

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -817,6 +817,17 @@
 		_p(2,'<EnableDefaultCompileItems>%s</EnableDefaultCompileItems>', iif(cfg.enableDefaultCompileItems, "true", "false"))
 	end
 
+	function dotnetbase.netcore.enableImplicitUsings(cfg)
+		local types = {
+			Off = "false",
+			On = "true"
+		}
+
+		if _ACTION >= "vs2022" and dotnetbase.isNewFormatProject(cfg) and types[cfg.enableimplicitusings] then
+			_p(2,'<ImplicitUsings>%s</ImplicitUsings>', types[cfg.enableimplicitusings])
+		end
+	end
+
 	function dotnetbase.netcore.useWpf(cfg)
 		if cfg.wpf == p.ON then
 			_p(2,'<UseWpf>true</UseWpf>')

--- a/website/docs/enableimplicitusings.md
+++ b/website/docs/enableimplicitusings.md
@@ -1,0 +1,29 @@
+Specifies if C# implicit usings should be enabled. Defaults to `Off`.
+
+```lua
+enableimplicitusings ("value")
+```
+
+### Parameters ###
+
+`value` is one of:
+
+| Value   | Description |
+|---------|-------------|
+| Default | Don't include property for implicit usings |
+| On      | Enable C# implicit usings. |
+| Off     | Disable C# implicit usings. |
+
+## Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0.0 or later for Visual Studio C# Projects.
+
+### Examples ###
+
+```lua
+enableimplicitusings "On"
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -133,6 +133,7 @@ module.exports = {
 						'embedandsign',
 						'enable64bitchecks',
 						'enabledefaultcompileitems',
+						'enableimplicitusings',
 						'enablemodules',
 						'enablepch',
 						'enableunitybuild',


### PR DESCRIPTION
**What does this PR do?**

Adds support for [Implicit Usings](https://devblogs.microsoft.com/dotnet/welcome-to-csharp-10/)

**How does this PR change Premake's behavior?**

It adds a new project property called `enableimplicitusings` which defaults to "Off" but can be switched to "On"

**Anything else we should know?**

It's pretty much a straight copy of the `enabledefaultcompileitems` implementation

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
