### PR TITLE
Skip Generation of Unsupported Projects for compilecommands

### DIFF
--- a/modules/compilecommands/compilecommands.lua
+++ b/modules/compilecommands/compilecommands.lua
@@ -207,6 +207,62 @@ function m.getobjectfile(cfg, file, filecfg)
 end
 
 
+local function generateproject(wks, prj, platform, buildcfg, commands)
+	if not p.action.supports(prj.language) then
+		p.warn("Project '%s' has unsupported language '%s', skipping", prj.name, prj.language)
+		return
+	end
+
+	if not p.action.supportsToolset(prj) then
+		p.warn("Project '%s' has unsupported toolset '%s', skipping", prj.name, prj.toolset)
+		return
+	end
+
+	local cfg = p.project.getconfig(prj, buildcfg, platform)
+	if not cfg then
+		cfg = p.project.findClosestMatch(prj, buildcfg, platform)
+	end
+
+	if not cfg then
+		p.error("No configuration found for project '%s' with build configuration '%s' and platform '%s'", prj.name, buildcfg, platform)
+		return
+	end
+
+	p.oven.assignObjectSequences(prj)
+
+	local tr = p.project.getsourcetree(prj)
+	p.tree.traverse(tr, {
+		onleaf = function(node)
+			local filecfg = p.fileconfig.getconfig(node, cfg)
+
+			local args = m.getcompilecommandsarguments(cfg, node.abspath, filecfg)
+			if not args then
+				return
+			end
+
+			local objfile = m.getobjectfile(cfg, node, filecfg)
+			if not objfile then
+				p.warn("Could not determine object file for '%s', skipping", node.abspath)
+				return
+			end
+
+			objfile = path.getabsolute(objfile)
+
+			args = table.join(args, { "-o", objfile })
+
+			local compile_command = {
+				directory = path.getabsolute(prj.location),
+				file = node.abspath,
+				arguments = args,
+				output = objfile,
+			}
+			
+			table.insert(commands, compile_command)
+		end
+	})
+end
+
+
 function m.generate(wks, platform, buildcfg)
 	-- For each project in the workspace, for each file in the project, generate a compile command entry
 	-- Each entry contains:
@@ -218,54 +274,7 @@ function m.generate(wks, platform, buildcfg)
 	local commands = {}
 
 	for prj in p.workspace.eachproject(wks) do
-		if not p.action.supports(prj.language) then
-			p.warn("Project '%s' has unsupported language '%s', skipping", prj.name, prj.language)
-			return
-		end
-
-		if not p.action.supportsToolset(prj) then
-			p.warn("Project '%s' has unsupported toolset '%s', skipping", prj.name, prj.toolset)
-			return
-		end
-
-		local cfg = p.project.getconfig(prj, buildcfg, platform)
-		if not cfg then
-			p.error("No configuration found for project '%s' with build configuration '%s' and platform '%s'", prj.name, buildcfg, platform)
-			return
-		end
-    
-    	p.oven.assignObjectSequences(prj)
-
-		local tr = p.project.getsourcetree(prj)
-		p.tree.traverse(tr, {
-			onleaf = function(node)
-				local filecfg = p.fileconfig.getconfig(node, cfg)
-
-				local args = m.getcompilecommandsarguments(cfg, node.abspath, filecfg)
-				if not args then
-					return
-				end
-
-				local objfile = m.getobjectfile(cfg, node, filecfg)
-				if not objfile then
-					p.warn("Could not determine object file for '%s', skipping", node.abspath)
-					return
-				end
-
-				objfile = path.getabsolute(objfile)
-
-				args = table.join(args, { "-o", objfile })
-
-				local compile_command = {
-					directory = path.getabsolute(prj.location),
-					file = node.abspath,
-					arguments = args,
-					output = objfile,
-				}
-				
-				table.insert(commands, compile_command)
-			end
-		})
+		generateproject(wks, prj, platform, buildcfg, commands)
 	end
 
 	return commands


### PR DESCRIPTION
**What does this PR do?**

Current behavior in premake ends generation of compilecommands when an unsupported project is encountered. Proposed/New behavior just skips the project.

**How does this PR change Premake's behavior?**

No breaking changes.

**Anything else we should know?**

Closes #2699 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*

@hanagasira I would appreciate you verifying the executable from the CI runs before we hit merge, if you have the time/ability to do so.
