### PR TITLE
Added ARM64 to the CI jobs for Linux and Windows

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -4,13 +4,18 @@ on: [push, pull_request]
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         config: [debug, release]
-        platform: [x64]
+        platform: [x64, ARM64]
         depsrc: [none, contrib, system]
         cc: [gcc, clang]
+        include:
+          - platform: x64
+            os: ubuntu-latest
+          - platform: ARM64
+            os: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
     - name: Checkout
@@ -59,13 +64,20 @@ jobs:
         name: premake-macosx-${{ matrix.platform }}
         path: bin/${{ matrix.config }}/
   windows:
-    runs-on: windows-2022
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         config: [debug, release]
-        platform: [Win32, x64]
+        platform: [Win32, x64, ARM64]
         msdev: [vs2022]
         cc: [msc, clang]
+        include:
+          - platform: Win32
+            os: windows-2022
+          - platform: x64
+            os: windows-2022
+          - platform: ARM64
+            os: windows-11-arm
     timeout-minutes: 15
     steps:
     - name: Checkout

--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -12,15 +12,17 @@ REM ===========================================================================
 SET "PlatformArg="
 SET "ConfigArg="
 
-IF NOT "%PLATFORM%" == "" (
-	SET "PlatformArg=PLATFORM=%PLATFORM%"
-) ELSE (
+IF "%PLATFORM%" == "" (
 	IF "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
-		SET "PlatformArg=PLATFORM=x64"
+		SET "PLATFORM=x64"
+	) ELSE IF "%PROCESSOR_ARCHITECTURE%" == "ARM64" (
+		SET "PLATFORM=ARM64"
 	) ELSE (
-		SET "PlatformArg=PLATFORM=Win32"
+		SET "PLATFORM=Win32"
 	)
 )
+
+SET "PlatformArg=PLATFORM=%PLATFORM%"
 
 IF NOT "%CONFIG%" == "" (
 	SET "ConfigArg=CONFIG=%CONFIG%"
@@ -122,6 +124,12 @@ IF NOT EXIST %VsWherePath% (
 SET VsWhereCmdLine="!VsWherePath! -nologo -latest -version [%VsVersionMin%,%VsVersionMax%) -property installationPath"
 
 FOR /F "usebackq delims=" %%i in (`!VsWhereCmdLine!`) DO (
+	IF /I "%PLATFORM%" == "ARM64" (
+		IF EXIST "%%i\VC\Auxiliary\Build\vcvarsarm64.bat" (
+			CALL "%%i\VC\Auxiliary\Build\vcvarsarm64.bat" && CALL :Build
+			EXIT /B !ERRORLEVEL!
+		)
+	)
 	IF EXIST "%%i\VC\Auxiliary\Build\vcvars64.bat" (
 		CALL "%%i\VC\Auxiliary\Build\vcvars64.bat" && CALL :Build
 		EXIT /B !ERRORLEVEL!
@@ -133,7 +141,7 @@ FOR /F "usebackq delims=" %%i in (`!VsWhereCmdLine!`) DO (
 	)
 )
 
-ECHO Could not find vcvars64.bat or vcvars32.bat to setup Visual Studio environment
+ECHO Could not find a suitable vcvars batch file to setup Visual Studio environment
 EXIT /B 2
 
 REM :VsWhereVisualBootstrap

--- a/premake5.lua
+++ b/premake5.lua
@@ -260,7 +260,7 @@
 		filter { "system:windows", "options:arch=ARM" }
 			platforms { "ARM" }
 
-		filter { "system:windows", "options:arch=AARCH64" }
+		filter { "system:windows", "options:arch=AARCH64 or arch=ARM64" }
 			platforms { "ARM64" }
 
 		filter { "system:windows", "options:arch=x86 or arch=Win32" }


### PR DESCRIPTION
- Expanded Bootstrap.bat to check for vcvarsarm64.bat

**What does this PR do?**

Adds ARM64 CI jobs for Linux and Windows.

**How does this PR change Premake's behavior?**

Bootstrap.bat now handles ARM64.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
