### PR TITLE
Enable buildstlmodules for ninja-msc

### DIFF
--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -45,6 +45,7 @@ function m.rules(prj)
 			m.cxxrule(cfg, toolset)
 			m.resourcerule(cfg, toolset)
 			m.linkrule(cfg, toolset)
+			m.cxxstdlibrule(cfg, toolset)
 			m.pchrule(cfg, toolset)
 			m.copyrule(cfg, toolset)
 			m.prebuildcommandrule(cfg, toolset)
@@ -56,6 +57,21 @@ function m.rules(prj)
 			rulesDone[toolsetKey] = true
 		end
 	end
+end
+
+function m.cxxstdlibrule(cfg, toolset)
+	toolset = toolset or ninja.gettoolset(cfg)
+	if not toolset.cppmodules then
+		return
+	end
+
+	local cppmodules = toolset.cppmodules
+	local cxxname = toolset.gettoolname(cfg, "cxx")
+	_p("rule cxxstdlib_%s", cfg.toolset)
+	_p("  command = $shell %s %s %s$bmi $cxxflags $stl %s$obj",
+		cxxname, cppmodules.bmiCompileFlags, cppmodules.bmiOutputFlag, cppmodules.objOutputFlag)
+	_p("  description = Building C++ standard library module $bmi")
+	_p("")
 end
 
 function m.ccrule(cfg, toolset)
@@ -634,6 +650,7 @@ function m.buildFiles(cfg)
 	local objList = {}
 	local copyList = {}
 	local pchFile = m.buildPch(cfg)
+	local stlModule, stlModuleObj = m.buildstlmodule(cfg)
 	
 	local prebuildTarget = m.buildPreBuildEvents(cfg)
 	cfg._hasPrebuild = (prebuildTarget ~= nil)
@@ -642,6 +659,10 @@ function m.buildFiles(cfg)
 		cfg.project._ninja_output_tracking = {}
 	end
 	local outputTracking = cfg.project._ninja_output_tracking
+
+	if stlModuleObj then
+		table.insert(objList, stlModuleObj)
+	end
 	
 	if not cfg._customRuleOutputs then
 		cfg._customRuleOutputs = {}
@@ -722,7 +743,7 @@ function m.buildFiles(cfg)
 							local objFile = m.objectFile(cfg, node, filecfg)
 							if objFile then
 								table.insert(objList, objFile)
-								m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
+								m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget, stlModule)
 							end
 						end
 					end
@@ -740,6 +761,49 @@ function m.buildFiles(cfg)
 	
 	cfg._objectFiles = objList
 	cfg._copyFiles = copyList
+end
+
+function m.buildstlmodule(cfg)
+	local toolset = ninja.gettoolset(cfg)
+	if not toolset.cppmodules or cfg.buildstlmodules ~= p.ON or not p.languages.iscpp(cfg.language) then
+		return nil
+	end
+
+	local cppmodules = toolset.cppmodules
+	if cppmodules.supported and not cppmodules.supported(cfg) then
+		return nil
+	end
+
+	local objdir = path.getrelative(cfg.workspace.location, cfg.objdir)
+	local moduleFile = path.join(objdir, "std." .. cppmodules.bmiExtension)
+	local objFile
+	if cppmodules.objOutputFlag then
+		objFile = path.join(objdir, "std") .. toolset.gettooloutputext("cc")
+	end
+	local stl = cppmodules.stl
+	if type(stl) == "function" then
+		stl = stl(cfg)
+	end
+	local shell = iif(cfg.system == p.WINDOWS, "cmd /c", "")
+	local outputs = { moduleFile }
+	if objFile then
+		table.insert(outputs, objFile)
+	end
+
+	_p("build %s: cxxstdlib_%s", table.concat(outputs, " "), cfg.toolset)
+	_p("  cxxflags = $cxxflags_%s", ninja.key(cfg))
+	_p("  bmi = %s", moduleFile)
+	if objFile then
+		_p("  obj = %s", objFile)
+	end
+	if stl then
+		_p("  stl = %s", stl)
+	end
+	if shell ~= "" then
+		_p("  shell = %s", shell)
+	end
+
+	return moduleFile, objFile
 end
 
 function m.objectFile(cfg, node, filecfg)
@@ -770,7 +834,7 @@ function m.objectFile(cfg, node, filecfg)
 	return nil
 end
 
-function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
+function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget, stlModule)
 	local ext = path.getextension(node.abspath):lower()
 	local rule = nil
 	local flags = ""
@@ -851,6 +915,18 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 				implicitDeps = " |"
 			end
 			implicitDeps = implicitDeps .. " " .. table.concat(cfg._dependsOnTargets, " ")
+		end
+
+		if stlModule and rule == "cxx" then
+			if implicitDeps == "" then
+				implicitDeps = " |"
+			end
+			implicitDeps = implicitDeps .. " " .. stlModule
+			local cppmodules = toolset.cppmodules
+			if cppmodules.bmiReferenceFlag then
+				local referenceFlag = cppmodules.bmiReferenceFlag .. "std=" .. p.quoted(stlModule)
+				table.insert(extraFlags, referenceFlag)
+			end
 		end
 		
 		local implicitOutput = ""

--- a/modules/ninja/tests/test_ninja_build_rules.lua
+++ b/modules/ninja/tests/test_ninja_build_rules.lua
@@ -115,6 +115,95 @@ rule cxx_msc
 		]]
 	end
 
+	function suite.cxxstdlibrule_onMSVC()
+		system "Windows"
+		toolset "msc"
+		language "C++"
+		local cfg = prepare()
+		cpp.cxxstdlibrule(cfg)
+		test.capture [[
+rule cxxstdlib_msc
+  command = $shell cl /nologo /c /interface /ifcOutput $bmi $cxxflags $stl /Fo$obj
+  description = Building C++ standard library module $bmi
+
+		]]
+	end
+
+	function suite.buildstlmodule_onMSVC()
+		system "Windows"
+		toolset "msc"
+		language "C++"
+		buildstlmodules "On"
+		local cfg = prepare()
+		local moduleFile, objFile = cpp.buildstlmodule(cfg)
+		test.capture [[
+build obj/Debug/std.ifc obj/Debug/std.obj: cxxstdlib_msc
+  cxxflags = $cxxflags_MyProject_Debug
+  bmi = obj/Debug/std.ifc
+  obj = obj/Debug/std.obj
+  stl = "%VCToolsInstallDir%\modules\std.ixx"
+  shell = cmd /c
+		]]
+		test.isequal("obj/Debug/std.ifc", moduleFile)
+		test.isequal("obj/Debug/std.obj", objFile)
+	end
+
+	function suite.buildstlmodule_ignoredForUnsupportedToolset()
+		toolset "clang"
+		language "C++"
+		buildstlmodules "On"
+		local cfg = prepare()
+		test.isnil(cpp.buildstlmodule(cfg))
+		test.capture ""
+	end
+
+	function suite.buildstlmodule_ignoredForC()
+		system "Windows"
+		toolset "msc"
+		language "C"
+		buildstlmodules "On"
+		local cfg = prepare()
+		test.isnil(cpp.buildstlmodule(cfg))
+		test.capture ""
+	end
+
+	function suite.buildFile_linksStlModule_onMSVC()
+		system "Windows"
+		toolset "msc"
+		language "C++"
+		files { "main.cpp" }
+		local cfg = prepare()
+		local node = p.project.getsourcetree(cfg.project).children["main.cpp"]
+		local filecfg = p.fileconfig.getconfig(node, cfg)
+		local objFile = cpp.objectFile(cfg, node, filecfg)
+		cpp.buildFile(cfg, node, filecfg, objFile, nil, nil, "obj/Debug/std.ifc")
+		test.capture [[
+build obj/Debug/main.obj: cxx_msc main.cpp | obj/Debug/std.ifc
+  cxxflags = $cxxflags_MyProject_Debug /reference std=obj/Debug/std.ifc
+		]]
+	end
+
+	function suite.buildFiles_withStlModule()
+		system "Windows"
+		toolset "msc"
+		language "C++"
+		files { "main.cpp" }
+		buildstlmodules "On"
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		test.capture [[
+build obj/Debug/std.ifc obj/Debug/std.obj: cxxstdlib_msc
+  cxxflags = $cxxflags_MyProject_Debug
+  bmi = obj/Debug/std.ifc
+  obj = obj/Debug/std.obj
+  stl = "%VCToolsInstallDir%\modules\std.ixx"
+  shell = cmd /c
+build obj/Debug/main.obj: cxx_msc main.cpp | obj/Debug/std.ifc
+  cxxflags = $cxxflags_MyProject_Debug /reference std=obj/Debug/std.ifc
+		]]
+		test.isequal({ "obj/Debug/std.obj", "obj/Debug/main.obj" }, cfg._objectFiles)
+	end
+
 	function suite.buildFile_generateAssembly_onMSVC()
 		toolset "msc"
 		language "C++"

--- a/modules/vstudio/_preload.lua
+++ b/modules/vstudio/_preload.lua
@@ -491,16 +491,6 @@
 	}
 
 	p.api.register {
-		name = "buildstlmodules",
-		scope = { "config" },
-		kind = "string",
-		allowed = {
-			"On",
-			"Off"
-		}
-	}
-
-	p.api.register {
 		name = "clangtidy",
 		scope = "config",
 		kind = "boolean"

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -94,6 +94,16 @@
 	}
 
 	api.register {
+		name = "buildstlmodules",
+		scope = "config",
+		kind = "string",
+		allowed = {
+			"On",
+			"Off",
+		},
+	}
+
+	api.register {
 		name = "buildinputs",
 		scope = "config",
 		kind = "list:file",

--- a/src/tools/msc.lua
+++ b/src/tools/msc.lua
@@ -57,6 +57,15 @@
 		},
 	}
 
+	msc.cppmodules = {
+		bmiExtension = "ifc",
+		stl = "\"%VCToolsInstallDir%\\modules\\std.ixx\"",
+		bmiCompileFlags = "/nologo /c /interface",
+		bmiOutputFlag = "/ifcOutput ",
+		bmiReferenceFlag = "/reference ",
+		objOutputFlag = "/Fo",
+	}
+
 	function msc.getassemblyflags(cfg, assemblyOutput)
 		local flags = config.mapFlags(cfg, msc.generateassembly)
 		if assemblyOutput and #flags > 0 then

--- a/website/docs/buildstlmodules.md
+++ b/website/docs/buildstlmodules.md
@@ -19,7 +19,7 @@ Project configurations.
 
 ### Availability ###
 
-Premake 5.0.0-beta3 or later for Visual Studio 2022 and later.
+Premake 5.0.0-beta3 or later for Visual Studio 2022 and later, or Ninja with the MSVC toolset.
 
 ### See Also ###
 


### PR DESCRIPTION
Written in a modular way to allow clang and gcc to be added later, as well as makefile rules. Each toolset has its own definition of the variables in the cppmodules table, but I have only started off with `msc` as I have access to a Windows machine. To try:

```
import std;

int main() {
  std::println("Hello");
  return 0;
}

```
Needs:

```
language "C++"
cppdialect "c++latest"
buildstlmodules "On"
```

It will build `std.ifc` and `std.obj`:
- The IFC file is consumed by every file being compiled
- The OBJ file is consumed at program link time.

Note on shell command:
- Shell (`cmd`) is called because we need to expand the macro that defines the fixed location of the standard library module for MSVC: `"%VCToolsInstallDir%\modules\std.ixx"`. This macro is only available at project build time (when one would assume CL is present due to `vcvars` being called), not necessarily at project generation time.