### PR TITLE
fix Clang LTO archiver selection on Apple platforms

### DIFF
--- a/modules/gmake/tests/test_gmake_clang.lua
+++ b/modules/gmake/tests/test_gmake_clang.lua
@@ -18,6 +18,9 @@
 	function suite.setup()
 		wks = test.createWorkspace()
 		toolset "clang"
+	end
+
+	local function prepare()
 		prj = p.workspace.getproject(wks, 1)
 	end
 
@@ -27,6 +30,7 @@
 --
 
 	function suite.usesCorrectCompilers()
+		prepare()
 		gmake.cpp.outputConfigurationSection(prj)
 		test.capture [[
 # Configurations
@@ -44,3 +48,24 @@ endif
 ]]
 	end
 
+	function suite.usesSystemArchiverForVersionedClangOnMacOSWithLinkTimeOptimization()
+		system "MacOSX"
+		toolset "clang-16"
+		linktimeoptimization "On"
+		prepare()
+		gmake.cpp.outputConfigurationSection(prj)
+		test.capture [[
+# Configurations
+# #############################################
+
+ifeq ($(origin CC), default)
+  CC = clang-16
+endif
+ifeq ($(origin CXX), default)
+  CXX = clang++-16
+endif
+ifeq ($(origin AR), default)
+  AR = ar
+endif
+]]
+	end

--- a/modules/gmakelegacy/tests/cpp/test_clang.lua
+++ b/modules/gmakelegacy/tests/cpp/test_clang.lua
@@ -20,6 +20,9 @@
 	function suite.setup()
 		wks = test.createWorkspace()
 		toolset "clang"
+	end
+
+	local function prepare()
 		prj = p.workspace.getproject(wks, 1)
 	end
 
@@ -29,6 +32,7 @@
 --
 
 	function suite.usesCorrectCompilers()
+		prepare()
 		make.cppConfigs(prj)
 		test.capture [[
 ifeq ($(config),debug)
@@ -45,7 +49,9 @@ ifeq ($(config),debug)
 	end
 
 	function suite.usesCorrectCompilersAndLinkTimeOptimizationViaAPI()
+		system "Linux"
 		linktimeoptimization "On"
+		prepare()
 		make.cppConfigs(prj)
 		test.capture [[
 ifeq ($(config),debug)
@@ -62,7 +68,9 @@ ifeq ($(config),debug)
 	end
 
 	function suite.usesCorrectCompilersAndFastLinkTimeOptimizationViaAPI()
+		system "Linux"
 		linktimeoptimization "Fast"
+		prepare()
 		make.cppConfigs(prj)
 		test.capture [[
 ifeq ($(config),debug)

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -391,6 +391,10 @@
 
 	function clang.gettoolname(cfg, tool)
 		local toolset, version = p.tools.canonical(cfg.toolset or p.CLANG)
+		-- Apple toolchains expose their LTO-capable archiver as "ar", without Clang-style version suffixes, nor "llvm-ar".
+		if tool == "ar" and (cfg.system == p.MACOSX or cfg.system == p.IOS or cfg.system == p.TVOS) then
+			return "ar"
+		end
 		local value = clang.tools[tool]
 		if type(value) == "function" then
 			value = value(cfg)

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -57,6 +57,24 @@
 		test.isequal("windres", clang.gettoolname(cfg, "rc"))
 	end
 
+	function suite.tools_onMacOSWithLinkTimeOptimization()
+		system "MacOSX"
+		linktimeoptimization "On"
+		prepare()
+		test.isequal("ar", clang.gettoolname(cfg, "ar"))
+	end
+
+	function suite.tools_forVersion_onMacOSWithLinkTimeOptimization()
+		system "MacOSX"
+		toolset "clang-16"
+		linktimeoptimization "On"
+		prepare()
+		test.isequal("clang-16", clang.gettoolname(cfg, "cc"))
+		test.isequal("clang++-16", clang.gettoolname(cfg, "cxx"))
+		test.isequal("ar", clang.gettoolname(cfg, "ar"))
+		test.isequal("windres-16", clang.gettoolname(cfg, "rc"))
+	end
+
 	function suite.tools_forVersion()
 		toolset "clang-16"
 		prepare()


### PR DESCRIPTION
**What does this PR do?**

Fixes Clang LTO builds on Apple platforms where Premake incorrectly selected `llvm-ar`, which is not provided by the default Apple toolchain. The Apple toolchain already uses LLVM, but the executable name is `ar`.

**How does this PR change Premake's behavior?**

On macOS, Premake now uses the system `ar` for static libraries. Other versioned toolsets, such as `clang-16`, retain the existing behavior. Other platforms continue to use `llvm-ar` when LTO is enabled.

**Anything else we should know?**

I just made my project build pass with LTO on, didn't test it fully.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [ ] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
