### PR TITLE
Allow disabling implicit includes in compilecommands

### DIFF
--- a/modules/compilecommands/_preload.lua
+++ b/modules/compilecommands/_preload.lua
@@ -28,6 +28,20 @@ newoption {
 	description = "Specify the output file path for compile_commands.json",
 }
 
+newoption {
+	category = "Compilation Database",
+
+	trigger = "implicit-includes",
+	description = "Include implicit include directories in compile_commands.json",
+	
+	allowed = {
+		{ "On" , "Include implicit include directories (default)" },
+		{ "Off", "Exclude implicit include directories" },
+	},
+
+	default = "On",
+}
+
 newaction {
 	trigger = "compilecommands",
 	shortname = "compilecommands",

--- a/modules/compilecommands/compilecommands.lua
+++ b/modules/compilecommands/compilecommands.lua
@@ -122,7 +122,12 @@ function m.getflags(cfg, toolset, fcfg, tool)
 		buildoptions = table.join(buildoptions, fcfg.buildoptions)
 	end
 
-	local implicitincludedirs = getstructuredimplicitincludedirs(toolset, fcfg or cfg, tool)
+	local implicitincludedirs = {}
+
+	if _OPTIONS["implicit-includes"] == "On" then
+		implicitincludedirs = getstructuredimplicitincludedirs(toolset, cfg, tool)
+	end
+
 	local explicitincludedirs = toolset.getstructuredincludedirs(cfg, includedirs, externalincludedirs, frameworkdirs, includedirsafter)
 	local allincludedirs = table.join(explicitincludedirs, implicitincludedirs)
 	local allincludedirflags = table.flatten(table.translate(allincludedirs, function(kv)

--- a/website/docs/Using-Premake.md
+++ b/website/docs/Using-Premake.md
@@ -96,5 +96,7 @@ To specify a platform and a configuration:
 premake5 compilecommands --cc-config=Release --cc-platform=x64
 ```
 
+Additionally, `compilecommands` will attempt to determine the implicit include directories for your target toolset. To disable this behavior, use `--implicit-includes=Off`.
+
 [1]: http://www.cygwin.com/
 [2]: http://www.mingw.org/


### PR DESCRIPTION
**What does this PR do?**

Allows disabling of implicit includes in `compilecommands` action.

**How does this PR change Premake's behavior?**

No breaking changes. Default behavior remains the same.

`--implicit-includes=On` - Tries to fetch the implicit include directories from the toolset, adds to the compilation database if successful. This is the default behavior.
`--implicit-includes=Off` - Does not attempt to find the implicitly added include directories to the compilation database.

**Anything else we should know?**

Closes #2693 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
