### PR TITLE
Fix clang linker on windows

### DIFF
--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -273,8 +273,12 @@
 		kind = {
 			SharedLib = function(cfg)
 				local r = { clang.getsharedlibarg(cfg) }
-				if cfg.system == "windows" and cfg.useimportlib ~= p.OFF then
-					table.insert(r, '-Wl,--out-implib="' .. cfg.linktarget.relpath .. '"')
+				if cfg.system == "windows" then
+					if cfg.useimportlib ~= p.OFF then
+						table.insert(r, '-Xlinker /IMPLIB:"' .. cfg.linktarget.relpath .. '"')
+					else
+						table.insert(r, '-Xlinker /NOIMPLIB')
+					end
 				elseif cfg.system == p.LINUX then
 					table.insert(r, '-Wl,-soname=' .. p.quoted(cfg.linktarget.name))
 				elseif table.contains(os.getSystemTags(cfg.system), "darwin") then

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -474,6 +474,21 @@ end
 		test.contains({ "-D_UNICODE", "-DUNICODE", "-municode" }, clang.getcxxflags(cfg))
 	end
 
+	function suite.ldflags_onWindowsSharedLib()
+		system "Windows"
+		kind "SharedLib"
+		prepare()
+		test.contains({ "-shared", '-Xlinker /IMPLIB:"bin/Debug/MyProject.lib"' }, clang.getldflags(cfg))
+	end
+
+	function suite.ldflags_onWindowsSharedLibWithoutImportLib()
+		system "Windows"
+		kind "SharedLib"
+		useimportlib "Off"
+		prepare()
+		test.contains({ "-shared", "-Xlinker /NOIMPLIB" }, clang.getldflags(cfg))
+	end
+
 	function suite.ldflags_onUnicode_Windows()
 		system "Windows"
 		characterset "Unicode"
@@ -501,4 +516,3 @@ end
 		prepare()
 		test.excludes({ "-municode" }, clang.getldflags(cfg))
 	end
-	


### PR DESCRIPTION
When clang is used on Windows for driving the linking, it will always call lld-link. Therefore, the call on Windows must be MS syntax, not GNU. 

Fixes #2762 