### PR TITLE
fix `zip.list()` missing the first item

### DIFF
--- a/src/host/zip_list.c
+++ b/src/host/zip_list.c
@@ -23,7 +23,7 @@ int zip_list(lua_State* L)
     {
         const char* full_name = zip_get_name(z_archive, i, 0);
         lua_pushstring(L, full_name);
-        lua_rawseti(L, -2, i);
+        lua_rawseti(L, -2, i + 1);
     }
     zip_close(z_archive);
     lua_pushnil(L);

--- a/website/docs/Lua-Library-Additions.md
+++ b/website/docs/Lua-Library-Additions.md
@@ -135,4 +135,4 @@
 ### Zip
 
 * [zip.extract](zip/zip.extract.md)
-
+* [zip.list](zip/zip.list.md)


### PR DESCRIPTION
**What does this PR do?**

Fixes an issue where `zip.list()` could cause the first entry in an archive to be skipped, and adds the missing documentation link.

Lua sequence indices conventionally start at 1, but the previous implementation returned a non-standard sequence:

```lua
{
    [0] = "1st ZIP entry",
    [1] = "2nd ZIP entry",
    ...
}
```

Both the `#` length operator and `ipairs()` ignore the entry at index 0, so callers using the usual Lua sequence operations would miss the first archive entry.

**How does this PR change Premake's behavior?**

The first entry returned by `zip.list()` is no longer skipped during normal Lua sequence traversal.

Premake's NuGet handling uses `zip.list()` when inspecting `.nupkg` files from a custom `nugetsource` directory or the local NuGet cache. As a result, the first entry in those packages will now be recognized correctly, potentially fixing issues when that entry is relevant to project generation.

**Anything else we should know?**

The ZIP implementation remains relatively fragile. See https://github.com/premake/premake-core/issues/2751 .

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
