### PR TITLE
Add appmanifest config option for dotnet projects

### DIFF
--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -158,6 +158,11 @@
 		kind = "boolean",
 		default = false
 	}
+	p.api.register {
+		name = "appmanifest",
+		scope = "config",
+		kind = "string"
+	}
 
 	p.api.register {
 		name = "enableimplicitusings",

--- a/modules/vstudio/tests/cs2005/test_netcore.lua
+++ b/modules/vstudio/tests/cs2005/test_netcore.lua
@@ -187,6 +187,23 @@ function suite.multiple_target_dotnet_frameworks()
 	]]
 end
 
+function suite.set_appmanifest()
+	p.action.set("vs2022")
+	dotnetframework { "net10.0" }
+	appmanifest "app.manifest"
+	prepareProjectProperties()
+	test.capture [[
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<TargetFramework>net10.0</TargetFramework>
+		<Configurations>Debug;Release;Distribution</Configurations>
+		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
+	</PropertyGroup>
+	]]
+end
+
 function suite.project_element_configurations()
 	p.action.set("vs2022")
 	dotnetframework "net8.0"

--- a/modules/vstudio/vs2005_csproj.lua
+++ b/modules/vstudio/vs2005_csproj.lua
@@ -55,6 +55,7 @@
 				dotnetbase.projectConfigurations,
 				dotnetbase.netcore.enableDefaultCompileItems,
 				dotnetbase.netcore.enableImplicitUsings,
+				dotnetbase.netcore.appManifest,
 				dotnetbase.netcore.dotnetsdk
 			}
 		else

--- a/modules/vstudio/vs2005_dotnetbase.lua
+++ b/modules/vstudio/vs2005_dotnetbase.lua
@@ -855,6 +855,12 @@
 		end
 	end
 
+	function dotnetbase.netcore.appManifest(cfg)
+		if cfg.appmanifest and string.len(cfg.appmanifest) > 0 then
+			_p(2,'<ApplicationManifest>%s</ApplicationManifest>', path.getrelative(cfg.project.location, cfg.appmanifest))
+		end
+	end
+
 	function dotnetbase.netcore.useWpf(cfg)
 		if cfg.wpf == p.ON then
 			_p(2,'<UseWpf>true</UseWpf>')

--- a/website/docs/appmanifest.md
+++ b/website/docs/appmanifest.md
@@ -1,0 +1,25 @@
+Adds the ApplicationManifest property to .NET projects
+
+```lua
+appmanifest ("path")
+```
+
+### Parameters ###
+
+`path` should contain the path to the application manifest file.
+
+## Applies To ###
+
+.NET project configurations.
+
+### Availability ###
+
+Premake 5.0.0
+
+### Examples ###
+
+If the app manifest file is called `app.manifest` and is located in the folder alongside the project then the following usage will reference it within the project:
+
+```lua
+appmanifest "app.manifest"
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -66,6 +66,7 @@ module.exports = {
 						'allowcopylocal',
 						'androidapilevel',
 						'androidapplibname',
+						'appmanifest',
 						'architecture',
 						'assemblydebug',
 						'atl',


### PR DESCRIPTION
**What does this PR do?**

Adds an appmanifest config option for adding an `<ApplicationManifest>` properties to dotnet projects.

Resolves [Issue 622](https://github.com/premake/premake-core/issues/622).

**How does this PR change Premake's behavior?**

You can now add `<ApplicationManifest>` properties to dotnet projects

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Add unit tests showing fix or feature works; all tests pass
- [X] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] Minimize the number of commits
- [X] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes
