### PR TITLE
Use TargetFrameworks tag if multiple frameworks are provided by dotnetframework

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -136,6 +136,7 @@
 		name = "dotnetframework",
 		scope = "config",
 		kind = "string",
+		list = true,
 	}
 	p.api.alias("dotnetframework", "framework") -- for backward compatibility
 

--- a/modules/vstudio/tests/cs2005/test_netcore.lua
+++ b/modules/vstudio/tests/cs2005/test_netcore.lua
@@ -18,116 +18,116 @@ local project = p.project
 local wks, prj
 
 function suite.setup()
-    p.action.set("vs2005")
-    wks, prj = test.createWorkspace()
+	p.action.set("vs2005")
+	wks, prj = test.createWorkspace()
 	configurations { "Debug", "Release", "Distribution"}
-    language "C#"
+	language "C#"
 end
 
 local function targetFrameworkPrepare()
-    local cfg = test.getconfig(prj, "Debug")
-    dn2005.netcore.targetFramework(cfg)
+	local cfg = test.getconfig(prj, "Debug")
+	dn2005.netcore.targetFramework(cfg)
 end
 
 local function targetFrameworkVersionPrepare()
-    local cfg = test.getconfig(prj, "Debug")
-    dn2005.targetFrameworkVersion(cfg)
+	local cfg = test.getconfig(prj, "Debug")
+	dn2005.targetFrameworkVersion(cfg)
 end
 
 local function projectConfigurationsPrepare()
-    dn2005.projectConfigurations(prj)
+	dn2005.projectConfigurations(prj)
 end
 
 local function prepareNetcore()
-    dn2005.projectElement(prj)
+	dn2005.projectElement(prj)
 end
 
 local function prepareProjectProperties()
-    local localProj = test.getproject(wks, 1)
+	local localProj = test.getproject(wks, 1)
 
-    dn2005.prepare(cs2005)
-    dn2005.projectProperties(localProj)
+	dn2005.prepare(cs2005)
+	dn2005.projectProperties(localProj)
 end
 
 function suite.targetFrameworkProperty_framework()
-    dotnetframework "4.7.2"
-    targetFrameworkPrepare()
-    test.isemptycapture()
+	dotnetframework "4.7.2"
+	targetFrameworkPrepare()
+	test.isemptycapture()
 end
 
 function suite.targetFrameworkProperty_core()
-    dotnetframework "netcoreapp2.2"
-    targetFrameworkPrepare()
-    test.capture [[
+	dotnetframework "netcoreapp2.2"
+	targetFrameworkPrepare()
+	test.capture [[
 		<TargetFramework>netcoreapp2.2</TargetFramework>
 	]]
 end
 
 function suite.targetFrameworkProperty_standard()
-    dotnetframework "netstandard1.2"
-    targetFrameworkPrepare()
-    test.capture [[
+	dotnetframework "netstandard1.2"
+	targetFrameworkPrepare()
+	test.capture [[
 		<TargetFramework>netstandard1.2</TargetFramework>
-    ]]
+	]]
 end
 
 function suite.targetFrameworkVersionProperty_framework()
-    dotnetframework "4.7.2"
-    targetFrameworkVersionPrepare()
-    test.capture [[
+	dotnetframework "4.7.2"
+	targetFrameworkVersionPrepare()
+	test.capture [[
 		<TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    ]]
+	]]
 end
 
 function suite.targetFrameworkVersionProperty_core()
-    dotnetframework "netcoreapp2.2"
-    targetFrameworkVersionPrepare()
-    test.isemptycapture()
+	dotnetframework "netcoreapp2.2"
+	targetFrameworkVersionPrepare()
+	test.isemptycapture()
 end
 
 function suite.targetFrameworkVersionProperty_standard()
-    dotnetframework "netstandard1.2"
-    targetFrameworkVersionPrepare()
-    test.isemptycapture()
+	dotnetframework "netstandard1.2"
+	targetFrameworkVersionPrepare()
+	test.isemptycapture()
 end
 
 function suite.project_element_standard()
-    dotnetframework "netstandard1.2"
-    prepareNetcore()
-    test.capture [[
+	dotnetframework "netstandard1.2"
+	prepareNetcore()
+	test.capture [[
 <Project Sdk="Microsoft.NET.Sdk">
-    ]]
+	]]
 end
 
 function suite.project_element_core()
-    dotnetframework "netcoreapp1.2"
-    prepareNetcore()
-    test.capture [[
+	dotnetframework "netcoreapp1.2"
+	prepareNetcore()
+	test.capture [[
 <Project Sdk="Microsoft.NET.Sdk">
-    ]]
+	]]
 end
 
 function suite.project_element_net5()
-    dotnetframework "net5.0"
-    prepareNetcore()
-    test.capture [[
+	dotnetframework "net5.0"
+	prepareNetcore()
+	test.capture [[
 <Project Sdk="Microsoft.NET.Sdk">
-    ]]
+	]]
 end
 
 function suite.project_element_framework()
-    dotnetframework "4.7.2"
-    prepareNetcore()
-    test.capture [[
+	dotnetframework "4.7.2"
+	prepareNetcore()
+	test.capture [[
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    ]]
+	]]
 end
 
 function suite.allowUnsafeProperty_core()
-    dotnetframework "netcoreapp2.2"
-    clr "Unsafe"
-    prepareProjectProperties()
-    test.capture [[
+	dotnetframework "netcoreapp2.2"
+	clr "Unsafe"
+	prepareProjectProperties()
+	test.capture [[
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<AppDesignerFolder>Properties</AppDesignerFolder>
@@ -135,15 +135,15 @@ function suite.allowUnsafeProperty_core()
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 	</PropertyGroup>
-    ]]
+	]]
 end
 
 function suite.implicitUsings_on()
-    p.action.set("vs2022")
-    dotnetframework "net10.0"
-    enableimplicitusings "On"
-    prepareProjectProperties()
-    test.capture [[
+	p.action.set("vs2022")
+	dotnetframework "net10.0"
+	enableimplicitusings "On"
+	prepareProjectProperties()
+	test.capture [[
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<AppDesignerFolder>Properties</AppDesignerFolder>
@@ -152,15 +152,15 @@ function suite.implicitUsings_on()
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 		<ImplicitUsings>true</ImplicitUsings>
 	</PropertyGroup>
-    ]]
+	]]
 end
 
 function suite.implicitUsings_off()
-    p.action.set("vs2022")
-    dotnetframework "net10.0"
-    enableimplicitusings "Off"
-    prepareProjectProperties()
-    test.capture [[
+	p.action.set("vs2022")
+	dotnetframework "net10.0"
+	enableimplicitusings "Off"
+	prepareProjectProperties()
+	test.capture [[
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<AppDesignerFolder>Properties</AppDesignerFolder>
@@ -169,7 +169,22 @@ function suite.implicitUsings_off()
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 		<ImplicitUsings>false</ImplicitUsings>
 	</PropertyGroup>
-    ]]
+	]]
+end
+
+function suite.multiple_target_dotnet_frameworks()
+	p.action.set("vs2022")
+	dotnetframework { "net8.0", "net10.0" }
+	prepareProjectProperties()
+	test.capture [[
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<Configurations>Debug;Release;Distribution</Configurations>
+		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+	</PropertyGroup>
+	]]
 end
 
 function suite.project_element_configurations()

--- a/modules/vstudio/tests/vc2010/test_globals.lua
+++ b/modules/vstudio/tests/vc2010/test_globals.lua
@@ -111,6 +111,21 @@ function suite.frameworkVersionIsCorrectNetCore_onSpecificVersion()
 	]]
 end
 
+function suite.frameworkVersionIsCorrectNetCore_onSpecificVersions()
+	clr "NetCore"
+	dotnetframework { "net8.0", "net10.0" }
+	prepare()
+	test.capture [[
+<PropertyGroup Label="Globals">
+	<ProjectGuid>{42B5DBC6-AE1F-903D-F75D-41E363076E92}</ProjectGuid>
+	<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+	<Keyword>ManagedCProj</Keyword>
+	<RootNamespace>MyProject</RootNamespace>
+</PropertyGroup>
+	]]
+end
+
+
 --
 -- Omit Keyword and RootNamespace for non-Windows projects.
 --

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -454,7 +454,12 @@
 				local packageAPIInfo = vstudio.nuget2010.packageAPIInfo(prj, package)
 
 				local action = p.action.current()
-				local targetFramework = cfg.dotnetframework or action.vstudio.targetFramework
+				local targetFramework = nil
+				if #cfg.dotnetframework > 0 then
+					targetFramework = cfg.dotnetframework[#cfg.dotnetframework]
+				else
+					targetFramework = action.vstudio.targetFramework
+				end
 
 				local targetVersion = dotnetbase.makeVersionComparable(targetFramework)
 
@@ -754,7 +759,14 @@
 
 	function dotnetbase.targetFrameworkVersion(cfg)
 		local action = p.action.current()
-		local framework = cfg.dotnetframework or action.vstudio.targetFramework
+
+		local framework = nil
+		if #cfg.dotnetframework > 0 then
+			framework = cfg.dotnetframework[#cfg.dotnetframework]
+		else
+			framework = action.vstudio.targetFramework
+		end
+
 		if framework and not dotnetbase.isNewFormatProject(cfg) then
 			_p(2,'<TargetFrameworkVersion>v%s</TargetFrameworkVersion>', framework)
 		end
@@ -793,13 +805,11 @@
 	end
 
 	function dotnetbase.isNewFormatProject(cfg)
-		local framework = cfg.dotnetframework
-		if not framework then
-			return false
-		end
-
-		if framework:find('^net') ~= nil then
-			return true
+		local frameworks = cfg.dotnetframework
+		for _, currFramework in ipairs(frameworks) do
+			if currFramework:find('^net') ~= nil then
+				return true
+			end
 		end
 
 		return false
@@ -807,9 +817,26 @@
 
 	function dotnetbase.netcore.targetFramework(cfg)
 		local action = p.action.current()
-		local framework = cfg.dotnetframework or action.vstudio.targetFramework
-		if framework and dotnetbase.isNewFormatProject(cfg) then
-			_p(2,'<TargetFramework>%s</TargetFramework>', framework)
+
+		local frameworks = nil
+		if #cfg.dotnetframework > 0 then
+			frameworks = cfg.dotnetframework
+		else
+			targetFramework = action.vstudio.targetFramework
+			if targetFramework ~= nil then
+				frameworks = { [1] = targetFramework }
+			end
+
+		end
+
+		if frameworks ~= nil then
+			if dotnetbase.isNewFormatProject(cfg) then
+				if #frameworks > 1 then
+					_p(2, '<TargetFrameworks>%s</TargetFrameworks>', table.concat(frameworks, ";"))
+				else
+					_p(2, '<TargetFramework>%s</TargetFramework>', frameworks[1])
+				end
+			end
 		end
 	end
 

--- a/modules/vstudio/vs2010_nuget.lua
+++ b/modules/vstudio/vs2010_nuget.lua
@@ -31,7 +31,12 @@
 		if p.project.isdotnet(prj) then
 			local cfg = p.project.getfirstconfig(prj)
 			local action = p.action.current()
-			local framework = cfg.dotnetframework or action.vstudio.targetFramework
+			local framework = nil
+			if #cfg.dotnetframework > 0 then
+				framework = cfg.dotnetframework[#cfg.dotnetframework]
+			else
+				framework = action.vstudio.targetFramework
+			end
 			return dn2005.formatNuGetFrameworkVersion(framework)
 		else
 			return "native"

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -114,16 +114,30 @@
 
 	function m.targetFramework(prj)
 		local action = p.action.current()
-		local tools = string.format(' ToolsVersion="%s"', action.vstudio.toolsVersion)
 
-		local framework = prj.dotnetframework or action.vstudio.targetFramework or "4.0"
-		if framework and dotnetbase.isNewFormatProject(prj) then
-			p.w('<TargetFramework>%s</TargetFramework>', framework)
+		local frameworks = nil
+		if #prj.dotnetframework > 0 then
+			frameworks = prj.dotnetframework
 		else
-			p.w('<TargetFrameworkVersion>v%s</TargetFrameworkVersion>', framework)
+			targetFramework = action.vstudio.targetFramework or "4.0"
+			frameworks = { [1] = targetFramework }
+
+		end
+
+		if frameworks ~= nil then
+			if dotnetbase.isNewFormatProject(prj) then
+				if #frameworks > 1 then
+					p.w('<TargetFrameworks>%s</TargetFrameworks>', table.concat(frameworks, ";"))
+				else
+					p.w('<TargetFramework>%s</TargetFramework>', frameworks[1])
+				end
+			else
+				if #frameworks >= 1 then
+					p.w('<TargetFrameworkVersion>v%s</TargetFrameworkVersion>', frameworks[#frameworks])
+				end
+			end
 		end
 	end
-
 
 
 --

--- a/website/docs/dotnetframework.md
+++ b/website/docs/dotnetframework.md
@@ -1,24 +1,20 @@
-Selects a .NET framework version.
+Selects a .NET framework version(s).
 
 ```lua
-dotnetframework ("version")
+dotnetframework (versions)
 ```
 
 This value currently is only applied to Visual Studio 2005 or later, and GNU makefiles using Mono. If no .NET framework version is specified the toolset default is used.
 
 ### Parameters ###
 
-`version` is one of:
+`versions` is a list of version name strings where each element is one of:
 
 | Version | Documentation |
-| 1.0 | .NET Framework 1.0 |
-| 1.1 | .NET Framework 1.1 |
-| 2.0 | .NET Framework 2.0 |
-| 3.0 | .NET Framework 3.0 |
-| 3.5 | .NET Framework 3.5 |
-| 4.0 | .NET Framework 4.0 |
-| 4.5 | .NET Framework 4.5 |
-| 4.6 | .NET Framework 4.6 |
+| X.X | .NET Framework X.X |
+| netcoreappX.X | .NET Core X.X |
+| netstandardX.X | .NET Standard X.X |
+| netX.X | .NET X.X |
 
 ### Applies To ###
 
@@ -30,10 +26,35 @@ Premake 5.0.0-alpha1 or later.
 
 ### Examples ###
 
-Use the .NET framework 3.0.
+Use .NET 10.0:
 
 ```lua
-dotnetframework "3.0"
+dotnetframework "net10.0"
+```
+
+Use .NET 8.0 and .NET 10.0:
+
+```lua
+dotnetframework { "net8.0", "net10.0" }
+```
+
+Use .NET Core 2.1:
+
+```lua
+dotnetframework "netcoreapp2.1"
+```
+
+Use .NET Standard 2.1:
+
+```lua
+dotnetframework "netstandard2.1"
+```
+
+
+Use the .NET framework 4.6:
+
+```lua
+dotnetframework "4.6"
 ```
 
 ### See Also ###


### PR DESCRIPTION
**What does this PR do?**

Allows multiple target .NET frameworks to be supported by a single dotnet project

**How does this PR change Premake's behavior?**

Extends the `dotnetframework` property to switch from using `TargetFramework` to `TargetFrameworks` when multiple (semicolon-separated) target names are provided

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [X] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes