### PR TITLE
clang uses llvm-ar on Windows

### DIFF
--- a/modules/gmake/tests/test_gmake_clang.lua
+++ b/modules/gmake/tests/test_gmake_clang.lua
@@ -32,7 +32,7 @@
 	function suite.usesCorrectCompilers()
 		prepare()
 		gmake.cpp.outputConfigurationSection(prj)
-		test.capture [[
+		test.capture(string.format([[
 # Configurations
 # #############################################
 
@@ -43,9 +43,9 @@ ifeq ($(origin CXX), default)
   CXX = clang++
 endif
 ifeq ($(origin AR), default)
-  AR = ar
+  AR = %s
 endif
-]]
+]], os.istarget("windows") and "llvm-ar" or "ar"))
 	end
 
 	function suite.usesSystemArchiverForVersionedClangOnMacOSWithLinkTimeOptimization()

--- a/modules/gmakelegacy/tests/cpp/test_clang.lua
+++ b/modules/gmakelegacy/tests/cpp/test_clang.lua
@@ -34,7 +34,7 @@
 	function suite.usesCorrectCompilers()
 		prepare()
 		make.cppConfigs(prj)
-		test.capture [[
+		test.capture(string.format([[
 ifeq ($(config),debug)
   ifeq ($(origin CC), default)
     CC = clang
@@ -43,10 +43,11 @@ ifeq ($(config),debug)
     CXX = clang++
   endif
   ifeq ($(origin AR), default)
-    AR = ar
+    AR = %s
   endif
-		]]
+		]], os.istarget("windows") and "llvm-ar" or "ar"))
 	end
+
 
 	function suite.usesCorrectCompilersAndLinkTimeOptimizationViaAPI()
 		system "Linux"
@@ -85,4 +86,3 @@ ifeq ($(config),debug)
   endif
 		]]
 	end
-

--- a/src/tools/clang.lua
+++ b/src/tools/clang.lua
@@ -463,7 +463,7 @@
 	clang.tools = {
 		cc = "clang",
 		cxx = "clang++",
-		ar = function(cfg) return iif(cfg.linktimeoptimization == "On" or cfg.linktimeoptimization == "Fast", "llvm-ar", "ar") end,
+		ar = function(cfg) return iif(cfg.system == p.WINDOWS or cfg.linktimeoptimization == "On" or cfg.linktimeoptimization == "Fast", "llvm-ar", "ar") end,
 		rc = "windres"
 	}
 

--- a/tests/tools/test_clang.lua
+++ b/tests/tools/test_clang.lua
@@ -39,6 +39,12 @@
 		test.isequal("windres", clang.gettoolname(cfg, "rc"))
 	end
 
+	function suite.tools_onWindows()
+		system "Windows"
+		prepare()
+		test.isequal("llvm-ar", clang.gettoolname(cfg, "ar"))
+	end
+
 	function suite.tools_onLinkTimeOptimizationViaAPI()
 		linktimeoptimization "On"
 		prepare()
@@ -82,6 +88,13 @@
 		test.isequal("clang++-16", clang.gettoolname(cfg, "cxx"))
 		test.isequal("ar-16", clang.gettoolname(cfg, "ar"))
 		test.isequal("windres-16", clang.gettoolname(cfg, "rc"))
+	end
+
+	function suite.tools_forVersion_onWindows()
+		system "Windows"
+		toolset "clang-16"
+		prepare()
+		test.isequal("llvm-ar-16", clang.gettoolname(cfg, "ar"))
 	end
 
 	function suite.tools_forVersion_onLinkTimeOptimizationViaAPI()


### PR DESCRIPTION
- Required for Windows, as there is no ar.
- clang provides llvm-ar as gnu-syntax ar that can work on Windows and mingw.
