### PR TITLE
Fix getdefines calls for Ninja, compile commands, and CodeLite

### DIFF
--- a/modules/codelite/codelite_project.lua
+++ b/modules/codelite/codelite_project.lua
@@ -202,7 +202,7 @@
 		local toolset = m.getcompiler(cfg)
 		local externalincludedirs = toolset.getincludedirs(cfg, {}, cfg.externalincludedirs, cfg.frameworkdirs, cfg.includedirsafter)
 		local forceincludes = toolset.getforceincludes(cfg)
-		local defines = iif(#cfg.undefines > 0, table.join(toolset.getdefines(cfg.defines), toolset.getundefines(cfg.undefines)), {})
+		local defines = iif(#cfg.undefines > 0, table.join(toolset.getdefines(cfg.defines, cfg), toolset.getundefines(cfg.undefines)), {})
 		local cxxflags = table.concat(table.join(externalincludedirs, toolset.getcxxflags(cfg), forceincludes, cfg.buildoptions, defines), ";")
 		local cflags   = table.concat(table.join(externalincludedirs, toolset.getcflags(cfg), forceincludes, cfg.buildoptions, defines), ";")
 		local asmflags = ""

--- a/modules/codelite/tests/test_codelite_config.lua
+++ b/modules/codelite/tests/test_codelite_config.lua
@@ -141,6 +141,23 @@
 		]]
 	end
 
+	--
+	-- Check compiler options with MSC toolset, verifying that character set
+	-- and exception handling defines are included alongside user defines and undefines.
+	--
+	function suite.OnProjectCfg_Undefines_MSVC()
+		toolset "msc"
+		defines { "TEST" }
+		undefines { "UNDEF" }
+		prepare()
+		codelite.project.compiler(cfg)
+		test.capture [[
+      <Compiler Options="/EHsc;/D_UNICODE;/DUNICODE;/DTEST;/UUNDEF" C_Options="/D_UNICODE;/DUNICODE;/DTEST;/UUNDEF" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1">
+      </Compiler>
+		]]
+	end
+
+
 	function suite.OnProjectCfg_Pch()
 		  pchheader "pch.h"
 		prepare()
@@ -213,6 +230,23 @@
       </ResourceCompiler>
 		]]
 	end
+
+	--
+	-- Check resource compiler options with MSC toolset, verifying that
+	-- character set defines are not included in resource compiler flags.
+	--
+	function suite.OnProjectCfg_ResDefines_MSVC()
+		toolset "msc"
+		files { "x.rc" }
+		resdefines { "RC_DEF" }
+		prepare()
+		codelite.project.resourceCompiler(cfg)
+		test.capture [[
+      <ResourceCompiler Options="/DRC_DEF;" Required="yes">
+      </ResourceCompiler>
+		]]
+	end
+
 
 	function suite.OnProjectCfg_ResRegularInclude()
 		files { "x.rc" }

--- a/modules/compilecommands/compilecommands.lua
+++ b/modules/compilecommands/compilecommands.lua
@@ -135,7 +135,7 @@ function m.getflags(cfg, toolset, fcfg, tool)
 
 	-- Compile flags and join together
 	flags = table.join(flags,
-						toolset.getdefines(defines),
+						toolset.getdefines(defines, proxy),
 						toolset.getundefines(undefines),
 						allincludedirflags,
 						toolset.getforceincludes({ project = cfg.project, forceincludes = forceincludes }),

--- a/modules/compilecommands/tests/test_cpp_compile.lua
+++ b/modules/compilecommands/tests/test_cpp_compile.lua
@@ -428,3 +428,64 @@
 		test.isequal(expected, args)
 	end
 
+
+--
+-- Check that compilecommands.getflags passes project-level proxy configuration to toolset.getdefines.
+--
+
+	function suite.getflags_passes_proxy_to_getdefines()
+		local cfg = prepare()
+		local passedConfig = nil
+		local mockToolset = {
+			gettoolname = function() return "cxx" end,
+			getstructuredimplicitincludedirs = function() return {} end,
+			getcxxflags = function() return {} end,
+			getstructuredincludedirs = function() return {} end,
+			getdefines = function(defines, c)
+				passedConfig = c
+				return {}
+			end,
+			getundefines = function() return {} end,
+			getforceincludes = function() return {} end,
+		}
+
+		compilecommands.getflags(cfg, mockToolset, nil, "cxx")
+		test.istrue(cfg == passedConfig)
+	end
+
+
+--
+-- Check that compilecommands.getflags passes file-level proxy configuration to toolset.getdefines.
+--
+
+	function suite.getflags_passes_file_proxy_to_getdefines()
+		files { "special.cpp" }
+		filter "files:special.cpp"
+			characterset "MBCS"
+		filter {}
+
+		local cfg = prepare()
+		local tr = p.project.getsourcetree(prj)
+		local node = tr.children[1]
+		local fcfg = p.fileconfig.getconfig(node, cfg)
+
+		local passedConfig = nil
+		local mockToolset = {
+			gettoolname = function() return "cxx" end,
+			getstructuredimplicitincludedirs = function() return {} end,
+			getcxxflags = function() return {} end,
+			getstructuredincludedirs = function() return {} end,
+			getdefines = function(defines, c)
+				passedConfig = c
+				return {}
+			end,
+			getundefines = function() return {} end,
+			getforceincludes = function() return {} end,
+		}
+
+		compilecommands.getflags(cfg, mockToolset, fcfg, "cxx")
+		test.isnotnil(passedConfig)
+		test.isequal("MBCS", passedConfig.characterset)
+	end
+
+

--- a/modules/ninja/ninja_cpp.lua
+++ b/modules/ninja/ninja_cpp.lua
@@ -328,7 +328,7 @@ function m.getCFlags(cfg, toolset)
 	flags = table.join(flags, toolFlags)
 	
 	local escaper = p.escaper(p.quote)
-	local defines = toolset.getdefines(cfg.defines)
+	local defines = toolset.getdefines(cfg.defines, cfg)
 	flags = table.join(flags, defines)
 	
 	local undefines = toolset.getundefines(cfg.undefines)
@@ -372,7 +372,7 @@ function m.getFileCFlags(cfg, filecfg, toolset)
 	
 	local allDefines = table.join(cfg.defines or {}, filecfg.defines or {})
 	local escaper = p.escaper(p.quote)
-	local defines = toolset.getdefines(allDefines)
+	local defines = toolset.getdefines(allDefines, proxy)
 	flags = table.join(flags, defines)
 
 	local allUndefines = table.join(cfg.undefines or {}, filecfg.undefines or {})
@@ -406,7 +406,7 @@ function m.getCxxFlags(cfg, toolset)
 	flags = table.join(flags, toolFlags)
 
 	local escaper = p.escaper(p.quote)
-	local defines = toolset.getdefines(cfg.defines)
+	local defines = toolset.getdefines(cfg.defines, cfg)
 	flags = table.join(flags, defines)
 
 	local undefines = toolset.getundefines(cfg.undefines)
@@ -440,7 +440,7 @@ function m.getFileCxxFlags(cfg, filecfg, toolset)
 	
 	local allDefines = table.join(cfg.defines or {}, filecfg.defines or {})
 	local escaper = p.escaper(p.quote)
-	local defines = toolset.getdefines(allDefines)
+	local defines = toolset.getdefines(allDefines, proxy)
 	flags = table.join(flags, defines)
 
 	local allUndefines = table.join(cfg.undefines or {}, filecfg.undefines or {})

--- a/modules/ninja/tests/test_ninja_config.lua
+++ b/modules/ninja/tests/test_ninja_config.lua
@@ -66,7 +66,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cxxflags_MyProject_Debug = /EHsc
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE
+cxxflags_MyProject_Debug = /EHsc /D_UNICODE /DUNICODE
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -133,8 +134,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /D"DEBUG" /D"PLATFORM_WINDOWS"
-cxxflags_MyProject_Debug = /EHsc /D"DEBUG" /D"PLATFORM_WINDOWS"
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE /D"DEBUG" /D"PLATFORM_WINDOWS"
+cxxflags_MyProject_Debug = /EHsc /D_UNICODE /DUNICODE /D"DEBUG" /D"PLATFORM_WINDOWS"
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -177,8 +178,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /D"HELLO=\"HELLO WORLD\""
-cxxflags_MyProject_Debug = /EHsc /D"HELLO=\"HELLO WORLD\""
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE /D"HELLO=\"HELLO WORLD\""
+cxxflags_MyProject_Debug = /EHsc /D_UNICODE /DUNICODE /D"HELLO=\"HELLO WORLD\""
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -199,8 +200,8 @@ target_MyProject_Debug = MyProject.exe
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /D"VALUE=with_paren()"
-cxxflags_MyProject_Debug = /EHsc /D"VALUE=with_paren()"
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE /D"VALUE=with_paren()"
+cxxflags_MyProject_Debug = /EHsc /D_UNICODE /DUNICODE /D"VALUE=with_paren()"
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -247,8 +248,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /Iinclude /Iexternal
-cxxflags_MyProject_Debug = /EHsc /Iinclude /Iexternal
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE /Iinclude /Iexternal
+cxxflags_MyProject_Debug = /EHsc /D_UNICODE /DUNICODE /Iinclude /Iexternal
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -315,7 +316,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cxxflags_MyProject_Debug = /EHsc
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE
+cxxflags_MyProject_Debug = /EHsc /D_UNICODE /DUNICODE
 ldflags_MyProject_Debug = /NOLOGO /LIBPATH:"lib" /LIBPATH:"external/lib"
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -402,7 +404,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cxxflags_MyProject_Debug = /EHsc
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE
+cxxflags_MyProject_Debug = /EHsc /D_UNICODE /DUNICODE
 ldflags_MyProject_Debug = /NOLOGO
 links_MyProject_Debug = User32.lib Gdi32.lib
 objdir_MyProject_Debug = obj/Debug
@@ -471,8 +474,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /W4 /WX
-cxxflags_MyProject_Debug = /EHsc /W4 /WX
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE /W4 /WX
+cxxflags_MyProject_Debug = /EHsc /D_UNICODE /DUNICODE /W4 /WX
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -541,8 +544,8 @@ target_MyProject_Debug = MyProject
 		cpp.configurationVariables(cfg)
 
 		test.capture [[
-cflags_MyProject_Debug = /U"NDEBUG" /U"OLD_PLATFORM"
-cxxflags_MyProject_Debug = /EHsc /U"NDEBUG" /U"OLD_PLATFORM"
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE /U"NDEBUG" /U"OLD_PLATFORM"
+cxxflags_MyProject_Debug = /EHsc /D_UNICODE /DUNICODE /U"NDEBUG" /U"OLD_PLATFORM"
 ldflags_MyProject_Debug = /NOLOGO
 objdir_MyProject_Debug = obj/Debug
 targetdir_MyProject_Debug = bin/Debug
@@ -1108,3 +1111,111 @@ build obj/Debug/MyProject.postbuild: postbuild | bin/Debug/MyProject
   postbuildcommands = sh -c 'echo "Finishing build" && cp bin/Debug/MyProject /usr/local/bin/ && chmod +x /usr/local/bin/MyProject && touch "obj/Debug/MyProject.postbuild"'
 		]]
 	end
+
+
+---
+-- Character set and exception handling tests for MSC
+---
+
+--
+-- Check that characterset "Unicode" generates /D_UNICODE and /DUNICODE flags with MSC toolset.
+--
+
+	function suite.configVars_characterset_Unicode_MSVC()
+		toolset "msc"
+		_OS = "Windows"
+		kind "ConsoleApp"
+		files { "main.cpp" }
+		characterset "Unicode"
+
+		local cfg = prepare()
+		cpp.configurationVariables(cfg)
+
+		test.capture [[
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE
+cxxflags_MyProject_Debug = /EHsc /D_UNICODE /DUNICODE
+ldflags_MyProject_Debug = /NOLOGO
+objdir_MyProject_Debug = obj/Debug
+targetdir_MyProject_Debug = bin/Debug
+target_MyProject_Debug = MyProject.exe
+
+		]]
+	end
+
+
+--
+-- Check that characterset "MBCS" generates /D_MBCS flag with MSC toolset.
+--
+
+	function suite.configVars_characterset_MBCS_MSVC()
+		toolset "msc"
+		_OS = "Windows"
+		kind "ConsoleApp"
+		files { "main.cpp" }
+		characterset "MBCS"
+
+		local cfg = prepare()
+		cpp.configurationVariables(cfg)
+
+		test.capture [[
+cflags_MyProject_Debug = /D_MBCS
+cxxflags_MyProject_Debug = /EHsc /D_MBCS
+ldflags_MyProject_Debug = /NOLOGO
+objdir_MyProject_Debug = obj/Debug
+targetdir_MyProject_Debug = bin/Debug
+target_MyProject_Debug = MyProject.exe
+
+		]]
+	end
+
+
+--
+-- Check that characterset "ASCII" does not generate character set define flags with MSC toolset.
+--
+
+	function suite.configVars_characterset_ASCII_MSVC()
+		toolset "msc"
+		_OS = "Windows"
+		kind "ConsoleApp"
+		files { "main.cpp" }
+		characterset "ASCII"
+
+		local cfg = prepare()
+		cpp.configurationVariables(cfg)
+
+		test.capture [[
+cxxflags_MyProject_Debug = /EHsc
+ldflags_MyProject_Debug = /NOLOGO
+objdir_MyProject_Debug = obj/Debug
+targetdir_MyProject_Debug = bin/Debug
+target_MyProject_Debug = MyProject.exe
+
+		]]
+	end
+
+
+--
+-- Check that exceptionhandling "Off" generates /D_HAS_EXCEPTIONS=0 flag with MSC toolset.
+--
+
+	function suite.configVars_exceptionhandling_Off_MSVC()
+		toolset "msc"
+		_OS = "Windows"
+		kind "ConsoleApp"
+		files { "main.cpp" }
+		exceptionhandling "Off"
+
+		local cfg = prepare()
+		cpp.configurationVariables(cfg)
+
+		test.capture [[
+cflags_MyProject_Debug = /D_UNICODE /DUNICODE /D_HAS_EXCEPTIONS=0
+cxxflags_MyProject_Debug = /D_UNICODE /DUNICODE /D_HAS_EXCEPTIONS=0
+ldflags_MyProject_Debug = /NOLOGO
+objdir_MyProject_Debug = obj/Debug
+targetdir_MyProject_Debug = bin/Debug
+target_MyProject_Debug = MyProject.exe
+
+		]]
+	end
+

--- a/modules/ninja/tests/test_ninja_perfile_config.lua
+++ b/modules/ninja/tests/test_ninja_perfile_config.lua
@@ -82,7 +82,7 @@ build obj/Debug/special.o: cxx_gcc special.cpp
 build obj/Debug/main.obj: cxx_msc main.cpp
   cxxflags = $cxxflags_MyProject_Debug
 build obj/Debug/special.obj: cxx_msc special.cpp
-  cxxflags = /EHsc /D"MAIN_DEFINE" /D"SPECIAL_DEFINE"
+  cxxflags = /EHsc /D_UNICODE /DUNICODE /D"MAIN_DEFINE" /D"SPECIAL_DEFINE"
 		]]
 	end
 
@@ -260,7 +260,7 @@ build obj/Debug/special.o: cxx_gcc special.cpp
 build obj/Debug/main.obj: cxx_msc main.cpp
   cxxflags = $cxxflags_MyProject_Debug
 build obj/Debug/special.obj: cxx_msc special.cpp
-  cxxflags = /EHsc /D"MAIN_DEFINE" /D"SPECIAL_DEFINE" /Iinclude /Ispecial/include /O2
+  cxxflags = /EHsc /D_UNICODE /DUNICODE /D"MAIN_DEFINE" /D"SPECIAL_DEFINE" /Iinclude /Ispecial/include /O2
 		]]
 	end
 
@@ -344,7 +344,7 @@ build obj/Debug/simd.o: cxx_gcc simd.cpp
 build obj/Debug/main.obj: cxx_msc main.cpp
   cxxflags = $cxxflags_MyProject_Debug
 build obj/Debug/simd.obj: cxx_msc simd.cpp
-  cxxflags = /arch:AVX2 /EHsc
+  cxxflags = /arch:AVX2 /EHsc /D_UNICODE /DUNICODE
 		]]
 	end
 
@@ -371,7 +371,7 @@ build obj/Debug/simd.obj: cxx_msc simd.cpp
 build obj/Debug/main.obj: cc_msc main.c
   cflags = $cflags_MyProject_Debug
 build obj/Debug/simd.obj: cc_msc simd.c
-  cflags = /arch:AVX2 /wd4716
+  cflags = /arch:AVX2 /D_UNICODE /DUNICODE /wd4716
 		]]
 	end
 
@@ -450,7 +450,7 @@ build obj/Debug/simd.o: cxx_gcc simd.cpp
 build obj/Debug/main.obj: cxx_msc main.cpp
   cxxflags = $cxxflags_MyProject_Debug
 build obj/Debug/simd.obj: cxx_msc simd.cpp
-  cxxflags = /arch:AVX2 /EHsc
+  cxxflags = /arch:AVX2 /EHsc /D_UNICODE /DUNICODE
 		]]
 	end
 
@@ -657,3 +657,29 @@ build obj/Debug/special.o: cxx_gcc special.cpp
   cxxflags = -Werror=return-type -Werror=uninitialized
 		]]
 	end
+
+
+--
+-- Check that per-file characterset override generates inline flags with MSVC.
+--
+
+	function suite.perfile_characterset_override_MSVC()
+		toolset "msc"
+		_OS = "Windows"
+		files { "main.cpp", "special.cpp" }
+		
+		filter "files:special.cpp"
+			characterset "MBCS"
+		filter {}
+		
+		local cfg = prepare()
+		cpp.buildFiles(cfg)
+		
+		test.capture [[
+build obj/Debug/main.obj: cxx_msc main.cpp
+  cxxflags = $cxxflags_MyProject_Debug
+build obj/Debug/special.obj: cxx_msc special.cpp
+  cxxflags = /EHsc /D_MBCS
+		]]
+	end
+


### PR DESCRIPTION
**What does this PR do?**

Fixes how `getdefines` is called amongst exporters. Ensures the relevant config is passed.

**How does this PR change Premake's behavior?**

Addresses issues where defines were reliant on a passed config.

**Anything else we should know?**

Resolves #2800 

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits
- [ ] Align [documentation](https://github.com/premake/premake-core/tree/master/website) to your changes

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
