### PR TITLE
Fix remote project directories for Linux projects

### DIFF
--- a/modules/vstudio/tests/linux/test_linux_files.lua
+++ b/modules/vstudio/tests/linux/test_linux_files.lua
@@ -70,9 +70,9 @@ local vc2010 = p.vstudio.vc2010
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
 	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
-	<RemoteOutRelDir>$(RemoteProjectRelDir)bin\Debug\</RemoteOutRelDir>
+	<RemoteOutRelDir>$(RemoteProjectRelDir)bin/Debug/</RemoteOutRelDir>
 	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
-	<RemoteIntRelDir>$(RemoteProjectRelDir)obj\Debug\</RemoteIntRelDir>
+	<RemoteIntRelDir>$(RemoteProjectRelDir)obj/Debug/</RemoteIntRelDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>
 	</TargetExt>

--- a/modules/vstudio/tests/linux/test_linux_files.lua
+++ b/modules/vstudio/tests/linux/test_linux_files.lua
@@ -70,7 +70,9 @@ local vc2010 = p.vstudio.vc2010
 		test.capture [[
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
 	<OutDir>$(ProjectDir)bin\Debug\</OutDir>
+	<RemoteOutRelDir>$(RemoteProjectRelDir)bin\Debug\</RemoteOutRelDir>
 	<IntDir>$(ProjectDir)obj\Debug\</IntDir>
+	<RemoteIntRelDir>$(RemoteProjectRelDir)obj\Debug\</RemoteIntRelDir>
 	<TargetName>MyProject</TargetName>
 	<TargetExt>
 	</TargetExt>

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2877,7 +2877,8 @@
 
 		-- Keep the RemoteIntRelDir in sync with IntDir
 		if cfg.system == p.LINUX then
-			m.element("RemoteIntRelDir", nil, "%s\\", remoteobjdir)
+			remoteobjdir = string.gsub(remoteobjdir, "\\", "/")
+			m.element("RemoteIntRelDir", nil, "%s/", remoteobjdir)
 		end
 	end
 
@@ -3143,7 +3144,8 @@
 
 		-- Keep the RemoteOutRelDir in sync with OutDir or we won't be able to find the executable in the remote machine
 		if cfg.system == p.LINUX then
-			m.element("RemoteOutRelDir", nil, "%s\\", remoteoutdir)
+			remoteoutdir = string.gsub(remoteoutdir, "\\", "/")
+			m.element("RemoteOutRelDir", nil, "%s/", remoteoutdir)
 		end
 
 	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2865,12 +2865,20 @@
 
 	function m.intDir(cfg)
 		local objdir = vstudio.path(cfg, cfg.objdir)
+		local localobjdir = objdir
+		local remoteobjdir  = objdir
 
 		if not path.isabsolute(objdir) then
-			objdir = "$(ProjectDir)" .. objdir
+			localobjdir = "$(ProjectDir)" .. objdir
+			remoteobjdir = "$(RemoteProjectRelDir)" .. objdir
 		end
 
-		m.element("IntDir", nil, "%s\\", objdir)
+		m.element("IntDir", nil, "%s\\", localobjdir)
+
+		-- Keep the RemoteIntRelDir in sync with IntDir
+		if cfg.system == p.LINUX then
+			m.element("RemoteIntRelDir", nil, "%s\\", remoteobjdir)
+		end
 	end
 
 
@@ -3123,12 +3131,20 @@
 
 	function m.outDir(cfg)
 		local outdir = vstudio.path(cfg, cfg.buildtarget.directory)
+		local localoutdir = outdir
+		local remoteoutdir = outdir
 
 		if not path.isabsolute(outdir) then
-			outdir = "$(ProjectDir)" .. outdir
+			localoutdir = "$(ProjectDir)" .. outdir
+			remoteoutdir = "$(RemoteProjectRelDir)" .. outdir
 		end
 
-		m.element("OutDir", nil, "%s\\", outdir)
+		m.element("OutDir", nil, "%s\\", localoutdir)
+
+		-- Keep the RemoteOutRelDir in sync with OutDir or we won't be able to find the executable in the remote machine
+		if cfg.system == p.LINUX then
+			m.element("RemoteOutRelDir", nil, "%s\\", remoteoutdir)
+		end
 
 	end
 

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2877,7 +2877,7 @@
 
 		-- Keep the RemoteIntRelDir in sync with IntDir
 		if cfg.system == p.LINUX then
-			remoteobjdir = string.gsub(remoteobjdir, "\\", "/")
+			remoteobjdir = path.translate(remoteobjdir, "/")
 			m.element("RemoteIntRelDir", nil, "%s/", remoteobjdir)
 		end
 	end
@@ -3144,7 +3144,7 @@
 
 		-- Keep the RemoteOutRelDir in sync with OutDir or we won't be able to find the executable in the remote machine
 		if cfg.system == p.LINUX then
-			remoteoutdir = string.gsub(remoteoutdir, "\\", "/")
+			remoteoutdir = path.translate(remoteoutdir, "/")
 			m.element("RemoteOutRelDir", nil, "%s/", remoteoutdir)
 		end
 


### PR DESCRIPTION
**What does this PR do?**

Tracks remote directory with the same path as the local directory so projects find the right executable. Older versions of Premake did not modify the output directory so it matched the remote directory, whereas right now debugging isn't possible as the executable doesn't launch.

**How does this PR change Premake's behavior?**

Fixes launch behavior

**Anything else we should know?**

I don't know which CL broke it but that was the correct thing to do, and this one builds upon it.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
