### PR TITLE
Enable runtime for clang

### DIFF
--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -79,6 +79,32 @@
 		useshortenums = gcc.shared.useshortenums,
 	}
 
+	clang.shared.runtime = {
+		Debug = function(cfg)
+			if cfg.system ~= premake.WINDOWS then
+				return nil
+			end
+
+			if cfg.staticruntime == "On" then
+				return "-fms-runtime-lib=static_dbg"
+			end
+
+			return "-fms-runtime-lib=dll_dbg"
+		end,
+
+		Release = function(cfg)
+			if cfg.system ~= premake.WINDOWS then
+				return nil
+			end
+
+			if cfg.staticruntime == "On" then
+				return "-fms-runtime-lib=static"
+			end
+
+			return "-fms-runtime-lib=dll"
+		end,
+	}
+
 	clang.cflags = table.merge(gcc.cflags, {
 	})
 
@@ -301,6 +327,33 @@
 		system = {
 			wii = "$(MACHDEP)",
 		}
+	}
+
+	-- Clang on windows will link against the static runtime by default, so we need to explicitly tell it not to.
+	clang.ldflags.runtime = {
+		Debug = function(cfg)
+			if cfg.system ~= premake.WINDOWS then
+				return nil
+			end
+
+			if cfg.staticruntime == "On" then
+				return "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=static_dbg"
+			end
+
+			return "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=dll_dbg"
+		end,
+
+		Release = function(cfg)
+			if cfg.system ~= premake.WINDOWS then
+				return nil
+			end
+
+			if cfg.staticruntime == "On" then
+				return "-fms-runtime-lib=static"
+			end
+
+			return "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=dll"
+		end,
 	}
 
 	clang.wholearchive = gcc.wholearchive

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -79,6 +79,41 @@
 		useshortenums = gcc.shared.useshortenums,
 	}
 
+	clang.shared.runtime = {
+		_ = function(cfg)
+			if not cfg.runtime and (not cfg.staticruntime or cfg.staticruntime == "Default") then
+				return nil
+			end
+
+			local runtime = cfg.runtime or iif(config.isDebugBuild(cfg), "Debug", "Release")
+			return clang.shared.runtime[runtime](cfg)
+		end,
+
+		Debug = function(cfg)
+			if cfg.system ~= premake.WINDOWS then
+				return nil
+			end
+
+			if cfg.staticruntime == "On" then
+				return "-fms-runtime-lib=static_dbg"
+			end
+
+			return "-fms-runtime-lib=dll_dbg"
+		end,
+
+		Release = function(cfg)
+			if cfg.system ~= premake.WINDOWS then
+				return nil
+			end
+
+			if cfg.staticruntime == "On" then
+				return "-fms-runtime-lib=static"
+			end
+
+			return "-fms-runtime-lib=dll"
+		end,
+	}
+
 	clang.cflags = table.merge(gcc.cflags, {
 	})
 
@@ -301,6 +336,42 @@
 		system = {
 			wii = "$(MACHDEP)",
 		}
+	}
+
+	-- Clang on windows will link against the static runtime by default, so we need to explicitly tell it not to.
+	clang.ldflags.runtime = {
+		_ = function(cfg)
+			if not cfg.runtime and (not cfg.staticruntime or cfg.staticruntime == "Default") then
+				return nil
+			end
+
+			local runtime = cfg.runtime or iif(config.isDebugBuild(cfg), "Debug", "Release")
+			return clang.ldflags.runtime[runtime](cfg)
+		end,
+
+		Debug = function(cfg)
+			if cfg.system ~= premake.WINDOWS then
+				return nil
+			end
+
+			if cfg.staticruntime == "On" then
+				return "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=static_dbg"
+			end
+
+			return "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=dll_dbg"
+		end,
+
+		Release = function(cfg)
+			if cfg.system ~= premake.WINDOWS then
+				return nil
+			end
+
+			if cfg.staticruntime == "On" then
+				return "-fms-runtime-lib=static"
+			end
+
+			return "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=dll"
+		end,
 	}
 
 	clang.wholearchive = gcc.wholearchive

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -489,6 +489,81 @@ end
 		test.contains({ "-shared", "-Xlinker /NOIMPLIB" }, clang.getldflags(cfg))
 	end
 
+
+--
+-- Check handling of Run-Time Library flags.
+--
+
+	function suite.cflags_onWindowsStaticRuntime()
+		system "Windows"
+		staticruntime "On"
+		runtime "Debug"
+		prepare()
+		test.contains({ "-fms-runtime-lib=static_dbg" }, clang.getcflags(cfg))
+	end
+
+	function suite.cflags_onWindowsDynamicRuntime()
+		system "Windows"
+		staticruntime "Off"
+		runtime "Debug"
+		prepare()
+		test.contains({ "-fms-runtime-lib=dll_dbg" }, clang.getcflags(cfg))
+	end
+
+	function suite.cflags_onWindowsStaticRuntimeRelease()
+		system "Windows"
+		staticruntime "On"
+		runtime "Release"
+		prepare()
+		test.contains({ "-fms-runtime-lib=static" }, clang.getcflags(cfg))
+	end
+
+	function suite.cflags_onWindowsDynamicRuntimeRelease()
+		system "Windows"
+		staticruntime "Off"
+		runtime "Release"
+		prepare()
+		test.contains({ "-fms-runtime-lib=dll" }, clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_onWindowsStaticRuntime()
+		system "Windows"
+		staticruntime "On"
+		runtime "Debug"
+		prepare()
+		test.contains({ "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=static_dbg" }, clang.getldflags(cfg))
+	end
+
+	function suite.ldflags_onWindowsDynamicRuntime()
+		system "Windows"
+		staticruntime "Off"
+		runtime "Debug"
+		prepare()
+		test.contains({ "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=dll_dbg" }, clang.getldflags(cfg))
+	end
+
+	function suite.ldflags_onWindowsDynamicRuntimeRelease()
+		system "Windows"
+		staticruntime "Off"
+		runtime "Release"
+		prepare()
+		test.contains({ "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=dll" }, clang.getldflags(cfg))
+	end
+
+	function suite.cflags_onNonWindowsRuntime()
+		system "Linux"
+		staticruntime "On"
+		prepare()
+		test.excludes({ "-fms-runtime-lib=static_dbg" }, clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_onNonWindowsRuntime()
+		system "Linux"
+		staticruntime "On"
+		prepare()
+		test.excludes({ "-fms-runtime-lib=static_dbg" }, clang.getldflags(cfg))
+	end
+
 	function suite.ldflags_onUnicode_Windows()
 		system "Windows"
 		characterset "Unicode"

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -489,6 +489,81 @@ end
 		test.contains({ "-shared", "-Xlinker /NOIMPLIB" }, clang.getldflags(cfg))
 	end
 
+
+--
+-- Check handling of Run-Time Library flags.
+--
+
+	function suite.cflags_onWindowsStaticRuntime()
+		system "Windows"
+		staticruntime "On"
+		symbols "On"
+		prepare()
+		test.contains({ "-fms-runtime-lib=static_dbg" }, clang.getcflags(cfg))
+	end
+
+	function suite.cflags_onWindowsDynamicRuntime()
+		system "Windows"
+		staticruntime "Off"
+		runtime "Debug"
+		prepare()
+		test.contains({ "-fms-runtime-lib=dll_dbg" }, clang.getcflags(cfg))
+	end
+
+	function suite.cflags_onWindowsStaticRuntimeRelease()
+		system "Windows"
+		staticruntime "On"
+		runtime "Release"
+		prepare()
+		test.contains({ "-fms-runtime-lib=static" }, clang.getcflags(cfg))
+	end
+
+	function suite.cflags_onWindowsDynamicRuntimeRelease()
+		system "Windows"
+		staticruntime "Off"
+		runtime "Release"
+		prepare()
+		test.contains({ "-fms-runtime-lib=dll" }, clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_onWindowsStaticRuntime()
+		system "Windows"
+		staticruntime "On"
+		symbols "On"
+		prepare()
+		test.contains({ "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=static_dbg" }, clang.getldflags(cfg))
+	end
+
+	function suite.ldflags_onWindowsDynamicRuntime()
+		system "Windows"
+		staticruntime "Off"
+		runtime "Debug"
+		prepare()
+		test.contains({ "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=dll_dbg" }, clang.getldflags(cfg))
+	end
+
+	function suite.ldflags_onWindowsDynamicRuntimeRelease()
+		system "Windows"
+		staticruntime "Off"
+		runtime "Release"
+		prepare()
+		test.contains({ "-Xlinker /NODEFAULTLIB:libcmt -fms-runtime-lib=dll" }, clang.getldflags(cfg))
+	end
+
+	function suite.cflags_onNonWindowsRuntime()
+		system "Linux"
+		staticruntime "On"
+		prepare()
+		test.excludes({ "-fms-runtime-lib=static_dbg" }, clang.getcflags(cfg))
+	end
+
+	function suite.ldflags_onNonWindowsRuntime()
+		system "Linux"
+		staticruntime "On"
+		prepare()
+		test.excludes({ "-fms-runtime-lib=static_dbg" }, clang.getldflags(cfg))
+	end
+
 	function suite.ldflags_onUnicode_Windows()
 		system "Windows"
 		characterset "Unicode"


### PR DESCRIPTION
These are clang's equivalent to MSVC's /MT, /MTd, /MD and /MDd on Windows. Both compiler and linker flags are required.