### PR TITLE
Add Ubuntu 22.04, 26.04, x64 and arm variants

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -4,18 +4,25 @@ on: [push, pull_request]
 
 jobs:
   linux:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.target.os }}
     strategy:
       matrix:
         config: [debug, release]
-        platform: [x64, ARM64]
         depsrc: [none, contrib, system]
         cc: [gcc, clang]
-        include:
-          - platform: x64
-            os: ubuntu-latest
-          - platform: ARM64
-            os: ubuntu-24.04-arm
+        target:
+          - os: ubuntu-22.04
+            platform: x64
+          - os: ubuntu-24.04
+            platform: x64
+          - os: ubuntu-26.04
+            platform: x64
+          - os: ubuntu-22.04-arm
+            platform: ARM64
+          - os: ubuntu-24.04-arm
+            platform: ARM64
+          - os: ubuntu-26.04-arm
+            platform: ARM64
     timeout-minutes: 15
     steps:
     - name: Checkout
@@ -30,7 +37,7 @@ jobs:
         sudo apt-get update 
         sudo apt-get -y install libcurl4-openssl-dev libzip-dev liblua5.3-dev
     - name: Build
-      run: PLATFORM=${{ matrix.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--lib-src=${{ matrix.depsrc }} --cc=${{ matrix.cc }}" ./Bootstrap.sh
+      run: PLATFORM=${{ matrix.target.platform }} CONFIG=${{ matrix.config }} PREMAKE_OPTS="--lib-src=${{ matrix.depsrc }} --cc=${{ matrix.cc }}" ./Bootstrap.sh
     - name: Test
       run: bin/${{ matrix.config }}/premake5 test --test-all
     - name: Docs check
@@ -39,7 +46,12 @@ jobs:
       if: matrix.config == 'release' && matrix.depsrc == 'contrib' && matrix.cc == 'gcc'
       uses: actions/upload-artifact@v7
       with:
-        name: premake-linux-${{ matrix.platform }}
+        name: >-
+          premake-linux-${{ matrix.target.platform }}-glibc-${{ 
+            (matrix.target.os == 'ubuntu-22.04' || matrix.target.os == 'ubuntu-22.04-arm') && '2.35' || 
+            (matrix.target.os == 'ubuntu-24.04' || matrix.target.os == 'ubuntu-24.04-arm') && '2.39' || 
+            (matrix.target.os == 'ubuntu-26.04' || matrix.target.os == 'ubuntu-26.04-arm') && '2.43' 
+          }}
         path: bin/${{ matrix.config }}/
   macosx:
     runs-on: macos-latest


### PR DESCRIPTION
**What does this PR do?**

Adds CI runners for 22.04, 26.04 -- Both x64 and ARM

**How does this PR change Premake's behavior?**

No changes to Premake behavior

**Anything else we should know?**

22.04 is being deprecated soon, we should find an alternative for glibc 2.35 builds. Closes #2758 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
