### PR TITLE
fix gmake.mkdir parallel on Windows path

### DIFF
--- a/modules/gmake/gmake.lua
+++ b/modules/gmake/gmake.lua
@@ -125,7 +125,7 @@
 		_p('ifeq (posix,$(SHELLTYPE))')
 		_p('\t$(SILENT) mkdir -p %s', dirname)
 		_p('else')
-		_p('\t$(SILENT) if not exist $(subst /,\\\\,%s) mkdir $(subst /,\\\\,%s)', dirname, dirname)
+		_p('\t$(SILENT) mkdir $(subst /,\\\\,%s) 2>nul || if exist $(subst /,\\\\,%s)\\\\NUL (exit /b 0) else (exit /b 1)', dirname, dirname)
 		_p('endif')
 	end
 

--- a/modules/gmake/tests/test_gmake_target_rules.lua
+++ b/modules/gmake/tests/test_gmake_target_rules.lua
@@ -43,6 +43,25 @@ all: $(TARGET)
 
 
 --
+-- Directory creation should tolerate a parallel build where another project
+-- creates the same directory first.
+--
+
+	function suite.mkdirRules_onWindows()
+		gmake.mkdirRules("$(TARGETDIR)")
+		test.capture [[
+$(TARGETDIR):
+	@echo Creating $(TARGETDIR)
+ifeq (posix,$(SHELLTYPE))
+	$(SILENT) mkdir -p $(TARGETDIR)
+else
+	$(SILENT) mkdir $(subst /,\\,$(TARGETDIR)) 2>nul || if exist $(subst /,\\,$(TARGETDIR))\\NUL (exit /b 0) else (exit /b 1)
+endif
+		]]
+	end
+
+
+--
 -- Check rules for an OS X Cocoa application.
 --
 


### PR DESCRIPTION
**What does this PR do?**

Fixes the `gmake` module's Windows directory creation rule so a parallel build does not fail if another task already created the directory.

**How does this PR change Premake's behavior?**

- On Windows, `gmake.mkdirRules()` now runs:
  - `mkdir ... 2>nul || if exist ...\NUL (exit /b 0) else (exit /b 1)`
- This preserves the existing behavior of creating missing directories, but makes it resilient to race conditions during parallel builds.
- Added a unit test in test_gmake_target_rules.lua to verify the Windows mkdir rule output.

**Anything else we should know?**

Failing log:
https://github.com/mercury233/premake-core/actions/runs/27801586579/job/82272805280

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
