### PR TITLE
Fixed that build outputs are infinitely recursively processed

### DIFF
--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -199,7 +199,7 @@
 				table.insert(cfg._gmake.fileRules, file)
 
 				for _, output in ipairs(buildoutputs) do
-					cpp.addGeneratedFile(cfg, node, output)
+					cpp.addGeneratedFile(cfg, node, output, nil)
 				end
 			end
 		elseif filecfg.buildaction == "Copy" then
@@ -212,7 +212,7 @@
 				buildinputs = {'$(TARGETDIR)'}
 			}
 			table.insert(cfg._gmake.fileRules, file)
-			cpp.addGeneratedFile(cfg, node, output)
+			cpp.addGeneratedFile(cfg, node, output, nil)
 		else
 			cpp.addRuleFile(cfg, node)
 		end
@@ -233,7 +233,7 @@
 		return fileext;
 	end
 
-	function cpp.addGeneratedFile(cfg, source, filename)
+	function cpp.addGeneratedFile(cfg, source, filename, generatingRule)
 		-- mark that we have generated files.
 		cfg.project.hasGeneratedFiles = true
 
@@ -249,6 +249,11 @@
 		-- always overwrite the dependency information.
 		node.dependsOn = source
 		node.generated = true
+
+		-- if the generating node exists then use it
+		if generatingRule then
+            node.generatedByRule = generatingRule
+        end
 
 		-- add to config if not already added.
 		if not fileconfig.getconfig(node, cfg) then
@@ -284,7 +289,7 @@
 		local rules = cfg.project._gmake.rules
 		local fileext = cpp.determineFiletype(cfg, node)
 		local rule = rules[fileext]
-		if rule then
+		if rule and node.generatedByRule ~= rule then
 
 			local filecfg = fileconfig.getconfig(node, cfg)
 			local environ = table.shallowcopy(filecfg.environ)
@@ -313,7 +318,7 @@
 				table.insert(cfg._gmake.fileRules, file)
 
 				for _, output in ipairs(buildoutputs) do
-					cpp.addGeneratedFile(cfg, node, output)
+					cpp.addGeneratedFile(cfg, node, output, rule)
 				end
 			end
 		end

--- a/modules/gmake/gmake_utility.lua
+++ b/modules/gmake/gmake_utility.lua
@@ -114,7 +114,7 @@
 				table.insert(cfg._gmake.fileRules, file)
 
 				for _, output in ipairs(buildoutputs) do
-					utility.addGeneratedFile(cfg, node, output)
+					utility.addGeneratedFile(cfg, node, output, nil)
 				end
 			end
 		else
@@ -123,7 +123,7 @@
 	end
 
 
-	function utility.addGeneratedFile(cfg, source, filename)
+	function utility.addGeneratedFile(cfg, source, filename, generatingRule)
 		-- mark that we have generated files.
 		cfg.project.hasGeneratedFiles = true
 
@@ -139,6 +139,11 @@
 		-- always overwrite the dependency information.
 		node.dependsOn = source
 		node.generated = true
+
+		-- if the generating node exists then use it
+		if generatingRule then
+            node.generatedByRule = generatingRule
+        end
 
 		-- add to config if not already added.
 		if not fileconfig.getconfig(node, cfg) then
@@ -161,7 +166,7 @@
 	function utility.addRuleFile(cfg, node)
 		local rules = cfg.project._gmake.rules
 		local rule = rules[path.getextension(node.abspath):lower()]
-		if rule then
+		if rule and node.generatedByRule ~= rule then
 
 			local filecfg = fileconfig.getconfig(node, cfg)
 			local environ = table.shallowcopy(filecfg.environ)
@@ -190,7 +195,7 @@
 				table.insert(cfg._gmake.fileRules, file)
 
 				for _, output in ipairs(buildoutputs) do
-					utility.addGeneratedFile(cfg, node, output)
+					utility.addGeneratedFile(cfg, node, output, rule)
 				end
 			end
 		end

--- a/modules/gmake/tests/_tests.lua
+++ b/modules/gmake/tests/_tests.lua
@@ -15,6 +15,5 @@ return {
 	"test_gmake_perfile_flags.lua",
 	"test_gmake_target_rules.lua",
 	"test_gmake_tools.lua",
-	"test_gmake_customrules.lua",
 	"test_gmake_wks.lua"
 }

--- a/modules/gmake/tests/_tests.lua
+++ b/modules/gmake/tests/_tests.lua
@@ -15,5 +15,6 @@ return {
 	"test_gmake_perfile_flags.lua",
 	"test_gmake_target_rules.lua",
 	"test_gmake_tools.lua",
+	"test_gmake_customrules.lua",
 	"test_gmake_wks.lua"
 }


### PR DESCRIPTION
**What does this PR do?**

Fixes infinite recursion when a custom rule generates a file with the same extension as its input. Previously, generated files could be treated as new inputs for the same rule, causing the rule to be applied repeatedly.

**How does this PR change Premake's behavior?**

Generated files from custom rules are now tracked with the rule that created them. Before applying a rule, Premake checks whether the file was already generated by that same rule and skips it if so.

This prevents recursive rule application while keeping existing custom rule behavior unchanged. No breaking changes are introduced.

Closes #1940 

**Anything else we should know?**

This addresses issue [1940](https://github.com/premake/premake-core/issues/1940).

The fix was verified with a regression case where a custom rule generates another file with the same extension as its input. The generated output is created once and is not recursively processed.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes