### PR TITLE
Require 'custom:' prefix for custom build actions

### DIFF
--- a/modules/vstudio/tests/cs2005/test_files.lua
+++ b/modules/vstudio/tests/cs2005/test_files.lua
@@ -270,13 +270,31 @@
 		]]
 	end
 
-	function suite.fallbackUserAction()
+	function suite.customUserAction()
 		files { "Hello.custom" }
 		filter "files:Hello.custom"
-		buildaction "CustomAction"
+		buildaction "custom:CustomAction"
 		prepare()
 		test.capture [[
 		<CustomAction Include="Hello.custom" />
+		]]
+	end
+
+	function suite.NoUserAction()
+		files { "Hello.none" }
+		prepare()
+		test.capture [[
+		<None Include="Hello.none" />
+		]]
+	end
+
+	function suite.InvalidUserAction()
+		files { "Hello.oops" }
+		filter "files:Hello.oops"
+		buildaction "Invalid"
+		prepare()
+		test.capture [[
+		<None Include="Hello.oops" />
 		]]
 	end
 

--- a/src/tools/dotnet.lua
+++ b/src/tools/dotnet.lua
@@ -56,6 +56,8 @@
 		-- Determine the build action for the file, falling back to the file
 		-- extension if no explicit action is available.
 
+		local customprefix = "custom:"
+
 		if fcfg.buildaction == "Compile" or ext == ".cs" or ext == ".fs" then
 			info.action = "Compile"
 		elseif fcfg.buildaction == "Embed" or ext == ".resx" then
@@ -64,6 +66,8 @@
 			info.action = "Content"
 		elseif fcfg.buildaction == "Resource" then
 			info.action = "Resource"
+		elseif fcfg.buildaction ~= nil and fcfg.buildaction:startswith(customprefix) then
+			info.action = string.sub(fcfg.buildaction, #customprefix + 1)
 		elseif ext == ".xaml" then
 			if fcfg.buildaction == "Application" or path.getbasename(fname) == "App" then
 				if fcfg.project.kind == p.SHAREDLIB then
@@ -75,11 +79,10 @@
 				info.action = "Page"
 			end
 		else
-			if fcfg.buildaction == nil then
-				info.action = "None"
-			else
-				info.action = fcfg.buildaction
+			if fcfg.buildaction ~= nil then
+				premake.warn("Unknown buildaction: " .. fcfg.buildaction .. " falling back to None")
 			end
+			info.action = "None"
 		end
 
 		-- Try to work out any subtypes, based on the files in the project

--- a/website/docs/buildaction.md
+++ b/website/docs/buildaction.md
@@ -37,8 +37,9 @@ In C#, `action` can be one of
 | None        | Do nothing with this file.                                            |
 | Resource    | Copy/embed the file with the project resources.                       |
 | UserControl | Treat the source file as [visual user control][2].                    |
+| custom:{str}| Use contents of {str} verbatim as the build action.                   |
 
-If not matched by any of the above, the Action falls back to using the given action name verbatim (with no SubType). This allows project specific user defined custom BuildActions to be specified.
+If not matched by any of the above, the Action falls back to None.
 
 The descriptive actions such as **Component**, **Form*, and **UserControl** are only recognized by Visual Studio, and may be considered optional as Visual Studio will automatically deduce the types when it first examines the project. You only need to specify these actions to avoid unnecessary modifications to the project files on save.
 


### PR DESCRIPTION
**What does this PR do?**

Update to changes from [2729](https://github.com/premake/premake-core/pull/2729) to require a 'custom:' prefix for verbatim user build actions.

**How does this PR change Premake's behavior?**

This enables new premake builtin buildactions to be added in later versions without breaking existing custom actions which happen to use the same action name.

Fallback is returned to None as per the original implementation.

**Anything else we should know?**

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [X] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
