### PR TITLE
add defaultconfiguration API and config.getdefault

### DIFF
--- a/modules/compilecommands/_preload.lua
+++ b/modules/compilecommands/_preload.lua
@@ -74,9 +74,11 @@ newaction {
 
 			-- Configuration is set in the following order of precedence
 			-- 1. Command line option
-			-- 2. First build configuration of the workspace
-			-- 3. Empty string
-			local buildcfg = _OPTIONS["cc-config"] or wks.configurations[1] or ""
+			-- 2. Workspace default configuration
+			-- 3. First build configuration of the workspace
+			-- 4. Empty string
+			local defaultCfg = wks.defaultconfiguration and p.config.getdefault(wks)
+			local buildcfg = _OPTIONS["cc-config"] or (defaultCfg and defaultCfg.buildcfg) or wks.configurations[1] or ""
 
 			local compile_commands = p.modules.compilecommands.generate(wks, platform, buildcfg)
 			all_commands = table.join(all_commands, compile_commands)

--- a/modules/gmake/gmake.lua
+++ b/modules/gmake/gmake.lua
@@ -18,25 +18,7 @@
 --
 
 	function gmake.defaultconfig(target)
-		-- find the right configuration iterator function for this object
-		local eachconfig = iif(target.project, project.eachconfig, p.workspace.eachconfig)
-		local defaultconfig = nil
-
-		-- find the right default configuration platform, grab first configuration that matches
-		if target.defaultplatform then
-			for cfg in eachconfig(target) do
-				if cfg.platform == target.defaultplatform then
-					defaultconfig = cfg
-					break
-				end
-			end
-		end
-
-		-- grab the first configuration and write the block
-		if not defaultconfig then
-			local iter = eachconfig(target)
-			defaultconfig = iter()
-		end
+		local defaultconfig = p.config.getdefault(target)
 
 		if defaultconfig then
 			_p('ifndef config')

--- a/modules/gmake/tests/_tests.lua
+++ b/modules/gmake/tests/_tests.lua
@@ -3,6 +3,7 @@ require ("gmake")
 return {
 	"test_gmake_buildcmds.lua",
 	"test_gmake_clang.lua",
+	"test_gmake_default_config.lua",
 	"test_gmake_file_rules.lua",
 	"test_gmake_flags.lua",
 	"test_gmake_includes.lua",

--- a/modules/gmake/tests/test_gmake_default_config.lua
+++ b/modules/gmake/tests/test_gmake_default_config.lua
@@ -1,12 +1,12 @@
 --
--- tests/actions/make/test_default_config.lua
+-- modules/gmake/tests/test_gmake_default_config.lua
 -- Validate generation of default configuration block for makefiles.
--- Copyright (c) 2012-2015 Jess Perkins and the Premake project
 --
 
-	local suite = test.declare("make_default_config")
+	local suite = test.declare("gmake_default_config")
 
 	local p = premake
+	local gmake = premake.modules.gmake
 
 
 --
@@ -21,7 +21,7 @@
 
 	local function prepare()
 		prj = test.getproject(wks, 1)
-		p.makelegacy.defaultconfig(prj)
+		gmake.defaultconfig(prj)
 	end
 
 
@@ -40,55 +40,7 @@ endif
 
 
 --
--- Verify handling of build config/platform combination.
---
-
-	function suite.defaultsToFirstPairing_onPlatforms()
-		platforms { "Win32", "Win64" }
-		prepare()
-		test.capture [[
-ifndef config
-  config=debug_win32
-endif
-		]]
-	end
-
-
---
--- If the project excludes a workspace build cfg, it should be skipped
--- over as the default config as well.
---
-
-	function suite.usesFirstValidPairing_onExcludedConfig()
-		platforms { "Win32", "Win64" }
-		removeconfigurations { "Debug" }
-		prepare()
-		test.capture [[
-ifndef config
-  config=release_win32
-endif
-		]]
-	end
-
-
---
--- Verify handling of defaultplatform
---
-
-	function suite.defaultsToSpecifiedPlatform()
-		platforms { "Win32", "Win64" }
-		defaultplatform "Win64"
-		prepare()
-		test.capture [[
-ifndef config
-  config=debug_win64
-endif
-		]]
-	end
-
-
---
--- Verify handling of defaultconfiguration
+-- Verify handling of defaultconfiguration.
 --
 
 	function suite.defaultsToSpecifiedConfiguration()
@@ -103,7 +55,7 @@ endif
 
 
 --
--- Verify handling of defaultconfiguration and defaultplatform together
+-- Verify handling of defaultconfiguration and defaultplatform together.
 --
 
 	function suite.defaultsToSpecifiedConfigurationAndPlatform()
@@ -120,7 +72,23 @@ endif
 
 
 --
--- Verify that invalid defaultconfiguration falls back to first
+-- Verify handling of defaultplatform only (no defaultconfiguration).
+--
+
+	function suite.defaultsToSpecifiedPlatform_onNoPlatformDefault()
+		platforms { "Win32", "Win64" }
+		defaultplatform "Win64"
+		prepare()
+		test.capture [[
+ifndef config
+  config=debug_win64
+endif
+		]]
+	end
+
+
+--
+-- Verify that invalid defaultconfiguration falls back to first config.
 --
 
 	function suite.fallsBackToFirstConfig_onInvalidConfiguration()
@@ -135,7 +103,7 @@ endif
 
 
 --
--- Verify that invalid defaultplatform falls back to first platform
+-- Verify that invalid defaultplatform falls back to first platform.
 --
 
 	function suite.fallsBackToFirstPlatform_onInvalidPlatform()
@@ -151,7 +119,7 @@ endif
 
 
 --
--- Verify case-insensitive matching for defaultconfiguration
+-- Verify case-insensitive matching for defaultconfiguration.
 --
 
 	function suite.caseInsensitive_forConfiguration()
@@ -166,23 +134,23 @@ endif
 
 
 --
--- Verify case-insensitive matching for defaultplatform
+-- Verify case-insensitive matching for defaultplatform.
 --
 
 	function suite.caseInsensitive_forPlatform()
 		platforms { "Win32", "Win64" }
-		defaultplatform "WIN32"
+		defaultplatform "WIN64"
 		prepare()
 		test.capture [[
 ifndef config
-  config=debug_win32
+  config=debug_win64
 endif
 		]]
 	end
 
 
 --
--- Verify priority: valid defaultplatform with invalid defaultconfiguration
+-- Verify priority: valid defaultplatform with invalid defaultconfiguration.
 --
 
 	function suite.prefersValidPlatform_whenConfigInvalid()
@@ -193,6 +161,23 @@ endif
 		test.capture [[
 ifndef config
   config=debug_win64
+endif
+		]]
+	end
+
+
+--
+-- Verify priority: valid defaultconfiguration with invalid defaultplatform.
+--
+
+	function suite.prefersValidConfiguration_whenPlatformInvalid()
+		platforms { "Win32", "Win64" }
+		defaultconfiguration "Release"
+		defaultplatform "ARM"
+		prepare()
+		test.capture [[
+ifndef config
+  config=release_win32
 endif
 		]]
 	end

--- a/modules/gmakelegacy/gmakelegacy.lua
+++ b/modules/gmakelegacy/gmakelegacy.lua
@@ -23,25 +23,7 @@
 --
 
 	function make.defaultconfig(target)
-		-- find the right configuration iterator function for this object
-		local eachconfig = iif(target.project, project.eachconfig, p.workspace.eachconfig)
-		local defaultconfig = nil
-
-		-- find the right default configuration platform, grab first configuration that matches
-		if target.defaultplatform then
-			for cfg in eachconfig(target) do
-				if cfg.platform == target.defaultplatform then
-					defaultconfig = cfg
-					break
-				end
-			end
-		end
-
-		-- grab the first configuration and write the block
-		if not defaultconfig then
-			local iter = eachconfig(target)
-			defaultconfig = iter()
-		end
+		local defaultconfig = p.config.getdefault(target)
 
 		if defaultconfig then
 			_p('ifndef config')

--- a/modules/ninja/ninja_workspace.lua
+++ b/modules/ninja/ninja_workspace.lua
@@ -62,18 +62,7 @@ function m.defaultTarget(wks)
 	end
 	
 	-- Determine the default configuration to build
-	local defaultCfg = nil
-	for cfg in p.workspace.eachconfig(wks) do
-		-- If a default platform is specified, find the first config with that platform
-		if wks.defaultplatform and cfg.platform == wks.defaultplatform then
-			defaultCfg = cfg
-			break
-		end
-		-- Otherwise, fall back to the first configuration
-		if not defaultCfg then
-			defaultCfg = cfg
-		end
-	end
+	local defaultCfg = p.config.getdefault(wks)
 	
 	-- Build the list of default targets based on the selected projects and configuration
 	if defaultCfg then

--- a/modules/ninja/tests/test_ninja_workspace.lua
+++ b/modules/ninja/tests/test_ninja_workspace.lua
@@ -242,6 +242,109 @@ default TestProject_Debug
 
 
 --
+-- Check default target respects defaultconfiguration.
+--
+
+	function suite.defaultTarget_onDefaultConfiguration()
+		p.action.set("ninja")
+		local wks2 = workspace "TestWorkspace6"
+		configurations { "Debug", "Release" }
+		defaultconfiguration "Release"
+
+		project "TestProject"
+		kind "ConsoleApp"
+		files { "main.cpp" }
+
+		wks2 = test.getWorkspace(wks2)
+		wks_module.defaultTarget(wks2)
+
+		test.capture [[
+
+# Default build target
+default TestProject_Release
+		]]
+	end
+
+
+--
+-- Check default target respects defaultconfiguration and defaultplatform together.
+--
+
+	function suite.defaultTarget_onDefaultConfigurationAndDefaultPlatform()
+		p.action.set("ninja")
+		local wks2 = workspace "TestWorkspace5"
+		configurations { "Debug", "Release" }
+		platforms { "x86", "x64" }
+		defaultconfiguration "Release"
+		defaultplatform "x64"
+
+		project "TestProject"
+		kind "ConsoleApp"
+		files { "main.cpp" }
+
+		wks2 = test.getWorkspace(wks2)
+		wks_module.defaultTarget(wks2)
+
+		test.capture [[
+
+# Default build target
+default TestProject_Release_x64
+		]]
+	end
+
+
+--
+-- Check default target with invalid defaultconfiguration falls back.
+--
+
+	function suite.defaultTarget_onInvalidConfiguration()
+		p.action.set("ninja")
+		local wks2 = workspace "TestWorkspace8"
+		configurations { "Debug", "Release" }
+		defaultconfiguration "NonExistent"
+
+		project "TestProject"
+		kind "ConsoleApp"
+		files { "main.cpp" }
+
+		wks2 = test.getWorkspace(wks2)
+		wks_module.defaultTarget(wks2)
+
+		test.capture [[
+
+# Default build target
+default TestProject_Debug
+		]]
+	end
+
+
+--
+-- Check default target with invalid defaultplatform falls back.
+--
+
+	function suite.defaultTarget_onInvalidPlatform()
+		p.action.set("ninja")
+		local wks2 = workspace "TestWorkspace9"
+		configurations { "Debug", "Release" }
+		platforms { "x86", "x64" }
+		defaultplatform "ARM"
+
+		project "TestProject"
+		kind "ConsoleApp"
+		files { "main.cpp" }
+
+		wks2 = test.getWorkspace(wks2)
+		wks_module.defaultTarget(wks2)
+
+		test.capture [[
+
+# Default build target
+default TestProject_Debug_x64
+		]]
+	end
+
+
+--
 -- Check default target with platforms but no default platform uses first platform.
 --
 

--- a/modules/vstudio/tests/sln2005/test_platforms.lua
+++ b/modules/vstudio/tests/sln2005/test_platforms.lua
@@ -8,7 +8,6 @@
 	local suite = test.declare("vstudio_sln2005_platforms")
 	local sln2005 = p.vstudio.sln2005
 
-
 --
 -- Setup
 --
@@ -509,16 +508,16 @@ EndGlobalSection
 		prepare()
 		test.capture [[
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
-	Debug|x64 = Debug|x64
 	Debug|x86 = Debug|x86
+	Debug|x64 = Debug|x64
 	Release|x64 = Release|x64
 	Release|x86 = Release|x86
 EndGlobalSection
 GlobalSection(ProjectConfigurationPlatforms) = postSolution
-	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x64.ActiveCfg = Debug|x64
-	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x64.Build.0 = Debug|x64
 	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x86.ActiveCfg = Debug|x86
 	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x86.Build.0 = Debug|x86
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x64.ActiveCfg = Debug|x64
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x64.Build.0 = Debug|x64
 	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|x64.ActiveCfg = Release|x64
 	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|x64.Build.0 = Release|x64
 	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|x86.ActiveCfg = Release|x86
@@ -537,24 +536,24 @@ EndGlobalSection
 		prepare()
 		test.capture [[
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
-	Debug|x64 = Debug|x64
 	Debug|x86 = Debug|x86
+	Debug|x64 = Debug|x64
 	Release|x64 = Release|x64
 	Release|x86 = Release|x86
 EndGlobalSection
 GlobalSection(ProjectConfigurationPlatforms) = postSolution
-	{52AD9329-0D74-4F66-A213-E649D8CCD737}.Debug|x64.ActiveCfg = Debug|x64
-	{52AD9329-0D74-4F66-A213-E649D8CCD737}.Debug|x64.Build.0 = Debug|x64
 	{52AD9329-0D74-4F66-A213-E649D8CCD737}.Debug|x86.ActiveCfg = Debug|x86
 	{52AD9329-0D74-4F66-A213-E649D8CCD737}.Debug|x86.Build.0 = Debug|x86
+	{52AD9329-0D74-4F66-A213-E649D8CCD737}.Debug|x64.ActiveCfg = Debug|x64
+	{52AD9329-0D74-4F66-A213-E649D8CCD737}.Debug|x64.Build.0 = Debug|x64
 	{52AD9329-0D74-4F66-A213-E649D8CCD737}.Release|x64.ActiveCfg = Release|x64
 	{52AD9329-0D74-4F66-A213-E649D8CCD737}.Release|x64.Build.0 = Release|x64
 	{52AD9329-0D74-4F66-A213-E649D8CCD737}.Release|x86.ActiveCfg = Release|x86
 	{52AD9329-0D74-4F66-A213-E649D8CCD737}.Release|x86.Build.0 = Release|x86
-	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x64.ActiveCfg = Debug|x64
-	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x64.Build.0 = Debug|x64
 	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x86.ActiveCfg = Debug|Win32
 	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x86.Build.0 = Debug|Win32
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x64.ActiveCfg = Debug|x64
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x64.Build.0 = Debug|x64
 	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|x64.ActiveCfg = Release|x64
 	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|x64.Build.0 = Release|x64
 	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|x86.ActiveCfg = Release|Win32
@@ -805,8 +804,8 @@ EndGlobalSection
 
 
 ---
--- Check that when a default platform is specified it is written in a separate
--- configuration block so that Visual Studio picks it up as default.
+-- Check that when a default platform is specified its selected configuration
+-- is written first so that Visual Studio picks it up as default.
 ---
 
 	function suite.onDefaultPlatforms()
@@ -817,13 +816,111 @@ EndGlobalSection
 		test.capture [[
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
 	Debug|x64 = Debug|x64
+	Debug|Win32 = Debug|Win32
+	Release|Win32 = Release|Win32
 	Release|x64 = Release|x64
 EndGlobalSection
+		]]
+	end
+
+
+---
+-- Check that when a default configuration is specified it is written first so
+-- that Visual Studio picks it up as default.
+---
+
+	function suite.onDefaultConfiguration()
+		defaultconfiguration "Release"
+		project "MyProject"
+		prepare()
+		test.capture [[
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+	Release|Win32 = Release|Win32
+	Debug|Win32 = Debug|Win32
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|Win32.ActiveCfg = Release|Win32
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|Win32.Build.0 = Release|Win32
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|Win32.ActiveCfg = Debug|Win32
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|Win32.Build.0 = Debug|Win32
+EndGlobalSection
+		]]
+	end
+
+
+---
+-- Check that default configuration and default platform select the exact pair.
+---
+
+	function suite.onDefaultConfigurationAndDefaultPlatform()
+		platforms { "x86", "x86_64" }
+		defaultconfiguration "Release"
+		defaultplatform "x86_64"
+		project "MyProject"
+		prepare()
+		test.capture [[
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+	Release|x64 = Release|x64
+	Debug|Win32 = Debug|Win32
+	Debug|x64 = Debug|x64
+	Release|Win32 = Release|Win32
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|x64.ActiveCfg = Release|x64
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|x64.Build.0 = Release|x64
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|Win32.ActiveCfg = Debug|Win32
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|Win32.Build.0 = Debug|Win32
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x64.ActiveCfg = Debug|x64
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|x64.Build.0 = Debug|x64
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|Win32.ActiveCfg = Release|Win32
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|Win32.Build.0 = Release|Win32
+EndGlobalSection
+		]]
+	end
+
+
+---
+-- Check that invalid defaultconfiguration falls back gracefully.
+-- When defaultconfiguration is invalid but valid configs exist, 
+-- the first config becomes the default in its own block.
+---
+
+	function suite.onInvalidConfiguration()
+		defaultconfiguration "NonExistent"
+		project "MyProject"
+		prepare()
+		test.capture [[
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
 	Debug|Win32 = Debug|Win32
 	Release|Win32 = Release|Win32
 EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|Win32.ActiveCfg = Debug|Win32
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Debug|Win32.Build.0 = Debug|Win32
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|Win32.ActiveCfg = Release|Win32
+	{C9135098-6047-8142-B10E-D27E7F73FCB3}.Release|Win32.Build.0 = Release|Win32
+EndGlobalSection
 		]]
+	end
+
+
+---
+-- Check that invalid defaultplatform falls back gracefully.
+-- When defaultplatform is invalid, it creates an empty default block,
+-- then outputs all configs in the second block.
+---
+
+	function suite.onInvalidPlatform()
+		platforms { "x86", "x86_64" }
+		defaultplatform "ARM"
+		project "MyProject"
+		prepare()
+		local actual = p.captured()
+		test.isnil(actual:find("ARM", 1, true))
+		test.isnotnil(actual:find("Debug|Win32 = Debug|Win32", 1, true))
+		test.isnotnil(actual:find("Debug|x64 = Debug|x64", 1, true))
+		test.isnotnil(actual:find("Release|Win32 = Release|Win32", 1, true))
+		test.isnotnil(actual:find("Release|x64 = Release|x64", 1, true))
 	end
 
 ---

--- a/modules/vstudio/vs2005_solution.lua
+++ b/modules/vstudio/vs2005_solution.lua
@@ -283,6 +283,7 @@
 
 		local descriptors = {}
 		local sorted = {}
+		local defaultCfg = p.config.getdefault(wks)
 
 		for cfg in p.workspace.eachconfig(wks) do
 
@@ -300,30 +301,24 @@
 		end
 
 		-- Sort the solution configurations to match Visual Studio's preferred
-		-- order, which appears to be a simple alpha sort on the descriptors.
+		-- order, while keeping the selected default first.
 
 		table.sort(sorted, function(cfg0, cfg1)
+			if cfg0 == defaultCfg then
+				return cfg1 ~= defaultCfg
+			elseif cfg1 == defaultCfg then
+				return false
+			end
+
 			return descriptors[cfg0]:lower() < descriptors[cfg1]:lower()
 		end)
 
 		-- Now I can output the sorted list of solution configuration descriptors
 
 		-- Visual Studio assumes the first configurations as the defaults.
-		if wks.defaultplatform then
-			p.push('GlobalSection(SolutionConfigurationPlatforms) = preSolution')
-			table.foreachi(sorted, function (cfg)
-				if cfg.platform == wks.defaultplatform then
-					p.w('%s = %s', descriptors[cfg], descriptors[cfg])
-				end
-			end)
-			p.pop("EndGlobalSection")
-		end
-
 		p.push('GlobalSection(SolutionConfigurationPlatforms) = preSolution')
 		table.foreachi(sorted, function (cfg)
-			if not wks.defaultplatform or cfg.platform ~= wks.defaultplatform then
-				p.w('%s = %s', descriptors[cfg], descriptors[cfg])
-			end
+			p.w('%s = %s', descriptors[cfg], descriptors[cfg])
 		end)
 		p.pop("EndGlobalSection")
 

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -4870,6 +4870,100 @@
 	end
 
 
+	function suite.XCBuildConfigurationList_OnDefaultConfiguration()
+		defaultconfiguration "Release"
+		prepare()
+		xcode.XCBuildConfigurationList(tr)
+		test.capture [[
+/* Begin XCConfigurationList section */
+		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				347EC2AEE119A7C9E4B36F9E /* Debug */,
+				C315A3A02B9FEA659E8A89BE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A852E9BD08CE874C2F8CA435 /* Build configuration list for PBXNativeTarget "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0141F3FC0D9EB3163D17DF0F /* Debug */,
+				049C55E5E2D9CA8D4990DE13 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+				]]
+	end
+
+
+	function suite.XCBuildConfigurationList_OnDefaultConfigurationAndPlatform()
+		workspace("MyWorkspace")
+		platforms { "x86", "x64" }
+		defaultconfiguration "Release"
+		defaultplatform "x64"
+		prepare()
+		xcode.XCBuildConfigurationList(tr)
+		test.capture [[
+/* Begin XCConfigurationList section */
+		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				347EC2AEE119A7C9E4B36F9E /* Debug */,
+				347EC2AEE119A7C9E4B36F9E /* Debug */,
+				C315A3A02B9FEA659E8A89BE /* Release */,
+				C315A3A02B9FEA659E8A89BE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A852E9BD08CE874C2F8CA435 /* Build configuration list for PBXNativeTarget "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0141F3FC0D9EB3163D17DF0F /* Debug */,
+				0141F3FC0D9EB3163D17DF0F /* Debug */,
+				049C55E5E2D9CA8D4990DE13 /* Release */,
+				049C55E5E2D9CA8D4990DE13 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+				]]
+	end
+
+
+	function suite.XCBuildConfigurationList_OnInvalidConfiguration()
+		defaultconfiguration "NonExistent"
+		prepare()
+		xcode.XCBuildConfigurationList(tr)
+		test.capture [[
+/* Begin XCConfigurationList section */
+		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				347EC2AEE119A7C9E4B36F9E /* Debug */,
+				C315A3A02B9FEA659E8A89BE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		A852E9BD08CE874C2F8CA435 /* Build configuration list for PBXNativeTarget "MyProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0141F3FC0D9EB3163D17DF0F /* Debug */,
+				049C55E5E2D9CA8D4990DE13 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+				]]
+	end
+
+
 	function suite.XCBuildConfigurationList_OnMultiplePlatforms()
 		workspace("MyWorkspace")
 		platforms { "Universal32", "Universal64" }

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1726,8 +1726,8 @@
 
 
 	function xcode.XCBuildConfigurationList(tr)
-		local wks = tr.project.workspace
-		local defaultCfgName = xcode.stringifySetting(tr.configs[1].buildcfg)
+		local defaultCfg = p.config.getdefault(tr.project)
+		local defaultCfgName = xcode.stringifySetting(defaultCfg.buildcfg)
 		local settings = {}
 
 		for _, target in ipairs(tr.products.children) do

--- a/premake5.lua
+++ b/premake5.lua
@@ -191,7 +191,7 @@
 --
 -- TODO: Switch to these new APIs once they've had a chance to land everywhere
 --
---    defaultConfiguration "Release"
+--    defaultconfiguration "Release"
 --    symbols "On"
 --
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -239,6 +239,12 @@
 	}
 
 	api.register {
+		name = "defaultconfiguration",
+		scope = "project",
+		kind = "string",
+	}
+
+	api.register {
 		name = "defines",
 		scope = "config",
 		kind = "list:string",

--- a/src/base/config.lua
+++ b/src/base/config.lua
@@ -192,6 +192,70 @@
 
 
 ---
+-- Return the default configuration for a workspace or project.
+--
+-- @param target
+--    The workspace or project object to query.
+-- @return
+--    The selected configuration, or nil if none are available.
+---
+
+	function config.getdefault(target)
+		local eachconfig = iif(target.project, project.eachconfig, p.workspace.eachconfig)
+		local defaultConfiguration = target.defaultconfiguration
+		local defaultPlatform = target.defaultplatform
+		local defaultConfigurationLower = type(defaultConfiguration) == "string" and defaultConfiguration:lower()
+		local defaultPlatformLower = type(defaultPlatform) == "string" and defaultPlatform:lower()
+		local configs = {}
+		local first
+		local bestConfiguration
+		local bestPlatform
+		local foundDefaultConfiguration = false
+		local foundDefaultPlatform = false
+
+		for cfg in eachconfig(target) do
+			table.insert(configs, cfg)
+		end
+
+		-- Match workspace configuration ordering regardless of target type.
+		table.sort(configs, function(a, b) return a.name < b.name end)
+
+		for _, cfg in ipairs(configs) do
+			first = first or cfg
+
+			local matchesConfiguration = defaultConfigurationLower and cfg.buildcfg and cfg.buildcfg:lower() == defaultConfigurationLower
+			local matchesPlatform = defaultPlatformLower and cfg.platform and cfg.platform:lower() == defaultPlatformLower
+
+			if matchesConfiguration then
+				foundDefaultConfiguration = true
+			end
+
+			if matchesPlatform then
+				foundDefaultPlatform = true
+			end
+
+			if matchesConfiguration and matchesPlatform then
+				return cfg
+			elseif not bestConfiguration and matchesConfiguration then
+				bestConfiguration = cfg
+			elseif not bestPlatform and matchesPlatform then
+				bestPlatform = cfg
+			end
+		end
+
+		if type(defaultConfiguration) == "string" and not foundDefaultConfiguration then
+			p.warnOnce("defaultconfiguration:" .. tostring(target) .. ":" .. defaultConfigurationLower, "defaultconfiguration '%s' does not match any configuration in '%s'", defaultConfiguration, target.name)
+		end
+
+		if type(defaultPlatform) == "string" and not foundDefaultPlatform then
+			p.warnOnce("defaultplatform:" .. tostring(target) .. ":" .. defaultPlatformLower, "defaultplatform '%s' does not match any platform in '%s'", defaultPlatform, target.name)
+		end
+
+		return bestConfiguration or bestPlatform or first
+	end
+
+
+---
 -- Retrieve linking information for a specific configuration. That is,
 -- the path information that is required to link against the library
 -- built by this configuration.

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -5,6 +5,7 @@ return {
 	"test_string.lua",
 	"base/test_aliasing.lua",
 	"base/test_binmodules.lua",
+	"base/test_config_getdefault.lua",
 	"base/test_configset.lua",
 	"base/test_context.lua",
 	"base/test_criteria.lua",

--- a/tests/base/test_config_getdefault.lua
+++ b/tests/base/test_config_getdefault.lua
@@ -1,0 +1,213 @@
+--
+-- tests/base/test_config_getdefault.lua
+-- Unit tests for the config.getdefault() function.
+-- Tests the priority order and fallback behavior for default configurations.
+--
+
+	local p = premake
+	local suite = test.declare("config_getdefault")
+
+
+--
+-- Setup/teardown
+--
+
+	local wks, prj
+
+	function suite.setup()
+		wks = workspace("MyWorkspace")
+		configurations { "Release", "Debug", "Profile" }
+		prj = project("MyProject")
+		kind "ConsoleApp"
+	end
+
+
+--
+-- Verify project default behavior: returns first project configuration in
+-- alphabetic order.
+--
+
+	function suite.returnsFirstAlphabetically_onProjectNoDefaults()
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Debug", cfg.buildcfg)
+		test.isequal(nil, cfg.platform)
+	end
+
+
+--
+-- Verify matching defaultconfiguration only
+--
+
+	function suite.matchesDefaultConfiguration_whenSpecified()
+		defaultconfiguration "Release"
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Release", cfg.buildcfg)
+		test.isequal(nil, cfg.platform)
+	end
+
+
+--
+-- Verify matching defaultplatform only
+--
+
+	function suite.matchesDefaultPlatform_whenSpecified()
+		platforms { "x86", "x64" }
+		defaultplatform "x64"
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Debug", cfg.buildcfg)
+		test.isequal("x64", cfg.platform)
+	end
+
+
+--
+-- Verify matching both defaultconfiguration and defaultplatform
+-- Priority: both match > configuration match > platform match > first
+
+	function suite.prefersBothMatching_overPartial()
+		platforms { "x86", "x64" }
+		defaultconfiguration "Profile"
+		defaultplatform "x64"
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Profile", cfg.buildcfg)
+		test.isequal("x64", cfg.platform)
+	end
+
+
+--
+-- Verify that invalid defaultconfiguration falls back to first
+--
+
+	function suite.fallsBackToFirst_onInvalidConfiguration()
+		defaultconfiguration "NonExistent"
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Debug", cfg.buildcfg)
+		test.isequal(nil, cfg.platform)
+		test.stderr("defaultconfiguration 'NonExistent'")
+	end
+
+
+--
+-- Verify that invalid defaultplatform falls back to first
+--
+
+	function suite.fallsBackToFirst_onInvalidPlatform()
+		platforms { "x86", "x64" }
+		defaultplatform "ARM"
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Debug", cfg.buildcfg)
+		test.isequal("x64", cfg.platform)
+		test.stderr("defaultplatform 'ARM'")
+	end
+
+
+--
+-- Verify case-insensitivity of defaultconfiguration matching
+--
+
+	function suite.caseInsensitive_forConfiguration()
+		defaultconfiguration "RELEASE"
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Release", cfg.buildcfg)
+		test.isequal(nil, cfg.platform)
+	end
+
+
+--
+-- Verify case-insensitivity of defaultplatform matching
+--
+
+	function suite.caseInsensitive_forPlatform()
+		platforms { "x86", "x64" }
+		defaultplatform "X64"
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Debug", cfg.buildcfg)
+		test.isequal("x64", cfg.platform)
+	end
+
+
+--
+-- Verify priority: when both defaultconfiguration is invalid but defaultplatform is valid,
+-- return the defaultplatform match
+--
+
+	function suite.prefersValidPlatform_whenConfigInvalid()
+		platforms { "x86", "x64" }
+		defaultconfiguration "NonExistent"
+		defaultplatform "x64"
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Debug", cfg.buildcfg)
+		test.isequal("x64", cfg.platform)
+		test.stderr("defaultconfiguration 'NonExistent'")
+	end
+
+
+--
+-- Verify priority: when defaultconfiguration is valid but defaultplatform is invalid,
+-- return the defaultconfiguration match
+--
+
+	function suite.prefersValidConfiguration_whenPlatformInvalid()
+		platforms { "x86", "x64" }
+		defaultconfiguration "Release"
+		defaultplatform "ARM"
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Release", cfg.buildcfg)
+		test.isequal("x64", cfg.platform)
+		test.stderr("defaultplatform 'ARM'")
+	end
+
+
+--
+-- Verify with many configurations that the correct one is chosen
+--
+
+	function suite.selectsCorrectConfig_withMany()
+		configurations { "Debug", "Release", "Profile", "MinSize", "CustomDebug" }
+		platforms { "x86", "x64", "ARM" }
+		defaultconfiguration "Profile"
+		defaultplatform "ARM"
+		prj = test.getproject(wks, 1)
+		local cfg = p.config.getdefault(prj)
+		test.isequal("Profile", cfg.buildcfg)
+		test.isequal("ARM", cfg.platform)
+	end
+
+
+--
+-- Verify workspace default behavior: returns first workspace configuration in
+-- alphabetic order.
+--
+
+	function suite.returnsFirstAlphabetically_onWorkspaceNoDefaults()
+		local wks2 = workspace("WorkspaceForTest")
+		configurations { "Release", "Debug", "Profile" }
+		wks2 = test.getWorkspace(wks2)
+		local cfg = p.config.getdefault(wks2)
+		test.isequal("Debug", cfg.buildcfg)
+		test.isequal(nil, cfg.platform)
+	end
+
+
+--
+-- Verify workspace level defaultconfiguration.
+--
+
+	function suite.matchesDefaultConfiguration_onWorkspace()
+		local wks2 = workspace("WorkspaceForDefaultConfigurationTest")
+		configurations { "Release", "Debug", "Profile" }
+		defaultconfiguration "Release"
+		wks2 = test.getWorkspace(wks2)
+		local cfg = p.config.getdefault(wks2)
+		test.isequal("Release", cfg.buildcfg)
+		test.isequal(nil, cfg.platform)
+	end

--- a/website/docs/Project-API.md
+++ b/website/docs/Project-API.md
@@ -52,6 +52,7 @@
 | [debugremotehost](debugremotehost.md)                     | Target for remote debugging |
 | [debugsearchpaths](debugsearchpaths.md)                   | Search paths for source code while debugging |
 | [debugstartupcommands](debugstartupcommands.md)           | Debugger commands to execute on debugger startup |
+| [defaultconfiguration](defaultconfiguration.md)           |  |
 | [defaultplatform](defaultplatform.md)                     |  |
 | [defines](defines.md)                                     |  |
 | [dependson](dependson.md)                                 |  |

--- a/website/docs/configurations.md
+++ b/website/docs/configurations.md
@@ -40,3 +40,4 @@ configurations { "Debug", "Release", "DebugDLL", "ReleaseDLL" }
 
 * [Configurations and Platforms](Configurations-and-Platforms.md)
 * [platforms](platforms.md)
+* [defaultconfiguration](defaultconfiguration.md)

--- a/website/docs/defaultconfiguration.md
+++ b/website/docs/defaultconfiguration.md
@@ -1,0 +1,42 @@
+Specifies the default build configuration for a workspace.
+
+```lua
+defaultconfiguration ("configuration_name")
+```
+
+If a default configuration is not specified through this API, the first configuration in alphabetical order from `configurations` will be used as the default.
+
+### Parameters ###
+
+`configuration_name` - The name of the build configuration to use as default.
+
+### Applies To ###
+
+Workspace configurations.
+
+### Availability ###
+
+Premake 5.0.0 or later.
+
+### Examples ###
+
+```lua
+workspace "MyWorkspace"
+  configurations { "Debug", "Release" }
+  defaultconfiguration "Release"
+```
+
+When combined with [`defaultplatform`](defaultplatform.md), Premake will prefer the configuration/platform pair that matches both settings.
+
+```lua
+workspace "MyWorkspace"
+  configurations { "Debug", "Release" }
+  platforms { "x86", "x64" }
+  defaultconfiguration "Release"
+  defaultplatform "x64"
+```
+
+### See Also ###
+
+* [configurations](configurations.md)
+* [defaultplatform](defaultplatform.md)

--- a/website/docs/defaultplatform.md
+++ b/website/docs/defaultplatform.md
@@ -4,11 +4,11 @@ Specifies the default build platform for a workspace.
 defaultplatform ("platform_name")
 ```
 
-If `platform_name` has not been defined using [`platforms`](platforms.md) the default platform will not change from the generic one i.e. the first one passed to [`platforms`](platforms.md).
+If a default platform is not specified through this API, the first platform in alphabetical order from `platforms` will be used as the default.
 
 ### Parameters ###
 
-`platform_name` - Is the name of the platform you want to use as default.
+`platform_name` - The name of the platform to use as default.
 
 ### Applies To ###
 
@@ -45,4 +45,5 @@ workspace "MyWorkspace"
 ```
 ### See Also ###
 
+* [defaultconfiguration](defaultconfiguration.md)
 * [platforms](platforms.md)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -116,6 +116,7 @@ module.exports = {
 						'debugremotehost',
 						'debugsearchpaths',
 						'debugstartupcommands',
+						'defaultconfiguration',
 						'defaultplatform',
 						'defines',
 						'dependson',


### PR DESCRIPTION
**What does this PR do?**

Close #2709

- Adds the `defaultconfiguration` API to specify the default build configuration. For example, in gmake this controls which configuration is used when running `make` without explicitly passing `config=release`.
- Adds `config.getdefault()` to centralize the logic for selecting the default configuration.
- Updates generators/modules to use the new shared default-selection logic.
- Add warning for `defaultplatform` when a non-existent value is specified, and update the documentation.
- Adds related tests.

**How does this PR change Premake's behavior?**

When `defaultconfiguration` is specified, generators that support a default configuration will use it when selecting their default build target/configuration.

When `defaultconfiguration` is not specified, the expected behavior should remain consistent with the existing tests. The sorting performed by `config.getdefault()` is aligned with the workspace configuration ordering introduced by #2675, which sorted `workspace.eachconfig()` for deterministic output.

This can also be seen as a follow-up to #2675, extending the default-selection logic so it is shared and consistent across modules.

**Anything else we should know?**

There were existing design comments using the name `defaultConfiguration`, so this PR preserves that API name conceptually while exposing it in Premake's usual lowercase style as `defaultconfiguration`.

#2675 did not update `project.eachconfig()` to sort project configurations. That may have been intentional, but whether project-level configuration iteration should also be sorted may be worth discussing separately.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
