### PR TITLE
Make Bootstrap.bat use system arch by default

### DIFF
--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -14,6 +14,12 @@ SET "ConfigArg="
 
 IF NOT "%PLATFORM%" == "" (
 	SET "PlatformArg=PLATFORM=%PLATFORM%"
+) ELSE (
+	IF "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
+		SET "PlatformArg=PLATFORM=x64"
+	) ELSE (
+		SET "PlatformArg=PLATFORM=Win32"
+	)
 )
 
 IF NOT "%CONFIG%" == "" (


### PR DESCRIPTION
**What does this PR do?**

Tweaks the default `Bootstrap.bat` behavior to use system architecture by default rather than Win32/x86 by default.

**How does this PR change Premake's behavior?**

No changes to behavior.

**Anything else we should know?**

No

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
