### PR TITLE
Dotnet buildaction uses given build action verbatim if no matching mapping is found rather than using the None fallback

### DIFF
--- a/modules/vstudio/tests/cs2005/test_files.lua
+++ b/modules/vstudio/tests/cs2005/test_files.lua
@@ -270,6 +270,17 @@
 		]]
 	end
 
+	function suite.fallbackUserAction()
+		files { "Hello.custom" }
+		filter "files:Hello.custom"
+		buildaction "CustomAction"
+		prepare()
+		test.capture [[
+		<CustomAction Include="Hello.custom" />
+		]]
+	end
+
+
 
 --
 -- Files that exist outside the project folder should be added as

--- a/src/tools/dotnet.lua
+++ b/src/tools/dotnet.lua
@@ -75,7 +75,11 @@
 				info.action = "Page"
 			end
 		else
-			info.action = "None"
+			if fcfg.buildaction == nil then
+				info.action = "None"
+			else
+				info.action = fcfg.buildaction
+			end
 		end
 
 		-- Try to work out any subtypes, based on the files in the project

--- a/website/docs/buildaction.md
+++ b/website/docs/buildaction.md
@@ -24,7 +24,7 @@ For C/C++, `action` is the name of the MSBuild action as defined by the vcxproj 
 | Copy            | Copy the file to the target directory.                                           |
 
 For C# projects, `buildaction` behaviour is special to support legacy implementation.
-In C#, `action` is one of
+In C#, `action` can be one of
 
 | Action      | Description                                                           |
 |-------------|-----------------------------------------------------------------------|
@@ -37,6 +37,8 @@ In C#, `action` is one of
 | None        | Do nothing with this file.                                            |
 | Resource    | Copy/embed the file with the project resources.                       |
 | UserControl | Treat the source file as [visual user control][2].                    |
+
+If not matched by any of the above, the Action falls back to using the given action name verbatim (with no SubType). This allows project specific user defined custom BuildActions to be specified.
 
 The descriptive actions such as **Component**, **Form*, and **UserControl** are only recognized by Visual Studio, and may be considered optional as Visual Studio will automatically deduce the types when it first examines the project. You only need to specify these actions to avoid unnecessary modifications to the project files on save.
 


### PR DESCRIPTION
**What does this PR do?**

Allows user-specific build actions to be specified by using the given build action verbatim if no mapping is found rather than falling back to "None".

**How does this PR change Premake's behavior?**

If a build action is provided that doesn't match one of the pre-defined actions then it will be applied to the associated files as specified instead of being ignored.

For example, MonoGame projects use the custom "MonoGameContentReference" buildaction. With this change it's possible to specify that when using a premake project.

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes