### PR TITLE
Remove the duplicate rules from Ninja on multiple toolsets

### DIFF
--- a/modules/ninja/ninja.lua
+++ b/modules/ninja/ninja.lua
@@ -77,6 +77,21 @@ function ninja.gettoolset(cfg)
     return toolset
 end
 
+function ninja.toolsetname(cfg)
+    local default = (p.action.current() and p.action.current().toolset) or "gcc"
+    local identifier = cfg.toolset or default
+    if type(identifier) == "string" then
+        local norm = p.tools.normalize(identifier)
+        local parts = norm:explode("-", true, 1)
+        return parts[1]:gsub("[^%w_]", "_"):lower()
+    end
+    local toolset = ninja.gettoolset(cfg)
+    if toolset and toolset._NAME then
+        return toolset._NAME:gsub("[^%w_]", "_"):lower()
+    end
+    return "gcc"
+end
+
 function ninja.list(value)
     if #value > 0 then
         return " " .. table.concat(value, " ")

--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -38,30 +38,33 @@ function m.rules(prj)
 	
 	for cfg in project.eachconfig(prj) do
 		local toolset = ninja.gettoolset(cfg)
-		local toolsetKey = tostring(toolset)
+		local toolsetName = ninja.toolsetname(cfg)
 		
-		if not rulesDone[toolsetKey] then
+		if not rulesDone[toolsetName] then
 			m.ccrule(cfg, toolset)
 			m.cxxrule(cfg, toolset)
 			m.resourcerule(cfg, toolset)
 			m.linkrule(cfg, toolset)
 			m.pchrule(cfg, toolset)
-			m.copyrule(cfg, toolset)
-			m.prebuildcommandrule(cfg, toolset)
-			m.prelinkcommandrule(cfg, toolset)
-			m.postbuildcommandrule(cfg, toolset)
-			m.customcommand(cfg, toolset)
-			m.customrule(cfg, toolset, prj)
 			
-			rulesDone[toolsetKey] = true
+			rulesDone[toolsetName] = true
 		end
 	end
+
+	local firstCfg = project.getfirstconfig(prj)
+	m.copyrule(firstCfg)
+	m.prebuildcommandrule(firstCfg)
+	m.prelinkcommandrule(firstCfg)
+	m.postbuildcommandrule(firstCfg)
+	m.customcommand(firstCfg)
+	m.customrule(firstCfg, nil, prj)
 end
 
 function m.ccrule(cfg, toolset)
 	toolset = toolset or ninja.gettoolset(cfg)
+	local toolsetName = ninja.toolsetname(cfg)
 	local ccname = toolset.gettoolname(cfg, "cc")
-	_p("rule cc_%s", cfg.toolset)
+	_p("rule cc_%s", toolsetName)
 
 	if toolset == p.tools.msc then
 		_p("  command = %s $cflags /nologo /showIncludes -c /Tc$in /Fo$out", ccname)
@@ -79,8 +82,9 @@ end
 
 function m.cxxrule(cfg, toolset)
 	toolset = toolset or ninja.gettoolset(cfg)
+	local toolsetName = ninja.toolsetname(cfg)
 	local cxxname = toolset.gettoolname(cfg, "cxx")
-	_p("rule cxx_%s", cfg.toolset)
+	_p("rule cxx_%s", toolsetName)
 	
 	if toolset == p.tools.msc then
 		_p("  command = %s $cxxflags /nologo /showIncludes -c /Tp$in /Fo$out", cxxname)
@@ -98,9 +102,10 @@ end
 
 function m.resourcerule(cfg, toolset)
 	toolset = toolset or ninja.gettoolset(cfg)
+	local toolsetName = ninja.toolsetname(cfg)
 	local rcname = toolset.gettoolname(cfg, "rc")
 
-	_p("rule rc_%s", cfg.toolset)
+	_p("rule rc_%s", toolsetName)
 	
 	if toolset == p.tools.msc then
 		_p("  command = %s /nologo /fo$out $in $resflags", rcname)
@@ -114,22 +119,23 @@ end
 
 function m.linkrule(cfg, toolset)
 	toolset = toolset or ninja.gettoolset(cfg)
+	local toolsetName = ninja.toolsetname(cfg)
 
 	if toolset == p.tools.msc then
 		local arname = toolset.gettoolname(cfg, "ar")
-		_p("rule ar_%s", cfg.toolset)
+		_p("rule ar_%s", toolsetName)
 		_p("  command = %s $in /nologo -OUT:$out", arname)
 		_p("  description = Archiving static library $out")
 		_p("")
 
 		local ldname = toolset.gettoolname(cfg, iif(cfg.language == "C", "cc", "cxx"))
-		_p("rule link_%s", cfg.toolset)
+		_p("rule link_%s", toolsetName)
 		_p("  command = %s $in $links /link $ldflags /nologo /out:$out", ldname)
 		_p("  description = Linking target $out")
 		_p("")
 	else
 		local arname = toolset.gettoolname(cfg, "ar")
-		_p("rule ar_%s", cfg.toolset)
+		_p("rule ar_%s", toolsetName)
 		_p("  command = %s -rcs $out $in", arname)
 		_p("  description = Archiving static library $out")
 		_p("")
@@ -140,7 +146,7 @@ function m.linkrule(cfg, toolset)
 		commands = commands:gsub("(.-)%s*$", "%1")
 		commands = commands:gsub("%s+", " ")
 
-		_p("rule link_%s", cfg.toolset)
+		_p("rule link_%s", toolsetName)
 		_p("  %s", commands)
 		_p("  description = Linking target $out")
 		_p("")
@@ -149,9 +155,10 @@ end
 
 function m.pchrule(cfg, toolset)
 	toolset = toolset or ninja.gettoolset(cfg)
+	local toolsetName = ninja.toolsetname(cfg)
 	local pchname = toolset.gettoolname(cfg, cfg.language == "C" and "cc" or "cxx")
 
-	_p("rule pch_%s", cfg.toolset)
+	_p("rule pch_%s", toolsetName)
 	if toolset == p.tools.msc then
 		-- MSVC: /Yc creates the PCH, /Fp specifies output, /Fo specifies obj output
 		_p("  command = %s /nologo /Yc$pchheader /Fp$out /Fo$objdir/ $cflags /c $in", pchname)
@@ -550,6 +557,7 @@ function m.buildPch(cfg)
 	end
 	
 	local toolset = ninja.gettoolset(cfg)
+	local toolsetName = ninja.toolsetname(cfg)
 	local pchPath = m.getPchPath(cfg)
 	local depfile = pchPath .. ".d"
 	
@@ -574,7 +582,7 @@ function m.buildPch(cfg)
 		
 		local wksRelPchPath = path.getrelative(cfg.workspace.location, path.join(cfg.project.location, pchPath))
 		
-		_p("build %s | %s: pch_%s %s%s", wksRelPchPath, objFile, cfg.toolset, relPath, implicitDeps)
+		_p("build %s | %s: pch_%s %s%s", wksRelPchPath, objFile, toolsetName, relPath, implicitDeps)
 		_p("  pchheader = %s", cfg.pchheader)
 		_p("  objdir = %s", objdir)
 		if cfg.language == "C" then
@@ -598,7 +606,7 @@ function m.buildPch(cfg)
 		local wksRelPchPath = path.getrelative(cfg.workspace.location, path.join(cfg.project.location, pchPath))
 		local wksRelPchDepPath = path.getrelative(cfg.workspace.location, path.join(cfg.project.location, depfile))
 		
-		_p("build %s | %s: pch_%s %s%s", wksRelPchPath, wksRelPchDepPath, cfg.toolset, relPath, implicitDeps)
+		_p("build %s | %s: pch_%s %s%s", wksRelPchPath, wksRelPchDepPath, toolsetName, relPath, implicitDeps)
 		
 		if cfg.language == "C" then
 			_p("  cflags = $cflags_%s", ninja.key(cfg))
@@ -759,6 +767,7 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 	local flags = ""
 	local extraFlags = {}
 	local toolset = ninja.gettoolset(cfg)
+	local toolsetName = ninja.toolsetname(cfg)
 	local assemblyFile
 	if toolset.getassemblyflags then
 		local assemblyCfg = filecfg.generateassembly and filecfg or cfg
@@ -839,7 +848,7 @@ function m.buildFile(cfg, node, filecfg, objFile, pchFile, prebuildTarget)
 		if assemblyFile then
 			implicitOutput = " | " .. assemblyFile
 		end
-		_p("build %s%s: %s_%s %s%s", objFile, implicitOutput, rule, cfg.toolset, relPath, implicitDeps)
+		_p("build %s%s: %s_%s %s%s", objFile, implicitOutput, rule, toolsetName, relPath, implicitDeps)
 		
 		if usePch then
 			if toolset == p.tools.msc then
@@ -1126,6 +1135,7 @@ function m.linkTarget(cfg)
 	end
 	
 	local toolset = ninja.gettoolset(cfg)
+	local toolsetName = ninja.toolsetname(cfg)
 	local targetPath = path.getrelative(cfg.workspace.location, cfg.buildtarget.directory) .. "/" .. cfg.buildtarget.name
 	
 	local prelinkTarget = m.buildPreLinkEvents(cfg, cfg._objectFiles)
@@ -1206,9 +1216,9 @@ function m.linkTarget(cfg)
 	end
 	
 	if #implicitoutputs > 0 then
-		_p("build %s | %s: %s_%s %s%s", targetPath, table.concat(implicitoutputs, " "), rule, cfg.toolset, table.concat(cfg._objectFiles, " "), implicitDeps)
+		_p("build %s | %s: %s_%s %s%s", targetPath, table.concat(implicitoutputs, " "), rule, toolsetName, table.concat(cfg._objectFiles, " "), implicitDeps)
 	else
-		_p("build %s: %s_%s %s%s", targetPath, rule, cfg.toolset, table.concat(cfg._objectFiles, " "), implicitDeps)
+		_p("build %s: %s_%s %s%s", targetPath, rule, toolsetName, table.concat(cfg._objectFiles, " "), implicitDeps)
 	end
 	
 	if cfg.kind ~= p.STATICLIB then

--- a/modules/ninja/tests/test_ninja_project.lua
+++ b/modules/ninja/tests/test_ninja_project.lua
@@ -2,7 +2,7 @@
 -- test_ninja_project.lua
 -- Test the generation of complete project ninja files
 -- Author: Nick Clark
--- Copyright (c) 2025 Jess Perkins and the Premake project
+-- Copyright (c) 2025-2026 Jess Perkins and the Premake project
 --
 
 local suite = test.declare("ninja_project")
@@ -371,4 +371,83 @@ build bin/Debug/libMyProject2.so: link_gcc obj/Debug/main.o
   ldflags = $ldflags_MyProject2_Debug
 		]]
 
+	end
+
+
+--
+-- Test that having multiple toolsets does not emit duplicate rules
+-- and emits compilation rules for each toolset.
+--
+
+	function suite.multipleToolsetsNoDuplicateRules()
+		local wks, prj = test.createWorkspace()
+		configurations { "Debug", "Release" }
+		kind "ConsoleApp"
+		language "C++"
+		files { "main.cpp" }
+
+		filter "configurations:Debug"
+			toolset "gcc"
+
+		filter "configurations:Release"
+			toolset "clang"
+
+		filter {}
+
+		prj = test.getproject(wks, 1)
+
+		local output = p.capture(function()
+			ninja.cpp.generate(prj)
+		end)
+
+		-- Both toolset rules must be present
+		test.istrue(output:find("rule cc_gcc") ~= nil)
+		test.istrue(output:find("rule cxx_gcc") ~= nil)
+		test.istrue(output:find("rule link_gcc") ~= nil)
+		test.istrue(output:find("rule cc_clang") ~= nil)
+		test.istrue(output:find("rule cxx_clang") ~= nil)
+		test.istrue(output:find("rule link_clang") ~= nil)
+
+		-- Utility rules must be emitted exactly once
+		local _, copyCount = output:gsub("rule copy\n", "")
+		test.isequal(1, copyCount)
+
+		local _, prebuildCount = output:gsub("rule prebuild\n", "")
+		test.isequal(1, prebuildCount)
+
+		local _, prelinkCount = output:gsub("rule prelink\n", "")
+		test.isequal(1, prelinkCount)
+
+		local _, postbuildCount = output:gsub("rule postbuild\n", "")
+		test.isequal(1, postbuildCount)
+
+		local _, customCount = output:gsub("rule custom\n", "")
+		test.isequal(1, customCount)
+
+		-- Ensure build commands use their respective toolset rule
+		test.istrue(output:find("cxx_gcc") ~= nil)
+		test.istrue(output:find("cxx_clang") ~= nil)
+		test.istrue(output:find("link_gcc") ~= nil)
+		test.istrue(output:find("link_clang") ~= nil)
+	end
+
+
+--
+-- Test that default toolset does not produce _nil rules
+--
+
+	function suite.defaultToolsetNotNil()
+		local wks, prj = test.createWorkspace()
+		configurations { "Debug" }
+		kind "ConsoleApp"
+		language "C++"
+		files { "main.cpp" }
+
+		prj = test.getproject(wks, 1)
+
+		local output = p.capture(function()
+			ninja.cpp.generate(prj)
+		end)
+
+		test.isnil(output:find("_nil"))
 	end


### PR DESCRIPTION
**What does this PR do?**

Removes the remainder of the duplicate rules from ninja when multiple toolsets exist.

**How does this PR change Premake's behavior?**

Current behavior: On multiple toolsets being handled, the ninja generator currently emits multiple rules with the same name, such as copy and the build events.
New Behavior: For toolset independent rule definitions, emit the rule once. For toolset dependent rule definitions, emit the rule once per toolset with a canonicalized name attached for rule disambiguation.

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [x] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
