### PR TITLE
Add infoplist API + Info.plist embedding in Apple OS console apps

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -235,7 +235,7 @@
 		end
 
 		local toolset = m.getcompiler(cfg)
-		local flags   = table.join(toolset.getldflags(cfg), toolset.getincludedirs(cfg, {}, nil, cfg.frameworkdirs), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), cfg.linkoptions, toolset.getlinks(cfg))
+		local flags   = table.join(toolset.getldflags(cfg), toolset.getincludedirs(cfg, {}, nil, cfg.frameworkdirs), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), toolset.getSections(cfg), cfg.linkoptions, toolset.getlinks(cfg))
 
 		_x(3, '<Linker Options="%s" Required="yes">', table.concat(flags, ";"))
 

--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -235,7 +235,7 @@
 		end
 
 		local toolset = m.getcompiler(cfg)
-		local flags   = table.join(toolset.getldflags(cfg), toolset.getincludedirs(cfg, {}, nil, cfg.frameworkdirs), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), toolset.getSections(cfg), cfg.linkoptions, toolset.getlinks(cfg))
+		local flags   = table.join(toolset.getldflags(cfg), toolset.getincludedirs(cfg, {}, nil, cfg.frameworkdirs), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), toolset.getsections(cfg), cfg.linkoptions, toolset.getlinks(cfg))
 
 		_x(3, '<Linker Options="%s" Required="yes">', table.concat(flags, ";"))
 

--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -456,7 +456,7 @@
 
 
 	function cpp.ldFlags(cfg, toolset)
-		local flags = table.join(toolset.getLibraryDirectories(cfg), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), toolset.getSections(cfg), toolset.getldflags(cfg), cfg.linkoptions)
+		local flags = table.join(toolset.getLibraryDirectories(cfg), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), toolset.getsections(cfg), toolset.getldflags(cfg), cfg.linkoptions)
 		p.outln('ALL_LDFLAGS += $(LDFLAGS)' .. gmake.list(flags))
 	end
 

--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -456,7 +456,7 @@
 
 
 	function cpp.ldFlags(cfg, toolset)
-		local flags = table.join(toolset.getLibraryDirectories(cfg), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), toolset.getldflags(cfg), cfg.linkoptions)
+		local flags = table.join(toolset.getLibraryDirectories(cfg), toolset.getrunpathdirs(cfg, table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))), toolset.getSections(cfg), toolset.getldflags(cfg), cfg.linkoptions)
 		p.outln('ALL_LDFLAGS += $(LDFLAGS)' .. gmake.list(flags))
 	end
 

--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -528,7 +528,10 @@ function m.getLdFlags(cfg, toolset)
 	
 	local libdirs = toolset.getLibraryDirectories(cfg)
 	flags = table.join(flags, libdirs)
-	
+
+	local sections = toolset.getSections(cfg)
+	flags = table.join(flags, sections)
+
 	if toolset.getrunpathdirs then
 		local runpathdirs = table.join(cfg.runpathdirs, config.getsiblingtargetdirs(cfg))
 		local rpaths = toolset.getrunpathdirs(cfg, runpathdirs)

--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -529,7 +529,7 @@ function m.getLdFlags(cfg, toolset)
 	local libdirs = toolset.getLibraryDirectories(cfg)
 	flags = table.join(flags, libdirs)
 
-	local sections = toolset.getSections(cfg)
+	local sections = toolset.getsections(cfg)
 	flags = table.join(flags, sections)
 
 	if toolset.getrunpathdirs then

--- a/modules/xcode/tests/test_xcode_project.lua
+++ b/modules/xcode/tests/test_xcode_project.lua
@@ -2130,6 +2130,28 @@
 				]]
 	end
 
+	function suite.XCBuildConfigurationTarget_infoplist()
+		files { "./a/b/c/MyProject-Info.plist" }
+		infoplist "./a/b/c/Override.plist"
+		prepare()
+		xcode.XCBuildConfiguration_Target(tr, tr.products.children[1], tr.configs[1])
+		test.capture [[
+		0141F3FC0D9EB3163D17DF0F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INFOPLIST_FILE = a/b/c/Override.plist;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = MyProject;
+			};
+			name = Debug;
+		};
+				]]
+	end
+
 
 	function suite.XCBuildConfigurationTarget_OnSymbols()
 		symbols "On"

--- a/modules/xcode/xcode_common.lua
+++ b/modules/xcode/xcode_common.lua
@@ -1359,6 +1359,10 @@
 			end
 		end
 
+		if cfg.infoplist then
+			settings["INFOPLIST_FILE"] = p.tools.getrelative(cfg.project, cfg.infoplist)
+		end
+
 		--ms not by default ...add it manually if you need it
 		--settings['COMBINE_HIDPI_IMAGES'] = 'YES'
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -409,6 +409,13 @@
 	}
 
 	api.register {
+		name = "infoplist",
+		scope = "config",
+		kind = "path",
+		tokens = true,
+	}
+
+	api.register {
 		name = "bindirs",
 		scope = "config",
 		kind = "list:directory",

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -242,6 +242,7 @@
 	clang.getstructuredimplicitincludedirs = gcc.getstructuredimplicitincludedirs
 
 	clang.getrunpathdirs = gcc.getrunpathdirs
+	clang.getSections = gcc.getSections
 
 --
 -- get the right output flag.

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -242,7 +242,7 @@
 	clang.getstructuredimplicitincludedirs = gcc.getstructuredimplicitincludedirs
 
 	clang.getrunpathdirs = gcc.getrunpathdirs
-	clang.getSections = gcc.getSections
+	clang.getsections = gcc.getsections
 
 --
 -- get the right output flag.

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -535,7 +535,7 @@
 --
 -- get the link-time file embedding flags
 --
-	function gcc.getSections(cfg)
+	function gcc.getsections(cfg)
 		local result = {}
 		if table.contains(os.getSystemTags(cfg.system), "darwin") then
 			if cfg.infoplist then

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -533,6 +533,19 @@
 	end
 
 --
+-- get the link-time file embedding flags
+--
+	function gcc.getSections(cfg)
+		local result = {}
+		if table.contains(os.getSystemTags(cfg.system), "darwin") then
+			if cfg.infoplist then
+				local relative = p.tools.getrelative(cfg.project, cfg.infoplist)
+				table.insert(result, "-Wl,-sectcreate,__TEXT,__info_plist," .. p.quoted(relative))
+			end
+		end
+		return result
+	end
+--
 -- get the right output flag.
 --
 	function gcc.getsharedlibarg(cfg)

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -314,7 +314,7 @@
 		return {}
 	end
 
-	function msc.getSections()
+	function msc.getsections()
 		return {}
 	end
 

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -314,6 +314,10 @@
 		return {}
 	end
 
+	function msc.getSections()
+		return {}
+	end
+
 --
 -- Decorate include file search paths for the MSVC command line.
 --

--- a/src/tools/snc.lua
+++ b/src/tools/snc.lua
@@ -110,6 +110,7 @@
 	snc.getstructuredincludedirs = gcc.getstructuredincludedirs
 	snc.getstructuredimplicitincludedirs = gcc.getstructuredimplicitincludedirs
 	snc.getrunpathdirs = gcc.getrunpathdirs
+	snc.getSections = gcc.getSections
 	snc.getLibraryDirectories = gcc.getLibraryDirectories
 	snc.getlinks = gcc.getlinks
 

--- a/src/tools/snc.lua
+++ b/src/tools/snc.lua
@@ -110,7 +110,7 @@
 	snc.getstructuredincludedirs = gcc.getstructuredincludedirs
 	snc.getstructuredimplicitincludedirs = gcc.getstructuredimplicitincludedirs
 	snc.getrunpathdirs = gcc.getrunpathdirs
-	snc.getSections = gcc.getSections
+	snc.getsections = gcc.getsections
 	snc.getLibraryDirectories = gcc.getLibraryDirectories
 	snc.getlinks = gcc.getlinks
 

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -1559,7 +1559,7 @@ end
 
 		prepare()
 	
-		local actual = gcc.getSections(cfg)
+		local actual = gcc.getsections(cfg)
 		local expected = "-Wl,-sectcreate,__TEXT,__info_plist,MyInfo.plist"
 		test.contains({expected}, actual)
 	end
@@ -1570,7 +1570,7 @@ end
 
 		prepare()
 
-		local actual = gcc.getSections(cfg)
+		local actual = gcc.getsections(cfg)
 		local notExpected = "-Wl,-sectcreate,__TEXT,__info_plist,MyInfo.plist"
 		test.excludes({notExpected}, actual)
 		--test.contains ("", "")

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -1562,8 +1562,6 @@ end
 		local actual = gcc.getSections(cfg)
 		local expected = "-Wl,-sectcreate,__TEXT,__info_plist,MyInfo.plist"
 		test.contains({expected}, actual)
-		--test.contains ("", "")
-		--test.contains ("", "")
 	end
 
 	function suite.notOnMacOSXInfoPlist()

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -1551,6 +1551,37 @@ end
 	end
 
 --
+-- Check Info.plist embedding on Apple platforms.
+--
+	function suite.onMacOSXInfoPlist()
+		system "MacOSX"
+		infoplist "./MyInfo.plist"
+
+		prepare()
+	
+		local actual = gcc.getSections(cfg)
+		local expected = "-Wl,-sectcreate,__TEXT,__info_plist,MyInfo.plist"
+		test.contains({expected}, actual)
+		--test.contains ("", "")
+		--test.contains ("", "")
+	end
+
+	function suite.notOnMacOSXInfoPlist()
+		system "Linux"
+		infoplist "./MyInfo.plist"
+
+		prepare()
+
+		local actual = gcc.getSections(cfg)
+		local notExpected = "-Wl,-sectcreate,__TEXT,__info_plist,MyInfo.plist"
+		test.excludes({notExpected}, actual)
+		--test.contains ("", "")
+		--test.contains ("", "")
+	end
+
+
+
+--
 -- Make sure unicode support is handled properly.
 --
 

--- a/website/docs/Project-API.md
+++ b/website/docs/Project-API.md
@@ -96,6 +96,7 @@
 | [includedirs](includedirs.md)                             |  |
 | [includedirsafter](includedirsafter.md)                   |  |
 | [includeexternal](globals/includeexternal.md)             |  |
+| [infoplist](infoplist.md)                                   | Sets the Apple ap bundle infos.                  |
 | [inlining](inlining.md)                                   | Tells the compiler when it should inline functions |
 | [intrinsics](intrinsics.md)                               |  |
 | [kind](kind.md)                                           |  |

--- a/website/docs/infoplist.md
+++ b/website/docs/infoplist.md
@@ -1,0 +1,35 @@
+Sets the application bundle information file for any Apple platform application.
+
+```lua
+infoplist ("path")
+```
+
+When generating Xcode action, this command will override the auto-detected Info.plist from the project file list.
+
+When used in Console application projects, the Info.plist is embedded in the application binary using Apple toolchain specific linker flags.
+
+### Parameters ###
+
+`path` is the file system path to the Apple property list file to use as Info.plist.
+
+### Applies To ###
+
+Project configurations.
+
+### Availability ###
+
+Premake 5.0 beta 8 or later for Apple platform applications.
+
+### Examples ###
+
+This project defines a default Info.plist and a different one for the Debug configuration.
+
+```lua
+project "MyProject"
+
+	infoplist "Default.plist"
+
+  filter { "configurations:Debug" }
+    infoplist "DebugInfo.plist"
+```
+

--- a/website/docs/infoplist.md
+++ b/website/docs/infoplist.md
@@ -18,7 +18,7 @@ Project configurations.
 
 ### Availability ###
 
-Premake 5.0 beta 8 or later for Apple platform applications.
+Premake 5.0 or later for Apple platform applications.
 
 ### Examples ###
 
@@ -27,7 +27,7 @@ This project defines a default Info.plist and a different one for the Debug conf
 ```lua
 project "MyProject"
 
-	infoplist "Default.plist"
+  infoplist "Default.plist"
 
   filter { "configurations:Debug" }
     infoplist "DebugInfo.plist"

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -176,6 +176,7 @@ module.exports = {
 						'includedirsafter',
 						'incrementallink',
 						'inheritdependencies',
+						'infoplist',
 						'inlinesvisibility',
 						'inlining',
 						'intrinsics',


### PR DESCRIPTION
**What does this PR do?**

The `infoplist` API adds a more explicit way to set the App bundle info in Xcode.
gmake, codelite and ninja generators now supports Info.plist by adding Apple toolchain specific flags provided by the new `toolset.getSections()` function. 

The `gcc.getSections()` allows other generator to embed the Info.plist in the binary.
This will allow command line tools to have bundle informations and security entitlements.

**How does this PR change Premake's behavior?**

If `infoplist "file"` is set in premake script. The automatic detection of .plist in xcode will be ignored.

**Anything else we should know?**


In the future, `toolset.getSections()` may be used to embed any file into the binary
by adding a new dedicated API or by handling
```lua
filter {"*.bin"}
	buildaction "Embed"
	``` 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*


