### PR TITLE
implement defaultconfiguration to sln2026

### DIFF
--- a/modules/vstudio/tests/sln2026/test_configurations.lua
+++ b/modules/vstudio/tests/sln2026/test_configurations.lua
@@ -1,12 +1,12 @@
 --
--- tests/actions/vstudio/sln2026/test_dependencies.lua
+-- tests/actions/vstudio/sln2026/test_configurations.lua
 -- Validate generation of Visual Studio 2026+ solution project dependencies.
 -- Author Nick Clark
 -- Copyright (c) 2025 Jess Perkins and the Premake project
 --
 
 local p = premake
-local suite = test.declare("vstudio_sln2026_dependencies")
+local suite = test.declare("vstudio_sln2026_configurations")
 local sln2026 = p.vstudio.sln2026
 
 
@@ -75,6 +75,64 @@ function suite.multiple_platforms()
 
 	test.capture [[
 <Configurations>
+	<BuildType Name="Debug" />
+	<Platform Name="x64" />
+	<Platform Name="Win32" />
+</Configurations>
+	]]
+end
+
+
+function suite.default_configuration()
+	local wks = workspace "MyWorkspace"
+
+	configurations { "Debug", "Release" }
+	defaultconfiguration "Release"
+
+	sln2026.configurations(wks)
+
+	test.capture [[
+<Configurations>
+	<BuildType Name="Release" />
+	<BuildType Name="Debug" />
+	<Platform Name="Win32" />
+</Configurations>
+	]]
+end
+
+
+function suite.default_platform()
+	local wks = workspace "MyWorkspace"
+
+	configurations { "Debug" }
+	platforms { "x86", "x64" }
+	defaultplatform "x64"
+
+	sln2026.configurations(wks)
+
+	test.capture [[
+<Configurations>
+	<BuildType Name="Debug" />
+	<Platform Name="x64" />
+	<Platform Name="Win32" />
+</Configurations>
+	]]
+end
+
+
+function suite.default_configuration_and_platform()
+	local wks = workspace "MyWorkspace"
+
+	configurations { "Debug", "Release" }
+	platforms { "x86", "x64" }
+	defaultconfiguration "Release"
+	defaultplatform "x86"
+
+	sln2026.configurations(wks)
+
+	test.capture [[
+<Configurations>
+	<BuildType Name="Release" />
 	<BuildType Name="Debug" />
 	<Platform Name="Win32" />
 	<Platform Name="x64" />

--- a/modules/vstudio/tests/sln2026/test_configurations.lua
+++ b/modules/vstudio/tests/sln2026/test_configurations.lua
@@ -15,6 +15,12 @@ function suite.setup()
 end
 
 
+local function prepare(wks)
+	wks = test.getWorkspace(wks)
+	sln2026.configurations(wks)
+end
+
+
 function suite.solution_header()
 	sln2026.solution()
 
@@ -27,7 +33,7 @@ end
 function suite.default_configurations()
 	local wks = workspace "MyWorkspace"
 
-	sln2026.configurations(wks)
+	prepare(wks)
 
 	test.capture [[
 <Configurations>
@@ -41,7 +47,7 @@ function suite.multiple_configurations()
 
 	configurations { "Debug", "Release" }
 
-	sln2026.configurations(wks)
+	prepare(wks)
 
 	test.capture [[
 <Configurations>
@@ -56,7 +62,7 @@ end
 function suite.default_platforms()
 	local wks = workspace "MyWorkspace"
 
-	sln2026.configurations(wks)
+	prepare(wks)
 
 	test.capture [[
 <Configurations>
@@ -71,7 +77,7 @@ function suite.multiple_platforms()
 	configurations { "Debug" }
 	platforms { "x86", "x64" }
 
-	sln2026.configurations(wks)
+	prepare(wks)
 
 	test.capture [[
 <Configurations>
@@ -89,7 +95,7 @@ function suite.default_configuration()
 	configurations { "Debug", "Release" }
 	defaultconfiguration "Release"
 
-	sln2026.configurations(wks)
+	prepare(wks)
 
 	test.capture [[
 <Configurations>
@@ -108,7 +114,7 @@ function suite.default_platform()
 	platforms { "x86", "x64" }
 	defaultplatform "x64"
 
-	sln2026.configurations(wks)
+	prepare(wks)
 
 	test.capture [[
 <Configurations>
@@ -128,7 +134,7 @@ function suite.default_configuration_and_platform()
 	defaultconfiguration "Release"
 	defaultplatform "x86"
 
-	sln2026.configurations(wks)
+	prepare(wks)
 
 	test.capture [[
 <Configurations>

--- a/modules/vstudio/vs2026_solution.lua
+++ b/modules/vstudio/vs2026_solution.lua
@@ -62,8 +62,6 @@ end
 function m.configurations(wks)
 	p.push('<Configurations>')
 
-	wks = p.oven.bakeWorkspace(wks)
-
 	local cfgs = {}
 	local platforms = {}
 	local defaultCfg = p.config.getdefault(wks)

--- a/modules/vstudio/vs2026_solution.lua
+++ b/modules/vstudio/vs2026_solution.lua
@@ -62,8 +62,13 @@ end
 function m.configurations(wks)
 	p.push('<Configurations>')
 
+	wks = p.oven.bakeWorkspace(wks)
+
 	local cfgs = {}
 	local platforms = {}
+	local defaultCfg = p.config.getdefault(wks)
+	local defaultBuildcfg = defaultCfg and defaultCfg.buildcfg
+	local defaultPlatform = defaultCfg and vstudio.solutionPlatform(defaultCfg)
 
 	for cfg in p.workspace.eachconfig(wks) do
 		local platform = vstudio.solutionPlatform(cfg)
@@ -74,8 +79,25 @@ function m.configurations(wks)
 	cfgs = table.unique(cfgs)
 	platforms = table.unique(platforms)
 
-	table.sort(cfgs, function(a, b) return a:lower() < b:lower() end)
-	table.sort(platforms, function(a, b) return a:lower() < b:lower() end)
+	table.sort(cfgs, function(a, b)
+		if a == defaultBuildcfg then
+			return b ~= defaultBuildcfg
+		elseif b == defaultBuildcfg then
+			return false
+		end
+
+		return a:lower() < b:lower()
+	end)
+
+	table.sort(platforms, function(a, b)
+		if a == defaultPlatform then
+			return b ~= defaultPlatform
+		elseif b == defaultPlatform then
+			return false
+		end
+
+		return a:lower() < b:lower()
+	end)
 
 	for _, buildcfg in ipairs(cfgs) do
 		p.push('<BuildType Name="%s" />', buildcfg)

--- a/website/docs/defaultconfiguration.md
+++ b/website/docs/defaultconfiguration.md
@@ -36,6 +36,10 @@ workspace "MyWorkspace"
   defaultplatform "x64"
 ```
 
+### Remarks ###
+
+When generating Visual Studio solutions (`.sln` or `.slnx`), Premake writes the selected build configuration and platform first. Neither Microsoft solution format provides fields that explicitly identify the default configuration or platform, so this is a best-effort hint based on entry ordering. Microsoft tools or other consumers may apply their own defaults instead; for example, MSBuild prefers `Debug` when that configuration exists.
+
 ### See Also ###
 
 * [configurations](configurations.md)

--- a/website/docs/defaultplatform.md
+++ b/website/docs/defaultplatform.md
@@ -43,6 +43,11 @@ workspace "MyWorkspace"
     architecture "x64"
 
 ```
+
+### Remarks ###
+
+When generating Visual Studio solutions (`.sln` or `.slnx`), Premake writes the selected platform and build configuration first. Neither Microsoft solution format provides fields that explicitly identify the default platform or configuration, so this is a best-effort hint based on entry ordering. Microsoft tools or other consumers may apply their own defaults instead; for example, MSBuild prefers `Mixed Platforms`, then `Any CPU`, when either is available.
+
 ### See Also ###
 
 * [defaultconfiguration](defaultconfiguration.md)


### PR DESCRIPTION
**What does this PR do?**

- Apply the same ordering of `defaultconfiguration` and `defaultplatform` in `.slnx` format as in `.sln` format.
- Add documentation explaining the limitations of setting default configurations in both formats.
- Small fix sln2026 configurations test.

**How does this PR change Premake's behavior?**

The order will be consistent. 

**Anything else we should know?**


**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
