### PR TITLE
fix os.isdir() and os.mkdir()

### DIFF
--- a/src/host/os_isdir.c
+++ b/src/host/os_isdir.c
@@ -24,25 +24,13 @@ int os_isdir(lua_State* L)
 	}
 
 #if PLATFORM_WINDOWS
-	struct _stat buf;
 	const wchar_t *wpath = luaL_checkconvertstring(L, 1);
-	if (_wstat(wpath, &buf) == 0)
-	{
-		int isdir = (buf.st_mode & S_IFDIR) != 0;
-		lua_pushboolean(L, isdir);
-	}
+	DWORD attributes = GetFileAttributesW(wpath);
+	lua_pushboolean(L, attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
 #else
 	struct stat buf;
-	if (stat(path, &buf) == 0)
-	{
-		int isdir = (buf.st_mode & S_IFDIR) != 0;
-		lua_pushboolean(L, isdir);
-	}
+	lua_pushboolean(L, stat(path, &buf) == 0 && S_ISDIR(buf.st_mode));
 #endif
-	else
-	{
-		lua_pushboolean(L, 0);
-	}
 
 	return 1;
 }

--- a/src/host/os_mkdir.c
+++ b/src/host/os_mkdir.c
@@ -25,21 +25,20 @@
 
 int do_mkdir(lua_State *L, const char* path)
 {
-	int i, length, s;
+	int i, length;
 #if PLATFORM_WINDOWS
-	struct _stat sb;
+	DWORD attributes;
 	const wchar_t *wpath = luaL_convertstring(L, path);
 	if (!wpath) return 0;  /* unable to encode path */
-	s = _wstat(wpath, &sb);
+	attributes = GetFileAttributesW(wpath);
 	lua_pop(L, 1);
+	if (attributes != INVALID_FILE_ATTRIBUTES)
+		return (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
 #else
 	struct stat sb;
-	s = stat(path, &sb);
+	if (stat(path, &sb) == 0)
+		return S_ISDIR(sb.st_mode);
 #endif
-
-	// if it already exists, return.
-	if (s == 0)
-		return 1;
 
 	// find the parent folder name.
 	length = (int)strlen(path);

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -179,6 +179,16 @@
 		test.isfalse(os.islink("folder/ok2.lua"))
 	end
 
+--
+-- os.mkdir() tests
+--
+
+	function suite.mkdir_ReturnsError_OnExistingFile()
+		test.istrue(os.isfile("folder/ok.lua"))
+		local ok, err = os.mkdir("folder/ok.lua")
+		test.isnil(ok)
+		test.isequal("string", type(err))
+	end
 
 --
 -- os.matchdirs() tests

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -179,6 +179,24 @@
 		test.isfalse(os.islink("folder/ok2.lua"))
 	end
 
+--
+-- os.mkdir() tests
+--
+
+	function suite.mkdir_ReturnsTrue_OnExistingDirectoryLink()
+		test.istrue(os.linkdir("folder/subfolder", "folder/subfolder2"))
+		test.istrue(os.mkdir("folder/subfolder2"))
+		test.istrue(os.islink("folder/subfolder2"))
+		test.istrue(os.isdir("folder/subfolder2"))
+		test.istrue(os.rmdir("folder/subfolder2"))
+	end
+
+	function suite.mkdir_ReturnsError_OnExistingFile()
+		local ok, err = os.mkdir("folder/ok.lua")
+		test.isnil(ok)
+		test.isequal("string", type(err))
+		test.istrue(os.isfile("folder/ok.lua"))
+	end
 
 --
 -- os.matchdirs() tests

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -7,6 +7,29 @@
 	local suite = test.declare("base_os")
 
 	local cwd
+	local real_io_open = io.open
+
+	local tmpname = function()
+		local p = os.tmpname()
+		if p:startswith("\\") then
+			p = "." .. p
+		end
+		os.remove(p) -- just needed on POSIX
+		return p
+	end
+
+	local tmpfile = function()
+		local p = tmpname()
+		local f = assert(real_io_open(p, "w"))
+		f:close()
+		return p
+	end
+
+	local tmpdir = function()
+		local p = tmpname()
+		os.mkdir(p)
+		return p
+	end
 
 	function suite.setup()
 		cwd = os.getcwd()
@@ -184,8 +207,9 @@
 --
 
 	function suite.mkdir_ReturnsError_OnExistingFile()
-		test.istrue(os.isfile("folder/ok.lua"))
-		local ok, err = os.mkdir("folder/ok.lua")
+		local filename = tmpfile()
+		local ok, err = os.mkdir(filename)
+		os.remove(filename)
 		test.isnil(ok)
 		test.isequal("string", type(err))
 	end
@@ -552,9 +576,8 @@
 -- Helpers
 --
 
-	-- Save the real functions before test runner installs its stubs.
+	-- Save the real function before test runner installs its stub.
 	local real_writefile_ifnotequal = os.writefile_ifnotequal
-	local real_io_open = io.open
 
 	local function real_readfile(filepath)
 		local f = real_io_open(filepath, "rb")
@@ -563,32 +586,6 @@
 		f:close()
 		return content
 	end
-
-	local tmpname = function()
-		local p = os.tmpname()
-        if p:startswith("\\") then
-            p = "." .. p
-        end
-		os.remove(p) -- just needed on POSIX
-		return p
-	end
-
-	local tmpfile = function()
-		local p = tmpname()
-		if os.ishost("windows") then
-			os.execute("type nul >" .. p)
-		else
-			os.execute("touch " .. p)
-		end
-		return p
-	end
-
-	local tmpdir = function()
-		local p = tmpname()
-		os.mkdir(p)
-		return p
-	end
-
 
 --
 -- os.writefile_ifnotequal() tests.

--- a/tests/base/test_os.lua
+++ b/tests/base/test_os.lua
@@ -184,18 +184,27 @@
 --
 
 	function suite.mkdir_ReturnsTrue_OnExistingDirectoryLink()
-		test.istrue(os.linkdir("folder/subfolder", "folder/subfolder2"))
-		test.istrue(os.mkdir("folder/subfolder2"))
-		test.istrue(os.islink("folder/subfolder2"))
-		test.istrue(os.isdir("folder/subfolder2"))
-		test.istrue(os.rmdir("folder/subfolder2"))
+		-- BSD CI mounts the workspace through SSHFS, so keep topology tests on local storage.
+		local root = os.tmpname()
+		os.remove(root)
+		local target = path.join(root, "subfolder")
+		local link = path.join(root, "subfolder2")
+
+		test.istrue(os.mkdir(target))
+		test.istrue(os.linkdir(target, link))
+		test.istrue(os.mkdir(link))
+		test.istrue(os.islink(link))
+		test.istrue(os.isdir(link))
+		test.istrue(os.rmdir(link))
+		test.istrue(os.rmdir(target))
+		test.istrue(os.rmdir(root))
 	end
 
 	function suite.mkdir_ReturnsError_OnExistingFile()
+		test.istrue(os.isfile("folder/ok.lua"))
 		local ok, err = os.mkdir("folder/ok.lua")
 		test.isnil(ok)
 		test.isequal("string", type(err))
-		test.istrue(os.isfile("folder/ok.lua"))
 	end
 
 --


### PR DESCRIPTION
**What does this PR do?**

* On MinGW, `_wstat` does not fully recognize reparse points (symbolic links); `GetFileAttributesW` needs to be used instead.
* Fixed an issue where `os.mkdir` incorrectly returned success when the target already existed and was a file, added the test.
* Simplified the implementation of `os.isdir`.

**How does this PR change Premake's behavior?**

In the edge case where the target of `mkdir` already exists and is a file, the operation may now terminate earlier.

**Anything else we should know?**


**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
