### PR TITLE
Enable GNU ar tool selection on MacOS

### DIFF
--- a/modules/gmake/tests/test_gmake_tools.lua
+++ b/modules/gmake/tests/test_gmake_tools.lua
@@ -19,6 +19,7 @@
 	local cfg
 
 	function suite.setup()
+		system "Linux"
 		local wks, prj = test.createWorkspace()
 		cfg = test.getconfig(prj, "Debug")
 	end

--- a/modules/gmakelegacy/tests/cpp/test_tools.lua
+++ b/modules/gmakelegacy/tests/cpp/test_tools.lua
@@ -18,6 +18,7 @@
 	local cfg
 
 	function suite.setup()
+		system "Linux"
 		local wks, prj = test.createWorkspace()
 		cfg = test.getconfig(prj, "Debug")
 	end

--- a/modules/ninja/tests/test_ninja_build_rules.lua
+++ b/modules/ninja/tests/test_ninja_build_rules.lua
@@ -20,6 +20,7 @@
 
 	function suite.setup()
 		p.action.set("ninja")
+		system "Linux"
 		wks, prj = test.createWorkspace()
 	end
 

--- a/src/tools/gcc.lua
+++ b/src/tools/gcc.lua
@@ -826,7 +826,8 @@
 	gcc.tools = {
 		cc = "gcc",
 		cxx = "g++",
-		ar = "ar",
+		-- Apple's ar does not support the GCC LTO object format and is not part of the GNU toolchain.
+		ar = function(cfg) return iif(cfg.system == p.MACOSX, "gcc-ar", "ar") end,
 		rc = "windres"
 	}
 
@@ -837,7 +838,12 @@
 		else
 			version = ""
 		end
-		return (cfg.gccprefix or "") .. gcc.tools[tool] .. version
+
+		local value = gcc.tools[tool]
+		if type(value) == "function" then
+			value = value(cfg)
+		end
+		return (cfg.gccprefix or "") .. value .. version
 	end
 
 	function gcc.gettooloutputext(tool)

--- a/tests/tools/test_gcc.lua
+++ b/tests/tools/test_gcc.lua
@@ -47,6 +47,12 @@
 		test.isequal("windres", gcc.gettoolname(cfg, "rc"))
 	end
 
+	function suite.tools_onMacOS()
+		system "MacOSX"
+		prepare()
+		test.isequal("gcc-ar", gcc.gettoolname(cfg, "ar"))
+	end
+
 	function suite.tools_withPrefix()
 		gccprefix "test-prefix-"
 		prepare()
@@ -63,6 +69,13 @@
 		test.isequal("g++-16", gcc.gettoolname(cfg, "cxx"))
 		test.isequal("ar-16", gcc.gettoolname(cfg, "ar"))
 		test.isequal("windres-16", gcc.gettoolname(cfg, "rc"))
+	end
+
+	function suite.tools_forVersion_onMacOS()
+		system "MacOSX"
+		toolset "gcc-16"
+		prepare()
+		test.isequal("gcc-ar-16", gcc.gettoolname(cfg, "ar"))
 	end
 
 --


### PR DESCRIPTION
- select gcc-ar rather than Apple ar (which is neither llvm or gnu).
- there is no point using "gcc" as a toolset on macos as it symlinks to clang, and changing that symlink to actual GNU is dangerous. Premake treats "gcc" as a GNU toolchain and passes GNU flags, which may not apply to apple clang.
- probably macos users have added gcc-N to path and that is what they mean when they explicitly specify --cc=gcc-N (e.g. gcc-16). This is what homebrew does. In which case, this change is reflective of the actual intentions of the user to use the real GNU toolchain.

I am not sure what to do. Making this change means that it might break compilation for users who rely on this behaviour:

```
$ gcc --version  
Apple clang version 21.0.0 (clang-2100.1.1.101)
Target: arm64-apple-darwin25.5.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

Fixes #2773 
