### PR TITLE
fix exit value in Bootstrap.bat

### DIFF
--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -121,11 +121,11 @@ SET VsWhereCmdLine="!VsWherePath! -nologo -latest -version [%VsVersionMin%,%VsVe
 FOR /F "usebackq delims=" %%i in (`!VsWhereCmdLine!`) DO (
 	IF EXIST "%%i\VC\Auxiliary\Build\vcvars64.bat" (
 		CALL "%%i\VC\Auxiliary\Build\vcvars64.bat" && CALL :Build
-		EXIT /B %ERRORLEVEL%
+		EXIT /B !ERRORLEVEL!
 	) ELSE (
 		IF EXIST "%%i\VC\Auxiliary\Build\vcvars32.bat" (
 			CALL "%%i\VC\Auxiliary\Build\vcvars32.bat" && CALL :Build
-			EXIT /B %ERRORLEVEL%
+			EXIT /B !ERRORLEVEL!
 		)
 	)
 )
@@ -162,7 +162,7 @@ IF EXIST %VsWherePath% (
 
 		CALL %SelfPath% vs%%i
 
-		EXIT /B %ERRORLEVEL%
+		EXIT /B !ERRORLEVEL!
 	)
 
 )
@@ -192,7 +192,7 @@ SET PremakeVsVersion=%PremakeVsVersion:;=&REM.%
 
 IF NOT "%PremakeVsVersion%" == "" (
 	CALL %SelfPath% %PremakeVsVersion%
-	EXIT /B %ERRORLEVEL%
+	EXIT /B !ERRORLEVEL!
 )
 
 ECHO Could not find a Visual Studio installation


### PR DESCRIPTION
**What does this PR do?**

Fix error level propagation in Bootstrap.bat by using delayed expansion (`!ERRORLEVEL!` instead of `%ERRORLEVEL%`) in FOR loops and conditional blocks.
This follows batch script best practices and relies on the existing `SETLOCAL ENABLEDELAYEDEXPANSION` directive.

**How does this PR change Premake's behavior?**

Build exit codes are now correctly propagated instead of being lost in certain scenarios. No breaking changes.

**Anything else we should know?**

The CI build referenced in https://github.com/premake/premake-core/pull/2716 failed within the "Build with gmake and msc" step, but the step didn't fail.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
