### PR TITLE
Fixed per-file flags in ninja, compilecommands

### DIFF
--- a/modules/compilecommands/compilecommands.lua
+++ b/modules/compilecommands/compilecommands.lua
@@ -60,22 +60,14 @@ function m.getflags(cfg, toolset, fcfg, tool)
 	local flags = {}
 	toolset = toolset or m.gettoolset(cfg)
 
+	local activeCfg = fcfg or cfg
+
 	if tool == "cc" then
-		if fcfg and fcfg.cdialect and fcfg.cdialect ~= cfg.cdialect then
-			local toolflags = toolset.getcflags(fcfg)
-			flags = table.join(flags, toolflags)
-		else
-			local toolflags = toolset.getcflags(cfg)
-			flags = table.join(flags, toolflags)
-		end
+		local toolflags = toolset.getcflags(activeCfg)
+		flags = table.join(flags, toolflags)
 	elseif tool == "cxx" then
-		if fcfg and fcfg.cppdialect and fcfg.cppdialect ~= cfg.cppdialect then
-			local toolflags = toolset.getcxxflags(fcfg)
-			flags = table.join(flags, toolflags)
-		else
-			local toolflags = toolset.getcxxflags(cfg)
-			flags = table.join(flags, toolflags)
-		end
+		local toolflags = toolset.getcxxflags(activeCfg)
+		flags = table.join(flags, toolflags)
 	else
 		error("Unsupported tool '" .. tool .. "' for getting flags")
 	end
@@ -122,6 +114,12 @@ function m.getflags(cfg, toolset, fcfg, tool)
 		buildoptions = table.join(buildoptions, fcfg.buildoptions)
 	end
 
+	-- Force includes
+	local forceincludes = cfg.forceincludes or {}
+	if fcfg and fcfg.forceincludes then
+		forceincludes = table.join(forceincludes, fcfg.forceincludes)
+	end
+
 	local implicitincludedirs = {}
 
 	if _OPTIONS["implicit-includes"] == "On" then
@@ -140,7 +138,7 @@ function m.getflags(cfg, toolset, fcfg, tool)
 						toolset.getdefines(defines),
 						toolset.getundefines(undefines),
 						allincludedirflags,
-						toolset.getforceincludes(fcfg or cfg),
+						toolset.getforceincludes({ project = cfg.project, forceincludes = forceincludes }),
 						buildoptions)
 
 	return flags

--- a/modules/compilecommands/tests/test_c_compile.lua
+++ b/modules/compilecommands/tests/test_c_compile.lua
@@ -178,3 +178,44 @@
 
 		test.isequal(expected, args)
 	end
+
+
+	function suite.compile_perfile_vectorextensions()
+		toolset "clang"
+		files { "main.c", "simd.c" }
+
+		filter "files:simd.c"
+			vectorextensions "AVX2"
+		filter {}
+
+		local cfg = prepare()
+		local args = compilecommands.generate(wks, "Debug", "")
+
+		local expected = {
+			{
+				directory = path.getabsolute(prj.location),
+				file = path.getabsolute("main.c"),
+				arguments = {
+					"clang",
+					path.getabsolute("main.c"),
+					"-o",
+					path.getabsolute("obj/Debug/main.o"),
+				},
+				output = path.getabsolute("obj/Debug/main.o"),
+			},
+			{
+				directory = path.getabsolute(prj.location),
+				file = path.getabsolute("simd.c"),
+				arguments = {
+					"clang",
+					"-mavx2",
+					path.getabsolute("simd.c"),
+					"-o",
+					path.getabsolute("obj/Debug/simd.o"),
+				},
+				output = path.getabsolute("obj/Debug/simd.o"),
+			}
+		}
+
+		test.isequal(expected, args)
+	end

--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -340,16 +340,43 @@ function m.getCFlags(cfg, toolset)
 	return flags
 end
 
+local function getCompileAsFlag(filecfg, toolset)
+	if filecfg and filecfg.compileas and toolset and toolset.shared and toolset.shared.compileas then
+		if p.languages.isc(filecfg.compileas) then
+			return toolset.shared.compileas["C"]
+		elseif p.languages.iscpp(filecfg.compileas) then
+			return toolset.shared.compileas["C++"]
+		end
+	end
+	return nil
+end
+
+local function fileConfigProxy(cfg, filecfg)
+	if not filecfg then
+		return cfg
+	end
+	return setmetatable({}, {
+		__index = function(t, k)
+			local v = filecfg[k]
+			if v ~= nil then
+				return v
+			end
+			return cfg[k]
+		end
+	})
+end
+
 function m.getFileCFlags(cfg, filecfg, toolset)
 	local flags = {}
+	toolset = toolset or ninja.gettoolset(cfg)
+	local compileasFlag = getCompileAsFlag(filecfg, toolset)
 
-	if filecfg.cdialect and filecfg.cdialect ~= cfg.cdialect then
-		local toolFlags = toolset.getcflags(filecfg)
-		flags = table.join(flags, toolFlags)
-	else
-		local toolFlags = toolset.getcflags(cfg)
-		flags = table.join(flags, toolFlags)
+	local proxy = fileConfigProxy(cfg, filecfg)
+	local toolFlags = toolset.getcflags(proxy)
+	if compileasFlag then
+		toolFlags = table.filter(toolFlags, function(flag) return flag ~= compileasFlag end)
 	end
+	flags = table.join(flags, toolFlags)
 	
 	local allDefines = table.join(cfg.defines or {}, filecfg.defines or {})
 	local escaper = p.escaper(p.quote)
@@ -367,7 +394,8 @@ function m.getFileCFlags(cfg, filecfg, toolset)
 	local includedirs = toolset.getincludedirs(cfg, allIncludedirs, allExternalIncludedirs, allFrameworkdirs, allIncludedirsafter)
 	flags = table.join(flags, includedirs)
 	
-	local forceincludes = toolset.getforceincludes(filecfg)
+	local allForceincludes = table.join(cfg.forceincludes or {}, filecfg.forceincludes or {})
+	local forceincludes = toolset.getforceincludes({ project = cfg.project, forceincludes = allForceincludes })
 	flags = table.join(flags, forceincludes)
 
 	local allBuildopts = table.join(cfg.buildoptions or {}, filecfg.buildoptions or {})
@@ -408,14 +436,15 @@ end
 
 function m.getFileCxxFlags(cfg, filecfg, toolset)
 	local flags = {}
+	toolset = toolset or ninja.gettoolset(cfg)
+	local compileasFlag = getCompileAsFlag(filecfg, toolset)
 
-	if filecfg.cppdialect and filecfg.cppdialect ~= cfg.cppdialect then
-		local toolFlags = toolset.getcxxflags(filecfg)
-		flags = table.join(flags, toolFlags)
-	else
-		local toolFlags = toolset.getcxxflags(cfg)
-		flags = table.join(flags, toolFlags)
+	local proxy = fileConfigProxy(cfg, filecfg)
+	local toolFlags = toolset.getcxxflags(proxy)
+	if compileasFlag then
+		toolFlags = table.filter(toolFlags, function(flag) return flag ~= compileasFlag end)
 	end
+	flags = table.join(flags, toolFlags)
 	
 	local allDefines = table.join(cfg.defines or {}, filecfg.defines or {})
 	local escaper = p.escaper(p.quote)
@@ -433,7 +462,8 @@ function m.getFileCxxFlags(cfg, filecfg, toolset)
 	local includedirs = toolset.getincludedirs(cfg, allIncludedirs, allExternalIncludedirs, allFrameworkdirs, allIncludedirsafter)
 	flags = table.join(flags, includedirs)
 	
-	local forceincludes = toolset.getforceincludes(filecfg)
+	local allForceincludes = table.join(cfg.forceincludes or {}, filecfg.forceincludes or {})
+	local forceincludes = toolset.getforceincludes({ project = cfg.project, forceincludes = allForceincludes })
 	flags = table.join(flags, forceincludes)
 
 	local allBuildopts = table.join(cfg.buildoptions or {}, filecfg.buildoptions or {})
@@ -444,73 +474,26 @@ function m.getFileCxxFlags(cfg, filecfg, toolset)
 	return flags
 end
 
-function m.hasPerFileConfiguration(cfg, filecfg)
-	if filecfg.defines and #filecfg.defines > 0 then
-		local parentDefines = cfg.defines or {}
-		if #filecfg.defines ~= #parentDefines then
+function m.hasPerFileConfiguration(cfg, filecfg, rule)
+	if not filecfg then
+		return false
+	end
+	
+	local toolset = ninja.gettoolset(cfg)
+	if not rule or rule == "cc" then
+		local cflagsBase = table.concat(m.getCFlags(cfg, toolset), " ")
+		local cflagsFile = table.concat(m.getFileCFlags(cfg, filecfg, toolset), " ")
+		if cflagsBase ~= cflagsFile then
 			return true
 		end
-		for i, define in ipairs(filecfg.defines) do
-			if define ~= parentDefines[i] then
-				return true
-			end
-		end
 	end
-	
-	if filecfg.undefines and #filecfg.undefines > 0 then
-		local parentUndefines = cfg.undefines or {}
-		if #filecfg.undefines ~= #parentUndefines then
+
+	if not rule or rule == "cxx" then
+		local cxxflagsBase = table.concat(m.getCxxFlags(cfg, toolset), " ")
+		local cxxflagsFile = table.concat(m.getFileCxxFlags(cfg, filecfg, toolset), " ")
+		if cxxflagsBase ~= cxxflagsFile then
 			return true
 		end
-		for i, undefine in ipairs(filecfg.undefines) do
-			if undefine ~= parentUndefines[i] then
-				return true
-			end
-		end
-	end
-	
-	if filecfg.buildoptions and #filecfg.buildoptions > 0 then
-		local parentBuildopts = cfg.buildoptions or {}
-		if #filecfg.buildoptions ~= #parentBuildopts then
-			return true
-		end
-		for i, opt in ipairs(filecfg.buildoptions) do
-			if opt ~= parentBuildopts[i] then
-				return true
-			end
-		end
-	end
-	
-	if filecfg.includedirs and #filecfg.includedirs > 0 then
-		local parentIncludedirs = cfg.includedirs or {}
-		if #filecfg.includedirs ~= #parentIncludedirs then
-			return true
-		end
-		for i, dir in ipairs(filecfg.includedirs) do
-			if dir ~= parentIncludedirs[i] then
-				return true
-			end
-		end
-	end
-	
-	if filecfg.externalincludedirs and #filecfg.externalincludedirs > 0 then
-		local parentExternalIncludedirs = cfg.externalincludedirs or {}
-		if #filecfg.externalincludedirs ~= #parentExternalIncludedirs then
-			return true
-		end
-		for i, dir in ipairs(filecfg.externalincludedirs) do
-			if dir ~= parentExternalIncludedirs[i] then
-				return true
-			end
-		end
-	end
-	
-	if filecfg.cdialect and filecfg.cdialect ~= cfg.cdialect then
-		return true
-	end
-	
-	if filecfg.cppdialect and filecfg.cppdialect ~= cfg.cppdialect then
-		return true
 	end
 	
 	return false
@@ -777,7 +760,6 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 	local extraFlags = {}
 	local toolset = ninja.gettoolset(cfg)
 	local assemblyFile
-	local hasPerFileConfig = m.hasPerFileConfiguration(cfg, filecfg)
 	if toolset.getassemblyflags then
 		local assemblyCfg = filecfg.generateassembly and filecfg or cfg
 		if toolset.getassemblyoutput then
@@ -885,6 +867,7 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 		end
 		
 		-- If the file has per-file configuration, generate flags directly rather than using variables
+		local hasPerFileConfig = m.hasPerFileConfiguration(cfg, filecfg, rule)
 		if hasPerFileConfig then
 			local fileFlags = {}
 			if rule == "cc" then

--- a/modules/ninja/tests/test_ninja_perfile_config.lua
+++ b/modules/ninja/tests/test_ninja_perfile_config.lua
@@ -296,6 +296,199 @@ build obj/Debug/special.o: cxx_gcc special.cpp
 
 
 ---
+-- Per-file vector extensions tests
+---
+
+--
+-- Check that a file with overridden vectorextensions generates inline flags with GCC.
+--
+
+	function suite.perfile_vectorextensions_override_GCC()
+		toolset "gcc"
+		_OS = "Linux"
+		files { "main.cpp", "simd.cpp" }
+		
+		filter "files:simd.cpp"
+			vectorextensions "AVX2"
+		filter {}
+		
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		
+		test.capture [[
+build obj/Debug/main.o: cxx_gcc main.cpp
+  cxxflags = $cxxflags_MyProject_Debug
+build obj/Debug/simd.o: cxx_gcc simd.cpp
+  cxxflags = -mavx2
+		]]
+	end
+
+
+--
+-- Check that a file with overridden vectorextensions generates inline flags with MSVC.
+--
+
+	function suite.perfile_vectorextensions_override_MSVC()
+		toolset "msc"
+		_OS = "Windows"
+		files { "main.cpp", "simd.cpp" }
+		
+		filter "files:simd.cpp"
+			vectorextensions "AVX2"
+		filter {}
+		
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		
+		test.capture [[
+build obj/Debug/main.obj: cxx_msc main.cpp
+  cxxflags = $cxxflags_MyProject_Debug
+build obj/Debug/simd.obj: cxx_msc simd.cpp
+  cxxflags = /arch:AVX2 /EHsc
+		]]
+	end
+
+
+--
+-- Check that a C file with vectorextensions and buildoptions generates inline flags with MSVC.
+--
+
+	function suite.perfile_vectorextensions_and_buildoptions_C_MSVC()
+		toolset "msc"
+		_OS = "Windows"
+		language "C"
+		files { "main.c", "simd.c" }
+		
+		filter "files:simd.c"
+			vectorextensions "AVX2"
+			buildoptions { "/wd4716" }
+		filter {}
+		
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		
+		test.capture [[
+build obj/Debug/main.obj: cc_msc main.c
+  cflags = $cflags_MyProject_Debug
+build obj/Debug/simd.obj: cc_msc simd.c
+  cflags = /arch:AVX2 /wd4716
+		]]
+	end
+
+
+--
+-- Check that a C file with vectorextensions and buildoptions generates inline flags with GCC.
+--
+
+	function suite.perfile_vectorextensions_and_buildoptions_C_GCC()
+		toolset "gcc"
+		_OS = "Linux"
+		language "C"
+		files { "main.c", "simd.c" }
+		
+		filter "files:simd.c"
+			vectorextensions "AVX2"
+			buildoptions { "-O3" }
+		filter {}
+		
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		
+		test.capture [[
+build obj/Debug/main.o: cc_gcc main.c
+  cflags = $cflags_MyProject_Debug
+build obj/Debug/simd.o: cc_gcc simd.c
+  cflags = -mavx2 -O3
+		]]
+	end
+
+
+--
+-- Check that a file with overridden vectorextensions replaces project vectorextensions with GCC.
+--
+
+	function suite.perfile_vectorextensions_replaces_project_vectorextensions_GCC()
+		toolset "gcc"
+		_OS = "Linux"
+		files { "main.cpp", "simd.cpp" }
+		vectorextensions "SSE2"
+		
+		filter "files:simd.cpp"
+			vectorextensions "AVX2"
+		filter {}
+		
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		
+		test.capture [[
+build obj/Debug/main.o: cxx_gcc main.cpp
+  cxxflags = $cxxflags_MyProject_Debug
+build obj/Debug/simd.o: cxx_gcc simd.cpp
+  cxxflags = -mavx2
+		]]
+	end
+
+
+--
+-- Check that a file with overridden vectorextensions replaces project vectorextensions with MSVC.
+--
+
+	function suite.perfile_vectorextensions_replaces_project_vectorextensions_MSVC()
+		toolset "msc"
+		_OS = "Windows"
+		files { "main.cpp", "simd.cpp" }
+		vectorextensions "AVX"
+		
+		filter "files:simd.cpp"
+			vectorextensions "AVX2"
+		filter {}
+		
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		
+		test.capture [[
+build obj/Debug/main.obj: cxx_msc main.cpp
+  cxxflags = $cxxflags_MyProject_Debug
+build obj/Debug/simd.obj: cxx_msc simd.cpp
+  cxxflags = /arch:AVX2 /EHsc
+		]]
+	end
+
+
+--
+-- Check that multiple matching filter blocks merge lists and replace scalars.
+--
+
+	function suite.perfile_multiple_filter_blocks_merged_and_replaced()
+		toolset "gcc"
+		_OS = "Linux"
+		files { "main.cpp", "special.cpp" }
+		defines { "PROJ_DEF" }
+		cppdialect "C++11"
+		
+		filter "files:special.cpp"
+			defines { "FILTER1_DEF" }
+			cppdialect "C++14"
+		filter {}
+		
+		filter "files:*.cpp"
+			defines { "FILTER2_DEF" }
+			cppdialect "C++17"
+		filter {}
+		
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		
+		test.capture [[
+build obj/Debug/main.o: cxx_gcc main.cpp
+  cxxflags = -std=c++17 -D"PROJ_DEF" -D"FILTER2_DEF"
+build obj/Debug/special.o: cxx_gcc special.cpp
+  cxxflags = -std=c++17 -D"PROJ_DEF" -D"FILTER1_DEF" -D"FILTER2_DEF"
+		]]
+	end
+
+
+---
 -- Test that files without per-file config still use variables
 ---
 
@@ -318,5 +511,53 @@ build obj/Debug/main.o: cxx_gcc main.cpp
   cxxflags = $cxxflags_MyProject_Debug
 build obj/Debug/other.o: cxx_gcc other.cpp
   cxxflags = $cxxflags_MyProject_Debug
+		]]
+	end
+
+
+--
+-- Check that project-level forceincludes does not cause files to emit inline flags.
+--
+
+	function suite.forceincludes_project_level_uses_variable()
+		toolset "gcc"
+		_OS = "Linux"
+		files { "main.c", "other.c" }
+		forceincludes { "unistd.h" }
+		
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		
+		test.capture [[
+build obj/Debug/main.o: cc_gcc main.c
+  cflags = $cflags_MyProject_Debug
+build obj/Debug/other.o: cc_gcc other.c
+  cflags = $cflags_MyProject_Debug
+		]]
+	end
+
+
+--
+-- Check that per-file forceincludes merges with project forceincludes.
+--
+
+	function suite.perfile_forceincludes_override_GCC()
+		toolset "gcc"
+		_OS = "Linux"
+		files { "main.c", "special.c" }
+		forceincludes { "unistd.h" }
+		
+		filter "files:special.c"
+			forceincludes { "extra.h" }
+		filter {}
+		
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		
+		test.capture [[
+build obj/Debug/main.o: cc_gcc main.c
+  cflags = $cflags_MyProject_Debug
+build obj/Debug/special.o: cc_gcc special.c
+  cflags = -include unistd.h -include extra.h
 		]]
 	end


### PR DESCRIPTION
**What does this PR do?**

Fixes per-file flags in ninja and compilecommands generators. Existing behavior would not reliably propagate per-file flags into the generated files. 

**How does this PR change Premake's behavior?**

No breaking ABI or API changes, fixes bug.

**Anything else we should know?**

Resolves #2789 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
