### PR TITLE
Make removal of symlinks more robust, fix FreeBSD build

### DIFF
--- a/src/base/os.lua
+++ b/src/base/os.lua
@@ -580,6 +580,9 @@
 	function os.remove(f)
 		-- in case of string, just match files
 		if type(f) == "string" then
+			if os.islink(f) then
+				return builtin_remove(f)
+			end
 			local p = os.matchfiles(f)
 			for _, v in pairs(p) do
 				local ok, err, code = builtin_remove(v)


### PR DESCRIPTION
**What does this PR do?**

Fixes an issue arising in FreeBSD 15.1 where remove on a symlink would fail to remove a symlink to a file.

**How does this PR change Premake's behavior?**

No changes to documented behavior. This make the FreeBSD behavior consistent before and after 15.1

**Anything else we should know?**

No

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
