### PR TITLE
Fixed MSC support in gmake generator

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -141,6 +141,27 @@ jobs:
       with:
         name: premake-${{ matrix.msystem }}-${{ matrix.platform }}
         path: bin\${{ matrix.config }}\
+  windows-gmake-msc:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        config: [debug, release]
+        platform: [x86, x64]
+    timeout-minutes: 15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Install GNU make
+      run: choco install make --no-progress -y
+      shell: cmd
+    - name: Build with gmake and msc
+      run: ./Bootstrap.bat gmake
+      shell: cmd
+      env:
+        PLATFORM: ${{ matrix.platform }}
+        CONFIG: ${{ matrix.config }}
+    - name: Test
+      run: bin/${{ matrix.config }}/premake5.exe test --test-all
   cosmopolitan:
     runs-on: ubuntu-latest
     strategy:

--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -58,6 +58,9 @@ IF "%vsversion%" == "vs2010" (
 ) ELSE IF "%vsversion%" == "vs18" (
 	CALL :VsWhereVisualBootstrap "vs2026" "18.0" "19.0"
 
+) ELSE IF "%vsversion%" == "gmake" (
+	CALL :VsWhereVisualBootstrap "gmake" "15.0" "99.0" %PREMAKE_OPTS%
+
 ) ELSE (
 	ECHO Unrecognized Visual Studio version %vsversion%
 	EXIT /B 2
@@ -117,11 +120,11 @@ SET VsWhereCmdLine="!VsWherePath! -nologo -latest -version [%VsVersionMin%,%VsVe
 
 FOR /F "usebackq delims=" %%i in (`!VsWhereCmdLine!`) DO (
 	IF EXIST "%%i\VC\Auxiliary\Build\vcvars64.bat" (
-		CALL "%%i\VC\Auxiliary\Build\vcvars64.bat" && nmake MSDEV="%PremakeVsVersion%" %PlatformArg% %ConfigArg%  %PREMAKE_OPTS% -f Bootstrap.mak windows
+		CALL "%%i\VC\Auxiliary\Build\vcvars64.bat" && CALL :Build
 		EXIT /B %ERRORLEVEL%
 	) ELSE (
 		IF EXIST "%%i\VC\Auxiliary\Build\vcvars32.bat" (
-			CALL "%%i\VC\Auxiliary\Build\vcvars32.bat" && nmake MSDEV="%PremakeVsVersion%" %PlatformArg% %ConfigArg% %PREMAKE_OPTS% -f Bootstrap.mak windows
+			CALL "%%i\VC\Auxiliary\Build\vcvars32.bat" && CALL :Build
 			EXIT /B %ERRORLEVEL%
 		)
 	)
@@ -131,6 +134,19 @@ ECHO Could not find vcvars64.bat or vcvars32.bat to setup Visual Studio environm
 EXIT /B 2
 
 REM :VsWhereVisualBootstrap
+
+REM ===========================================================================
+
+:Build
+
+IF "%PremakeVsVersion%" == "gmake" (
+	make -f Bootstrap.mak windows-gmake SHELL=cmd.exe %PlatformArg% %ConfigArg% %PREMAKE_OPTS%
+) ELSE (
+	nmake MSDEV="%PremakeVsVersion%" %PlatformArg% %ConfigArg% %PREMAKE_OPTS% -f Bootstrap.mak windows
+)
+EXIT /B %ERRORLEVEL%
+
+REM :Build
 
 REM ===========================================================================
 

--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -64,7 +64,8 @@ HOST_PLATFORM= none
 .PHONY: default none clean nix-clean windows-clean \
 	mingw-clean mingw macosx macosx-clean osx-clean osx \
 	linux-clean linux bsd-clean bsd solaris-clean solaris \
-	haiku-clean haiku windows-base windows windows-msbuild
+	haiku-clean haiku windows-base windows windows-msbuild \
+	windows-gmake-clean windows-gmake
 
 default: $(HOST_PLATFORM)
 
@@ -172,6 +173,16 @@ windows: windows-base
 
 windows-msbuild: windows-base
 	msbuild /p:Configuration=$(CONFIG) /p:Platform=$(PLATFORM:x86=win32) .\build\bootstrap\Premake5.$(SLN_EXT)
+
+windows-gmake-clean: windows-clean
+
+# NOTE: this Windows target assumes cmd is the shell. Use 'make -f Bootstrap.mak windows-gmake SHELL=cmd.exe'
+windows-gmake: windows-gmake-clean
+	if not exist build\bootstrap (mkdir build\bootstrap)
+	cl /Fo.\build\bootstrap\ /Fe.\build\bootstrap\premake_bootstrap.exe /DPREMAKE_NO_BUILTIN_SCRIPTS /DLUA_STATICLIB /DUNICODE /D_UNICODE /I"$(LUA_DIR)" /I"$(LUASHIM_DIR)" user32.lib ole32.lib advapi32.lib $(SRC)
+	.\build\bootstrap\premake_bootstrap.exe embed
+	.\build\bootstrap\premake_bootstrap --arch=$(PLATFORM) --os=windows --to=build/bootstrap --cc=msc $(PREMAKE_OPTS) gmake
+	$(MAKE) -C build/bootstrap -j$(NUMBER_OF_PROCESSORS) config=$(CONFIG)_$(PLATFORM:x86=win32)
 
 cosmo-clean: nix-clean
 

--- a/contrib/libzip/premake5.lua
+++ b/contrib/libzip/premake5.lua
@@ -18,7 +18,7 @@ project "zip-lib"
 	filter "system:windows"
 		defines { "_WINDOWS" }
 
-	filter { "system:windows", "action:not vs*" }
+	filter { "system:windows", "action:not vs*", "toolset:not msc" }
 		defines { "HAVE_SSIZE_T_LIBZIP" }
 
 	filter "system:macosx"

--- a/modules/gmake/gmake.lua
+++ b/modules/gmake/gmake.lua
@@ -125,7 +125,7 @@
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) mkdir -p %s', dirname)
 		_p('else')
-		_p('\t$(SILENT) mkdir $(subst /,\\\\,%s)', dirname)
+		_p('\t$(SILENT) if not exist $(subst /,\\\\,%s) mkdir $(subst /,\\\\,%s)', dirname, dirname)
 		_p('endif')
 	end
 

--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -60,19 +60,19 @@
 			fileExtension { ".cc", ".cpp", ".cxx", ".mm" }
 			buildoutputs  { "$(OBJDIR)/%{file.objname}%{premake.modules.gmake.cpp.gettooloutputext('cxx', cfg)}" }
 			buildmessage  '$(notdir $<)'
-			buildcommands {'$(CXX) %{premake.modules.gmake.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"'}
+			buildcommands {'$(CXX) %{premake.modules.gmake.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) %{premake.modules.gmake.cpp.toolFlags(cfg, "cxx")}'}
 
 		rule 'cc'
 			fileExtension {".c", ".s", ".m"}
 			buildoutputs  { "$(OBJDIR)/%{file.objname}%{premake.modules.gmake.cpp.gettooloutputext('cc', cfg)}" }
 			buildmessage  '$(notdir $<)'
-			buildcommands {'$(CC) %{premake.modules.gmake.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"'}
+			buildcommands {'$(CC) %{premake.modules.gmake.cpp.fileFlags(cfg, file)} $(FORCE_INCLUDE) %{premake.modules.gmake.cpp.toolFlags(cfg, "cc")}'}
 
 		rule 'resource'
 			fileExtension ".rc"
 			buildoutputs  { "$(OBJDIR)/%{file.objname}%{premake.modules.gmake.cpp.gettooloutputext('rc', cfg)}" }
 			buildmessage  '$(notdir $<)'
-			buildcommands {'$(RESCOMP) $< -O coff -o "$@" $(ALL_RESFLAGS)'}
+			buildcommands {'$(RESCOMP) $(ALL_RESFLAGS) %{premake.modules.gmake.cpp.toolFlags(cfg, "rc")}'}
 
 		global(nil)
 	end
@@ -84,6 +84,19 @@
 		end
 
 		return iif(tool == "rc", ".res", ".o")
+	end
+
+	function cpp.toolFlags(cfg, tool)
+		local toolset = gmake.getToolSet(cfg)
+		if toolset.gettoolflags ~= nil then
+			return toolset.gettoolflags(cfg, tool, '"$<"', '"$@"', '"$(@:%.o=%.d)"')
+		end
+
+		if tool == "rc" then
+			return '"$<" -O coff -o "$@"'
+		else
+			return '-o "$@" -MF "$(@:%.o=%.d)" -c "$<"'
+		end
 	end
 
 	function cpp.createRuleTable(prj)
@@ -376,7 +389,8 @@
 
 
 	function cpp.pch(cfg, toolset)
-		local pch = p.tools.gcc.getpch(cfg)
+		local getpch = toolset.getpch or p.tools.gcc.getpch
+		local pch = getpch(cfg)
 		-- If there is no header, or if PCH has been disabled, I can early out
 		if pch == nil then
 			return
@@ -448,23 +462,32 @@
 
 
 	function cpp.linkCmd(cfg, toolset)
+		if cfg.kind == p.UTILITY then
+			-- Empty LINKCMD for Utility (only custom build rules)
+			p.outln('LINKCMD =')
+			return
+		end
+
+		local linker = iif(cfg.kind == p.STATICLIB, "$(AR)", iif(p.languages.isc(cfg.language), "$(CC)", "$(CXX)"))
+
+		if toolset.getlinkcommand ~= nil then
+			p.outln('LINKCMD = ' .. toolset.getlinkcommand(cfg, linker, '"$@"', '$(OBJECTS)', '$(RESOURCES)', '$(ALL_LDFLAGS)', '$(LIBS)'))
+			return
+		end
+
+		-- Fallback to previous version
 		if cfg.kind == p.STATICLIB then
 			if cfg.architecture == p.UNIVERSAL then
 				p.outln('LINKCMD = libtool -o "$@" $(OBJECTS)')
 			else
-				p.outln('LINKCMD = $(AR) -rcs "$@" $(OBJECTS)')
+				p.outln('LINKCMD = ' .. linker .. ' -rcs "$@" $(OBJECTS)')
 			end
-		elseif cfg.kind == p.UTILITY then
-			-- Empty LINKCMD for Utility (only custom build rules)
-			p.outln('LINKCMD =')
 		else
 			-- this was $(TARGET) $(LDFLAGS) $(OBJECTS)
 			--   but had trouble linking to certain static libs; $(OBJECTS) moved up
 			-- $(LDFLAGS) moved to end (http://sourceforge.net/p/premake/patches/107/)
 			-- $(LIBS) moved to end (http://sourceforge.net/p/premake/bugs/279/)
-
-			local cc = iif(p.languages.isc(cfg.language), "CC", "CXX")
-			p.outln('LINKCMD = $(' .. cc .. ') -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)')
+			p.outln('LINKCMD = ' .. linker .. ' -o "$@" $(OBJECTS) $(RESOURCES) $(ALL_LDFLAGS) $(LIBS)')
 		end
 	end
 
@@ -563,7 +586,9 @@
 		local fcfg = fileconfig.getconfig(file, cfg)
 		local flags = {}
 
-		if cfg.pchheader and cfg.enablepch ~= p.OFF and (not fcfg or fcfg.enablepch ~= p.OFF) then
+		local toolset = gmake.getToolSet(cfg)
+		local getpch = toolset.getpch or p.tools.gcc.getpch
+		if getpch(cfg) and cfg.pchheader and cfg.enablepch ~= p.OFF and (not fcfg or fcfg.enablepch ~= p.OFF) then
 			table.insert(flags, "-include $(PCH_PLACEHOLDER)")
 		end
 
@@ -790,10 +815,38 @@
 ---------------------------------------------------------------------------
 
 
+	-- Returns true if the configuration's toolset produces GNU make dependency files
+	function cpp.usesDependencyFiles(cfg)
+		return gmake.getToolSet(cfg) ~= p.tools.msc
+	end
+
 	function cpp.dependencies(prj)
-		-- include the dependencies, built by GCC (with the -MD flag)
-		_p('-include $(OBJECTS:%%.o=%%.d)')
-		_p('ifneq (,$(PCH))')
-			_p('  -include $(PCH_PLACEHOLDER).d')
-		_p('endif')
+		local function emitInclude()
+			_p('-include $(OBJECTS:%%.o=%%.d)')
+			_p('ifneq (,$(PCH))')
+				_p('  -include $(PCH_PLACEHOLDER).d')
+			_p('endif')
+		end
+
+		local depConfigs = {}
+		local total = 0
+		for cfg in project.eachconfig(prj) do
+			total = total + 1
+			if cpp.usesDependencyFiles(cfg) then
+				table.insert(depConfigs, cfg.shortname)
+			end
+		end
+
+		if #depConfigs == 0 then
+			-- No configuration produces dependency files, emit nothing.
+			return
+		elseif #depConfigs == total then
+			-- Every configuration produces dependency files, no guard needed.
+			emitInclude()
+		else
+			-- Mixed toolsets, so only include for the configs that produce dependency files.
+			_x('ifneq (,$(filter $(config),%s))', table.concat(depConfigs, ' '))
+			emitInclude()
+			_p('endif')
+		end
 	end

--- a/modules/gmake/tests/test_gmake_file_rules.lua
+++ b/modules/gmake/tests/test_gmake_file_rules.lua
@@ -112,10 +112,10 @@ $(OBJDIR)/test.o: src/test.c
 
 $(OBJDIR)/hello.obj: src/hello.cpp
 	@echo "$(notdir $<)"
-	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) /nologo /Fo"$@" /c /Tp"$<"
 $(OBJDIR)/test.obj: src/test.c
 	@echo "$(notdir $<)"
-	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) /nologo /Fo"$@" /c /Tc"$<"
 
 ]]
 	end

--- a/modules/gmake/tests/test_gmake_pch.lua
+++ b/modules/gmake/tests/test_gmake_pch.lua
@@ -26,7 +26,7 @@
 
 	local function prepareVars()
 		local cfg = test.getconfig(prj, "Debug")
-		gmake.cpp.pch(cfg)
+		gmake.cpp.pch(cfg, p.tools.gcc)
 	end
 
 	local function prepareRules()

--- a/modules/ninja/tests/test_ninja_config.lua
+++ b/modules/ninja/tests/test_ninja_config.lua
@@ -66,8 +66,7 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /MD
-cxxflags_MyProject_Debug = /MD /EHsc
+cxxflags_MyProject_Debug = /EHsc
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -134,8 +133,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /MD /D"DEBUG" /D"PLATFORM_WINDOWS"
-cxxflags_MyProject_Debug = /MD /EHsc /D"DEBUG" /D"PLATFORM_WINDOWS"
+cflags_MyProject_Debug = /D"DEBUG" /D"PLATFORM_WINDOWS"
+cxxflags_MyProject_Debug = /EHsc /D"DEBUG" /D"PLATFORM_WINDOWS"
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -178,8 +177,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /MD /D"HELLO=\"HELLO WORLD\""
-cxxflags_MyProject_Debug = /MD /EHsc /D"HELLO=\"HELLO WORLD\""
+cflags_MyProject_Debug = /D"HELLO=\"HELLO WORLD\""
+cxxflags_MyProject_Debug = /EHsc /D"HELLO=\"HELLO WORLD\""
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -200,8 +199,8 @@ target_MyProject_Debug = MyProject.exe
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /MD /D"VALUE=with_paren()"
-cxxflags_MyProject_Debug = /MD /EHsc /D"VALUE=with_paren()"
+cflags_MyProject_Debug = /D"VALUE=with_paren()"
+cxxflags_MyProject_Debug = /EHsc /D"VALUE=with_paren()"
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -248,8 +247,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /MD /Iinclude /Iexternal
-cxxflags_MyProject_Debug = /MD /EHsc /Iinclude /Iexternal
+cflags_MyProject_Debug = /Iinclude /Iexternal
+cxxflags_MyProject_Debug = /EHsc /Iinclude /Iexternal
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -316,8 +315,7 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /MD
-cxxflags_MyProject_Debug = /MD /EHsc
+cxxflags_MyProject_Debug = /EHsc
 ldflags_MyProject_Debug = /NOLOGO /LIBPATH:"lib" /LIBPATH:"external/lib"
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -404,8 +402,7 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /MD
-cxxflags_MyProject_Debug = /MD /EHsc
+cxxflags_MyProject_Debug = /EHsc
 ldflags_MyProject_Debug = /NOLOGO
 links_MyProject_Debug = User32.lib Gdi32.lib
 objdir_MyProject_Debug = obj/Debug
@@ -474,8 +471,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /MD /W4 /WX
-cxxflags_MyProject_Debug = /MD /EHsc /W4 /WX
+cflags_MyProject_Debug = /W4 /WX
+cxxflags_MyProject_Debug = /EHsc /W4 /WX
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -544,8 +541,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /MD /U"NDEBUG" /U"OLD_PLATFORM"
-cxxflags_MyProject_Debug = /MD /EHsc /U"NDEBUG" /U"OLD_PLATFORM"
+cflags_MyProject_Debug = /U"NDEBUG" /U"OLD_PLATFORM"
+cxxflags_MyProject_Debug = /EHsc /U"NDEBUG" /U"OLD_PLATFORM"
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug

--- a/modules/ninja/tests/test_ninja_perfile_config.lua
+++ b/modules/ninja/tests/test_ninja_perfile_config.lua
@@ -82,7 +82,7 @@ build obj/Debug/special.o: cxx_gcc special.cpp
 build obj/Debug/main.obj: cxx_msc main.cpp
   cxxflags = $cxxflags_MyProject_Debug
 build obj/Debug/special.obj: cxx_msc special.cpp
-  cxxflags = /MD /EHsc /D"MAIN_DEFINE" /D"SPECIAL_DEFINE"
+  cxxflags = /EHsc /D"MAIN_DEFINE" /D"SPECIAL_DEFINE"
 		]]
 	end
 
@@ -260,7 +260,7 @@ build obj/Debug/special.o: cxx_gcc special.cpp
 build obj/Debug/main.obj: cxx_msc main.cpp
   cxxflags = $cxxflags_MyProject_Debug
 build obj/Debug/special.obj: cxx_msc special.cpp
-  cxxflags = /MD /EHsc /D"MAIN_DEFINE" /D"SPECIAL_DEFINE" /Iinclude /Ispecial/include /O2
+  cxxflags = /EHsc /D"MAIN_DEFINE" /D"SPECIAL_DEFINE" /Iinclude /Ispecial/include /O2
 		]]
 	end
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -269,7 +269,7 @@
 		filter { "system:windows", "options:arch=x86_64 or arch=x64" }
 			platforms { "x64" }
 
-		filter { "system:windows", "options:arch=" }
+		filter { "system:windows", "options:not arch" }
 			platforms { "x86", "x64" }
 
 		filter "configurations:Debug"
@@ -290,7 +290,7 @@
 		filter { "system:windows", "action:vs*" }
 			characterset "Unicode"
 
-		filter { "system:windows", "action:not vs*" } -- TODO: mingw doesn't support `characterset "Unicode"`
+		filter { "system:windows", "action:not vs*", "toolset:not msc" } -- TODO: mingw doesn't support `characterset "Unicode"`
 			defines { "UNICODE", "_UNICODE" }
 			buildoptions { "-municode" }
 			linkoptions { "-municode" }
@@ -368,6 +368,9 @@
 			links		{ "crypt32", "bcrypt" }
 
 		filter { "system:windows", "toolset:clang", "action:not vs*" }
+			links		{ "crypt32", "bcrypt" }
+
+		filter { "system:windows", "toolset:msc", "action:gmake" }
 			links		{ "crypt32", "bcrypt" }
 
 		filter "system:linux or bsd or hurd"

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -404,3 +404,11 @@
 	function clang.gettooloutputext(tool)
 		return gcc.gettooloutputext(tool)
 	end
+
+	function clang.gettoolflags(cfg, tool, input, output, depfile)
+		return gcc.gettoolflags(cfg, tool, input, output, depfile)
+	end
+
+	function clang.getlinkcommand(cfg, linker, output, objects, resources, ldflags, libs)
+		return gcc.getlinkcommand(cfg, linker, output, objects, resources, ldflags, libs)
+	end

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -830,3 +830,20 @@
 	function gcc.gettooloutputext(tool)
 		return iif(tool == "rc", ".res", ".o")
 	end
+
+	function gcc.gettoolflags(cfg, tool, input, output, depfile)
+		if tool == "rc" then
+			return string.format('%s -O coff -o %s', input, output)
+		end
+		return string.format('-o %s -MF %s -c %s', output, depfile, input)
+	end
+
+	function gcc.getlinkcommand(cfg, linker, output, objects, resources, ldflags, libs)
+		if cfg.kind == p.STATICLIB then
+			if cfg.architecture == p.UNIVERSAL then
+				return string.format('libtool -o %s %s', output, objects)
+			end
+			return string.format('%s -rcs %s %s', linker, output, objects)
+		end
+		return string.format('%s -o %s %s %s %s %s', linker, output, objects, resources, ldflags, libs)
+	end

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -138,8 +138,6 @@
 			On = "/Zl",
 		},
 		staticruntime = {
-			-- this option must always be emit (does it??)
-			_ = function(cfg) return getRuntimeFlag(cfg, false) end,
 			-- runtime defaults to dynamic in VS
 			Default = function(cfg) return getRuntimeFlag(cfg, false) end,
 			On = function(cfg) return getRuntimeFlag(cfg, true) end,
@@ -305,6 +303,11 @@
 		end)
 
 		return result
+	end
+
+	function msc.getpch(cfg)
+		-- TODO: Add support for MSC precompiled headers in gmake
+		return nil
 	end
 
 	function msc.getrunpathdirs()
@@ -534,6 +537,22 @@
 
 	function msc.gettooloutputext(tool)
 		return iif(tool == "rc", ".res", ".obj")
+	end
+
+	function msc.gettoolflags(cfg, tool, input, output, depfile)
+		if tool == "rc" then
+			return string.format('/nologo /fo%s %s', output, input)
+		end
+		local lang = iif(tool == "cc", "/Tc", "/Tp")
+		return string.format('/nologo /Fo%s /c %s%s', output, lang, input)
+	end
+
+	function msc.getlinkcommand(cfg, linker, output, objects, resources, ldflags, libs)
+		if cfg.kind == p.STATICLIB then
+			return string.format('%s /nologo /OUT:%s %s', linker, output, objects)
+		end
+		local shared = iif(cfg.kind == p.SHAREDLIB, " /LD", "")
+		return string.format('%s%s /nologo /Fe%s %s %s %s /link %s', linker, shared, output, objects, resources, libs, ldflags)
 	end
 
 

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -853,13 +853,13 @@ end
 	function suite.mixedToolFlags_onCFlags()
 		fatalwarnings "All"
 		prepare()
-		test.isequal({ "/WX", "/MD" }, msc.getcflags(cfg))
+		test.isequal({ "/WX" }, msc.getcflags(cfg))
 	end
 
 	function suite.mixedToolFlags_onCxxFlags()
 		fatalwarnings "All"
 		prepare()
-		test.isequal({ "/WX", "/MD", "/EHsc" }, msc.getcxxflags(cfg))
+		test.isequal({ "/WX", "/EHsc" }, msc.getcxxflags(cfg))
 	end
 
 


### PR DESCRIPTION
- Added CI job to use the gmake generator
- Updated bootstrap process to allow usage of gmake on Windows with msc
- MSC no longer always emits runtime flag

**What does this PR do?**

Allows users to use MSC on Windows. Also adds gmake as an option in the bootstrap process on Windows, still builds with nmake initially though.

**How does this PR change Premake's behavior?**

Fixes issue with MSC emitting duplicate and/or conflicting runtime flags as part of the per-file flags.

**Anything else we should know?**

Some of the changes made for this could be applied to the Ninja generator too, but was out of scope for this PR.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
