### PR TITLE
docs: added The unofficial premake registry to modules under library…

### DIFF
--- a/website/community/modules.md
+++ b/website/community/modules.md
@@ -46,4 +46,4 @@ These add-on modules are available from other developers; follow the links for m
 
 ## Library Collection
 
-* [Premake Registry (unofficial)](https://premake-registry-ywxg.onrender.com/) : Online website registry containing libraries and modules with ready made premake scripts
+* [Premake Registry (unofficial)](https://premake-registry-ywxg.onrender.com/) : Online website registry containing libraries and modules with ready made Premake scripts

--- a/website/community/modules.md
+++ b/website/community/modules.md
@@ -43,3 +43,7 @@ These add-on modules are available from other developers; follow the links for m
 * [CUDA](https://github.com/theComputeKid/premake5-cuda) : Enables CUDA development in Visual Studio using the native CUDA Toolkit integration and with nvcc on Linux
 * [Qt](https://github.com/dcourtois/premake-qt) : [Qt](https://www.qt.io) support
 * [WIX](https://github.com/mikisch81/premake-wix) : Premake extension to support [WIX](http://wixtoolset.org/) project files on Visual Studio
+
+## Library Collection
+
+* [Premake Registry (unofficial)](https://premake-registry-ywxg.onrender.com/): online website registry containing libs+modules

--- a/website/community/modules.md
+++ b/website/community/modules.md
@@ -46,4 +46,4 @@ These add-on modules are available from other developers; follow the links for m
 
 ## Library Collection
 
-* [Premake Registry (unofficial)](https://premake-registry-ywxg.onrender.com/): online website registry containing libs+modules
+* [Premake Registry (unofficial)](https://premake-registry-ywxg.onrender.com/) : Online website registry containing libraries and modules with ready made premake scripts


### PR DESCRIPTION
**What does this PR do?**

added the unnoficial Premake Registry website to the community modules section.


**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
