### PR TITLE
Enable assembly generation

### DIFF
--- a/modules/gmake/gmake_cpp.lua
+++ b/modules/gmake/gmake_cpp.lua
@@ -609,6 +609,11 @@
 			end
 		end
 
+		if fcfg and toolset.getassemblyflags then
+			local assemblyCfg = fcfg.generateassembly and fcfg or cfg
+			table.insertflat(flags, toolset.getassemblyflags(assemblyCfg, '"$(@:%.obj=%.asm)"'))
+		end
+
 		return table.concat(flags, ' ')
 	end
 

--- a/modules/gmake/tests/test_gmake_file_rules.lua
+++ b/modules/gmake/tests/test_gmake_file_rules.lua
@@ -120,6 +120,26 @@ $(OBJDIR)/test.obj: src/test.c
 ]]
 	end
 
+	function suite.assemblyOutput_onConfigAndFile()
+		toolset "msc"
+		files { "src/hello.cpp", "src/test.cpp" }
+		generateassembly "On"
+		filter "files:src/hello.cpp"
+		generateassembly "Verbose"
+		prepare()
+		test.capture [[
+# File Rules
+# #############################################
+
+$(OBJDIR)/hello.obj: src/hello.cpp
+	@echo "$(notdir $<)"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) /FAs /Fa"$(@:%.obj=%.asm)" $(FORCE_INCLUDE) /nologo /Fo"$@" /c /Tp"$<"
+$(OBJDIR)/test.obj: src/test.cpp
+	@echo "$(notdir $<)"
+	$(SILENT) $(CXX) $(ALL_CXXFLAGS) /FA /Fa"$(@:%.obj=%.asm)" $(FORCE_INCLUDE) /nologo /Fo"$@" /c /Tp"$<"
+
+]]
+	end
 
 --
 -- Two files with the same base name should have different object files.
@@ -472,4 +492,3 @@ endif
 endif
 ]]
 	end
-

--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -776,7 +776,15 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 	local flags = ""
 	local extraFlags = {}
 	local toolset = ninja.gettoolset(cfg)
+	local assemblyFile
 	local hasPerFileConfig = m.hasPerFileConfiguration(cfg, filecfg)
+	if toolset.getassemblyflags then
+		local assemblyCfg = filecfg.generateassembly and filecfg or cfg
+		if toolset.getassemblyoutput then
+			assemblyFile = toolset.getassemblyoutput(assemblyCfg, objFile)
+		end
+		table.insertflat(extraFlags, toolset.getassemblyflags(assemblyCfg, assemblyFile and p.quoted(assemblyFile)))
+	end
 	
 	if filecfg and filecfg.compileas and filecfg.compileas ~= "Default" then
 		if p.languages.isc(filecfg.compileas) then
@@ -845,7 +853,11 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 			implicitDeps = implicitDeps .. " " .. table.concat(cfg._dependsOnTargets, " ")
 		end
 		
-		_p("build %s: %s_%s %s%s", objFile, rule, cfg.toolset, relPath, implicitDeps)
+		local implicitOutput = ""
+		if assemblyFile then
+			implicitOutput = " | " .. assemblyFile
+		end
+		_p("build %s%s: %s_%s %s%s", objFile, implicitOutput, rule, cfg.toolset, relPath, implicitDeps)
 		
 		if usePch then
 			if toolset == p.tools.msc then

--- a/modules/ninja/tests/test_ninja_build_rules.lua
+++ b/modules/ninja/tests/test_ninja_build_rules.lua
@@ -114,6 +114,25 @@ rule cxx_msc
 		]]
 	end
 
+	function suite.buildFile_generateAssembly_onMSVC()
+		toolset "msc"
+		language "C++"
+		files { "main.cpp" }
+		buildoptions { "/projectFlag" }
+		generateassembly "Verbose"
+		filter "files:main.cpp"
+		generateassembly "On"
+		local cfg = prepare()
+		local node = p.project.getsourcetree(cfg.project).children["main.cpp"]
+		local filecfg = p.fileconfig.getconfig(node, cfg)
+		local objFile = cpp.objectFile(cfg, node, filecfg)
+		cpp.buildFile(cfg, node, filecfg, objFile, nil, nil)
+		test.capture [[
+build obj/Debug/main.obj | obj/Debug/main.asm: cxx_msc main.cpp
+  cxxflags = $cxxflags_MyProject_Debug /FA /Faobj/Debug/main.asm
+		]]
+	end
+
 
 --
 -- Check the C++ compile rule for GCC.

--- a/modules/vstudio/tests/vc2010/test_compile_settings.lua
+++ b/modules/vstudio/tests/vc2010/test_compile_settings.lua
@@ -42,6 +42,16 @@
 		]]
 	end
 
+	function suite.assemblerOutput_onConfig()
+		toolset "msc"
+		generateassembly "On"
+		local cfg = test.getconfig(prj, "Debug")
+		vc2010.assemblerOutput(cfg)
+		test.capture [[
+<AssemblerOutput>AssemblyCode</AssemblerOutput>
+		]]
+	end
+
 
 ---
 -- Test precompiled header handling; the header should be treated as

--- a/modules/vstudio/tests/vc2010/test_files.lua
+++ b/modules/vstudio/tests/vc2010/test_files.lua
@@ -480,6 +480,62 @@
 		]]
 	end
 
+	function suite.assemblyOutput_onSourceNameCollision()
+		toolset "msc"
+		files { "hello.cpp", "greetings/hello.cpp" }
+		filter "files:**.cpp"
+		generateassembly "On"
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="greetings\hello.cpp">
+		<AssemblerListingLocation>$(IntDir)\hello.asm</AssemblerListingLocation>
+		<AssemblerOutput>AssemblyCode</AssemblerOutput>
+	</ClCompile>
+	<ClCompile Include="hello.cpp">
+		<ObjectFileName>$(IntDir)\hello1.obj</ObjectFileName>
+		<AssemblerListingLocation>$(IntDir)\hello1.asm</AssemblerListingLocation>
+		<AssemblerOutput>AssemblyCode</AssemblerOutput>
+	</ClCompile>
+</ItemGroup>
+		]]
+	end
+
+	function suite.assemblyOutput_onConfigAndFileOverride()
+		toolset "msc"
+		files { "hello.cpp", "main.cpp" }
+		generateassembly "On"
+		filter "files:main.cpp"
+		generateassembly "Off"
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="hello.cpp">
+		<AssemblerListingLocation>$(IntDir)\hello.asm</AssemblerListingLocation>
+	</ClCompile>
+	<ClCompile Include="main.cpp">
+		<AssemblerOutput>NoListing</AssemblerOutput>
+	</ClCompile>
+</ItemGroup>
+		]]
+	end
+
+	function suite.assemblyOutputVerbose_onClangToolset()
+		toolset "clang"
+		files { "main.cpp" }
+		filter "files:main.cpp"
+		generateassembly "Verbose"
+		prepare()
+		test.capture [[
+<ItemGroup>
+	<ClCompile Include="main.cpp">
+		<AssemblerListingLocation>$(IntDir)\main.asm</AssemblerListingLocation>
+		<AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+	</ClCompile>
+</ItemGroup>
+		]]
+	end
+
 
 	function suite.uniqueObjectNames_onBaseNameCollision1()
 		files { "a/hello.cpp", "b/hello.cpp", "c/hello1.cpp" }

--- a/modules/vstudio/vs2010_vcxproj.lua
+++ b/modules/vstudio/vs2010_vcxproj.lua
@@ -612,6 +612,7 @@
 			m.enableModules,
 			m.buildStlModules,
 			m.useDynamicDebugging,
+			m.assemblerOutput,
 		}
 
 		if cfg.kind == p.STATICLIB then
@@ -1122,6 +1123,7 @@
 		return {
 			m.excludedFromBuild,
 			m.objectFileName,
+			m.assemblerListingLocation,
 			m.clCompilePreprocessorDefinitions,
 			m.clCompileUndefinePreprocessorDefinitions,
 			m.languageStandard,
@@ -1135,6 +1137,7 @@
 			m.disableSpecificWarnings,
 			m.treatSpecificWarningsAsErrors,
 			m.basicRuntimeChecks,
+			m.assemblerOutput,
 			m.exceptionHandling,
 			m.compileAsManaged,
 			m.compileAs,
@@ -2196,6 +2199,40 @@
 		end
 	end
 
+	local function supportsAssemblerOutput(cfg)
+		cfg = cfg.config or cfg
+		if not cfg.toolset or cfg.system == p.LINUX or cfg.system == p.ANDROID then
+			return false
+		end
+		local toolset = p.tools.canonical(cfg.toolset)
+		return toolset == p.tools.msc or toolset == p.tools.clang
+	end
+
+	local assemblerOutputs = {
+		On = "AssemblyCode",
+		Verbose = "AssemblyAndSourceCode",
+	}
+
+	function m.assemblerOutput(cfg, condition)
+		if not supportsAssemblerOutput(cfg) then
+			return
+		end
+
+		local value = assemblerOutputs[cfg.generateassembly]
+		if not value and cfg.config and cfg.generateassembly and assemblerOutputs[cfg.config.generateassembly] then
+			value = "NoListing"
+		end
+		if value then
+			m.element("AssemblerOutput", condition, value)
+		end
+	end
+
+	function m.assemblerListingLocation(fcfg, condition)
+		local value = fcfg.generateassembly or fcfg.config.generateassembly
+		if supportsAssemblerOutput(fcfg) and assemblerOutputs[value] then
+			m.element("AssemblerListingLocation", condition, "$(IntDir)\\%s.asm", fcfg.objname)
+		end
+	end
 
 	function m.additionalLinkOptions(cfg)
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -1268,6 +1268,18 @@
 	}
 
 	api.register {
+		name = "generateassembly",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"Default",
+			"On",
+			"Verbose",
+			"Off",
+		},
+	}
+
+	api.register {
 		name = "nodefaultlib",
 		scope = "config",
 		kind = "string",

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -42,6 +42,8 @@
 --    An array of C compiler flags.
 --
 
+	clang.getassemblyflags = gcc.getassemblyflags
+
 	clang.shared = {
 		architecture = gcc.shared.architecture,
 		characterset = gcc.shared.characterset,

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -52,6 +52,17 @@
 --
 -- Returns list of C compiler flags for a configuration.
 --
+	gcc.generateassembly = {
+		generateassembly = {
+			On = "-save-temps=obj",
+			Verbose = { "-save-temps=obj", "-fverbose-asm" },
+		},
+	}
+
+	function gcc.getassemblyflags(cfg)
+		return config.mapFlags(cfg, gcc.generateassembly)
+	end
+
 	gcc.shared = {
 		architecture = {
 			x86 = function (cfg) return iif(cfg.system == p.MACOSX, "-arch i386", "-m32") end,

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -50,6 +50,21 @@
 		return flag
 	end
 
+	msc.generateassembly = {
+		generateassembly = {
+			On = "/FA",
+			Verbose = "/FAs",
+		},
+	}
+
+	function msc.getassemblyflags(cfg, assemblyOutput)
+		local flags = config.mapFlags(cfg, msc.generateassembly)
+		if assemblyOutput and #flags > 0 then
+			table.insert(flags, "/Fa" .. assemblyOutput)
+		end
+		return flags
+	end
+
 	msc.shared = {
 		clr = {
 			On = "/clr",
@@ -541,6 +556,12 @@
 
 	function msc.gettooloutputext(tool)
 		return iif(tool == "rc", ".res", ".obj")
+	end
+
+	function msc.getassemblyoutput(cfg, objectOutput)
+		if #msc.getassemblyflags(cfg) > 0 then
+			return path.replaceextension(objectOutput, ".asm")
+		end
 	end
 
 	function msc.gettoolflags(cfg, tool, input, output, depfile)

--- a/tests/_tests.lua
+++ b/tests/_tests.lua
@@ -72,6 +72,7 @@ return {
 	"tools/test_clang.lua",
 	"tools/test_msc.lua",
 	"tools/test_enablepch.lua",
+	"tools/test_generateassembly.lua",
 	"tools/test_incrementallink.lua",
 	"tools/test_manifest.lua",
 	"tools/test_minimalrebuild.lua",

--- a/tests/tools/test_generateassembly.lua
+++ b/tests/tools/test_generateassembly.lua
@@ -1,0 +1,81 @@
+-- tests/tools/test_generateassembly.lua
+-- Test generateassembly compiler flags.
+
+	local p = premake
+	local suite = test.declare("test_generateassembly")
+
+	local gcc = p.tools.gcc
+	local clang = p.tools.clang
+	local msc = p.tools.msc
+	local wks, prj, cfg, filecfg
+
+	function suite.setup()
+		wks, prj = test.createWorkspace()
+		system "Linux"
+		files { "main.cpp" }
+	end
+
+	local function prepare(toolsetName)
+		if toolsetName then
+			toolset(toolsetName)
+		end
+		cfg = test.getconfig(prj, "Debug")
+		local node = p.project.getsourcetree(cfg.project).children["main.cpp"]
+		filecfg = p.fileconfig.getconfig(node, cfg)
+	end
+
+	function suite.gccOn()
+		filter "files:main.cpp"
+		generateassembly "On"
+		prepare("gcc")
+		test.isnil(cfg.generateassembly)
+		test.isequal("On", filecfg.generateassembly)
+		test.contains("-save-temps=obj", gcc.getassemblyflags(filecfg))
+	end
+
+	function suite.configValueUsedWhenFileUnset()
+		generateassembly "On"
+		prepare("gcc")
+		test.isequal("On", cfg.generateassembly)
+		test.isnil(filecfg.generateassembly)
+		test.contains("-save-temps=obj", gcc.getassemblyflags(cfg))
+	end
+
+	function suite.gccVerbose()
+		filter "files:main.cpp"
+		generateassembly "Verbose"
+		prepare("gcc")
+		test.contains({ "-save-temps=obj", "-fverbose-asm" }, gcc.getassemblyflags(filecfg))
+	end
+
+	function suite.clangVerbose()
+		filter "files:main.cpp"
+		generateassembly "Verbose"
+		prepare("clang")
+		test.contains({ "-save-temps=obj", "-fverbose-asm" }, clang.getassemblyflags(filecfg))
+	end
+
+	function suite.mscOn()
+		filter "files:main.cpp"
+		generateassembly "On"
+		prepare("msc")
+		test.contains({ "/FA", '/Fa"main.asm"' }, msc.getassemblyflags(filecfg, '"main.asm"'))
+		test.isequal("main.asm", msc.getassemblyoutput(filecfg, "main.obj"))
+	end
+
+	function suite.mscVerbose()
+		filter "files:main.cpp"
+		generateassembly "Verbose"
+		prepare("msc")
+		test.contains("/FAs", msc.getassemblyflags(filecfg))
+	end
+
+	function suite.off()
+		generateassembly "On"
+		filter "files:main.cpp"
+		generateassembly "Off"
+		prepare("gcc")
+		test.isequal("On", cfg.generateassembly)
+		test.isequal("Off", filecfg.generateassembly)
+		test.excludes({ "-save-temps=obj", "-fverbose-asm" }, gcc.getassemblyflags(filecfg))
+	end

--- a/website/docs/generateassembly.md
+++ b/website/docs/generateassembly.md
@@ -1,0 +1,42 @@
+Controls whether assembly output is generated for source files (in addition to normal compilation).
+
+```lua
+generateassembly ("value")
+```
+
+### Parameters ###
+
+`value` specifies the desired behavior:
+
+| Value   | Description                                                              |
+|---------|--------------------------------------------------------------------------|
+| Default | Use the toolset or action's default behavior for this file.              |
+| On      | Generate assembly output while continuing to produce the normal object. |
+| Verbose | Generate assembly output with source code or explanatory comments.       |
+| Off     | Disable assembly output.                                                 |
+
+Notes:
+
+- GCC and Clang use `-save-temps=obj` when `generateassembly` is `On`. `Verbose` additionally uses `-fverbose-asm`.
+- MSVC uses `/FA` for `On` and `/FAs` for `Verbose`.
+- Assembly files are written to the object directory.
+
+### Applies To ###
+
+Project configurations and files.
+
+### Availability ###
+
+Premake 5.0.0 or later.
+
+### Examples ###
+
+Generate assembly for a configuration, with verbose output for one file:
+
+```lua
+filter "configurations:Debug"
+   generateassembly "On"
+
+filter { "configurations:Debug", "files:main.cpp" }
+   generateassembly "Verbose"
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -163,6 +163,7 @@ module.exports = {
 						'frameworkdirs',
 						'functionlevellinking',
 						'gccprefix',
+						'generateassembly',
 						'group',
 						'icon',
 						'ignoredefaultlibraries',


### PR DESCRIPTION
- GCC and Clang use `-save-temps=obj` when `generateassembly` is `On`. `Verbose` additionally uses `-fverbose-asm`.
- MSVC uses `/FA` for `On` and `/FAs` for `Verbose`.
- Assembly is output in the object directory. Some logic has been added to avoid output name clashes, by deriving it from the object file name and assigning to `/Fa$(asm_name).asm` for msvc-syntax compilers. This requires modifying the vs/ninja/makefile generators for those compilers.

Future work can decouple assembly generation and output location. But having asm output to the object directory is a good starting point and a very common use case when you want to inspect the assembly for optimization purposes.
