### PR TITLE
Emit link and ar rules instead of conditional emit

### DIFF
--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -116,38 +116,34 @@ function m.linkrule(cfg, toolset)
 	toolset = toolset or ninja.gettoolset(cfg)
 
 	if toolset == p.tools.msc then
-		if cfg.kind == p.STATICLIB then
-			local arname = toolset.gettoolname(cfg, "ar")
-			_p("rule ar_%s", cfg.toolset)
-			_p("  command = %s $in /nologo -OUT:$out", arname)
-			_p("  description = Archiving static library $out")
-			_p("")
-		else
-			local ldname = toolset.gettoolname(cfg, iif(cfg.language == "C", "cc", "cxx"))
-			_p("rule link_%s", cfg.toolset)
-			_p("  command = %s $in $links /link $ldflags /nologo /out:$out", ldname)
-			_p("  description = Linking target $out")
-			_p("")
-		end
-	else
-		if cfg.kind == p.STATICLIB then
-			local arname = toolset.gettoolname(cfg, "ar")
-			_p("rule ar_%s", cfg.toolset)
-			_p("  command = %s -rcs $out $in", arname)
-			_p("  description = Archiving static library $out")
-			_p("")
-		else
-			local ldname = toolset.gettoolname(cfg, iif(cfg.language == "C", "cc", "cxx"))
-			local commands = string.format("command = %s -o $out $in $links $ldflags", ldname);
-			
-			commands = commands:gsub("(.-)%s*$", "%1")
-			commands = commands:gsub("%s+", " ")
+		local arname = toolset.gettoolname(cfg, "ar")
+		_p("rule ar_%s", cfg.toolset)
+		_p("  command = %s $in /nologo -OUT:$out", arname)
+		_p("  description = Archiving static library $out")
+		_p("")
 
-			_p("rule link_%s", cfg.toolset)
-			_p("  %s", commands)
-			_p("  description = Linking target $out")
-			_p("")
-		end
+		local ldname = toolset.gettoolname(cfg, iif(cfg.language == "C", "cc", "cxx"))
+		_p("rule link_%s", cfg.toolset)
+		_p("  command = %s $in $links /link $ldflags /nologo /out:$out", ldname)
+		_p("  description = Linking target $out")
+		_p("")
+	else
+		local arname = toolset.gettoolname(cfg, "ar")
+		_p("rule ar_%s", cfg.toolset)
+		_p("  command = %s -rcs $out $in", arname)
+		_p("  description = Archiving static library $out")
+		_p("")
+
+		local ldname = toolset.gettoolname(cfg, iif(cfg.language == "C", "cc", "cxx"))
+		local commands = string.format("command = %s -o $out $in $links $ldflags", ldname);
+		
+		commands = commands:gsub("(.-)%s*$", "%1")
+		commands = commands:gsub("%s+", " ")
+
+		_p("rule link_%s", cfg.toolset)
+		_p("  %s", commands)
+		_p("  description = Linking target $out")
+		_p("")
 	end
 end
 

--- a/modules/ninja/tests/test_ninja_build_rules.lua
+++ b/modules/ninja/tests/test_ninja_build_rules.lua
@@ -208,6 +208,10 @@ rule rc_gcc
 		local cfg = prepare()
 		cpp.linkrule(cfg)
 		test.capture [[
+rule ar_msc
+  command = lib $in /nologo -OUT:$out
+  description = Archiving static library $out
+
 rule link_msc
   command = cl $in $links /link $ldflags /nologo /out:$out
   description = Linking target $out
@@ -227,6 +231,10 @@ rule link_msc
 		local cfg = prepare()
 		cpp.linkrule(cfg)
 		test.capture [[
+rule ar_gcc
+  command = ar -rcs $out $in
+  description = Archiving static library $out
+
 rule link_gcc
   command = g++ -o $out $in $links $ldflags
   description = Linking target $out
@@ -246,6 +254,10 @@ rule link_gcc
 		local cfg = prepare()
 		cpp.linkrule(cfg)
 		test.capture [[
+rule ar_gcc
+  command = ar -rcs $out $in
+  description = Archiving static library $out
+
 rule link_gcc
   command = gcc -o $out $in $links $ldflags
   description = Linking target $out
@@ -266,49 +278,16 @@ rule link_gcc
 		local cfg = prepare()
 		cpp.linkrule(cfg)
 		test.capture [[
+rule ar_gcc
+  command = ar -rcs $out $in
+  description = Archiving static library $out
+
 rule link_gcc
   command = g++ -o $out $in $links $ldflags
   description = Linking target $out
 
 		]]
 	end
-
-
---
--- Check the archive rule for a static library with MSVC.
---
-
-	function suite.linkrule_onMSVCStaticLib()
-		toolset "msc"
-		kind "StaticLib"
-		local cfg = prepare()
-		cpp.linkrule(cfg)
-		test.capture [[
-rule ar_msc
-  command = lib $in /nologo -OUT:$out
-  description = Archiving static library $out
-
-		]]
-	end
-
-
---
--- Check the archive rule for a static library with GCC.
---
-
-	function suite.linkrule_onGCCStaticLib()
-		toolset "gcc"
-		kind "StaticLib"
-		local cfg = prepare()
-		cpp.linkrule(cfg)
-		test.capture [[
-rule ar_gcc
-  command = ar -rcs $out $in
-  description = Archiving static library $out
-
-		]]
-	end
-
 
 ---
 -- Precompiled header rules


### PR DESCRIPTION
**What does this PR do?**

Always emit both `link_<toolset>` and `ar_<toolset>` rules. This simplifies the logic in the generator, since we do selection of rule to build with and selection of which rules to generate. By generating all rules, we don't have to worry about which rule(s) to generate and they will be available for `build` statements.

**How does this PR change Premake's behavior?**

No breaking changes.

**Anything else we should know?**

Fixes #2712

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
