### PR TITLE
Exclude system mingw32 builds

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -101,6 +101,9 @@ jobs:
             msystem: mingw32
           - platform: x64
             msystem: mingw64
+        exclude:
+          - msystem: mingw32
+            depsrc: system
     timeout-minutes: 15
     defaults:
       run:


### PR DESCRIPTION
**What does this PR do?**

MinGW is finally dropping its support for 32-bit packages (they dropped support for 32 bit environments a while back). This drops using the 32 bit packages in MinGW, instead only allowing for `none` or `contrib` configurations.

See Discussion Here: https://www.msys2.org/news/#2023-12-13-starting-to-drop-some-32-bit-packages

**How does this PR change Premake's behavior?**

No breaking changes to behavior. CI only changes.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
