### PR TITLE
Add AVX512 to vectorextensions

### DIFF
--- a/modules/vstudio/tests/vc2010/test_vectorextensions.lua
+++ b/modules/vstudio/tests/vc2010/test_vectorextensions.lua
@@ -91,3 +91,19 @@
 		prepare()
 		test.isemptycapture()
 	end
+
+	function suite.instructionSet_onAVX512()
+		p.action.set("vs2017")
+		vectorextensions "AVX512"
+		prepare()
+		test.capture [[
+<EnableEnhancedInstructionSet>AdvancedVectorExtensions512</EnableEnhancedInstructionSet>
+		]]
+	end
+
+	function suite.instructionSet_onAVX512_onVS2015()
+		p.action.set("vs2015")
+		vectorextensions "AVX512"
+		prepare()
+		test.isemptycapture()
+	end

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -2454,6 +2454,8 @@
 			v = "AdvancedVectorExtensions"
 		elseif x == "AVX2" and _ACTION > "vs2012" then
 			v = "AdvancedVectorExtensions2"
+		elseif x == "AVX512" and _ACTION >= "vs2017" then
+			v = "AdvancedVectorExtensions512"
 		elseif cfg.architecture ~= "x86_64" then
 			if x == "SSE2" or x == "SSE3" or x == "SSSE3" or x == "SSE4.1" or x == "SSE4.2" then
 				v = "StreamingSIMDExtensions2"

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -960,6 +960,7 @@
 			"Default",
 			"AVX",
 			"AVX2",
+			"AVX512",
 			"IA32",
 			"SSE",
 			"SSE2",

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -99,6 +99,7 @@
 		vectorextensions = {
 			AVX = "-mavx",
 			AVX2 = "-mavx2",
+			AVX512 = "-mavx512f",
 			SSE = "-msse",
 			SSE2 = "-msse2",
 			SSE3 = "-msse3",

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -111,6 +111,7 @@
 		vectorextensions = {
 			AVX = "/arch:AVX",
 			AVX2 = "/arch:AVX2",
+			AVX512 = "/arch:AVX512",
 			SSE = "/arch:SSE",
 			SSE2 = "/arch:SSE2",
 			SSE3 = "/arch:SSE2",

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -162,6 +162,12 @@ end
 		test.excludes("-fopenmp", clang.getcflags(cfg))
 	end
 
+	function suite.cflags_onAVX512()
+		vectorextensions "AVX512"
+		prepare()
+		test.contains({ "-mavx512f" }, clang.getcflags(cfg))
+	end
+
 	function suite.cxxflags_onOpenmpOn()
 		openmp "On"
 		prepare()
@@ -483,4 +489,3 @@ end
 		prepare()
 		test.excludes({ "-municode" }, clang.getldflags(cfg))
 	end
-	

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -232,6 +232,12 @@
 		test.contains({ "-mavx2" }, gcc.getcflags(cfg))
 	end
 
+	function suite.cflags_onAVX512()
+		vectorextensions "AVX512"
+		prepare()
+		test.contains({ "-mavx512f" }, gcc.getcflags(cfg))
+	end
+
 	function suite.cflags_onMOVBE()
 		isaextensions "MOVBE"
 		prepare()

--- a/tests/tools/test_msc.lua
+++ b/tests/tools/test_msc.lua
@@ -571,6 +571,12 @@ end
 		test.contains("/arch:AVX2", msc.getcflags(cfg))
 	end
 
+	function suite.cflags_onAVX512()
+		vectorextensions "AVX512"
+		prepare()
+		test.contains("/arch:AVX512", msc.getcflags(cfg))
+	end
+
 
 --
 -- Check the defines and undefines.

--- a/website/docs/vectorextensions.md
+++ b/website/docs/vectorextensions.md
@@ -15,6 +15,7 @@ If no value is set for a configuration, the toolset's default vector extension s
 | Default     | Use the toolset's default vector extension settings.   |
 | AVX         | Use Advanced Vector Extensions.                        |
 | AVX2        | Use Advanced Vector Extensions 2.                      |
+| AVX512      | Use Advanced Vector Extensions 512.                    |
 | IA32        | Use Intel Architecture 32-bit                          |
 | SSE         | Use the basic SSE instruction set.                     |
 | SSE2        | Use the SSE2 instruction set.                          |
@@ -25,6 +26,9 @@ If no value is set for a configuration, the toolset's default vector extension s
 | ALTIVEC     | Use Altivec (ISA 2.02) instruction set.                |
 | NEON        | Use the NEON instruction set (Android only)            |
 | MXU         | Use the XBurst SIMD instructions (Android only)        |
+
+Note:
+- AVX512 enables all instructions with the `msc` toolset (`/arch:AVX512`), but only enables foundational (`-mavx512f`) instructions in the `gcc` and `clang` toolset.
 
 ### Applies To ###
 


### PR DESCRIPTION
- Added for [msvc](https://devblogs.microsoft.com/cppblog/avx-512-auto-vectorization-in-msvc/) in vs (EnableEnhancedInstructionSet = AdvancedVectorExtensions512)
- Added for msvc (/arch:AVX512), clang and gcc (-mavx512f) as c/cxx flags

Fixes #2730 