### PR TITLE
Add Unicode support for GCC and Clang on Windows

### DIFF
--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -44,6 +44,7 @@
 
 	clang.shared = {
 		architecture = gcc.shared.architecture,
+		characterset = gcc.shared.characterset,
 		fatalwarnings = {
 			All = "-Werror"
 		},
@@ -264,6 +265,7 @@
 			WASM32 = "-m32",
 			WASM64 = "-m64",
 		}),
+		characterset = gcc.ldflags.characterset,
 		linkerfatalwarnings = {
 			All = "-Wl,--fatal-warnings",
 		},

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -58,6 +58,9 @@
 			x86_64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch x86_64", "-m64") end,
 			AARCH64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch arm64", nil) end,
 		},
+		characterset = {
+			Unicode = function (cfg) return iif(cfg.system == p.WINDOWS, { "-D_UNICODE", "-DUNICODE", "-municode" }, {}) end,
+		},
 		fatalwarnings = {
 			All = "-Werror",
 		},
@@ -563,6 +566,9 @@
 			x86 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch i386", "-m32") end,
 			x86_64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch x86_64", "-m64") end,
 			AARCH64 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch arm64", nil) end,
+		},
+		characterset = {
+			Unicode = function (cfg) return iif(cfg.system == p.WINDOWS, { "-municode" }, {}) end,
 		},
 		linkerfatalwarnings = {
 			All = "-Wl,--fatal-warnings",

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -437,3 +437,50 @@ end
 		prepare()
 		test.contains({ "-arch arm64" }, clang.getldflags(cfg))
 	end
+
+--
+-- Make sure unicode support is handled properly.
+--
+
+	function suite.cflags_onUnicode_Windows()
+		system "Windows"
+		characterset "Unicode"
+		prepare()
+		test.contains({ "-D_UNICODE", "-DUNICODE", "-municode" }, clang.getcflags(cfg))
+	end
+
+	function suite.cxxflags_onUnicode_Windows()
+		system "Windows"
+		characterset "Unicode"
+		prepare()
+		test.contains({ "-D_UNICODE", "-DUNICODE", "-municode" }, clang.getcxxflags(cfg))
+	end
+
+	function suite.ldflags_onUnicode_Windows()
+		system "Windows"
+		characterset "Unicode"
+		prepare()
+		test.contains({ "-municode" }, clang.getldflags(cfg))
+	end
+
+	function suite.cflags_onUnicode_NonWindows()
+		system "Linux"
+		characterset "Unicode"
+		prepare()
+		test.excludes({ "-D_UNICODE", "-DUNICODE", "-municode" }, clang.getcflags(cfg))
+	end
+
+	function suite.cxxflags_onUnicode_NonWindows()
+		system "Linux"
+		characterset "Unicode"
+		prepare()
+		test.excludes({ "-D_UNICODE", "-DUNICODE", "-municode" }, clang.getcxxflags(cfg))
+	end
+
+	function suite.ldflags_onUnicode_NonWindows()
+		system "Linux"
+		characterset "Unicode"
+		prepare()
+		test.excludes({ "-municode" }, clang.getldflags(cfg))
+	end
+	

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -1549,3 +1549,49 @@ end
 	
 		test.contains({ "-Wl,-rpath,'/usr/local/lib/mylibs'" }, gcc.getrunpathdirs(cfg, paths))
 	end
+
+--
+-- Make sure unicode support is handled properly.
+--
+
+	function suite.cflags_onUnicode_Windows()
+		system "Windows"
+		characterset "Unicode"
+		prepare()
+		test.contains({ "-D_UNICODE", "-DUNICODE", "-municode" }, gcc.getcflags(cfg))
+	end
+
+	function suite.cxxflags_onUnicode_Windows()
+		system "Windows"
+		characterset "Unicode"
+		prepare()
+		test.contains({ "-D_UNICODE", "-DUNICODE", "-municode" }, gcc.getcxxflags(cfg))
+	end
+
+	function suite.ldflags_onUnicode_Windows()
+		system "Windows"
+		characterset "Unicode"
+		prepare()
+		test.contains({ "-municode" }, gcc.getldflags(cfg))
+	end
+
+	function suite.cflags_onUnicode_NonWindows()
+		system "Linux"
+		characterset "Unicode"
+		prepare()
+		test.excludes({ "-D_UNICODE", "-DUNICODE", "-municode" }, gcc.getcflags(cfg))
+	end
+
+	function suite.cxxflags_onUnicode_NonWindows()
+		system "Linux"
+		characterset "Unicode"
+		prepare()
+		test.excludes({ "-D_UNICODE", "-DUNICODE", "-municode" }, gcc.getcxxflags(cfg))
+	end
+
+	function suite.ldflags_onUnicode_NonWindows()
+		system "Linux"
+		characterset "Unicode"
+		prepare()
+		test.excludes({ "-municode" }, gcc.getldflags(cfg))
+	end


### PR DESCRIPTION
**What does this PR do?**

Adds support for `chararcterset "Unicode"` for GCC and Clang for Windows.

**How does this PR change Premake's behavior?**

No breaking changes.

**Anything else we should know?**

Closes #2659 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
