### PR TITLE
Added CI job to use the ninja generator

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -162,6 +162,61 @@ jobs:
         CONFIG: ${{ matrix.config }}
     - name: Test
       run: bin/${{ matrix.config }}/premake5.exe test --test-all
+  windows-ninja-msc:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        config: [debug, release]
+        platform: [x86, x64]
+    timeout-minutes: 15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Install Ninja
+      run: choco install ninja --no-progress -y
+      shell: cmd
+    - name: Build with ninja and msc
+      run: ./Bootstrap.bat ninja
+      shell: cmd
+      env:
+        PLATFORM: ${{ matrix.platform }}
+        CONFIG: ${{ matrix.config }}
+    - name: Test
+      run: bin/${{ matrix.config }}/premake5.exe test --test-all
+  linux-ninja:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config: [debug, release]
+        cc: [gcc, clang]
+    timeout-minutes: 15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install uuid-dev ninja-build
+    - name: Build with ninja
+      run: CONFIG=${{ matrix.config }} PREMAKE_OPTS="--cc=${{ matrix.cc }}" ./Bootstrap.sh -ninja
+    - name: Test
+      run: bin/${{ matrix.config }}/premake5 test --test-all
+  macos-ninja:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        config: [debug, release]
+        platform: [x64, ARM64]
+    timeout-minutes: 15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Install Ninja
+      run: brew install ninja
+    - name: Build with ninja
+      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} ./Bootstrap.sh -ninja
+    - name: Test
+      run: bin/${{ matrix.config }}/premake5 test --test-all
   cosmopolitan:
     runs-on: ubuntu-latest
     strategy:

--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -61,6 +61,9 @@ IF "%vsversion%" == "vs2010" (
 ) ELSE IF "%vsversion%" == "gmake" (
 	CALL :VsWhereVisualBootstrap "gmake" "15.0" "99.0" %PREMAKE_OPTS%
 
+) ELSE IF "%vsversion%" == "ninja" (
+	CALL :VsWhereVisualBootstrap "ninja" "15.0" "99.0" %PREMAKE_OPTS%
+
 ) ELSE (
 	ECHO Unrecognized Visual Studio version %vsversion%
 	EXIT /B 2
@@ -141,6 +144,8 @@ REM ===========================================================================
 
 IF "%PremakeVsVersion%" == "gmake" (
 	make -f Bootstrap.mak windows-gmake SHELL=cmd.exe %PlatformArg% %ConfigArg% %PREMAKE_OPTS%
+) ELSE IF "%PremakeVsVersion%" == "ninja" (
+	nmake -f Bootstrap.mak windows-ninja %PlatformArg% %ConfigArg% %PREMAKE_OPTS%
 ) ELSE (
 	nmake MSDEV="%PremakeVsVersion%" %PlatformArg% %ConfigArg% %PREMAKE_OPTS% -f Bootstrap.mak windows
 )

--- a/Bootstrap.mak
+++ b/Bootstrap.mak
@@ -51,10 +51,17 @@ SLN_EXT = sln
 SLN_EXT = slnx
 !endif
 
+# ninja config targets use the declared casing (Release/Debug).
+NINJA_CONFIG_TMP = $(CONFIG:release=Release)
+NINJA_CONFIG = $(NINJA_CONFIG_TMP:debug=Debug)
+
 !else
 else
 
 # make
+
+# ninja config targets use the declared casing (Release/Debug).
+NINJA_CONFIG := $(subst debug,Debug,$(subst release,Release,$(CONFIG)))
 
 endif
 !endif : # !endif has to be last to work in make
@@ -65,7 +72,8 @@ HOST_PLATFORM= none
 	mingw-clean mingw macosx macosx-clean osx-clean osx \
 	linux-clean linux bsd-clean bsd solaris-clean solaris \
 	haiku-clean haiku windows-base windows windows-msbuild \
-	windows-gmake-clean windows-gmake
+	windows-gmake-clean windows-gmake \
+	linux-ninja osx-ninja macosx-ninja windows-ninja windows-ninja-clean
 
 default: $(HOST_PLATFORM)
 
@@ -134,6 +142,22 @@ linux: linux-clean
 	./build/bootstrap/premake_bootstrap --to=build/bootstrap $(PREMAKE_OPTS) gmake
 	$(MAKE) -C build/bootstrap -j`getconf _NPROCESSORS_ONLN` config=$(CONFIG)
 
+linux-ninja: linux-clean
+	mkdir -p build/bootstrap
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_STATICLIB -DLUA_USE_POSIX -DLUA_USE_DLOPEN -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" $(SRC) -lm -ldl -lrt -luuid
+	./build/bootstrap/premake_bootstrap embed
+	./build/bootstrap/premake_bootstrap --to=build/bootstrap $(PREMAKE_OPTS) ninja
+	ninja -C build/bootstrap $(NINJA_CONFIG)
+
+macosx-ninja: osx-ninja
+
+osx-ninja: osx-clean
+	mkdir -p build/bootstrap
+	$(CC) -o build/bootstrap/premake_bootstrap -DPREMAKE_NO_BUILTIN_SCRIPTS -DLUA_STATICLIB -DLUA_USE_MACOSX -I"$(LUA_DIR)" -I"$(LUASHIM_DIR)" -framework CoreServices -framework Foundation -framework Security -lreadline $(SRC)
+	./build/bootstrap/premake_bootstrap embed
+	./build/bootstrap/premake_bootstrap --arch=$(PLATFORM) --to=build/bootstrap $(PREMAKE_OPTS) ninja
+	ninja -C build/bootstrap $(NINJA_CONFIG)
+
 bsd-clean: nix-clean
 
 bsd: bsd-clean
@@ -183,6 +207,16 @@ windows-gmake: windows-gmake-clean
 	.\build\bootstrap\premake_bootstrap.exe embed
 	.\build\bootstrap\premake_bootstrap --arch=$(PLATFORM) --os=windows --to=build/bootstrap --cc=msc $(PREMAKE_OPTS) gmake
 	$(MAKE) -C build/bootstrap -j$(NUMBER_OF_PROCESSORS) config=$(CONFIG)_$(PLATFORM:x86=win32)
+
+windows-ninja-clean: windows-clean
+
+# NOTE: this Windows target assumes cmd is the shell. Use 'nmake -f Bootstrap.mak windows-ninja'
+windows-ninja: windows-ninja-clean
+	if not exist build\bootstrap (mkdir build\bootstrap)
+	cl /Fo.\build\bootstrap\ /Fe.\build\bootstrap\premake_bootstrap.exe /DPREMAKE_NO_BUILTIN_SCRIPTS /DLUA_STATICLIB /DUNICODE /D_UNICODE /I"$(LUA_DIR)" /I"$(LUASHIM_DIR)" user32.lib ole32.lib advapi32.lib $(SRC)
+	.\build\bootstrap\premake_bootstrap.exe embed
+	.\build\bootstrap\premake_bootstrap --arch=$(PLATFORM) --os=windows --to=build/bootstrap --cc=msc $(PREMAKE_OPTS) ninja
+	ninja -C build/bootstrap $(NINJA_CONFIG)_$(PLATFORM:x86=Win32)
 
 cosmo-clean: nix-clean
 

--- a/Bootstrap.sh
+++ b/Bootstrap.sh
@@ -4,10 +4,12 @@ DIR=$( cd "$( dirname "$0" )" && pwd )
 cd "$DIR"
 
 COSMO_FLAG=""
+NINJA_FLAG=""
 for arg in "$@"; do
   if [ "$arg" = "-cosmo" ]; then
     COSMO_FLAG="cosmo"
-    break
+  elif [ "$arg" = "-ninja" ]; then
+    NINJA_FLAG="-ninja"
   fi
 done
 
@@ -43,11 +45,11 @@ fi
 case "${SYSTEM}" in
    Linux)
      NPROC=$(nproc --all)
-     make -f Bootstrap.mak ${COSMO_FLAG:-linux} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
+     make -f Bootstrap.mak ${COSMO_FLAG:-linux$NINJA_FLAG} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
      ;;
    Darwin)
      NPROC=$(sysctl -n hw.ncpu)
-     make -f Bootstrap.mak ${COSMO_FLAG:-osx} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
+     make -f Bootstrap.mak ${COSMO_FLAG:-osx$NINJA_FLAG} $PLATFORM_ARG $CONFIG_ARG "$PREMAKE_OPTS_ARG" -j$NPROC
      ;;
    FreeBSD|OpenBSD|NetBSD|DragonFly)
      NPROC=$(sysctl -n hw.ncpu)

--- a/premake5.lua
+++ b/premake5.lua
@@ -269,7 +269,7 @@
 		filter { "system:windows", "options:arch=x86_64 or arch=x64" }
 			platforms { "x64" }
 
-		filter { "system:windows", "options:not arch" }
+		filter { "system:windows", "options:not arch=*" }
 			platforms { "x86", "x64" }
 
 		filter "configurations:Debug"
@@ -367,10 +367,7 @@
 		filter { "system:windows", "toolset:not msc" }
 			links		{ "crypt32", "bcrypt" }
 
-		filter { "system:windows", "toolset:clang", "action:not vs*" }
-			links		{ "crypt32", "bcrypt" }
-
-		filter { "system:windows", "toolset:msc", "action:gmake" }
+		filter { "system:windows", "toolset:clang or msc", "action:not vs*" }
 			links		{ "crypt32", "bcrypt" }
 
 		filter "system:linux or bsd or hurd"


### PR DESCRIPTION
- Updated bootstrap process to allow usage of ninja for Linux, macOS and Windows

**What does this PR do?**

Adds Ninja to the bootstrap process for Linux, macOS and Windows (still builds with nmake initially on Windows). Also adds CI jobs using Ninja for those platforms too.

**How does this PR change Premake's behavior?**

N/A

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
